### PR TITLE
Remove stuttering type names

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -108,16 +108,16 @@ const synapseSpark = 'https://raw.githubusercontent.com/Azure/azure-rest-api-spe
 generateFromReadme("azspark", synapseSpark, 'package-spark-2019-11-01-preview', 'test/synapse/2019-06-01/azspark', '--security=AADToken --security-scopes="https://dev.azuresynapse.net/.default" --module="azspark" --openapi-type="data-plane"');
 
 const tables = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/cosmos-db/data-plane/readme.md';
-generateFromReadme("aztables", tables, 'package-2019-02', 'test/tables/2019-02-02/aztables', '--security=AADToken --security-scopes="https://tables.azure.com/.default" --module=aztables --openapi-type="data-plane" --export-clients --azure-validator=false --group-parameters=false');
+generateFromReadme("aztables", tables, 'package-2019-02', 'test/tables/2019-02-02/aztables', '--security=AADToken --security-scopes="https://tables.azure.com/.default" --module=aztables --openapi-type="data-plane" --export-clients --azure-validator=false --group-parameters=false --stutter=table');
 
-const keyvault = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/readme.md';
-generateFromReadme("azkeyvault", keyvault, 'package-7.2', 'test/keyvault/7.2/azkeyvault', '--security=AADToken --security-scopes="https://vault.azure.net/.default" --module=azkeyvault --openapi-type="data-plane" --export-clients');
+const keyvault = fullPath('test/keyvault/7.2/azkeyvault/autorest.md');
+generateFromReadme("azkeyvault", keyvault, 'package-7.2', 'test/keyvault/7.2/azkeyvault');
 
 const consumption = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/3865f04d22e82db481be0727b406021d29cd2b70/specification/consumption/resource-manager/readme.md';
 generateFromReadme("armconsumption", consumption, 'package-2019-10', 'test/consumption/2019-10-01/armconsumption', '--module=armconsumption --azure-arm=true');
 
-const databoxedge = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/3865f04d22e82db481be0727b406021d29cd2b70/specification/databoxedge/resource-manager/readme.md';
-generateFromReadme("armdataboxedge", databoxedge, 'package-2021-02-01', 'test/databoxedge/2021-02-01/armdataboxedge', '--module=armdataboxedge ---azure-arm=true');
+const databoxedge = fullPath('test/databoxedge/2021-02-01/armdataboxedge/autorest.md');
+generateFromReadme("armdataboxedge", databoxedge, 'package-2021-02-01', 'test/databoxedge/2021-02-01/armdataboxedge');
 
 generate("azalias", 'test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --openapi-type="data-plane"');
 
@@ -139,6 +139,9 @@ function generate(name, inputFile, outputDir, additionalArgs) {
     if (!should_generate(name)) {
         return
     }
+    if (additionalArgs === undefined) {
+        additionalArgs = '';
+    }
     sem.take(function() {
         console.log('generating ' + inputFile);
         outputDir = fullPath(outputDir);
@@ -150,6 +153,9 @@ function generate(name, inputFile, outputDir, additionalArgs) {
 function generateFromReadme(name, readme, tag, outputDir, additionalArgs) {
     if (!should_generate(name)) {
         return
+    }
+    if (additionalArgs === undefined) {
+        additionalArgs = '';
     }
     sem.take(function() {
         console.log('generating ' + readme);

--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -74,4 +74,7 @@ help-content:
       - key: group-parameters
         description: Enables parameter grouping via x-ms-parameter-grouping, defaults to true.
         type: boolean
+      - key: stutter
+        type: string
+        description: Uses the specified value to remove stuttering from types and funcs instead of the built-in algorithm.
 ```

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -317,46 +317,6 @@ func (e CloudError) Error() string {
 	return e.raw
 }
 
-// ComputeOperationListResult - The List Compute Operation operation response.
-type ComputeOperationListResult struct {
-	// READ-ONLY; The list of compute operations
-	Value []*ComputeOperationValue `json:"value,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type ComputeOperationListResult.
-func (c ComputeOperationListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", c.Value)
-	return json.Marshal(objectMap)
-}
-
-// ComputeOperationValue - Describes the properties of a Compute Operation value.
-type ComputeOperationValue struct {
-	// Describes the properties of a Compute Operation Value Display.
-	Display *ComputeOperationValueDisplay `json:"display,omitempty"`
-
-	// READ-ONLY; The name of the compute operation.
-	Name *string `json:"name,omitempty" azure:"ro"`
-
-	// READ-ONLY; The origin of the compute operation.
-	Origin *string `json:"origin,omitempty" azure:"ro"`
-}
-
-// ComputeOperationValueDisplay - Describes the properties of a Compute Operation Value Display.
-type ComputeOperationValueDisplay struct {
-	// READ-ONLY; The description of the operation.
-	Description *string `json:"description,omitempty" azure:"ro"`
-
-	// READ-ONLY; The display name of the compute operation.
-	Operation *string `json:"operation,omitempty" azure:"ro"`
-
-	// READ-ONLY; The resource provider for the operation.
-	Provider *string `json:"provider,omitempty" azure:"ro"`
-
-	// READ-ONLY; The display name of the resource the operation applies to.
-	Resource *string `json:"resource,omitempty" azure:"ro"`
-}
-
 // ContainerService - Container service.
 type ContainerService struct {
 	Resource
@@ -3201,6 +3161,46 @@ func (o OSProfile) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "secrets", o.Secrets)
 	populate(objectMap, "windowsConfiguration", o.WindowsConfiguration)
 	return json.Marshal(objectMap)
+}
+
+// OperationListResult - The List Compute Operation operation response.
+type OperationListResult struct {
+	// READ-ONLY; The list of compute operations
+	Value []*OperationValue `json:"value,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OperationListResult.
+func (o OperationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", o.Value)
+	return json.Marshal(objectMap)
+}
+
+// OperationValue - Describes the properties of a Compute Operation value.
+type OperationValue struct {
+	// Describes the properties of a Compute Operation Value Display.
+	Display *OperationValueDisplay `json:"display,omitempty"`
+
+	// READ-ONLY; The name of the compute operation.
+	Name *string `json:"name,omitempty" azure:"ro"`
+
+	// READ-ONLY; The origin of the compute operation.
+	Origin *string `json:"origin,omitempty" azure:"ro"`
+}
+
+// OperationValueDisplay - Describes the properties of a Compute Operation Value Display.
+type OperationValueDisplay struct {
+	// READ-ONLY; The description of the operation.
+	Description *string `json:"description,omitempty" azure:"ro"`
+
+	// READ-ONLY; The display name of the compute operation.
+	Operation *string `json:"operation,omitempty" azure:"ro"`
+
+	// READ-ONLY; The resource provider for the operation.
+	Provider *string `json:"provider,omitempty" azure:"ro"`
+
+	// READ-ONLY; The display name of the resource the operation applies to.
+	Resource *string `json:"resource,omitempty" azure:"ro"`
 }
 
 // OperationsListOptions contains the optional parameters for the OperationsClient.List method.

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
@@ -79,7 +79,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 // listHandleResponse handles the List response.
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsListResponse, error) {
 	result := OperationsListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.ComputeOperationListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil

--- a/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
@@ -2118,7 +2118,7 @@ type OperationsListResponse struct {
 
 // OperationsListResult contains the result from method Operations.List.
 type OperationsListResult struct {
-	ComputeOperationListResult
+	OperationListResult
 }
 
 // ProximityPlacementGroupsCreateOrUpdateResponse contains the response from method ProximityPlacementGroups.CreateOrUpdate.

--- a/test/databoxedge/2021-02-01/armdataboxedge/autorest.md
+++ b/test/databoxedge/2021-02-01/armdataboxedge/autorest.md
@@ -1,0 +1,20 @@
+### AutoRest Configuration
+
+> see https://aka.ms/autorest
+
+``` yaml
+azure-arm: true
+require:
+- https://github.com/Azure/azure-rest-api-specs/blob/3865f04d22e82db481be0727b406021d29cd2b70/specification/databoxedge/resource-manager/readme.md
+- https://github.com/Azure/azure-rest-api-specs/blob/3865f04d22e82db481be0727b406021d29cd2b70/specification/databoxedge/resource-manager/readme.go.md
+license-header: MICROSOFT_MIT_NO_VERSION
+module: armdataboxedge
+module-version: 0.1.0
+
+# stuttering clean-up causes a name collision so we fix up the name
+# https://github.com/Azure/autorest/blob/main/docs/generate/built-in-directives.md#rename-model
+directive:
+  - rename-model:
+      from: 'Sku'
+      to: 'SkuType'
+```

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // BandwidthSchedulesClient contains the methods for the BandwidthSchedules group.
 // Don't use this type directly, use NewBandwidthSchedulesClient() instead.
 type BandwidthSchedulesClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewBandwidthSchedulesClient creates a new instance of BandwidthSchedulesClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewBandwidthSchedulesClient(subscriptionID string, options *azcore.ClientOptions) *BandwidthSchedulesClient {
-	cp := azcore.ClientOptions{}
+func NewBandwidthSchedulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *BandwidthSchedulesClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &BandwidthSchedulesClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -105,7 +112,7 @@ func (client *BandwidthSchedulesClient) createOrUpdateCreateRequest(ctx context.
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +197,7 @@ func (client *BandwidthSchedulesClient) deleteCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +261,7 @@ func (client *BandwidthSchedulesClient) getCreateRequest(ctx context.Context, de
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +327,7 @@ func (client *BandwidthSchedulesClient) listByDataBoxEdgeDeviceCreateRequest(ctx
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_constants.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_constants.go
@@ -8,8 +8,6 @@
 
 package armdataboxedge
 
-const host = "https://management.azure.com"
-
 const (
 	module  = "armdataboxedge"
 	version = "v0.1.0"

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // ContainersClient contains the methods for the Containers group.
 // Don't use this type directly, use NewContainersClient() instead.
 type ContainersClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewContainersClient creates a new instance of ContainersClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewContainersClient(subscriptionID string, options *azcore.ClientOptions) *ContainersClient {
-	cp := azcore.ClientOptions{}
+func NewContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *ContainersClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &ContainersClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -110,7 +117,7 @@ func (client *ContainersClient) createOrUpdateCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +206,7 @@ func (client *ContainersClient) deleteCreateRequest(ctx context.Context, deviceN
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +275,7 @@ func (client *ContainersClient) getCreateRequest(ctx context.Context, deviceName
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +346,7 @@ func (client *ContainersClient) listByStorageAccountCreateRequest(ctx context.Co
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +444,7 @@ func (client *ContainersClient) refreshCreateRequest(ctx context.Context, device
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_diagnosticsettings_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_diagnosticsettings_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // DiagnosticSettingsClient contains the methods for the DiagnosticSettings group.
 // Don't use this type directly, use NewDiagnosticSettingsClient() instead.
 type DiagnosticSettingsClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewDiagnosticSettingsClient creates a new instance of DiagnosticSettingsClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewDiagnosticSettingsClient(subscriptionID string, options *azcore.ClientOptions) *DiagnosticSettingsClient {
-	cp := azcore.ClientOptions{}
+func NewDiagnosticSettingsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *DiagnosticSettingsClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &DiagnosticSettingsClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -80,7 +87,7 @@ func (client *DiagnosticSettingsClient) getDiagnosticProactiveLogCollectionSetti
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +157,7 @@ func (client *DiagnosticSettingsClient) getDiagnosticRemoteSupportSettingsCreate
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +249,7 @@ func (client *DiagnosticSettingsClient) updateDiagnosticProactiveLogCollectionSe
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +332,7 @@ func (client *DiagnosticSettingsClient) updateDiagnosticRemoteSupportSettingsCre
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_jobs_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_jobs_client.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,21 +25,27 @@ import (
 // JobsClient contains the methods for the Jobs group.
 // Don't use this type directly, use NewJobsClient() instead.
 type JobsClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewJobsClient creates a new instance of JobsClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewJobsClient(subscriptionID string, options *azcore.ClientOptions) *JobsClient {
-	cp := azcore.ClientOptions{}
+func NewJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *JobsClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &JobsClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -82,7 +90,7 @@ func (client *JobsClient) getCreateRequest(ctx context.Context, deviceName strin
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_models.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_models.go
@@ -881,8 +881,14 @@ type DCAccessCodeProperties struct {
 	AuthCode *string `json:"authCode,omitempty"`
 }
 
-// DataBoxEdgeDevice - The Data Box Edge/Gateway device.
-type DataBoxEdgeDevice struct {
+// DataResidency - Wraps data-residency related information for edge-resource and this should be used with ARM layer.
+type DataResidency struct {
+	// DataResidencyType enum
+	Type *DataResidencyType `json:"type,omitempty"`
+}
+
+// Device - The Data Box Edge/Gateway device.
+type Device struct {
 	ARMBaseModel
 	// REQUIRED; The location of the device. This is a supported and registered Azure geographical region (for example, West US,
 	// East US, or Southeast Asia). The geographical region of a device cannot be changed once
@@ -899,10 +905,10 @@ type DataBoxEdgeDevice struct {
 	Kind *DataBoxEdgeDeviceKind `json:"kind,omitempty"`
 
 	// The properties of the Data Box Edge/Gateway device.
-	Properties *DataBoxEdgeDeviceProperties `json:"properties,omitempty"`
+	Properties *DeviceProperties `json:"properties,omitempty"`
 
 	// The SKU type.
-	SKU *SKU `json:"sku,omitempty"`
+	SKU *SKUType `json:"sku,omitempty"`
 
 	// The list of tags that describe the device. These tags can be used to view and group this device (across resource groups).
 	Tags map[string]*string `json:"tags,omitempty"`
@@ -911,8 +917,8 @@ type DataBoxEdgeDevice struct {
 	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeDevice.
-func (d DataBoxEdgeDevice) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type Device.
+func (d Device) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	d.ARMBaseModel.marshalInternal(objectMap)
 	populate(objectMap, "etag", d.Etag)
@@ -926,8 +932,8 @@ func (d DataBoxEdgeDevice) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type DataBoxEdgeDevice.
-func (d *DataBoxEdgeDevice) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type Device.
+func (d *Device) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
@@ -970,23 +976,23 @@ func (d *DataBoxEdgeDevice) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// DataBoxEdgeDeviceExtendedInfo - The extended Info of the Data Box Edge/Gateway device.
-type DataBoxEdgeDeviceExtendedInfo struct {
+// DeviceExtendedInfo - The extended Info of the Data Box Edge/Gateway device.
+type DeviceExtendedInfo struct {
 	ARMBaseModel
 	// The extended info properties.
-	Properties *DataBoxEdgeDeviceExtendedInfoProperties `json:"properties,omitempty"`
+	Properties *DeviceExtendedInfoProperties `json:"properties,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeDeviceExtendedInfo.
-func (d DataBoxEdgeDeviceExtendedInfo) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type DeviceExtendedInfo.
+func (d DeviceExtendedInfo) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	d.ARMBaseModel.marshalInternal(objectMap)
 	populate(objectMap, "properties", d.Properties)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type DataBoxEdgeDeviceExtendedInfo.
-func (d *DataBoxEdgeDeviceExtendedInfo) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type DeviceExtendedInfo.
+func (d *DeviceExtendedInfo) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
@@ -1008,8 +1014,8 @@ func (d *DataBoxEdgeDeviceExtendedInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// DataBoxEdgeDeviceExtendedInfoPatch - The Data Box Edge/Gateway device extended info patch.
-type DataBoxEdgeDeviceExtendedInfoPatch struct {
+// DeviceExtendedInfoPatch - The Data Box Edge/Gateway device extended info patch.
+type DeviceExtendedInfoPatch struct {
 	// The name for Channel Integrity Key stored in the Client Key Vault
 	ChannelIntegrityKeyName *string `json:"channelIntegrityKeyName,omitempty"`
 
@@ -1027,8 +1033,8 @@ type DataBoxEdgeDeviceExtendedInfoPatch struct {
 	SyncStatus *KeyVaultSyncStatus `json:"syncStatus,omitempty"`
 }
 
-// DataBoxEdgeDeviceExtendedInfoProperties - The properties of the Data Box Edge/Gateway device extended info.
-type DataBoxEdgeDeviceExtendedInfoProperties struct {
+// DeviceExtendedInfoProperties - The properties of the Data Box Edge/Gateway device extended info.
+type DeviceExtendedInfoProperties struct {
 	// The name of Channel Integrity Key stored in the Client Key Vault
 	ChannelIntegrityKeyName *string `json:"channelIntegrityKeyName,omitempty"`
 
@@ -1057,8 +1063,8 @@ type DataBoxEdgeDeviceExtendedInfoProperties struct {
 	ResourceKey *string `json:"resourceKey,omitempty" azure:"ro"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeDeviceExtendedInfoProperties.
-func (d DataBoxEdgeDeviceExtendedInfoProperties) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type DeviceExtendedInfoProperties.
+func (d DeviceExtendedInfoProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "channelIntegrityKeyName", d.ChannelIntegrityKeyName)
 	populate(objectMap, "channelIntegrityKeyVersion", d.ChannelIntegrityKeyVersion)
@@ -1072,37 +1078,37 @@ func (d DataBoxEdgeDeviceExtendedInfoProperties) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// DataBoxEdgeDeviceList - The collection of Data Box Edge/Gateway devices.
-type DataBoxEdgeDeviceList struct {
+// DeviceList - The collection of Data Box Edge/Gateway devices.
+type DeviceList struct {
 	// READ-ONLY; Link to the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// READ-ONLY; The list of Data Box Edge/Gateway devices.
-	Value []*DataBoxEdgeDevice `json:"value,omitempty" azure:"ro"`
+	Value []*Device `json:"value,omitempty" azure:"ro"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeDeviceList.
-func (d DataBoxEdgeDeviceList) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type DeviceList.
+func (d DeviceList) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "nextLink", d.NextLink)
 	populate(objectMap, "value", d.Value)
 	return json.Marshal(objectMap)
 }
 
-// DataBoxEdgeDevicePatch - The Data Box Edge/Gateway device patch.
-type DataBoxEdgeDevicePatch struct {
+// DevicePatch - The Data Box Edge/Gateway device patch.
+type DevicePatch struct {
 	// Msi identity of the resource
 	Identity *ResourceIdentity `json:"identity,omitempty"`
 
 	// The properties associated with the Data Box Edge/Gateway resource
-	Properties *DataBoxEdgeDevicePropertiesPatch `json:"properties,omitempty"`
+	Properties *DevicePropertiesPatch `json:"properties,omitempty"`
 
 	// The tags attached to the Data Box Edge/Gateway resource.
 	Tags map[string]*string `json:"tags,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeDevicePatch.
-func (d DataBoxEdgeDevicePatch) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type DevicePatch.
+func (d DevicePatch) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "identity", d.Identity)
 	populate(objectMap, "properties", d.Properties)
@@ -1110,8 +1116,8 @@ func (d DataBoxEdgeDevicePatch) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// DataBoxEdgeDeviceProperties - The properties of the Data Box Edge/Gateway device.
-type DataBoxEdgeDeviceProperties struct {
+// DeviceProperties - The properties of the Data Box Edge/Gateway device.
+type DeviceProperties struct {
 	// The status of the Data Box Edge/Gateway device.
 	DataBoxEdgeDeviceStatus *DataBoxEdgeDeviceStatus `json:"dataBoxEdgeDeviceStatus,omitempty"`
 
@@ -1167,8 +1173,8 @@ type DataBoxEdgeDeviceProperties struct {
 	TimeZone *string `json:"timeZone,omitempty" azure:"ro"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeDeviceProperties.
-func (d DataBoxEdgeDeviceProperties) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type DeviceProperties.
+func (d DeviceProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "configuredRoleTypes", d.ConfiguredRoleTypes)
 	populate(objectMap, "culture", d.Culture)
@@ -1191,119 +1197,10 @@ func (d DataBoxEdgeDeviceProperties) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// DataBoxEdgeDevicePropertiesPatch - The Data Box Edge/Gateway device properties patch.
-type DataBoxEdgeDevicePropertiesPatch struct {
+// DevicePropertiesPatch - The Data Box Edge/Gateway device properties patch.
+type DevicePropertiesPatch struct {
 	// Edge Profile property of the Data Box Edge/Gateway device
 	EdgeProfile *EdgeProfilePatch `json:"edgeProfile,omitempty"`
-}
-
-// DataBoxEdgeMoveRequest - Resource Move details
-type DataBoxEdgeMoveRequest struct {
-	// REQUIRED; List of resources to be moved
-	Resources []*string `json:"resources,omitempty"`
-
-	// REQUIRED; Target resource group ARMId
-	TargetResourceGroup *string `json:"targetResourceGroup,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeMoveRequest.
-func (d DataBoxEdgeMoveRequest) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "resources", d.Resources)
-	populate(objectMap, "targetResourceGroup", d.TargetResourceGroup)
-	return json.Marshal(objectMap)
-}
-
-// DataBoxEdgeSKU - The Sku information.
-type DataBoxEdgeSKU struct {
-	// READ-ONLY; The API versions in which Sku is available.
-	APIVersions []*string `json:"apiVersions,omitempty" azure:"ro"`
-
-	// READ-ONLY; Links to the next set of results
-	Availability *SKUAvailability `json:"availability,omitempty" azure:"ro"`
-
-	// READ-ONLY; The capability info of the SKU.
-	Capabilities []*SKUCapability `json:"capabilities,omitempty" azure:"ro"`
-
-	// READ-ONLY; The pricing info of the Sku.
-	Costs []*SKUCost `json:"costs,omitempty" azure:"ro"`
-
-	// READ-ONLY; The Sku family.
-	Family *string `json:"family,omitempty" azure:"ro"`
-
-	// READ-ONLY; The Sku kind.
-	Kind *string `json:"kind,omitempty" azure:"ro"`
-
-	// READ-ONLY; Availability of the Sku for the location/zone/site.
-	LocationInfo []*SKULocationInfo `json:"locationInfo,omitempty" azure:"ro"`
-
-	// READ-ONLY; Availability of the Sku for the region.
-	Locations []*string `json:"locations,omitempty" azure:"ro"`
-
-	// READ-ONLY; The Sku name.
-	Name *SKUName `json:"name,omitempty" azure:"ro"`
-
-	// READ-ONLY; The type of the resource.
-	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
-
-	// READ-ONLY; List of Shipment Types supported by this SKU
-	ShipmentTypes []*ShipmentType `json:"shipmentTypes,omitempty" azure:"ro"`
-
-	// READ-ONLY; Sku can be signed up by customer or not.
-	SignupOption *SKUSignupOption `json:"signupOption,omitempty" azure:"ro"`
-
-	// READ-ONLY; The Sku kind.
-	Size *string `json:"size,omitempty" azure:"ro"`
-
-	// READ-ONLY; The Sku tier.
-	Tier *SKUTier `json:"tier,omitempty" azure:"ro"`
-
-	// READ-ONLY; Availability of the Sku as preview/stable.
-	Version *SKUVersion `json:"version,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeSKU.
-func (d DataBoxEdgeSKU) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "apiVersions", d.APIVersions)
-	populate(objectMap, "availability", d.Availability)
-	populate(objectMap, "capabilities", d.Capabilities)
-	populate(objectMap, "costs", d.Costs)
-	populate(objectMap, "family", d.Family)
-	populate(objectMap, "kind", d.Kind)
-	populate(objectMap, "locationInfo", d.LocationInfo)
-	populate(objectMap, "locations", d.Locations)
-	populate(objectMap, "name", d.Name)
-	populate(objectMap, "resourceType", d.ResourceType)
-	populate(objectMap, "shipmentTypes", d.ShipmentTypes)
-	populate(objectMap, "signupOption", d.SignupOption)
-	populate(objectMap, "size", d.Size)
-	populate(objectMap, "tier", d.Tier)
-	populate(objectMap, "version", d.Version)
-	return json.Marshal(objectMap)
-}
-
-// DataBoxEdgeSKUList - List of SKU Information objects.
-type DataBoxEdgeSKUList struct {
-	// READ-ONLY; Links to the next set of results
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
-
-	// READ-ONLY; List of ResourceType Sku
-	Value []*DataBoxEdgeSKU `json:"value,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type DataBoxEdgeSKUList.
-func (d DataBoxEdgeSKUList) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "nextLink", d.NextLink)
-	populate(objectMap, "value", d.Value)
-	return json.Marshal(objectMap)
-}
-
-// DataResidency - Wraps data-residency related information for edge-resource and this should be used with ARM layer.
-type DataResidency struct {
-	// DataResidencyType enum
-	Type *DataResidencyType `json:"type,omitempty"`
 }
 
 // DevicesBeginCreateOrUpdateSecuritySettingsOptions contains the optional parameters for the DevicesClient.BeginCreateOrUpdateSecuritySettings
@@ -2470,6 +2367,23 @@ type MountPointMap struct {
 	RoleType *RoleTypes `json:"roleType,omitempty" azure:"ro"`
 }
 
+// MoveRequest - Resource Move details
+type MoveRequest struct {
+	// REQUIRED; List of resources to be moved
+	Resources []*string `json:"resources,omitempty"`
+
+	// REQUIRED; Target resource group ARMId
+	TargetResourceGroup *string `json:"targetResourceGroup,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type MoveRequest.
+func (m MoveRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "resources", m.Resources)
+	populate(objectMap, "targetResourceGroup", m.TargetResourceGroup)
+	return json.Marshal(objectMap)
+}
+
 // NetworkAdapter - Represents the networkAdapter on a device.
 type NetworkAdapter struct {
 	// Value indicating whether this adapter has DHCP enabled.
@@ -3384,13 +3298,73 @@ type RolesListByDataBoxEdgeDeviceOptions struct {
 	// placeholder for future optional parameters
 }
 
-// SKU - The SKU type.
+// SKU - The Sku information.
 type SKU struct {
-	// SKU name.
-	Name *SKUName `json:"name,omitempty"`
+	// READ-ONLY; The API versions in which Sku is available.
+	APIVersions []*string `json:"apiVersions,omitempty" azure:"ro"`
 
-	// The SKU tier. This is based on the SKU name.
-	Tier *SKUTier `json:"tier,omitempty"`
+	// READ-ONLY; Links to the next set of results
+	Availability *SKUAvailability `json:"availability,omitempty" azure:"ro"`
+
+	// READ-ONLY; The capability info of the SKU.
+	Capabilities []*SKUCapability `json:"capabilities,omitempty" azure:"ro"`
+
+	// READ-ONLY; The pricing info of the Sku.
+	Costs []*SKUCost `json:"costs,omitempty" azure:"ro"`
+
+	// READ-ONLY; The Sku family.
+	Family *string `json:"family,omitempty" azure:"ro"`
+
+	// READ-ONLY; The Sku kind.
+	Kind *string `json:"kind,omitempty" azure:"ro"`
+
+	// READ-ONLY; Availability of the Sku for the location/zone/site.
+	LocationInfo []*SKULocationInfo `json:"locationInfo,omitempty" azure:"ro"`
+
+	// READ-ONLY; Availability of the Sku for the region.
+	Locations []*string `json:"locations,omitempty" azure:"ro"`
+
+	// READ-ONLY; The Sku name.
+	Name *SKUName `json:"name,omitempty" azure:"ro"`
+
+	// READ-ONLY; The type of the resource.
+	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
+
+	// READ-ONLY; List of Shipment Types supported by this SKU
+	ShipmentTypes []*ShipmentType `json:"shipmentTypes,omitempty" azure:"ro"`
+
+	// READ-ONLY; Sku can be signed up by customer or not.
+	SignupOption *SKUSignupOption `json:"signupOption,omitempty" azure:"ro"`
+
+	// READ-ONLY; The Sku kind.
+	Size *string `json:"size,omitempty" azure:"ro"`
+
+	// READ-ONLY; The Sku tier.
+	Tier *SKUTier `json:"tier,omitempty" azure:"ro"`
+
+	// READ-ONLY; Availability of the Sku as preview/stable.
+	Version *SKUVersion `json:"version,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SKU.
+func (s SKU) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "apiVersions", s.APIVersions)
+	populate(objectMap, "availability", s.Availability)
+	populate(objectMap, "capabilities", s.Capabilities)
+	populate(objectMap, "costs", s.Costs)
+	populate(objectMap, "family", s.Family)
+	populate(objectMap, "kind", s.Kind)
+	populate(objectMap, "locationInfo", s.LocationInfo)
+	populate(objectMap, "locations", s.Locations)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "resourceType", s.ResourceType)
+	populate(objectMap, "shipmentTypes", s.ShipmentTypes)
+	populate(objectMap, "signupOption", s.SignupOption)
+	populate(objectMap, "size", s.Size)
+	populate(objectMap, "tier", s.Tier)
+	populate(objectMap, "version", s.Version)
+	return json.Marshal(objectMap)
 }
 
 // SKUCapability - The metadata to describe the capability.
@@ -3476,6 +3450,23 @@ func (s SKUInformationList) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
+// SKUList - List of SKU Information objects.
+type SKUList struct {
+	// READ-ONLY; Links to the next set of results
+	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+
+	// READ-ONLY; List of ResourceType Sku
+	Value []*SKU `json:"value,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SKUList.
+func (s SKUList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
+}
+
 // SKULocationInfo - The location info.
 type SKULocationInfo struct {
 	// READ-ONLY; The location.
@@ -3495,6 +3486,15 @@ func (s SKULocationInfo) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "sites", s.Sites)
 	populate(objectMap, "zones", s.Zones)
 	return json.Marshal(objectMap)
+}
+
+// SKUType - The SKU type.
+type SKUType struct {
+	// SKU name.
+	Name *SKUName `json:"name,omitempty"`
+
+	// The SKU tier. This is based on the SKU name.
+	Tier *SKUTier `json:"tier,omitempty"`
 }
 
 // Secret - Holds device secret either as a KeyVault reference or as an encrypted value.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // MonitoringConfigClient contains the methods for the MonitoringConfig group.
 // Don't use this type directly, use NewMonitoringConfigClient() instead.
 type MonitoringConfigClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewMonitoringConfigClient creates a new instance of MonitoringConfigClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewMonitoringConfigClient(subscriptionID string, options *azcore.ClientOptions) *MonitoringConfigClient {
-	cp := azcore.ClientOptions{}
+func NewMonitoringConfigClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *MonitoringConfigClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &MonitoringConfigClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -105,7 +112,7 @@ func (client *MonitoringConfigClient) createOrUpdateCreateRequest(ctx context.Co
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +197,7 @@ func (client *MonitoringConfigClient) deleteCreateRequest(ctx context.Context, d
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +261,7 @@ func (client *MonitoringConfigClient) getCreateRequest(ctx context.Context, devi
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +331,7 @@ func (client *MonitoringConfigClient) listCreateRequest(ctx context.Context, dev
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // OrdersClient contains the methods for the Orders group.
 // Don't use this type directly, use NewOrdersClient() instead.
 type OrdersClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewOrdersClient creates a new instance of OrdersClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewOrdersClient(subscriptionID string, options *azcore.ClientOptions) *OrdersClient {
-	cp := azcore.ClientOptions{}
+func NewOrdersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *OrdersClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &OrdersClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -99,7 +106,7 @@ func (client *OrdersClient) createOrUpdateCreateRequest(ctx context.Context, dev
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +185,7 @@ func (client *OrdersClient) deleteCreateRequest(ctx context.Context, deviceName 
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +244,7 @@ func (client *OrdersClient) getCreateRequest(ctx context.Context, deviceName str
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +310,7 @@ func (client *OrdersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Con
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +378,7 @@ func (client *OrdersClient) listDCAccessCodeCreateRequest(ctx context.Context, d
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pagers.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pagers.go
@@ -144,7 +144,7 @@ func (p *AvailableSKUsListPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.DataBoxEdgeSKUList.NextLink == nil || len(*p.current.DataBoxEdgeSKUList.NextLink) == 0 {
+		if p.current.SKUList.NextLink == nil || len(*p.current.SKUList.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -306,7 +306,7 @@ func (p *DevicesListByResourceGroupPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.DataBoxEdgeDeviceList.NextLink == nil || len(*p.current.DataBoxEdgeDeviceList.NextLink) == 0 {
+		if p.current.DeviceList.NextLink == nil || len(*p.current.DeviceList.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -360,7 +360,7 @@ func (p *DevicesListBySubscriptionPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.DataBoxEdgeDeviceList.NextLink == nil || len(*p.current.DataBoxEdgeDeviceList.NextLink) == 0 {
+		if p.current.DeviceList.NextLink == nil || len(*p.current.DeviceList.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_response_types.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_response_types.go
@@ -26,6 +26,7 @@ type AddonsCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l AddonsCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsCreateOrUpdateResponse, error) {
 	respType := AddonsCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AddonsCreateOrUpdateResult)
@@ -87,6 +88,7 @@ type AddonsDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l AddonsDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsDeleteResponse, error) {
 	respType := AddonsDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -188,7 +190,7 @@ type AvailableSKUsListResponse struct {
 
 // AvailableSKUsListResult contains the result from method AvailableSKUs.List.
 type AvailableSKUsListResult struct {
-	DataBoxEdgeSKUList
+	SKUList
 }
 
 // BandwidthSchedulesCreateOrUpdatePollerResponse contains the response from method BandwidthSchedules.CreateOrUpdate.
@@ -202,6 +204,7 @@ type BandwidthSchedulesCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l BandwidthSchedulesCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BandwidthSchedulesCreateOrUpdateResponse, error) {
 	respType := BandwidthSchedulesCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BandwidthSchedule)
@@ -253,6 +256,7 @@ type BandwidthSchedulesDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l BandwidthSchedulesDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BandwidthSchedulesDeleteResponse, error) {
 	respType := BandwidthSchedulesDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -322,6 +326,7 @@ type ContainersCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ContainersCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersCreateOrUpdateResponse, error) {
 	respType := ContainersCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Container)
@@ -373,6 +378,7 @@ type ContainersDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ContainersDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersDeleteResponse, error) {
 	respType := ContainersDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -442,6 +448,7 @@ type ContainersRefreshPollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ContainersRefreshPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersRefreshResponse, error) {
 	respType := ContainersRefreshResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -485,7 +492,7 @@ type DevicesCreateOrUpdateResponse struct {
 
 // DevicesCreateOrUpdateResult contains the result from method Devices.CreateOrUpdate.
 type DevicesCreateOrUpdateResult struct {
-	DataBoxEdgeDevice
+	Device
 }
 
 // DevicesCreateOrUpdateSecuritySettingsPollerResponse contains the response from method Devices.CreateOrUpdateSecuritySettings.
@@ -499,6 +506,7 @@ type DevicesCreateOrUpdateSecuritySettingsPollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesCreateOrUpdateSecuritySettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesCreateOrUpdateSecuritySettingsResponse, error) {
 	respType := DevicesCreateOrUpdateSecuritySettingsResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -544,6 +552,7 @@ type DevicesDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesDeleteResponse, error) {
 	respType := DevicesDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -589,6 +598,7 @@ type DevicesDownloadUpdatesPollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesDownloadUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesDownloadUpdatesResponse, error) {
 	respType := DevicesDownloadUpdatesResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -644,7 +654,7 @@ type DevicesGetExtendedInformationResponse struct {
 
 // DevicesGetExtendedInformationResult contains the result from method Devices.GetExtendedInformation.
 type DevicesGetExtendedInformationResult struct {
-	DataBoxEdgeDeviceExtendedInfo
+	DeviceExtendedInfo
 }
 
 // DevicesGetNetworkSettingsResponse contains the response from method Devices.GetNetworkSettings.
@@ -668,7 +678,7 @@ type DevicesGetResponse struct {
 
 // DevicesGetResult contains the result from method Devices.Get.
 type DevicesGetResult struct {
-	DataBoxEdgeDevice
+	Device
 }
 
 // DevicesGetUpdateSummaryResponse contains the response from method Devices.GetUpdateSummary.
@@ -694,6 +704,7 @@ type DevicesInstallUpdatesPollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesInstallUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesInstallUpdatesResponse, error) {
 	respType := DevicesInstallUpdatesResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -737,7 +748,7 @@ type DevicesListByResourceGroupResponse struct {
 
 // DevicesListByResourceGroupResult contains the result from method Devices.ListByResourceGroup.
 type DevicesListByResourceGroupResult struct {
-	DataBoxEdgeDeviceList
+	DeviceList
 }
 
 // DevicesListBySubscriptionResponse contains the response from method Devices.ListBySubscription.
@@ -749,7 +760,7 @@ type DevicesListBySubscriptionResponse struct {
 
 // DevicesListBySubscriptionResult contains the result from method Devices.ListBySubscription.
 type DevicesListBySubscriptionResult struct {
-	DataBoxEdgeDeviceList
+	DeviceList
 }
 
 // DevicesScanForUpdatesPollerResponse contains the response from method Devices.ScanForUpdates.
@@ -763,6 +774,7 @@ type DevicesScanForUpdatesPollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesScanForUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesScanForUpdatesResponse, error) {
 	respType := DevicesScanForUpdatesResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -806,7 +818,7 @@ type DevicesUpdateExtendedInformationResponse struct {
 
 // DevicesUpdateExtendedInformationResult contains the result from method Devices.UpdateExtendedInformation.
 type DevicesUpdateExtendedInformationResult struct {
-	DataBoxEdgeDeviceExtendedInfo
+	DeviceExtendedInfo
 }
 
 // DevicesUpdateResponse contains the response from method Devices.Update.
@@ -818,7 +830,7 @@ type DevicesUpdateResponse struct {
 
 // DevicesUpdateResult contains the result from method Devices.Update.
 type DevicesUpdateResult struct {
-	DataBoxEdgeDevice
+	Device
 }
 
 // DevicesUploadCertificateResponse contains the response from method Devices.UploadCertificate.
@@ -868,6 +880,7 @@ type DiagnosticSettingsUpdateDiagnosticProactiveLogCollectionSettingsPollerRespo
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DiagnosticSettingsUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiagnosticSettingsUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
 	respType := DiagnosticSettingsUpdateDiagnosticProactiveLogCollectionSettingsResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -914,6 +927,7 @@ type DiagnosticSettingsUpdateDiagnosticRemoteSupportSettingsPollerResponse struc
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DiagnosticSettingsUpdateDiagnosticRemoteSupportSettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiagnosticSettingsUpdateDiagnosticRemoteSupportSettingsResponse, error) {
 	respType := DiagnosticSettingsUpdateDiagnosticRemoteSupportSettingsResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -972,6 +986,7 @@ type MonitoringConfigCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l MonitoringConfigCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (MonitoringConfigCreateOrUpdateResponse, error) {
 	respType := MonitoringConfigCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.MonitoringMetricConfiguration)
@@ -1023,6 +1038,7 @@ type MonitoringConfigDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l MonitoringConfigDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (MonitoringConfigDeleteResponse, error) {
 	respType := MonitoringConfigDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1128,6 +1144,7 @@ type OrdersCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l OrdersCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (OrdersCreateOrUpdateResponse, error) {
 	respType := OrdersCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Order)
@@ -1179,6 +1196,7 @@ type OrdersDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l OrdersDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (OrdersDeleteResponse, error) {
 	respType := OrdersDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1260,6 +1278,7 @@ type RolesCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RolesCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RolesCreateOrUpdateResponse, error) {
 	respType := RolesCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RolesCreateOrUpdateResult)
@@ -1321,6 +1340,7 @@ type RolesDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RolesDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RolesDeleteResponse, error) {
 	respType := RolesDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1400,6 +1420,7 @@ type SharesCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SharesCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesCreateOrUpdateResponse, error) {
 	respType := SharesCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Share)
@@ -1451,6 +1472,7 @@ type SharesDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SharesDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesDeleteResponse, error) {
 	respType := SharesDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1520,6 +1542,7 @@ type SharesRefreshPollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SharesRefreshPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesRefreshResponse, error) {
 	respType := SharesRefreshResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1565,6 +1588,7 @@ type StorageAccountCredentialsCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l StorageAccountCredentialsCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountCredentialsCreateOrUpdateResponse, error) {
 	respType := StorageAccountCredentialsCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.StorageAccountCredential)
@@ -1616,6 +1640,7 @@ type StorageAccountCredentialsDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l StorageAccountCredentialsDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountCredentialsDeleteResponse, error) {
 	respType := StorageAccountCredentialsDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1685,6 +1710,7 @@ type StorageAccountsCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l StorageAccountsCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountsCreateOrUpdateResponse, error) {
 	respType := StorageAccountsCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.StorageAccount)
@@ -1736,6 +1762,7 @@ type StorageAccountsDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l StorageAccountsDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountsDeleteResponse, error) {
 	respType := StorageAccountsDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1805,6 +1832,7 @@ type SupportPackagesTriggerSupportPackagePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SupportPackagesTriggerSupportPackagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SupportPackagesTriggerSupportPackageResponse, error) {
 	respType := SupportPackagesTriggerSupportPackageResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1850,6 +1878,7 @@ type TriggersCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l TriggersCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersCreateOrUpdateResponse, error) {
 	respType := TriggersCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggersCreateOrUpdateResult)
@@ -1911,6 +1940,7 @@ type TriggersDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l TriggersDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersDeleteResponse, error) {
 	respType := TriggersDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
@@ -1990,6 +2020,7 @@ type UsersCreateOrUpdatePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l UsersCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (UsersCreateOrUpdateResponse, error) {
 	respType := UsersCreateOrUpdateResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.User)
@@ -2041,6 +2072,7 @@ type UsersDeletePollerResponse struct {
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l UsersDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (UsersDeleteResponse, error) {
 	respType := UsersDeleteResponse{}
 	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // SharesClient contains the methods for the Shares group.
 // Don't use this type directly, use NewSharesClient() instead.
 type SharesClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewSharesClient creates a new instance of SharesClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewSharesClient(subscriptionID string, options *azcore.ClientOptions) *SharesClient {
-	cp := azcore.ClientOptions{}
+func NewSharesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *SharesClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &SharesClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -104,7 +111,7 @@ func (client *SharesClient) createOrUpdateCreateRequest(ctx context.Context, dev
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +195,7 @@ func (client *SharesClient) deleteCreateRequest(ctx context.Context, deviceName 
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +259,7 @@ func (client *SharesClient) getCreateRequest(ctx context.Context, deviceName str
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +325,7 @@ func (client *SharesClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Con
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +418,7 @@ func (client *SharesClient) refreshCreateRequest(ctx context.Context, deviceName
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // StorageAccountCredentialsClient contains the methods for the StorageAccountCredentials group.
 // Don't use this type directly, use NewStorageAccountCredentialsClient() instead.
 type StorageAccountCredentialsClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewStorageAccountCredentialsClient creates a new instance of StorageAccountCredentialsClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewStorageAccountCredentialsClient(subscriptionID string, options *azcore.ClientOptions) *StorageAccountCredentialsClient {
-	cp := azcore.ClientOptions{}
+func NewStorageAccountCredentialsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *StorageAccountCredentialsClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &StorageAccountCredentialsClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -105,7 +112,7 @@ func (client *StorageAccountCredentialsClient) createOrUpdateCreateRequest(ctx c
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +197,7 @@ func (client *StorageAccountCredentialsClient) deleteCreateRequest(ctx context.C
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +262,7 @@ func (client *StorageAccountCredentialsClient) getCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +328,7 @@ func (client *StorageAccountCredentialsClient) listByDataBoxEdgeDeviceCreateRequ
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // StorageAccountsClient contains the methods for the StorageAccounts group.
 // Don't use this type directly, use NewStorageAccountsClient() instead.
 type StorageAccountsClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewStorageAccountsClient creates a new instance of StorageAccountsClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewStorageAccountsClient(subscriptionID string, options *azcore.ClientOptions) *StorageAccountsClient {
-	cp := azcore.ClientOptions{}
+func NewStorageAccountsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *StorageAccountsClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &StorageAccountsClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -105,7 +112,7 @@ func (client *StorageAccountsClient) createOrUpdateCreateRequest(ctx context.Con
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +197,7 @@ func (client *StorageAccountsClient) deleteCreateRequest(ctx context.Context, de
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +261,7 @@ func (client *StorageAccountsClient) getCreateRequest(ctx context.Context, devic
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +327,7 @@ func (client *StorageAccountsClient) listByDataBoxEdgeDeviceCreateRequest(ctx co
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // TriggersClient contains the methods for the Triggers group.
 // Don't use this type directly, use NewTriggersClient() instead.
 type TriggersClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewTriggersClient creates a new instance of TriggersClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewTriggersClient(subscriptionID string, options *azcore.ClientOptions) *TriggersClient {
-	cp := azcore.ClientOptions{}
+func NewTriggersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *TriggersClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &TriggersClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -105,7 +112,7 @@ func (client *TriggersClient) createOrUpdateCreateRequest(ctx context.Context, d
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +196,7 @@ func (client *TriggersClient) deleteCreateRequest(ctx context.Context, deviceNam
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +260,7 @@ func (client *TriggersClient) getCreateRequest(ctx context.Context, deviceName s
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +326,7 @@ func (client *TriggersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.C
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,21 +25,27 @@ import (
 // UsersClient contains the methods for the Users group.
 // Don't use this type directly, use NewUsersClient() instead.
 type UsersClient struct {
+	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
 // NewUsersClient creates a new instance of UsersClient with the specified values.
 // subscriptionID - The subscription ID.
+// credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewUsersClient(subscriptionID string, options *azcore.ClientOptions) *UsersClient {
-	cp := azcore.ClientOptions{}
+func NewUsersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *UsersClient {
+	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
 	}
+	if len(cp.Host) == 0 {
+		cp.Host = arm.AzurePublicCloud
+	}
 	client := &UsersClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(module, version, nil, nil, &cp),
+		host:           string(cp.Host),
+		pl:             armruntime.NewPipeline(module, version, credential, &cp),
 	}
 	return client
 }
@@ -105,7 +112,7 @@ func (client *UsersClient) createOrUpdateCreateRequest(ctx context.Context, devi
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +196,7 @@ func (client *UsersClient) deleteCreateRequest(ctx context.Context, deviceName s
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +260,7 @@ func (client *UsersClient) getCreateRequest(ctx context.Context, deviceName stri
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +326,7 @@ func (client *UsersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/keyvault/7.2/azkeyvault/autorest.md
+++ b/test/keyvault/7.2/azkeyvault/autorest.md
@@ -1,0 +1,35 @@
+### AutoRest Configuration
+
+> see https://aka.ms/autorest
+
+``` yaml
+require:
+- https://github.com/Azure/azure-rest-api-specs/blob/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/readme.md
+- https://github.com/Azure/azure-rest-api-specs/blob/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/readme.go.md
+license-header: MICROSOFT_MIT_NO_VERSION
+module: azkeyvault
+module-version: 0.1.0
+security: AADToken
+security-scopes: https://vault.azure.net/.default
+export-clients: true
+
+# stuttering clean-up causes a name collision so we fix up the name
+# we can't use the in-box rename-model directive due to cross-file references
+# so we copy it and make the necessary modifications
+directive:
+  - from: swagger-document
+    where: $.definitions
+    transform: >
+      if ($.Error) { $.ErrorInfo = $.Error; delete $.Error; }
+
+  - from: swagger-document
+    where: $..['$ref']
+    transform: >
+      $ = $ === "#/definitions/${$.Error}" ? "#/definitions/${$.ErrorInfo}" : $
+
+  - from: swagger-document
+    where: $..['$ref']
+    debug: true
+    transform: >
+      $ = $ === "https://github.com/Azure/azure-rest-api-specs/blob/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/common.json#/definitions/Error" ? "https://github.com/Azure/azure-rest-api-specs/blob/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/common.json#/definitions/ErrorInfo" : $
+```

--- a/test/keyvault/7.2/azkeyvault/zz_generated_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_client.go
@@ -20,16 +20,16 @@ import (
 	"strings"
 )
 
-// KeyVaultClient contains the methods for the KeyVaultClient group.
-// Don't use this type directly, use NewKeyVaultClient() instead.
-type KeyVaultClient struct {
+// Client contains the methods for the KeyVaultClient group.
+// Don't use this type directly, use NewClient() instead.
+type Client struct {
 	pl runtime.Pipeline
 }
 
-// NewKeyVaultClient creates a new instance of KeyVaultClient with the specified values.
+// NewClient creates a new instance of Client with the specified values.
 // pl - the pipeline used for sending requests and handling responses.
-func NewKeyVaultClient(pl runtime.Pipeline) *KeyVaultClient {
-	client := &KeyVaultClient{
+func NewClient(pl runtime.Pipeline) *Client {
+	client := &Client{
 		pl: pl,
 	}
 	return client
@@ -37,12 +37,11 @@ func NewKeyVaultClient(pl runtime.Pipeline) *KeyVaultClient {
 
 // BackupCertificate - Requests that a backup of the specified certificate be downloaded to the client. All versions of the
 // certificate will be downloaded. This operation requires the certificates/backup permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
-// options - KeyVaultClientBackupCertificateOptions contains the optional parameters for the KeyVaultClient.BackupCertificate
-// method.
-func (client *KeyVaultClient) BackupCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientBackupCertificateOptions) (KeyVaultClientBackupCertificateResponse, error) {
+// options - KeyVaultClientBackupCertificateOptions contains the optional parameters for the Client.BackupCertificate method.
+func (client *Client) BackupCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientBackupCertificateOptions) (KeyVaultClientBackupCertificateResponse, error) {
 	req, err := client.backupCertificateCreateRequest(ctx, vaultBaseURL, certificateName, options)
 	if err != nil {
 		return KeyVaultClientBackupCertificateResponse{}, err
@@ -58,7 +57,7 @@ func (client *KeyVaultClient) BackupCertificate(ctx context.Context, vaultBaseUR
 }
 
 // backupCertificateCreateRequest creates the BackupCertificate request.
-func (client *KeyVaultClient) backupCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientBackupCertificateOptions) (*policy.Request, error) {
+func (client *Client) backupCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientBackupCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/backup"
@@ -78,7 +77,7 @@ func (client *KeyVaultClient) backupCertificateCreateRequest(ctx context.Context
 }
 
 // backupCertificateHandleResponse handles the BackupCertificate response.
-func (client *KeyVaultClient) backupCertificateHandleResponse(resp *http.Response) (KeyVaultClientBackupCertificateResponse, error) {
+func (client *Client) backupCertificateHandleResponse(resp *http.Response) (KeyVaultClientBackupCertificateResponse, error) {
 	result := KeyVaultClientBackupCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupCertificateResult); err != nil {
 		return KeyVaultClientBackupCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -87,12 +86,12 @@ func (client *KeyVaultClient) backupCertificateHandleResponse(resp *http.Respons
 }
 
 // backupCertificateHandleError handles the BackupCertificate error response.
-func (client *KeyVaultClient) backupCertificateHandleError(resp *http.Response) error {
+func (client *Client) backupCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -109,11 +108,11 @@ func (client *KeyVaultClient) backupCertificateHandleError(resp *http.Response) 
 // a BACKUP from one geographical area cannot be restored to another
 // geographical area. For example, a backup from the US geographical area cannot be restored in an EU geographical area. This
 // operation requires the key/backup permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
-// options - KeyVaultClientBackupKeyOptions contains the optional parameters for the KeyVaultClient.BackupKey method.
-func (client *KeyVaultClient) BackupKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBackupKeyOptions) (KeyVaultClientBackupKeyResponse, error) {
+// options - KeyVaultClientBackupKeyOptions contains the optional parameters for the Client.BackupKey method.
+func (client *Client) BackupKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBackupKeyOptions) (KeyVaultClientBackupKeyResponse, error) {
 	req, err := client.backupKeyCreateRequest(ctx, vaultBaseURL, keyName, options)
 	if err != nil {
 		return KeyVaultClientBackupKeyResponse{}, err
@@ -129,7 +128,7 @@ func (client *KeyVaultClient) BackupKey(ctx context.Context, vaultBaseURL string
 }
 
 // backupKeyCreateRequest creates the BackupKey request.
-func (client *KeyVaultClient) backupKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBackupKeyOptions) (*policy.Request, error) {
+func (client *Client) backupKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBackupKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/backup"
@@ -149,7 +148,7 @@ func (client *KeyVaultClient) backupKeyCreateRequest(ctx context.Context, vaultB
 }
 
 // backupKeyHandleResponse handles the BackupKey response.
-func (client *KeyVaultClient) backupKeyHandleResponse(resp *http.Response) (KeyVaultClientBackupKeyResponse, error) {
+func (client *Client) backupKeyHandleResponse(resp *http.Response) (KeyVaultClientBackupKeyResponse, error) {
 	result := KeyVaultClientBackupKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupKeyResult); err != nil {
 		return KeyVaultClientBackupKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -158,12 +157,12 @@ func (client *KeyVaultClient) backupKeyHandleResponse(resp *http.Response) (KeyV
 }
 
 // backupKeyHandleError handles the BackupKey error response.
-func (client *KeyVaultClient) backupKeyHandleError(resp *http.Response) error {
+func (client *Client) backupKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -172,11 +171,11 @@ func (client *KeyVaultClient) backupKeyHandleError(resp *http.Response) error {
 
 // BackupSecret - Requests that a backup of the specified secret be downloaded to the client. All versions of the secret will
 // be downloaded. This operation requires the secrets/backup permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
-// options - KeyVaultClientBackupSecretOptions contains the optional parameters for the KeyVaultClient.BackupSecret method.
-func (client *KeyVaultClient) BackupSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientBackupSecretOptions) (KeyVaultClientBackupSecretResponse, error) {
+// options - KeyVaultClientBackupSecretOptions contains the optional parameters for the Client.BackupSecret method.
+func (client *Client) BackupSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientBackupSecretOptions) (KeyVaultClientBackupSecretResponse, error) {
 	req, err := client.backupSecretCreateRequest(ctx, vaultBaseURL, secretName, options)
 	if err != nil {
 		return KeyVaultClientBackupSecretResponse{}, err
@@ -192,7 +191,7 @@ func (client *KeyVaultClient) BackupSecret(ctx context.Context, vaultBaseURL str
 }
 
 // backupSecretCreateRequest creates the BackupSecret request.
-func (client *KeyVaultClient) backupSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientBackupSecretOptions) (*policy.Request, error) {
+func (client *Client) backupSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientBackupSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/secrets/{secret-name}/backup"
@@ -212,7 +211,7 @@ func (client *KeyVaultClient) backupSecretCreateRequest(ctx context.Context, vau
 }
 
 // backupSecretHandleResponse handles the BackupSecret response.
-func (client *KeyVaultClient) backupSecretHandleResponse(resp *http.Response) (KeyVaultClientBackupSecretResponse, error) {
+func (client *Client) backupSecretHandleResponse(resp *http.Response) (KeyVaultClientBackupSecretResponse, error) {
 	result := KeyVaultClientBackupSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupSecretResult); err != nil {
 		return KeyVaultClientBackupSecretResponse{}, runtime.NewResponseError(err, resp)
@@ -221,12 +220,12 @@ func (client *KeyVaultClient) backupSecretHandleResponse(resp *http.Response) (K
 }
 
 // backupSecretHandleError handles the BackupSecret error response.
-func (client *KeyVaultClient) backupSecretHandleError(resp *http.Response) error {
+func (client *Client) backupSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -235,12 +234,12 @@ func (client *KeyVaultClient) backupSecretHandleError(resp *http.Response) error
 
 // BackupStorageAccount - Requests that a backup of the specified storage account be downloaded to the client. This operation
 // requires the storage/backup permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
-// options - KeyVaultClientBackupStorageAccountOptions contains the optional parameters for the KeyVaultClient.BackupStorageAccount
+// options - KeyVaultClientBackupStorageAccountOptions contains the optional parameters for the Client.BackupStorageAccount
 // method.
-func (client *KeyVaultClient) BackupStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientBackupStorageAccountOptions) (KeyVaultClientBackupStorageAccountResponse, error) {
+func (client *Client) BackupStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientBackupStorageAccountOptions) (KeyVaultClientBackupStorageAccountResponse, error) {
 	req, err := client.backupStorageAccountCreateRequest(ctx, vaultBaseURL, storageAccountName, options)
 	if err != nil {
 		return KeyVaultClientBackupStorageAccountResponse{}, err
@@ -256,7 +255,7 @@ func (client *KeyVaultClient) BackupStorageAccount(ctx context.Context, vaultBas
 }
 
 // backupStorageAccountCreateRequest creates the BackupStorageAccount request.
-func (client *KeyVaultClient) backupStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientBackupStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) backupStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientBackupStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}/backup"
@@ -276,7 +275,7 @@ func (client *KeyVaultClient) backupStorageAccountCreateRequest(ctx context.Cont
 }
 
 // backupStorageAccountHandleResponse handles the BackupStorageAccount response.
-func (client *KeyVaultClient) backupStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientBackupStorageAccountResponse, error) {
+func (client *Client) backupStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientBackupStorageAccountResponse, error) {
 	result := KeyVaultClientBackupStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupStorageResult); err != nil {
 		return KeyVaultClientBackupStorageAccountResponse{}, runtime.NewResponseError(err, resp)
@@ -285,12 +284,12 @@ func (client *KeyVaultClient) backupStorageAccountHandleResponse(resp *http.Resp
 }
 
 // backupStorageAccountHandleError handles the BackupStorageAccount error response.
-func (client *KeyVaultClient) backupStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) backupStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -299,13 +298,12 @@ func (client *KeyVaultClient) backupStorageAccountHandleError(resp *http.Respons
 
 // CreateCertificate - If this is the first version, the certificate resource is created. This operation requires the certificates/create
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
 // parameters - The parameters to create a certificate.
-// options - KeyVaultClientCreateCertificateOptions contains the optional parameters for the KeyVaultClient.CreateCertificate
-// method.
-func (client *KeyVaultClient) CreateCertificate(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateCreateParameters, options *KeyVaultClientCreateCertificateOptions) (KeyVaultClientCreateCertificateResponse, error) {
+// options - KeyVaultClientCreateCertificateOptions contains the optional parameters for the Client.CreateCertificate method.
+func (client *Client) CreateCertificate(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateCreateParameters, options *KeyVaultClientCreateCertificateOptions) (KeyVaultClientCreateCertificateResponse, error) {
 	req, err := client.createCertificateCreateRequest(ctx, vaultBaseURL, certificateName, parameters, options)
 	if err != nil {
 		return KeyVaultClientCreateCertificateResponse{}, err
@@ -321,7 +319,7 @@ func (client *KeyVaultClient) CreateCertificate(ctx context.Context, vaultBaseUR
 }
 
 // createCertificateCreateRequest creates the CreateCertificate request.
-func (client *KeyVaultClient) createCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateCreateParameters, options *KeyVaultClientCreateCertificateOptions) (*policy.Request, error) {
+func (client *Client) createCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateCreateParameters, options *KeyVaultClientCreateCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/create"
@@ -341,7 +339,7 @@ func (client *KeyVaultClient) createCertificateCreateRequest(ctx context.Context
 }
 
 // createCertificateHandleResponse handles the CreateCertificate response.
-func (client *KeyVaultClient) createCertificateHandleResponse(resp *http.Response) (KeyVaultClientCreateCertificateResponse, error) {
+func (client *Client) createCertificateHandleResponse(resp *http.Response) (KeyVaultClientCreateCertificateResponse, error) {
 	result := KeyVaultClientCreateCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
 		return KeyVaultClientCreateCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -350,12 +348,12 @@ func (client *KeyVaultClient) createCertificateHandleResponse(resp *http.Respons
 }
 
 // createCertificateHandleError handles the CreateCertificate error response.
-func (client *KeyVaultClient) createCertificateHandleError(resp *http.Response) error {
+func (client *Client) createCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -365,12 +363,12 @@ func (client *KeyVaultClient) createCertificateHandleError(resp *http.Response) 
 // CreateKey - The create key operation can be used to create any key type in Azure Key Vault. If the named key already exists,
 // Azure Key Vault creates a new version of the key. It requires the keys/create
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name for the new key. The system will generate the version name for the new key.
 // parameters - The parameters to create a key.
-// options - KeyVaultClientCreateKeyOptions contains the optional parameters for the KeyVaultClient.CreateKey method.
-func (client *KeyVaultClient) CreateKey(ctx context.Context, vaultBaseURL string, keyName string, parameters KeyCreateParameters, options *KeyVaultClientCreateKeyOptions) (KeyVaultClientCreateKeyResponse, error) {
+// options - KeyVaultClientCreateKeyOptions contains the optional parameters for the Client.CreateKey method.
+func (client *Client) CreateKey(ctx context.Context, vaultBaseURL string, keyName string, parameters KeyCreateParameters, options *KeyVaultClientCreateKeyOptions) (KeyVaultClientCreateKeyResponse, error) {
 	req, err := client.createKeyCreateRequest(ctx, vaultBaseURL, keyName, parameters, options)
 	if err != nil {
 		return KeyVaultClientCreateKeyResponse{}, err
@@ -386,7 +384,7 @@ func (client *KeyVaultClient) CreateKey(ctx context.Context, vaultBaseURL string
 }
 
 // createKeyCreateRequest creates the CreateKey request.
-func (client *KeyVaultClient) createKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, parameters KeyCreateParameters, options *KeyVaultClientCreateKeyOptions) (*policy.Request, error) {
+func (client *Client) createKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, parameters KeyCreateParameters, options *KeyVaultClientCreateKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/create"
@@ -406,7 +404,7 @@ func (client *KeyVaultClient) createKeyCreateRequest(ctx context.Context, vaultB
 }
 
 // createKeyHandleResponse handles the CreateKey response.
-func (client *KeyVaultClient) createKeyHandleResponse(resp *http.Response) (KeyVaultClientCreateKeyResponse, error) {
+func (client *Client) createKeyHandleResponse(resp *http.Response) (KeyVaultClientCreateKeyResponse, error) {
 	result := KeyVaultClientCreateKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return KeyVaultClientCreateKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -415,12 +413,12 @@ func (client *KeyVaultClient) createKeyHandleResponse(resp *http.Response) (KeyV
 }
 
 // createKeyHandleError handles the CreateKey error response.
-func (client *KeyVaultClient) createKeyHandleError(resp *http.Response) error {
+func (client *Client) createKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -432,13 +430,13 @@ func (client *KeyVaultClient) createKeyHandleError(resp *http.Response) error {
 // data may be decrypted, the size of this block is dependent on the target key and the algorithm to be used. The DECRYPT
 // operation applies to asymmetric and symmetric keys stored in Azure Key Vault
 // since it uses the private portion of the key. This operation requires the keys/decrypt permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
 // keyVersion - The version of the key.
 // parameters - The parameters for the decryption operation.
-// options - KeyVaultClientDecryptOptions contains the optional parameters for the KeyVaultClient.Decrypt method.
-func (client *KeyVaultClient) Decrypt(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientDecryptOptions) (KeyVaultClientDecryptResponse, error) {
+// options - KeyVaultClientDecryptOptions contains the optional parameters for the Client.Decrypt method.
+func (client *Client) Decrypt(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientDecryptOptions) (KeyVaultClientDecryptResponse, error) {
 	req, err := client.decryptCreateRequest(ctx, vaultBaseURL, keyName, keyVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientDecryptResponse{}, err
@@ -454,7 +452,7 @@ func (client *KeyVaultClient) Decrypt(ctx context.Context, vaultBaseURL string, 
 }
 
 // decryptCreateRequest creates the Decrypt request.
-func (client *KeyVaultClient) decryptCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientDecryptOptions) (*policy.Request, error) {
+func (client *Client) decryptCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientDecryptOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/{key-version}/decrypt"
@@ -478,7 +476,7 @@ func (client *KeyVaultClient) decryptCreateRequest(ctx context.Context, vaultBas
 }
 
 // decryptHandleResponse handles the Decrypt response.
-func (client *KeyVaultClient) decryptHandleResponse(resp *http.Response) (KeyVaultClientDecryptResponse, error) {
+func (client *Client) decryptHandleResponse(resp *http.Response) (KeyVaultClientDecryptResponse, error) {
 	result := KeyVaultClientDecryptResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return KeyVaultClientDecryptResponse{}, runtime.NewResponseError(err, resp)
@@ -487,12 +485,12 @@ func (client *KeyVaultClient) decryptHandleResponse(resp *http.Response) (KeyVau
 }
 
 // decryptHandleError handles the Decrypt error response.
-func (client *KeyVaultClient) decryptHandleError(resp *http.Response) error {
+func (client *Client) decryptHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -502,12 +500,11 @@ func (client *KeyVaultClient) decryptHandleError(resp *http.Response) error {
 // DeleteCertificate - Deletes all versions of a certificate object along with its associated policy. Delete certificate cannot
 // be used to remove individual versions of a certificate object. This operation requires the
 // certificates/delete permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
-// options - KeyVaultClientDeleteCertificateOptions contains the optional parameters for the KeyVaultClient.DeleteCertificate
-// method.
-func (client *KeyVaultClient) DeleteCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientDeleteCertificateOptions) (KeyVaultClientDeleteCertificateResponse, error) {
+// options - KeyVaultClientDeleteCertificateOptions contains the optional parameters for the Client.DeleteCertificate method.
+func (client *Client) DeleteCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientDeleteCertificateOptions) (KeyVaultClientDeleteCertificateResponse, error) {
 	req, err := client.deleteCertificateCreateRequest(ctx, vaultBaseURL, certificateName, options)
 	if err != nil {
 		return KeyVaultClientDeleteCertificateResponse{}, err
@@ -523,7 +520,7 @@ func (client *KeyVaultClient) DeleteCertificate(ctx context.Context, vaultBaseUR
 }
 
 // deleteCertificateCreateRequest creates the DeleteCertificate request.
-func (client *KeyVaultClient) deleteCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientDeleteCertificateOptions) (*policy.Request, error) {
+func (client *Client) deleteCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientDeleteCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}"
@@ -543,7 +540,7 @@ func (client *KeyVaultClient) deleteCertificateCreateRequest(ctx context.Context
 }
 
 // deleteCertificateHandleResponse handles the DeleteCertificate response.
-func (client *KeyVaultClient) deleteCertificateHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateResponse, error) {
+func (client *Client) deleteCertificateHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateResponse, error) {
 	result := KeyVaultClientDeleteCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateBundle); err != nil {
 		return KeyVaultClientDeleteCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -552,12 +549,12 @@ func (client *KeyVaultClient) deleteCertificateHandleResponse(resp *http.Respons
 }
 
 // deleteCertificateHandleError handles the DeleteCertificate error response.
-func (client *KeyVaultClient) deleteCertificateHandleError(resp *http.Response) error {
+func (client *Client) deleteCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -566,11 +563,11 @@ func (client *KeyVaultClient) deleteCertificateHandleError(resp *http.Response) 
 
 // DeleteCertificateContacts - Deletes the certificate contacts for a specified key vault certificate. This operation requires
 // the certificates/managecontacts permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientDeleteCertificateContactsOptions contains the optional parameters for the KeyVaultClient.DeleteCertificateContacts
+// options - KeyVaultClientDeleteCertificateContactsOptions contains the optional parameters for the Client.DeleteCertificateContacts
 // method.
-func (client *KeyVaultClient) DeleteCertificateContacts(ctx context.Context, vaultBaseURL string, options *KeyVaultClientDeleteCertificateContactsOptions) (KeyVaultClientDeleteCertificateContactsResponse, error) {
+func (client *Client) DeleteCertificateContacts(ctx context.Context, vaultBaseURL string, options *KeyVaultClientDeleteCertificateContactsOptions) (KeyVaultClientDeleteCertificateContactsResponse, error) {
 	req, err := client.deleteCertificateContactsCreateRequest(ctx, vaultBaseURL, options)
 	if err != nil {
 		return KeyVaultClientDeleteCertificateContactsResponse{}, err
@@ -586,7 +583,7 @@ func (client *KeyVaultClient) DeleteCertificateContacts(ctx context.Context, vau
 }
 
 // deleteCertificateContactsCreateRequest creates the DeleteCertificateContacts request.
-func (client *KeyVaultClient) deleteCertificateContactsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientDeleteCertificateContactsOptions) (*policy.Request, error) {
+func (client *Client) deleteCertificateContactsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientDeleteCertificateContactsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/contacts"
@@ -602,7 +599,7 @@ func (client *KeyVaultClient) deleteCertificateContactsCreateRequest(ctx context
 }
 
 // deleteCertificateContactsHandleResponse handles the DeleteCertificateContacts response.
-func (client *KeyVaultClient) deleteCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateContactsResponse, error) {
+func (client *Client) deleteCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateContactsResponse, error) {
 	result := KeyVaultClientDeleteCertificateContactsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
 		return KeyVaultClientDeleteCertificateContactsResponse{}, runtime.NewResponseError(err, resp)
@@ -611,12 +608,12 @@ func (client *KeyVaultClient) deleteCertificateContactsHandleResponse(resp *http
 }
 
 // deleteCertificateContactsHandleError handles the DeleteCertificateContacts error response.
-func (client *KeyVaultClient) deleteCertificateContactsHandleError(resp *http.Response) error {
+func (client *Client) deleteCertificateContactsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -625,12 +622,12 @@ func (client *KeyVaultClient) deleteCertificateContactsHandleError(resp *http.Re
 
 // DeleteCertificateIssuer - The DeleteCertificateIssuer operation permanently removes the specified certificate issuer from
 // the vault. This operation requires the certificates/manageissuers/deleteissuers permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // issuerName - The name of the issuer.
-// options - KeyVaultClientDeleteCertificateIssuerOptions contains the optional parameters for the KeyVaultClient.DeleteCertificateIssuer
+// options - KeyVaultClientDeleteCertificateIssuerOptions contains the optional parameters for the Client.DeleteCertificateIssuer
 // method.
-func (client *KeyVaultClient) DeleteCertificateIssuer(ctx context.Context, vaultBaseURL string, issuerName string, options *KeyVaultClientDeleteCertificateIssuerOptions) (KeyVaultClientDeleteCertificateIssuerResponse, error) {
+func (client *Client) DeleteCertificateIssuer(ctx context.Context, vaultBaseURL string, issuerName string, options *KeyVaultClientDeleteCertificateIssuerOptions) (KeyVaultClientDeleteCertificateIssuerResponse, error) {
 	req, err := client.deleteCertificateIssuerCreateRequest(ctx, vaultBaseURL, issuerName, options)
 	if err != nil {
 		return KeyVaultClientDeleteCertificateIssuerResponse{}, err
@@ -646,7 +643,7 @@ func (client *KeyVaultClient) DeleteCertificateIssuer(ctx context.Context, vault
 }
 
 // deleteCertificateIssuerCreateRequest creates the DeleteCertificateIssuer request.
-func (client *KeyVaultClient) deleteCertificateIssuerCreateRequest(ctx context.Context, vaultBaseURL string, issuerName string, options *KeyVaultClientDeleteCertificateIssuerOptions) (*policy.Request, error) {
+func (client *Client) deleteCertificateIssuerCreateRequest(ctx context.Context, vaultBaseURL string, issuerName string, options *KeyVaultClientDeleteCertificateIssuerOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/issuers/{issuer-name}"
@@ -666,7 +663,7 @@ func (client *KeyVaultClient) deleteCertificateIssuerCreateRequest(ctx context.C
 }
 
 // deleteCertificateIssuerHandleResponse handles the DeleteCertificateIssuer response.
-func (client *KeyVaultClient) deleteCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateIssuerResponse, error) {
+func (client *Client) deleteCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateIssuerResponse, error) {
 	result := KeyVaultClientDeleteCertificateIssuerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
 		return KeyVaultClientDeleteCertificateIssuerResponse{}, runtime.NewResponseError(err, resp)
@@ -675,12 +672,12 @@ func (client *KeyVaultClient) deleteCertificateIssuerHandleResponse(resp *http.R
 }
 
 // deleteCertificateIssuerHandleError handles the DeleteCertificateIssuer error response.
-func (client *KeyVaultClient) deleteCertificateIssuerHandleError(resp *http.Response) error {
+func (client *Client) deleteCertificateIssuerHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -689,12 +686,12 @@ func (client *KeyVaultClient) deleteCertificateIssuerHandleError(resp *http.Resp
 
 // DeleteCertificateOperation - Deletes the creation operation for a specified certificate that is in the process of being
 // created. The certificate is no longer created. This operation requires the certificates/update permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
-// options - KeyVaultClientDeleteCertificateOperationOptions contains the optional parameters for the KeyVaultClient.DeleteCertificateOperation
+// options - KeyVaultClientDeleteCertificateOperationOptions contains the optional parameters for the Client.DeleteCertificateOperation
 // method.
-func (client *KeyVaultClient) DeleteCertificateOperation(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientDeleteCertificateOperationOptions) (KeyVaultClientDeleteCertificateOperationResponse, error) {
+func (client *Client) DeleteCertificateOperation(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientDeleteCertificateOperationOptions) (KeyVaultClientDeleteCertificateOperationResponse, error) {
 	req, err := client.deleteCertificateOperationCreateRequest(ctx, vaultBaseURL, certificateName, options)
 	if err != nil {
 		return KeyVaultClientDeleteCertificateOperationResponse{}, err
@@ -710,7 +707,7 @@ func (client *KeyVaultClient) DeleteCertificateOperation(ctx context.Context, va
 }
 
 // deleteCertificateOperationCreateRequest creates the DeleteCertificateOperation request.
-func (client *KeyVaultClient) deleteCertificateOperationCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientDeleteCertificateOperationOptions) (*policy.Request, error) {
+func (client *Client) deleteCertificateOperationCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientDeleteCertificateOperationOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/pending"
@@ -730,7 +727,7 @@ func (client *KeyVaultClient) deleteCertificateOperationCreateRequest(ctx contex
 }
 
 // deleteCertificateOperationHandleResponse handles the DeleteCertificateOperation response.
-func (client *KeyVaultClient) deleteCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateOperationResponse, error) {
+func (client *Client) deleteCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateOperationResponse, error) {
 	result := KeyVaultClientDeleteCertificateOperationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
 		return KeyVaultClientDeleteCertificateOperationResponse{}, runtime.NewResponseError(err, resp)
@@ -739,12 +736,12 @@ func (client *KeyVaultClient) deleteCertificateOperationHandleResponse(resp *htt
 }
 
 // deleteCertificateOperationHandleError handles the DeleteCertificateOperation error response.
-func (client *KeyVaultClient) deleteCertificateOperationHandleError(resp *http.Response) error {
+func (client *Client) deleteCertificateOperationHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -754,11 +751,11 @@ func (client *KeyVaultClient) deleteCertificateOperationHandleError(resp *http.R
 // DeleteKey - The delete key operation cannot be used to remove individual versions of a key. This operation removes the
 // cryptographic material associated with the key, which means the key is not usable for
 // Sign/Verify, Wrap/Unwrap or Encrypt/Decrypt operations. This operation requires the keys/delete permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key to delete.
-// options - KeyVaultClientDeleteKeyOptions contains the optional parameters for the KeyVaultClient.DeleteKey method.
-func (client *KeyVaultClient) DeleteKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientDeleteKeyOptions) (KeyVaultClientDeleteKeyResponse, error) {
+// options - KeyVaultClientDeleteKeyOptions contains the optional parameters for the Client.DeleteKey method.
+func (client *Client) DeleteKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientDeleteKeyOptions) (KeyVaultClientDeleteKeyResponse, error) {
 	req, err := client.deleteKeyCreateRequest(ctx, vaultBaseURL, keyName, options)
 	if err != nil {
 		return KeyVaultClientDeleteKeyResponse{}, err
@@ -774,7 +771,7 @@ func (client *KeyVaultClient) DeleteKey(ctx context.Context, vaultBaseURL string
 }
 
 // deleteKeyCreateRequest creates the DeleteKey request.
-func (client *KeyVaultClient) deleteKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientDeleteKeyOptions) (*policy.Request, error) {
+func (client *Client) deleteKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientDeleteKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}"
@@ -794,7 +791,7 @@ func (client *KeyVaultClient) deleteKeyCreateRequest(ctx context.Context, vaultB
 }
 
 // deleteKeyHandleResponse handles the DeleteKey response.
-func (client *KeyVaultClient) deleteKeyHandleResponse(resp *http.Response) (KeyVaultClientDeleteKeyResponse, error) {
+func (client *Client) deleteKeyHandleResponse(resp *http.Response) (KeyVaultClientDeleteKeyResponse, error) {
 	result := KeyVaultClientDeleteKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyBundle); err != nil {
 		return KeyVaultClientDeleteKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -803,12 +800,12 @@ func (client *KeyVaultClient) deleteKeyHandleResponse(resp *http.Response) (KeyV
 }
 
 // deleteKeyHandleError handles the DeleteKey error response.
-func (client *KeyVaultClient) deleteKeyHandleError(resp *http.Response) error {
+func (client *Client) deleteKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -817,13 +814,13 @@ func (client *KeyVaultClient) deleteKeyHandleError(resp *http.Response) error {
 
 // DeleteSasDefinition - Deletes a SAS definition from a specified storage account. This operation requires the storage/deletesas
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // sasDefinitionName - The name of the SAS definition.
-// options - KeyVaultClientDeleteSasDefinitionOptions contains the optional parameters for the KeyVaultClient.DeleteSasDefinition
+// options - KeyVaultClientDeleteSasDefinitionOptions contains the optional parameters for the Client.DeleteSasDefinition
 // method.
-func (client *KeyVaultClient) DeleteSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientDeleteSasDefinitionOptions) (KeyVaultClientDeleteSasDefinitionResponse, error) {
+func (client *Client) DeleteSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientDeleteSasDefinitionOptions) (KeyVaultClientDeleteSasDefinitionResponse, error) {
 	req, err := client.deleteSasDefinitionCreateRequest(ctx, vaultBaseURL, storageAccountName, sasDefinitionName, options)
 	if err != nil {
 		return KeyVaultClientDeleteSasDefinitionResponse{}, err
@@ -839,7 +836,7 @@ func (client *KeyVaultClient) DeleteSasDefinition(ctx context.Context, vaultBase
 }
 
 // deleteSasDefinitionCreateRequest creates the DeleteSasDefinition request.
-func (client *KeyVaultClient) deleteSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientDeleteSasDefinitionOptions) (*policy.Request, error) {
+func (client *Client) deleteSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientDeleteSasDefinitionOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}/sas/{sas-definition-name}"
@@ -863,7 +860,7 @@ func (client *KeyVaultClient) deleteSasDefinitionCreateRequest(ctx context.Conte
 }
 
 // deleteSasDefinitionHandleResponse handles the DeleteSasDefinition response.
-func (client *KeyVaultClient) deleteSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientDeleteSasDefinitionResponse, error) {
+func (client *Client) deleteSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientDeleteSasDefinitionResponse, error) {
 	result := KeyVaultClientDeleteSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionBundle); err != nil {
 		return KeyVaultClientDeleteSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
@@ -872,12 +869,12 @@ func (client *KeyVaultClient) deleteSasDefinitionHandleResponse(resp *http.Respo
 }
 
 // deleteSasDefinitionHandleError handles the DeleteSasDefinition error response.
-func (client *KeyVaultClient) deleteSasDefinitionHandleError(resp *http.Response) error {
+func (client *Client) deleteSasDefinitionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -886,11 +883,11 @@ func (client *KeyVaultClient) deleteSasDefinitionHandleError(resp *http.Response
 
 // DeleteSecret - The DELETE operation applies to any secret stored in Azure Key Vault. DELETE cannot be applied to an individual
 // version of a secret. This operation requires the secrets/delete permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
-// options - KeyVaultClientDeleteSecretOptions contains the optional parameters for the KeyVaultClient.DeleteSecret method.
-func (client *KeyVaultClient) DeleteSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientDeleteSecretOptions) (KeyVaultClientDeleteSecretResponse, error) {
+// options - KeyVaultClientDeleteSecretOptions contains the optional parameters for the Client.DeleteSecret method.
+func (client *Client) DeleteSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientDeleteSecretOptions) (KeyVaultClientDeleteSecretResponse, error) {
 	req, err := client.deleteSecretCreateRequest(ctx, vaultBaseURL, secretName, options)
 	if err != nil {
 		return KeyVaultClientDeleteSecretResponse{}, err
@@ -906,7 +903,7 @@ func (client *KeyVaultClient) DeleteSecret(ctx context.Context, vaultBaseURL str
 }
 
 // deleteSecretCreateRequest creates the DeleteSecret request.
-func (client *KeyVaultClient) deleteSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientDeleteSecretOptions) (*policy.Request, error) {
+func (client *Client) deleteSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientDeleteSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/secrets/{secret-name}"
@@ -926,7 +923,7 @@ func (client *KeyVaultClient) deleteSecretCreateRequest(ctx context.Context, vau
 }
 
 // deleteSecretHandleResponse handles the DeleteSecret response.
-func (client *KeyVaultClient) deleteSecretHandleResponse(resp *http.Response) (KeyVaultClientDeleteSecretResponse, error) {
+func (client *Client) deleteSecretHandleResponse(resp *http.Response) (KeyVaultClientDeleteSecretResponse, error) {
 	result := KeyVaultClientDeleteSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretBundle); err != nil {
 		return KeyVaultClientDeleteSecretResponse{}, runtime.NewResponseError(err, resp)
@@ -935,12 +932,12 @@ func (client *KeyVaultClient) deleteSecretHandleResponse(resp *http.Response) (K
 }
 
 // deleteSecretHandleError handles the DeleteSecret error response.
-func (client *KeyVaultClient) deleteSecretHandleError(resp *http.Response) error {
+func (client *Client) deleteSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -948,12 +945,12 @@ func (client *KeyVaultClient) deleteSecretHandleError(resp *http.Response) error
 }
 
 // DeleteStorageAccount - Deletes a storage account. This operation requires the storage/delete permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
-// options - KeyVaultClientDeleteStorageAccountOptions contains the optional parameters for the KeyVaultClient.DeleteStorageAccount
+// options - KeyVaultClientDeleteStorageAccountOptions contains the optional parameters for the Client.DeleteStorageAccount
 // method.
-func (client *KeyVaultClient) DeleteStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientDeleteStorageAccountOptions) (KeyVaultClientDeleteStorageAccountResponse, error) {
+func (client *Client) DeleteStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientDeleteStorageAccountOptions) (KeyVaultClientDeleteStorageAccountResponse, error) {
 	req, err := client.deleteStorageAccountCreateRequest(ctx, vaultBaseURL, storageAccountName, options)
 	if err != nil {
 		return KeyVaultClientDeleteStorageAccountResponse{}, err
@@ -969,7 +966,7 @@ func (client *KeyVaultClient) DeleteStorageAccount(ctx context.Context, vaultBas
 }
 
 // deleteStorageAccountCreateRequest creates the DeleteStorageAccount request.
-func (client *KeyVaultClient) deleteStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientDeleteStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) deleteStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientDeleteStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}"
@@ -989,7 +986,7 @@ func (client *KeyVaultClient) deleteStorageAccountCreateRequest(ctx context.Cont
 }
 
 // deleteStorageAccountHandleResponse handles the DeleteStorageAccount response.
-func (client *KeyVaultClient) deleteStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientDeleteStorageAccountResponse, error) {
+func (client *Client) deleteStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientDeleteStorageAccountResponse, error) {
 	result := KeyVaultClientDeleteStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageBundle); err != nil {
 		return KeyVaultClientDeleteStorageAccountResponse{}, runtime.NewResponseError(err, resp)
@@ -998,12 +995,12 @@ func (client *KeyVaultClient) deleteStorageAccountHandleResponse(resp *http.Resp
 }
 
 // deleteStorageAccountHandleError handles the DeleteStorageAccount error response.
-func (client *KeyVaultClient) deleteStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) deleteStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1017,13 +1014,13 @@ func (client *KeyVaultClient) deleteStorageAccountHandleError(resp *http.Respons
 // asymmetric key can be performed using public portion of the key. This operation is supported for asymmetric keys as a convenience
 // for callers that have a key-reference but do not have access to the
 // public key material. This operation requires the keys/encrypt permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
 // keyVersion - The version of the key.
 // parameters - The parameters for the encryption operation.
-// options - KeyVaultClientEncryptOptions contains the optional parameters for the KeyVaultClient.Encrypt method.
-func (client *KeyVaultClient) Encrypt(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientEncryptOptions) (KeyVaultClientEncryptResponse, error) {
+// options - KeyVaultClientEncryptOptions contains the optional parameters for the Client.Encrypt method.
+func (client *Client) Encrypt(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientEncryptOptions) (KeyVaultClientEncryptResponse, error) {
 	req, err := client.encryptCreateRequest(ctx, vaultBaseURL, keyName, keyVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientEncryptResponse{}, err
@@ -1039,7 +1036,7 @@ func (client *KeyVaultClient) Encrypt(ctx context.Context, vaultBaseURL string, 
 }
 
 // encryptCreateRequest creates the Encrypt request.
-func (client *KeyVaultClient) encryptCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientEncryptOptions) (*policy.Request, error) {
+func (client *Client) encryptCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientEncryptOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/{key-version}/encrypt"
@@ -1063,7 +1060,7 @@ func (client *KeyVaultClient) encryptCreateRequest(ctx context.Context, vaultBas
 }
 
 // encryptHandleResponse handles the Encrypt response.
-func (client *KeyVaultClient) encryptHandleResponse(resp *http.Response) (KeyVaultClientEncryptResponse, error) {
+func (client *Client) encryptHandleResponse(resp *http.Response) (KeyVaultClientEncryptResponse, error) {
 	result := KeyVaultClientEncryptResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return KeyVaultClientEncryptResponse{}, runtime.NewResponseError(err, resp)
@@ -1072,12 +1069,12 @@ func (client *KeyVaultClient) encryptHandleResponse(resp *http.Response) (KeyVau
 }
 
 // encryptHandleError handles the Encrypt error response.
-func (client *KeyVaultClient) encryptHandleError(resp *http.Response) error {
+func (client *Client) encryptHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1085,11 +1082,10 @@ func (client *KeyVaultClient) encryptHandleError(resp *http.Response) error {
 }
 
 // BeginFullBackup - Creates a full backup using a user-provided SAS token to an Azure blob storage container.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientBeginFullBackupOptions contains the optional parameters for the KeyVaultClient.BeginFullBackup
-// method.
-func (client *KeyVaultClient) BeginFullBackup(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullBackupOptions) (KeyVaultClientFullBackupPollerResponse, error) {
+// options - KeyVaultClientBeginFullBackupOptions contains the optional parameters for the Client.BeginFullBackup method.
+func (client *Client) BeginFullBackup(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullBackupOptions) (KeyVaultClientFullBackupPollerResponse, error) {
 	resp, err := client.fullBackup(ctx, vaultBaseURL, options)
 	if err != nil {
 		return KeyVaultClientFullBackupPollerResponse{}, err
@@ -1097,7 +1093,7 @@ func (client *KeyVaultClient) BeginFullBackup(ctx context.Context, vaultBaseURL 
 	result := KeyVaultClientFullBackupPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := runtime.NewPoller("KeyVaultClient.FullBackup", resp, client.pl, client.fullBackupHandleError)
+	pt, err := runtime.NewPoller("Client.FullBackup", resp, client.pl, client.fullBackupHandleError)
 	if err != nil {
 		return KeyVaultClientFullBackupPollerResponse{}, err
 	}
@@ -1108,8 +1104,8 @@ func (client *KeyVaultClient) BeginFullBackup(ctx context.Context, vaultBaseURL 
 }
 
 // FullBackup - Creates a full backup using a user-provided SAS token to an Azure blob storage container.
-// If the operation fails it returns the *KeyVaultError error type.
-func (client *KeyVaultClient) fullBackup(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullBackupOptions) (*http.Response, error) {
+// If the operation fails it returns the *Error error type.
+func (client *Client) fullBackup(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullBackupOptions) (*http.Response, error) {
 	req, err := client.fullBackupCreateRequest(ctx, vaultBaseURL, options)
 	if err != nil {
 		return nil, err
@@ -1125,7 +1121,7 @@ func (client *KeyVaultClient) fullBackup(ctx context.Context, vaultBaseURL strin
 }
 
 // fullBackupCreateRequest creates the FullBackup request.
-func (client *KeyVaultClient) fullBackupCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullBackupOptions) (*policy.Request, error) {
+func (client *Client) fullBackupCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullBackupOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/backup"
@@ -1144,12 +1140,12 @@ func (client *KeyVaultClient) fullBackupCreateRequest(ctx context.Context, vault
 }
 
 // fullBackupHandleError handles the FullBackup error response.
-func (client *KeyVaultClient) fullBackupHandleError(resp *http.Response) error {
+func (client *Client) fullBackupHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1157,12 +1153,11 @@ func (client *KeyVaultClient) fullBackupHandleError(resp *http.Response) error {
 }
 
 // FullBackupStatus - Returns the status of full backup operation
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // jobID - The id returned as part of the backup request
-// options - KeyVaultClientFullBackupStatusOptions contains the optional parameters for the KeyVaultClient.FullBackupStatus
-// method.
-func (client *KeyVaultClient) FullBackupStatus(ctx context.Context, vaultBaseURL string, jobID string, options *KeyVaultClientFullBackupStatusOptions) (KeyVaultClientFullBackupStatusResponse, error) {
+// options - KeyVaultClientFullBackupStatusOptions contains the optional parameters for the Client.FullBackupStatus method.
+func (client *Client) FullBackupStatus(ctx context.Context, vaultBaseURL string, jobID string, options *KeyVaultClientFullBackupStatusOptions) (KeyVaultClientFullBackupStatusResponse, error) {
 	req, err := client.fullBackupStatusCreateRequest(ctx, vaultBaseURL, jobID, options)
 	if err != nil {
 		return KeyVaultClientFullBackupStatusResponse{}, err
@@ -1178,7 +1173,7 @@ func (client *KeyVaultClient) FullBackupStatus(ctx context.Context, vaultBaseURL
 }
 
 // fullBackupStatusCreateRequest creates the FullBackupStatus request.
-func (client *KeyVaultClient) fullBackupStatusCreateRequest(ctx context.Context, vaultBaseURL string, jobID string, options *KeyVaultClientFullBackupStatusOptions) (*policy.Request, error) {
+func (client *Client) fullBackupStatusCreateRequest(ctx context.Context, vaultBaseURL string, jobID string, options *KeyVaultClientFullBackupStatusOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/backup/{jobId}/pending"
@@ -1198,7 +1193,7 @@ func (client *KeyVaultClient) fullBackupStatusCreateRequest(ctx context.Context,
 }
 
 // fullBackupStatusHandleResponse handles the FullBackupStatus response.
-func (client *KeyVaultClient) fullBackupStatusHandleResponse(resp *http.Response) (KeyVaultClientFullBackupStatusResponse, error) {
+func (client *Client) fullBackupStatusHandleResponse(resp *http.Response) (KeyVaultClientFullBackupStatusResponse, error) {
 	result := KeyVaultClientFullBackupStatusResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FullBackupOperation); err != nil {
 		return KeyVaultClientFullBackupStatusResponse{}, runtime.NewResponseError(err, resp)
@@ -1207,12 +1202,12 @@ func (client *KeyVaultClient) fullBackupStatusHandleResponse(resp *http.Response
 }
 
 // fullBackupStatusHandleError handles the FullBackupStatus error response.
-func (client *KeyVaultClient) fullBackupStatusHandleError(resp *http.Response) error {
+func (client *Client) fullBackupStatusHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1221,11 +1216,11 @@ func (client *KeyVaultClient) fullBackupStatusHandleError(resp *http.Response) e
 
 // BeginFullRestoreOperation - Restores all key materials using the SAS token pointing to a previously stored Azure Blob storage
 // backup folder
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientBeginFullRestoreOperationOptions contains the optional parameters for the KeyVaultClient.BeginFullRestoreOperation
+// options - KeyVaultClientBeginFullRestoreOperationOptions contains the optional parameters for the Client.BeginFullRestoreOperation
 // method.
-func (client *KeyVaultClient) BeginFullRestoreOperation(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullRestoreOperationOptions) (KeyVaultClientFullRestoreOperationPollerResponse, error) {
+func (client *Client) BeginFullRestoreOperation(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullRestoreOperationOptions) (KeyVaultClientFullRestoreOperationPollerResponse, error) {
 	resp, err := client.fullRestoreOperation(ctx, vaultBaseURL, options)
 	if err != nil {
 		return KeyVaultClientFullRestoreOperationPollerResponse{}, err
@@ -1233,7 +1228,7 @@ func (client *KeyVaultClient) BeginFullRestoreOperation(ctx context.Context, vau
 	result := KeyVaultClientFullRestoreOperationPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := runtime.NewPoller("KeyVaultClient.FullRestoreOperation", resp, client.pl, client.fullRestoreOperationHandleError)
+	pt, err := runtime.NewPoller("Client.FullRestoreOperation", resp, client.pl, client.fullRestoreOperationHandleError)
 	if err != nil {
 		return KeyVaultClientFullRestoreOperationPollerResponse{}, err
 	}
@@ -1245,8 +1240,8 @@ func (client *KeyVaultClient) BeginFullRestoreOperation(ctx context.Context, vau
 
 // FullRestoreOperation - Restores all key materials using the SAS token pointing to a previously stored Azure Blob storage
 // backup folder
-// If the operation fails it returns the *KeyVaultError error type.
-func (client *KeyVaultClient) fullRestoreOperation(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullRestoreOperationOptions) (*http.Response, error) {
+// If the operation fails it returns the *Error error type.
+func (client *Client) fullRestoreOperation(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullRestoreOperationOptions) (*http.Response, error) {
 	req, err := client.fullRestoreOperationCreateRequest(ctx, vaultBaseURL, options)
 	if err != nil {
 		return nil, err
@@ -1262,7 +1257,7 @@ func (client *KeyVaultClient) fullRestoreOperation(ctx context.Context, vaultBas
 }
 
 // fullRestoreOperationCreateRequest creates the FullRestoreOperation request.
-func (client *KeyVaultClient) fullRestoreOperationCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullRestoreOperationOptions) (*policy.Request, error) {
+func (client *Client) fullRestoreOperationCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientBeginFullRestoreOperationOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/restore"
@@ -1281,12 +1276,12 @@ func (client *KeyVaultClient) fullRestoreOperationCreateRequest(ctx context.Cont
 }
 
 // fullRestoreOperationHandleError handles the FullRestoreOperation error response.
-func (client *KeyVaultClient) fullRestoreOperationHandleError(resp *http.Response) error {
+func (client *Client) fullRestoreOperationHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1294,13 +1289,13 @@ func (client *KeyVaultClient) fullRestoreOperationHandleError(resp *http.Respons
 }
 
 // GetCertificate - Gets information about a specific certificate. This operation requires the certificates/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate in the given vault.
 // certificateVersion - The version of the certificate. This URI fragment is optional. If not specified, the latest version
 // of the certificate is returned.
-// options - KeyVaultClientGetCertificateOptions contains the optional parameters for the KeyVaultClient.GetCertificate method.
-func (client *KeyVaultClient) GetCertificate(ctx context.Context, vaultBaseURL string, certificateName string, certificateVersion string, options *KeyVaultClientGetCertificateOptions) (KeyVaultClientGetCertificateResponse, error) {
+// options - KeyVaultClientGetCertificateOptions contains the optional parameters for the Client.GetCertificate method.
+func (client *Client) GetCertificate(ctx context.Context, vaultBaseURL string, certificateName string, certificateVersion string, options *KeyVaultClientGetCertificateOptions) (KeyVaultClientGetCertificateResponse, error) {
 	req, err := client.getCertificateCreateRequest(ctx, vaultBaseURL, certificateName, certificateVersion, options)
 	if err != nil {
 		return KeyVaultClientGetCertificateResponse{}, err
@@ -1316,7 +1311,7 @@ func (client *KeyVaultClient) GetCertificate(ctx context.Context, vaultBaseURL s
 }
 
 // getCertificateCreateRequest creates the GetCertificate request.
-func (client *KeyVaultClient) getCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, certificateVersion string, options *KeyVaultClientGetCertificateOptions) (*policy.Request, error) {
+func (client *Client) getCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, certificateVersion string, options *KeyVaultClientGetCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/{certificate-version}"
@@ -1340,7 +1335,7 @@ func (client *KeyVaultClient) getCertificateCreateRequest(ctx context.Context, v
 }
 
 // getCertificateHandleResponse handles the GetCertificate response.
-func (client *KeyVaultClient) getCertificateHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateResponse, error) {
+func (client *Client) getCertificateHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateResponse, error) {
 	result := KeyVaultClientGetCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return KeyVaultClientGetCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -1349,12 +1344,12 @@ func (client *KeyVaultClient) getCertificateHandleResponse(resp *http.Response) 
 }
 
 // getCertificateHandleError handles the GetCertificate error response.
-func (client *KeyVaultClient) getCertificateHandleError(resp *http.Response) error {
+func (client *Client) getCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1363,11 +1358,11 @@ func (client *KeyVaultClient) getCertificateHandleError(resp *http.Response) err
 
 // GetCertificateContacts - The GetCertificateContacts operation returns the set of certificate contact resources in the specified
 // key vault. This operation requires the certificates/managecontacts permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetCertificateContactsOptions contains the optional parameters for the KeyVaultClient.GetCertificateContacts
+// options - KeyVaultClientGetCertificateContactsOptions contains the optional parameters for the Client.GetCertificateContacts
 // method.
-func (client *KeyVaultClient) GetCertificateContacts(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetCertificateContactsOptions) (KeyVaultClientGetCertificateContactsResponse, error) {
+func (client *Client) GetCertificateContacts(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetCertificateContactsOptions) (KeyVaultClientGetCertificateContactsResponse, error) {
 	req, err := client.getCertificateContactsCreateRequest(ctx, vaultBaseURL, options)
 	if err != nil {
 		return KeyVaultClientGetCertificateContactsResponse{}, err
@@ -1383,7 +1378,7 @@ func (client *KeyVaultClient) GetCertificateContacts(ctx context.Context, vaultB
 }
 
 // getCertificateContactsCreateRequest creates the GetCertificateContacts request.
-func (client *KeyVaultClient) getCertificateContactsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetCertificateContactsOptions) (*policy.Request, error) {
+func (client *Client) getCertificateContactsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetCertificateContactsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/contacts"
@@ -1399,7 +1394,7 @@ func (client *KeyVaultClient) getCertificateContactsCreateRequest(ctx context.Co
 }
 
 // getCertificateContactsHandleResponse handles the GetCertificateContacts response.
-func (client *KeyVaultClient) getCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateContactsResponse, error) {
+func (client *Client) getCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateContactsResponse, error) {
 	result := KeyVaultClientGetCertificateContactsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
 		return KeyVaultClientGetCertificateContactsResponse{}, runtime.NewResponseError(err, resp)
@@ -1408,12 +1403,12 @@ func (client *KeyVaultClient) getCertificateContactsHandleResponse(resp *http.Re
 }
 
 // getCertificateContactsHandleError handles the GetCertificateContacts error response.
-func (client *KeyVaultClient) getCertificateContactsHandleError(resp *http.Response) error {
+func (client *Client) getCertificateContactsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1422,12 +1417,12 @@ func (client *KeyVaultClient) getCertificateContactsHandleError(resp *http.Respo
 
 // GetCertificateIssuer - The GetCertificateIssuer operation returns the specified certificate issuer resources in the specified
 // key vault. This operation requires the certificates/manageissuers/getissuers permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // issuerName - The name of the issuer.
-// options - KeyVaultClientGetCertificateIssuerOptions contains the optional parameters for the KeyVaultClient.GetCertificateIssuer
+// options - KeyVaultClientGetCertificateIssuerOptions contains the optional parameters for the Client.GetCertificateIssuer
 // method.
-func (client *KeyVaultClient) GetCertificateIssuer(ctx context.Context, vaultBaseURL string, issuerName string, options *KeyVaultClientGetCertificateIssuerOptions) (KeyVaultClientGetCertificateIssuerResponse, error) {
+func (client *Client) GetCertificateIssuer(ctx context.Context, vaultBaseURL string, issuerName string, options *KeyVaultClientGetCertificateIssuerOptions) (KeyVaultClientGetCertificateIssuerResponse, error) {
 	req, err := client.getCertificateIssuerCreateRequest(ctx, vaultBaseURL, issuerName, options)
 	if err != nil {
 		return KeyVaultClientGetCertificateIssuerResponse{}, err
@@ -1443,7 +1438,7 @@ func (client *KeyVaultClient) GetCertificateIssuer(ctx context.Context, vaultBas
 }
 
 // getCertificateIssuerCreateRequest creates the GetCertificateIssuer request.
-func (client *KeyVaultClient) getCertificateIssuerCreateRequest(ctx context.Context, vaultBaseURL string, issuerName string, options *KeyVaultClientGetCertificateIssuerOptions) (*policy.Request, error) {
+func (client *Client) getCertificateIssuerCreateRequest(ctx context.Context, vaultBaseURL string, issuerName string, options *KeyVaultClientGetCertificateIssuerOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/issuers/{issuer-name}"
@@ -1463,7 +1458,7 @@ func (client *KeyVaultClient) getCertificateIssuerCreateRequest(ctx context.Cont
 }
 
 // getCertificateIssuerHandleResponse handles the GetCertificateIssuer response.
-func (client *KeyVaultClient) getCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateIssuerResponse, error) {
+func (client *Client) getCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateIssuerResponse, error) {
 	result := KeyVaultClientGetCertificateIssuerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
 		return KeyVaultClientGetCertificateIssuerResponse{}, runtime.NewResponseError(err, resp)
@@ -1472,12 +1467,12 @@ func (client *KeyVaultClient) getCertificateIssuerHandleResponse(resp *http.Resp
 }
 
 // getCertificateIssuerHandleError handles the GetCertificateIssuer error response.
-func (client *KeyVaultClient) getCertificateIssuerHandleError(resp *http.Response) error {
+func (client *Client) getCertificateIssuerHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1486,11 +1481,11 @@ func (client *KeyVaultClient) getCertificateIssuerHandleError(resp *http.Respons
 
 // GetCertificateIssuers - The GetCertificateIssuers operation returns the set of certificate issuer resources in the specified
 // key vault. This operation requires the certificates/manageissuers/getissuers permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetCertificateIssuersOptions contains the optional parameters for the KeyVaultClient.GetCertificateIssuers
+// options - KeyVaultClientGetCertificateIssuersOptions contains the optional parameters for the Client.GetCertificateIssuers
 // method.
-func (client *KeyVaultClient) GetCertificateIssuers(vaultBaseURL string, options *KeyVaultClientGetCertificateIssuersOptions) *KeyVaultClientGetCertificateIssuersPager {
+func (client *Client) GetCertificateIssuers(vaultBaseURL string, options *KeyVaultClientGetCertificateIssuersOptions) *KeyVaultClientGetCertificateIssuersPager {
 	return &KeyVaultClientGetCertificateIssuersPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -1503,7 +1498,7 @@ func (client *KeyVaultClient) GetCertificateIssuers(vaultBaseURL string, options
 }
 
 // getCertificateIssuersCreateRequest creates the GetCertificateIssuers request.
-func (client *KeyVaultClient) getCertificateIssuersCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetCertificateIssuersOptions) (*policy.Request, error) {
+func (client *Client) getCertificateIssuersCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetCertificateIssuersOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/issuers"
@@ -1522,7 +1517,7 @@ func (client *KeyVaultClient) getCertificateIssuersCreateRequest(ctx context.Con
 }
 
 // getCertificateIssuersHandleResponse handles the GetCertificateIssuers response.
-func (client *KeyVaultClient) getCertificateIssuersHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateIssuersResponse, error) {
+func (client *Client) getCertificateIssuersHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateIssuersResponse, error) {
 	result := KeyVaultClientGetCertificateIssuersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateIssuerListResult); err != nil {
 		return KeyVaultClientGetCertificateIssuersResponse{}, runtime.NewResponseError(err, resp)
@@ -1531,12 +1526,12 @@ func (client *KeyVaultClient) getCertificateIssuersHandleResponse(resp *http.Res
 }
 
 // getCertificateIssuersHandleError handles the GetCertificateIssuers error response.
-func (client *KeyVaultClient) getCertificateIssuersHandleError(resp *http.Response) error {
+func (client *Client) getCertificateIssuersHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1545,12 +1540,12 @@ func (client *KeyVaultClient) getCertificateIssuersHandleError(resp *http.Respon
 
 // GetCertificateOperation - Gets the creation operation associated with a specified certificate. This operation requires
 // the certificates/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
-// options - KeyVaultClientGetCertificateOperationOptions contains the optional parameters for the KeyVaultClient.GetCertificateOperation
+// options - KeyVaultClientGetCertificateOperationOptions contains the optional parameters for the Client.GetCertificateOperation
 // method.
-func (client *KeyVaultClient) GetCertificateOperation(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificateOperationOptions) (KeyVaultClientGetCertificateOperationResponse, error) {
+func (client *Client) GetCertificateOperation(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificateOperationOptions) (KeyVaultClientGetCertificateOperationResponse, error) {
 	req, err := client.getCertificateOperationCreateRequest(ctx, vaultBaseURL, certificateName, options)
 	if err != nil {
 		return KeyVaultClientGetCertificateOperationResponse{}, err
@@ -1566,7 +1561,7 @@ func (client *KeyVaultClient) GetCertificateOperation(ctx context.Context, vault
 }
 
 // getCertificateOperationCreateRequest creates the GetCertificateOperation request.
-func (client *KeyVaultClient) getCertificateOperationCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificateOperationOptions) (*policy.Request, error) {
+func (client *Client) getCertificateOperationCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificateOperationOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/pending"
@@ -1586,7 +1581,7 @@ func (client *KeyVaultClient) getCertificateOperationCreateRequest(ctx context.C
 }
 
 // getCertificateOperationHandleResponse handles the GetCertificateOperation response.
-func (client *KeyVaultClient) getCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateOperationResponse, error) {
+func (client *Client) getCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateOperationResponse, error) {
 	result := KeyVaultClientGetCertificateOperationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
 		return KeyVaultClientGetCertificateOperationResponse{}, runtime.NewResponseError(err, resp)
@@ -1595,12 +1590,12 @@ func (client *KeyVaultClient) getCertificateOperationHandleResponse(resp *http.R
 }
 
 // getCertificateOperationHandleError handles the GetCertificateOperation error response.
-func (client *KeyVaultClient) getCertificateOperationHandleError(resp *http.Response) error {
+func (client *Client) getCertificateOperationHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1609,12 +1604,12 @@ func (client *KeyVaultClient) getCertificateOperationHandleError(resp *http.Resp
 
 // GetCertificatePolicy - The GetCertificatePolicy operation returns the specified certificate policy resources in the specified
 // key vault. This operation requires the certificates/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate in a given key vault.
-// options - KeyVaultClientGetCertificatePolicyOptions contains the optional parameters for the KeyVaultClient.GetCertificatePolicy
+// options - KeyVaultClientGetCertificatePolicyOptions contains the optional parameters for the Client.GetCertificatePolicy
 // method.
-func (client *KeyVaultClient) GetCertificatePolicy(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificatePolicyOptions) (KeyVaultClientGetCertificatePolicyResponse, error) {
+func (client *Client) GetCertificatePolicy(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificatePolicyOptions) (KeyVaultClientGetCertificatePolicyResponse, error) {
 	req, err := client.getCertificatePolicyCreateRequest(ctx, vaultBaseURL, certificateName, options)
 	if err != nil {
 		return KeyVaultClientGetCertificatePolicyResponse{}, err
@@ -1630,7 +1625,7 @@ func (client *KeyVaultClient) GetCertificatePolicy(ctx context.Context, vaultBas
 }
 
 // getCertificatePolicyCreateRequest creates the GetCertificatePolicy request.
-func (client *KeyVaultClient) getCertificatePolicyCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificatePolicyOptions) (*policy.Request, error) {
+func (client *Client) getCertificatePolicyCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificatePolicyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/policy"
@@ -1650,7 +1645,7 @@ func (client *KeyVaultClient) getCertificatePolicyCreateRequest(ctx context.Cont
 }
 
 // getCertificatePolicyHandleResponse handles the GetCertificatePolicy response.
-func (client *KeyVaultClient) getCertificatePolicyHandleResponse(resp *http.Response) (KeyVaultClientGetCertificatePolicyResponse, error) {
+func (client *Client) getCertificatePolicyHandleResponse(resp *http.Response) (KeyVaultClientGetCertificatePolicyResponse, error) {
 	result := KeyVaultClientGetCertificatePolicyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificatePolicy); err != nil {
 		return KeyVaultClientGetCertificatePolicyResponse{}, runtime.NewResponseError(err, resp)
@@ -1659,12 +1654,12 @@ func (client *KeyVaultClient) getCertificatePolicyHandleResponse(resp *http.Resp
 }
 
 // getCertificatePolicyHandleError handles the GetCertificatePolicy error response.
-func (client *KeyVaultClient) getCertificatePolicyHandleError(resp *http.Response) error {
+func (client *Client) getCertificatePolicyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1673,12 +1668,12 @@ func (client *KeyVaultClient) getCertificatePolicyHandleError(resp *http.Respons
 
 // GetCertificateVersions - The GetCertificateVersions operation returns the versions of a certificate in the specified key
 // vault. This operation requires the certificates/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
-// options - KeyVaultClientGetCertificateVersionsOptions contains the optional parameters for the KeyVaultClient.GetCertificateVersions
+// options - KeyVaultClientGetCertificateVersionsOptions contains the optional parameters for the Client.GetCertificateVersions
 // method.
-func (client *KeyVaultClient) GetCertificateVersions(vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificateVersionsOptions) *KeyVaultClientGetCertificateVersionsPager {
+func (client *Client) GetCertificateVersions(vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificateVersionsOptions) *KeyVaultClientGetCertificateVersionsPager {
 	return &KeyVaultClientGetCertificateVersionsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -1691,7 +1686,7 @@ func (client *KeyVaultClient) GetCertificateVersions(vaultBaseURL string, certif
 }
 
 // getCertificateVersionsCreateRequest creates the GetCertificateVersions request.
-func (client *KeyVaultClient) getCertificateVersionsCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificateVersionsOptions) (*policy.Request, error) {
+func (client *Client) getCertificateVersionsCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetCertificateVersionsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/versions"
@@ -1714,7 +1709,7 @@ func (client *KeyVaultClient) getCertificateVersionsCreateRequest(ctx context.Co
 }
 
 // getCertificateVersionsHandleResponse handles the GetCertificateVersions response.
-func (client *KeyVaultClient) getCertificateVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateVersionsResponse, error) {
+func (client *Client) getCertificateVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateVersionsResponse, error) {
 	result := KeyVaultClientGetCertificateVersionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateListResult); err != nil {
 		return KeyVaultClientGetCertificateVersionsResponse{}, runtime.NewResponseError(err, resp)
@@ -1723,12 +1718,12 @@ func (client *KeyVaultClient) getCertificateVersionsHandleResponse(resp *http.Re
 }
 
 // getCertificateVersionsHandleError handles the GetCertificateVersions error response.
-func (client *KeyVaultClient) getCertificateVersionsHandleError(resp *http.Response) error {
+func (client *Client) getCertificateVersionsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1737,11 +1732,10 @@ func (client *KeyVaultClient) getCertificateVersionsHandleError(resp *http.Respo
 
 // GetCertificates - The GetCertificates operation returns the set of certificates resources in the specified key vault. This
 // operation requires the certificates/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetCertificatesOptions contains the optional parameters for the KeyVaultClient.GetCertificates
-// method.
-func (client *KeyVaultClient) GetCertificates(vaultBaseURL string, options *KeyVaultClientGetCertificatesOptions) *KeyVaultClientGetCertificatesPager {
+// options - KeyVaultClientGetCertificatesOptions contains the optional parameters for the Client.GetCertificates method.
+func (client *Client) GetCertificates(vaultBaseURL string, options *KeyVaultClientGetCertificatesOptions) *KeyVaultClientGetCertificatesPager {
 	return &KeyVaultClientGetCertificatesPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -1754,7 +1748,7 @@ func (client *KeyVaultClient) GetCertificates(vaultBaseURL string, options *KeyV
 }
 
 // getCertificatesCreateRequest creates the GetCertificates request.
-func (client *KeyVaultClient) getCertificatesCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetCertificatesOptions) (*policy.Request, error) {
+func (client *Client) getCertificatesCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetCertificatesOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates"
@@ -1776,7 +1770,7 @@ func (client *KeyVaultClient) getCertificatesCreateRequest(ctx context.Context, 
 }
 
 // getCertificatesHandleResponse handles the GetCertificates response.
-func (client *KeyVaultClient) getCertificatesHandleResponse(resp *http.Response) (KeyVaultClientGetCertificatesResponse, error) {
+func (client *Client) getCertificatesHandleResponse(resp *http.Response) (KeyVaultClientGetCertificatesResponse, error) {
 	result := KeyVaultClientGetCertificatesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateListResult); err != nil {
 		return KeyVaultClientGetCertificatesResponse{}, runtime.NewResponseError(err, resp)
@@ -1785,12 +1779,12 @@ func (client *KeyVaultClient) getCertificatesHandleResponse(resp *http.Response)
 }
 
 // getCertificatesHandleError handles the GetCertificates error response.
-func (client *KeyVaultClient) getCertificatesHandleError(resp *http.Response) error {
+func (client *Client) getCertificatesHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1800,12 +1794,12 @@ func (client *KeyVaultClient) getCertificatesHandleError(resp *http.Response) er
 // GetDeletedCertificate - The GetDeletedCertificate operation retrieves the deleted certificate information plus its attributes,
 // such as retention interval, scheduled permanent deletion and the current deletion recovery level.
 // This operation requires the certificates/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate
-// options - KeyVaultClientGetDeletedCertificateOptions contains the optional parameters for the KeyVaultClient.GetDeletedCertificate
+// options - KeyVaultClientGetDeletedCertificateOptions contains the optional parameters for the Client.GetDeletedCertificate
 // method.
-func (client *KeyVaultClient) GetDeletedCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetDeletedCertificateOptions) (KeyVaultClientGetDeletedCertificateResponse, error) {
+func (client *Client) GetDeletedCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetDeletedCertificateOptions) (KeyVaultClientGetDeletedCertificateResponse, error) {
 	req, err := client.getDeletedCertificateCreateRequest(ctx, vaultBaseURL, certificateName, options)
 	if err != nil {
 		return KeyVaultClientGetDeletedCertificateResponse{}, err
@@ -1821,7 +1815,7 @@ func (client *KeyVaultClient) GetDeletedCertificate(ctx context.Context, vaultBa
 }
 
 // getDeletedCertificateCreateRequest creates the GetDeletedCertificate request.
-func (client *KeyVaultClient) getDeletedCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetDeletedCertificateOptions) (*policy.Request, error) {
+func (client *Client) getDeletedCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientGetDeletedCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedcertificates/{certificate-name}"
@@ -1841,7 +1835,7 @@ func (client *KeyVaultClient) getDeletedCertificateCreateRequest(ctx context.Con
 }
 
 // getDeletedCertificateHandleResponse handles the GetDeletedCertificate response.
-func (client *KeyVaultClient) getDeletedCertificateHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedCertificateResponse, error) {
+func (client *Client) getDeletedCertificateHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedCertificateResponse, error) {
 	result := KeyVaultClientGetDeletedCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateBundle); err != nil {
 		return KeyVaultClientGetDeletedCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -1850,12 +1844,12 @@ func (client *KeyVaultClient) getDeletedCertificateHandleResponse(resp *http.Res
 }
 
 // getDeletedCertificateHandleError handles the GetDeletedCertificate error response.
-func (client *KeyVaultClient) getDeletedCertificateHandleError(resp *http.Response) error {
+func (client *Client) getDeletedCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1866,11 +1860,11 @@ func (client *KeyVaultClient) getDeletedCertificateHandleError(resp *http.Respon
 // in a deleted state and ready for recovery or purging. This operation includes deletion-specific
 // information. This operation requires the certificates/get/list permission. This operation can only be enabled on soft-delete
 // enabled vaults.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetDeletedCertificatesOptions contains the optional parameters for the KeyVaultClient.GetDeletedCertificates
+// options - KeyVaultClientGetDeletedCertificatesOptions contains the optional parameters for the Client.GetDeletedCertificates
 // method.
-func (client *KeyVaultClient) GetDeletedCertificates(vaultBaseURL string, options *KeyVaultClientGetDeletedCertificatesOptions) *KeyVaultClientGetDeletedCertificatesPager {
+func (client *Client) GetDeletedCertificates(vaultBaseURL string, options *KeyVaultClientGetDeletedCertificatesOptions) *KeyVaultClientGetDeletedCertificatesPager {
 	return &KeyVaultClientGetDeletedCertificatesPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -1883,7 +1877,7 @@ func (client *KeyVaultClient) GetDeletedCertificates(vaultBaseURL string, option
 }
 
 // getDeletedCertificatesCreateRequest creates the GetDeletedCertificates request.
-func (client *KeyVaultClient) getDeletedCertificatesCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetDeletedCertificatesOptions) (*policy.Request, error) {
+func (client *Client) getDeletedCertificatesCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetDeletedCertificatesOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedcertificates"
@@ -1905,7 +1899,7 @@ func (client *KeyVaultClient) getDeletedCertificatesCreateRequest(ctx context.Co
 }
 
 // getDeletedCertificatesHandleResponse handles the GetDeletedCertificates response.
-func (client *KeyVaultClient) getDeletedCertificatesHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedCertificatesResponse, error) {
+func (client *Client) getDeletedCertificatesHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedCertificatesResponse, error) {
 	result := KeyVaultClientGetDeletedCertificatesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateListResult); err != nil {
 		return KeyVaultClientGetDeletedCertificatesResponse{}, runtime.NewResponseError(err, resp)
@@ -1914,12 +1908,12 @@ func (client *KeyVaultClient) getDeletedCertificatesHandleResponse(resp *http.Re
 }
 
 // getDeletedCertificatesHandleError handles the GetDeletedCertificates error response.
-func (client *KeyVaultClient) getDeletedCertificatesHandleError(resp *http.Response) error {
+func (client *Client) getDeletedCertificatesHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1929,11 +1923,11 @@ func (client *KeyVaultClient) getDeletedCertificatesHandleError(resp *http.Respo
 // GetDeletedKey - The Get Deleted Key operation is applicable for soft-delete enabled vaults. While the operation can be
 // invoked on any vault, it will return an error if invoked on a non soft-delete enabled vault. This
 // operation requires the keys/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
-// options - KeyVaultClientGetDeletedKeyOptions contains the optional parameters for the KeyVaultClient.GetDeletedKey method.
-func (client *KeyVaultClient) GetDeletedKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientGetDeletedKeyOptions) (KeyVaultClientGetDeletedKeyResponse, error) {
+// options - KeyVaultClientGetDeletedKeyOptions contains the optional parameters for the Client.GetDeletedKey method.
+func (client *Client) GetDeletedKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientGetDeletedKeyOptions) (KeyVaultClientGetDeletedKeyResponse, error) {
 	req, err := client.getDeletedKeyCreateRequest(ctx, vaultBaseURL, keyName, options)
 	if err != nil {
 		return KeyVaultClientGetDeletedKeyResponse{}, err
@@ -1949,7 +1943,7 @@ func (client *KeyVaultClient) GetDeletedKey(ctx context.Context, vaultBaseURL st
 }
 
 // getDeletedKeyCreateRequest creates the GetDeletedKey request.
-func (client *KeyVaultClient) getDeletedKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientGetDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) getDeletedKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientGetDeletedKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedkeys/{key-name}"
@@ -1969,7 +1963,7 @@ func (client *KeyVaultClient) getDeletedKeyCreateRequest(ctx context.Context, va
 }
 
 // getDeletedKeyHandleResponse handles the GetDeletedKey response.
-func (client *KeyVaultClient) getDeletedKeyHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedKeyResponse, error) {
+func (client *Client) getDeletedKeyHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedKeyResponse, error) {
 	result := KeyVaultClientGetDeletedKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyBundle); err != nil {
 		return KeyVaultClientGetDeletedKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -1978,12 +1972,12 @@ func (client *KeyVaultClient) getDeletedKeyHandleResponse(resp *http.Response) (
 }
 
 // getDeletedKeyHandleError handles the GetDeletedKey error response.
-func (client *KeyVaultClient) getDeletedKeyHandleError(resp *http.Response) error {
+func (client *Client) getDeletedKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -1995,10 +1989,10 @@ func (client *KeyVaultClient) getDeletedKeyHandleError(resp *http.Response) erro
 // operation is applicable for vaults enabled for soft-delete. While the operation can be invoked on any vault, it will return
 // an error if invoked on a non soft-delete enabled vault. This operation
 // requires the keys/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetDeletedKeysOptions contains the optional parameters for the KeyVaultClient.GetDeletedKeys method.
-func (client *KeyVaultClient) GetDeletedKeys(vaultBaseURL string, options *KeyVaultClientGetDeletedKeysOptions) *KeyVaultClientGetDeletedKeysPager {
+// options - KeyVaultClientGetDeletedKeysOptions contains the optional parameters for the Client.GetDeletedKeys method.
+func (client *Client) GetDeletedKeys(vaultBaseURL string, options *KeyVaultClientGetDeletedKeysOptions) *KeyVaultClientGetDeletedKeysPager {
 	return &KeyVaultClientGetDeletedKeysPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2011,7 +2005,7 @@ func (client *KeyVaultClient) GetDeletedKeys(vaultBaseURL string, options *KeyVa
 }
 
 // getDeletedKeysCreateRequest creates the GetDeletedKeys request.
-func (client *KeyVaultClient) getDeletedKeysCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetDeletedKeysOptions) (*policy.Request, error) {
+func (client *Client) getDeletedKeysCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetDeletedKeysOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedkeys"
@@ -2030,7 +2024,7 @@ func (client *KeyVaultClient) getDeletedKeysCreateRequest(ctx context.Context, v
 }
 
 // getDeletedKeysHandleResponse handles the GetDeletedKeys response.
-func (client *KeyVaultClient) getDeletedKeysHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedKeysResponse, error) {
+func (client *Client) getDeletedKeysHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedKeysResponse, error) {
 	result := KeyVaultClientGetDeletedKeysResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyListResult); err != nil {
 		return KeyVaultClientGetDeletedKeysResponse{}, runtime.NewResponseError(err, resp)
@@ -2039,12 +2033,12 @@ func (client *KeyVaultClient) getDeletedKeysHandleResponse(resp *http.Response) 
 }
 
 // getDeletedKeysHandleError handles the GetDeletedKeys error response.
-func (client *KeyVaultClient) getDeletedKeysHandleError(resp *http.Response) error {
+func (client *Client) getDeletedKeysHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2053,13 +2047,13 @@ func (client *KeyVaultClient) getDeletedKeysHandleError(resp *http.Response) err
 
 // GetDeletedSasDefinition - The Get Deleted SAS Definition operation returns the specified deleted SAS definition along with
 // its attributes. This operation requires the storage/getsas permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // sasDefinitionName - The name of the SAS definition.
-// options - KeyVaultClientGetDeletedSasDefinitionOptions contains the optional parameters for the KeyVaultClient.GetDeletedSasDefinition
+// options - KeyVaultClientGetDeletedSasDefinitionOptions contains the optional parameters for the Client.GetDeletedSasDefinition
 // method.
-func (client *KeyVaultClient) GetDeletedSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientGetDeletedSasDefinitionOptions) (KeyVaultClientGetDeletedSasDefinitionResponse, error) {
+func (client *Client) GetDeletedSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientGetDeletedSasDefinitionOptions) (KeyVaultClientGetDeletedSasDefinitionResponse, error) {
 	req, err := client.getDeletedSasDefinitionCreateRequest(ctx, vaultBaseURL, storageAccountName, sasDefinitionName, options)
 	if err != nil {
 		return KeyVaultClientGetDeletedSasDefinitionResponse{}, err
@@ -2075,7 +2069,7 @@ func (client *KeyVaultClient) GetDeletedSasDefinition(ctx context.Context, vault
 }
 
 // getDeletedSasDefinitionCreateRequest creates the GetDeletedSasDefinition request.
-func (client *KeyVaultClient) getDeletedSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientGetDeletedSasDefinitionOptions) (*policy.Request, error) {
+func (client *Client) getDeletedSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientGetDeletedSasDefinitionOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedstorage/{storage-account-name}/sas/{sas-definition-name}"
@@ -2099,7 +2093,7 @@ func (client *KeyVaultClient) getDeletedSasDefinitionCreateRequest(ctx context.C
 }
 
 // getDeletedSasDefinitionHandleResponse handles the GetDeletedSasDefinition response.
-func (client *KeyVaultClient) getDeletedSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSasDefinitionResponse, error) {
+func (client *Client) getDeletedSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSasDefinitionResponse, error) {
 	result := KeyVaultClientGetDeletedSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionBundle); err != nil {
 		return KeyVaultClientGetDeletedSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
@@ -2108,12 +2102,12 @@ func (client *KeyVaultClient) getDeletedSasDefinitionHandleResponse(resp *http.R
 }
 
 // getDeletedSasDefinitionHandleError handles the GetDeletedSasDefinition error response.
-func (client *KeyVaultClient) getDeletedSasDefinitionHandleError(resp *http.Response) error {
+func (client *Client) getDeletedSasDefinitionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2122,12 +2116,12 @@ func (client *KeyVaultClient) getDeletedSasDefinitionHandleError(resp *http.Resp
 
 // GetDeletedSasDefinitions - The Get Deleted Sas Definitions operation returns the SAS definitions that have been deleted
 // for a vault enabled for soft-delete. This operation requires the storage/listsas permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
-// options - KeyVaultClientGetDeletedSasDefinitionsOptions contains the optional parameters for the KeyVaultClient.GetDeletedSasDefinitions
+// options - KeyVaultClientGetDeletedSasDefinitionsOptions contains the optional parameters for the Client.GetDeletedSasDefinitions
 // method.
-func (client *KeyVaultClient) GetDeletedSasDefinitions(vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetDeletedSasDefinitionsOptions) *KeyVaultClientGetDeletedSasDefinitionsPager {
+func (client *Client) GetDeletedSasDefinitions(vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetDeletedSasDefinitionsOptions) *KeyVaultClientGetDeletedSasDefinitionsPager {
 	return &KeyVaultClientGetDeletedSasDefinitionsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2140,7 +2134,7 @@ func (client *KeyVaultClient) GetDeletedSasDefinitions(vaultBaseURL string, stor
 }
 
 // getDeletedSasDefinitionsCreateRequest creates the GetDeletedSasDefinitions request.
-func (client *KeyVaultClient) getDeletedSasDefinitionsCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetDeletedSasDefinitionsOptions) (*policy.Request, error) {
+func (client *Client) getDeletedSasDefinitionsCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetDeletedSasDefinitionsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedstorage/{storage-account-name}/sas"
@@ -2163,7 +2157,7 @@ func (client *KeyVaultClient) getDeletedSasDefinitionsCreateRequest(ctx context.
 }
 
 // getDeletedSasDefinitionsHandleResponse handles the GetDeletedSasDefinitions response.
-func (client *KeyVaultClient) getDeletedSasDefinitionsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSasDefinitionsResponse, error) {
+func (client *Client) getDeletedSasDefinitionsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSasDefinitionsResponse, error) {
 	result := KeyVaultClientGetDeletedSasDefinitionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionListResult); err != nil {
 		return KeyVaultClientGetDeletedSasDefinitionsResponse{}, runtime.NewResponseError(err, resp)
@@ -2172,12 +2166,12 @@ func (client *KeyVaultClient) getDeletedSasDefinitionsHandleResponse(resp *http.
 }
 
 // getDeletedSasDefinitionsHandleError handles the GetDeletedSasDefinitions error response.
-func (client *KeyVaultClient) getDeletedSasDefinitionsHandleError(resp *http.Response) error {
+func (client *Client) getDeletedSasDefinitionsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2186,12 +2180,11 @@ func (client *KeyVaultClient) getDeletedSasDefinitionsHandleError(resp *http.Res
 
 // GetDeletedSecret - The Get Deleted Secret operation returns the specified deleted secret along with its attributes. This
 // operation requires the secrets/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
-// options - KeyVaultClientGetDeletedSecretOptions contains the optional parameters for the KeyVaultClient.GetDeletedSecret
-// method.
-func (client *KeyVaultClient) GetDeletedSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientGetDeletedSecretOptions) (KeyVaultClientGetDeletedSecretResponse, error) {
+// options - KeyVaultClientGetDeletedSecretOptions contains the optional parameters for the Client.GetDeletedSecret method.
+func (client *Client) GetDeletedSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientGetDeletedSecretOptions) (KeyVaultClientGetDeletedSecretResponse, error) {
 	req, err := client.getDeletedSecretCreateRequest(ctx, vaultBaseURL, secretName, options)
 	if err != nil {
 		return KeyVaultClientGetDeletedSecretResponse{}, err
@@ -2207,7 +2200,7 @@ func (client *KeyVaultClient) GetDeletedSecret(ctx context.Context, vaultBaseURL
 }
 
 // getDeletedSecretCreateRequest creates the GetDeletedSecret request.
-func (client *KeyVaultClient) getDeletedSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientGetDeletedSecretOptions) (*policy.Request, error) {
+func (client *Client) getDeletedSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientGetDeletedSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedsecrets/{secret-name}"
@@ -2227,7 +2220,7 @@ func (client *KeyVaultClient) getDeletedSecretCreateRequest(ctx context.Context,
 }
 
 // getDeletedSecretHandleResponse handles the GetDeletedSecret response.
-func (client *KeyVaultClient) getDeletedSecretHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSecretResponse, error) {
+func (client *Client) getDeletedSecretHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSecretResponse, error) {
 	result := KeyVaultClientGetDeletedSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretBundle); err != nil {
 		return KeyVaultClientGetDeletedSecretResponse{}, runtime.NewResponseError(err, resp)
@@ -2236,12 +2229,12 @@ func (client *KeyVaultClient) getDeletedSecretHandleResponse(resp *http.Response
 }
 
 // getDeletedSecretHandleError handles the GetDeletedSecret error response.
-func (client *KeyVaultClient) getDeletedSecretHandleError(resp *http.Response) error {
+func (client *Client) getDeletedSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2250,11 +2243,10 @@ func (client *KeyVaultClient) getDeletedSecretHandleError(resp *http.Response) e
 
 // GetDeletedSecrets - The Get Deleted Secrets operation returns the secrets that have been deleted for a vault enabled for
 // soft-delete. This operation requires the secrets/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetDeletedSecretsOptions contains the optional parameters for the KeyVaultClient.GetDeletedSecrets
-// method.
-func (client *KeyVaultClient) GetDeletedSecrets(vaultBaseURL string, options *KeyVaultClientGetDeletedSecretsOptions) *KeyVaultClientGetDeletedSecretsPager {
+// options - KeyVaultClientGetDeletedSecretsOptions contains the optional parameters for the Client.GetDeletedSecrets method.
+func (client *Client) GetDeletedSecrets(vaultBaseURL string, options *KeyVaultClientGetDeletedSecretsOptions) *KeyVaultClientGetDeletedSecretsPager {
 	return &KeyVaultClientGetDeletedSecretsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2267,7 +2259,7 @@ func (client *KeyVaultClient) GetDeletedSecrets(vaultBaseURL string, options *Ke
 }
 
 // getDeletedSecretsCreateRequest creates the GetDeletedSecrets request.
-func (client *KeyVaultClient) getDeletedSecretsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetDeletedSecretsOptions) (*policy.Request, error) {
+func (client *Client) getDeletedSecretsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetDeletedSecretsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedsecrets"
@@ -2286,7 +2278,7 @@ func (client *KeyVaultClient) getDeletedSecretsCreateRequest(ctx context.Context
 }
 
 // getDeletedSecretsHandleResponse handles the GetDeletedSecrets response.
-func (client *KeyVaultClient) getDeletedSecretsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSecretsResponse, error) {
+func (client *Client) getDeletedSecretsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSecretsResponse, error) {
 	result := KeyVaultClientGetDeletedSecretsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretListResult); err != nil {
 		return KeyVaultClientGetDeletedSecretsResponse{}, runtime.NewResponseError(err, resp)
@@ -2295,12 +2287,12 @@ func (client *KeyVaultClient) getDeletedSecretsHandleResponse(resp *http.Respons
 }
 
 // getDeletedSecretsHandleError handles the GetDeletedSecrets error response.
-func (client *KeyVaultClient) getDeletedSecretsHandleError(resp *http.Response) error {
+func (client *Client) getDeletedSecretsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2309,12 +2301,12 @@ func (client *KeyVaultClient) getDeletedSecretsHandleError(resp *http.Response) 
 
 // GetDeletedStorageAccount - The Get Deleted Storage Account operation returns the specified deleted storage account along
 // with its attributes. This operation requires the storage/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
-// options - KeyVaultClientGetDeletedStorageAccountOptions contains the optional parameters for the KeyVaultClient.GetDeletedStorageAccount
+// options - KeyVaultClientGetDeletedStorageAccountOptions contains the optional parameters for the Client.GetDeletedStorageAccount
 // method.
-func (client *KeyVaultClient) GetDeletedStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetDeletedStorageAccountOptions) (KeyVaultClientGetDeletedStorageAccountResponse, error) {
+func (client *Client) GetDeletedStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetDeletedStorageAccountOptions) (KeyVaultClientGetDeletedStorageAccountResponse, error) {
 	req, err := client.getDeletedStorageAccountCreateRequest(ctx, vaultBaseURL, storageAccountName, options)
 	if err != nil {
 		return KeyVaultClientGetDeletedStorageAccountResponse{}, err
@@ -2330,7 +2322,7 @@ func (client *KeyVaultClient) GetDeletedStorageAccount(ctx context.Context, vaul
 }
 
 // getDeletedStorageAccountCreateRequest creates the GetDeletedStorageAccount request.
-func (client *KeyVaultClient) getDeletedStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetDeletedStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) getDeletedStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetDeletedStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedstorage/{storage-account-name}"
@@ -2350,7 +2342,7 @@ func (client *KeyVaultClient) getDeletedStorageAccountCreateRequest(ctx context.
 }
 
 // getDeletedStorageAccountHandleResponse handles the GetDeletedStorageAccount response.
-func (client *KeyVaultClient) getDeletedStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedStorageAccountResponse, error) {
+func (client *Client) getDeletedStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedStorageAccountResponse, error) {
 	result := KeyVaultClientGetDeletedStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageBundle); err != nil {
 		return KeyVaultClientGetDeletedStorageAccountResponse{}, runtime.NewResponseError(err, resp)
@@ -2359,12 +2351,12 @@ func (client *KeyVaultClient) getDeletedStorageAccountHandleResponse(resp *http.
 }
 
 // getDeletedStorageAccountHandleError handles the GetDeletedStorageAccount error response.
-func (client *KeyVaultClient) getDeletedStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) getDeletedStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2373,11 +2365,11 @@ func (client *KeyVaultClient) getDeletedStorageAccountHandleError(resp *http.Res
 
 // GetDeletedStorageAccounts - The Get Deleted Storage Accounts operation returns the storage accounts that have been deleted
 // for a vault enabled for soft-delete. This operation requires the storage/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetDeletedStorageAccountsOptions contains the optional parameters for the KeyVaultClient.GetDeletedStorageAccounts
+// options - KeyVaultClientGetDeletedStorageAccountsOptions contains the optional parameters for the Client.GetDeletedStorageAccounts
 // method.
-func (client *KeyVaultClient) GetDeletedStorageAccounts(vaultBaseURL string, options *KeyVaultClientGetDeletedStorageAccountsOptions) *KeyVaultClientGetDeletedStorageAccountsPager {
+func (client *Client) GetDeletedStorageAccounts(vaultBaseURL string, options *KeyVaultClientGetDeletedStorageAccountsOptions) *KeyVaultClientGetDeletedStorageAccountsPager {
 	return &KeyVaultClientGetDeletedStorageAccountsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2390,7 +2382,7 @@ func (client *KeyVaultClient) GetDeletedStorageAccounts(vaultBaseURL string, opt
 }
 
 // getDeletedStorageAccountsCreateRequest creates the GetDeletedStorageAccounts request.
-func (client *KeyVaultClient) getDeletedStorageAccountsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetDeletedStorageAccountsOptions) (*policy.Request, error) {
+func (client *Client) getDeletedStorageAccountsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetDeletedStorageAccountsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedstorage"
@@ -2409,7 +2401,7 @@ func (client *KeyVaultClient) getDeletedStorageAccountsCreateRequest(ctx context
 }
 
 // getDeletedStorageAccountsHandleResponse handles the GetDeletedStorageAccounts response.
-func (client *KeyVaultClient) getDeletedStorageAccountsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedStorageAccountsResponse, error) {
+func (client *Client) getDeletedStorageAccountsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedStorageAccountsResponse, error) {
 	result := KeyVaultClientGetDeletedStorageAccountsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageListResult); err != nil {
 		return KeyVaultClientGetDeletedStorageAccountsResponse{}, runtime.NewResponseError(err, resp)
@@ -2418,12 +2410,12 @@ func (client *KeyVaultClient) getDeletedStorageAccountsHandleResponse(resp *http
 }
 
 // getDeletedStorageAccountsHandleError handles the GetDeletedStorageAccounts error response.
-func (client *KeyVaultClient) getDeletedStorageAccountsHandleError(resp *http.Response) error {
+func (client *Client) getDeletedStorageAccountsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2432,13 +2424,13 @@ func (client *KeyVaultClient) getDeletedStorageAccountsHandleError(resp *http.Re
 
 // GetKey - The get key operation is applicable to all key types. If the requested key is symmetric, then no key material
 // is released in the response. This operation requires the keys/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key to get.
 // keyVersion - Adding the version parameter retrieves a specific version of a key. This URI fragment is optional. If not
 // specified, the latest version of the key is returned.
-// options - KeyVaultClientGetKeyOptions contains the optional parameters for the KeyVaultClient.GetKey method.
-func (client *KeyVaultClient) GetKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, options *KeyVaultClientGetKeyOptions) (KeyVaultClientGetKeyResponse, error) {
+// options - KeyVaultClientGetKeyOptions contains the optional parameters for the Client.GetKey method.
+func (client *Client) GetKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, options *KeyVaultClientGetKeyOptions) (KeyVaultClientGetKeyResponse, error) {
 	req, err := client.getKeyCreateRequest(ctx, vaultBaseURL, keyName, keyVersion, options)
 	if err != nil {
 		return KeyVaultClientGetKeyResponse{}, err
@@ -2454,7 +2446,7 @@ func (client *KeyVaultClient) GetKey(ctx context.Context, vaultBaseURL string, k
 }
 
 // getKeyCreateRequest creates the GetKey request.
-func (client *KeyVaultClient) getKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, options *KeyVaultClientGetKeyOptions) (*policy.Request, error) {
+func (client *Client) getKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, options *KeyVaultClientGetKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/{key-version}"
@@ -2478,7 +2470,7 @@ func (client *KeyVaultClient) getKeyCreateRequest(ctx context.Context, vaultBase
 }
 
 // getKeyHandleResponse handles the GetKey response.
-func (client *KeyVaultClient) getKeyHandleResponse(resp *http.Response) (KeyVaultClientGetKeyResponse, error) {
+func (client *Client) getKeyHandleResponse(resp *http.Response) (KeyVaultClientGetKeyResponse, error) {
 	result := KeyVaultClientGetKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return KeyVaultClientGetKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -2487,12 +2479,12 @@ func (client *KeyVaultClient) getKeyHandleResponse(resp *http.Response) (KeyVaul
 }
 
 // getKeyHandleError handles the GetKey error response.
-func (client *KeyVaultClient) getKeyHandleError(resp *http.Response) error {
+func (client *Client) getKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2501,11 +2493,11 @@ func (client *KeyVaultClient) getKeyHandleError(resp *http.Response) error {
 
 // GetKeyVersions - The full key identifier, attributes, and tags are provided in the response. This operation requires the
 // keys/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
-// options - KeyVaultClientGetKeyVersionsOptions contains the optional parameters for the KeyVaultClient.GetKeyVersions method.
-func (client *KeyVaultClient) GetKeyVersions(vaultBaseURL string, keyName string, options *KeyVaultClientGetKeyVersionsOptions) *KeyVaultClientGetKeyVersionsPager {
+// options - KeyVaultClientGetKeyVersionsOptions contains the optional parameters for the Client.GetKeyVersions method.
+func (client *Client) GetKeyVersions(vaultBaseURL string, keyName string, options *KeyVaultClientGetKeyVersionsOptions) *KeyVaultClientGetKeyVersionsPager {
 	return &KeyVaultClientGetKeyVersionsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2518,7 +2510,7 @@ func (client *KeyVaultClient) GetKeyVersions(vaultBaseURL string, keyName string
 }
 
 // getKeyVersionsCreateRequest creates the GetKeyVersions request.
-func (client *KeyVaultClient) getKeyVersionsCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientGetKeyVersionsOptions) (*policy.Request, error) {
+func (client *Client) getKeyVersionsCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientGetKeyVersionsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/versions"
@@ -2541,7 +2533,7 @@ func (client *KeyVaultClient) getKeyVersionsCreateRequest(ctx context.Context, v
 }
 
 // getKeyVersionsHandleResponse handles the GetKeyVersions response.
-func (client *KeyVaultClient) getKeyVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetKeyVersionsResponse, error) {
+func (client *Client) getKeyVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetKeyVersionsResponse, error) {
 	result := KeyVaultClientGetKeyVersionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyListResult); err != nil {
 		return KeyVaultClientGetKeyVersionsResponse{}, runtime.NewResponseError(err, resp)
@@ -2550,12 +2542,12 @@ func (client *KeyVaultClient) getKeyVersionsHandleResponse(resp *http.Response) 
 }
 
 // getKeyVersionsHandleError handles the GetKeyVersions error response.
-func (client *KeyVaultClient) getKeyVersionsHandleError(resp *http.Response) error {
+func (client *Client) getKeyVersionsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2566,10 +2558,10 @@ func (client *KeyVaultClient) getKeyVersionsHandleError(resp *http.Response) err
 // key. The LIST operation is applicable to all key types, however only the base key
 // identifier, attributes, and tags are provided in the response. Individual versions of a key are not listed in the response.
 // This operation requires the keys/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetKeysOptions contains the optional parameters for the KeyVaultClient.GetKeys method.
-func (client *KeyVaultClient) GetKeys(vaultBaseURL string, options *KeyVaultClientGetKeysOptions) *KeyVaultClientGetKeysPager {
+// options - KeyVaultClientGetKeysOptions contains the optional parameters for the Client.GetKeys method.
+func (client *Client) GetKeys(vaultBaseURL string, options *KeyVaultClientGetKeysOptions) *KeyVaultClientGetKeysPager {
 	return &KeyVaultClientGetKeysPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2582,7 +2574,7 @@ func (client *KeyVaultClient) GetKeys(vaultBaseURL string, options *KeyVaultClie
 }
 
 // getKeysCreateRequest creates the GetKeys request.
-func (client *KeyVaultClient) getKeysCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetKeysOptions) (*policy.Request, error) {
+func (client *Client) getKeysCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetKeysOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys"
@@ -2601,7 +2593,7 @@ func (client *KeyVaultClient) getKeysCreateRequest(ctx context.Context, vaultBas
 }
 
 // getKeysHandleResponse handles the GetKeys response.
-func (client *KeyVaultClient) getKeysHandleResponse(resp *http.Response) (KeyVaultClientGetKeysResponse, error) {
+func (client *Client) getKeysHandleResponse(resp *http.Response) (KeyVaultClientGetKeysResponse, error) {
 	result := KeyVaultClientGetKeysResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyListResult); err != nil {
 		return KeyVaultClientGetKeysResponse{}, runtime.NewResponseError(err, resp)
@@ -2610,12 +2602,12 @@ func (client *KeyVaultClient) getKeysHandleResponse(resp *http.Response) (KeyVau
 }
 
 // getKeysHandleError handles the GetKeys error response.
-func (client *KeyVaultClient) getKeysHandleError(resp *http.Response) error {
+func (client *Client) getKeysHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2624,13 +2616,12 @@ func (client *KeyVaultClient) getKeysHandleError(resp *http.Response) error {
 
 // GetSasDefinition - Gets information about a SAS definition for the specified storage account. This operation requires the
 // storage/getsas permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // sasDefinitionName - The name of the SAS definition.
-// options - KeyVaultClientGetSasDefinitionOptions contains the optional parameters for the KeyVaultClient.GetSasDefinition
-// method.
-func (client *KeyVaultClient) GetSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientGetSasDefinitionOptions) (KeyVaultClientGetSasDefinitionResponse, error) {
+// options - KeyVaultClientGetSasDefinitionOptions contains the optional parameters for the Client.GetSasDefinition method.
+func (client *Client) GetSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientGetSasDefinitionOptions) (KeyVaultClientGetSasDefinitionResponse, error) {
 	req, err := client.getSasDefinitionCreateRequest(ctx, vaultBaseURL, storageAccountName, sasDefinitionName, options)
 	if err != nil {
 		return KeyVaultClientGetSasDefinitionResponse{}, err
@@ -2646,7 +2637,7 @@ func (client *KeyVaultClient) GetSasDefinition(ctx context.Context, vaultBaseURL
 }
 
 // getSasDefinitionCreateRequest creates the GetSasDefinition request.
-func (client *KeyVaultClient) getSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientGetSasDefinitionOptions) (*policy.Request, error) {
+func (client *Client) getSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientGetSasDefinitionOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}/sas/{sas-definition-name}"
@@ -2670,7 +2661,7 @@ func (client *KeyVaultClient) getSasDefinitionCreateRequest(ctx context.Context,
 }
 
 // getSasDefinitionHandleResponse handles the GetSasDefinition response.
-func (client *KeyVaultClient) getSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientGetSasDefinitionResponse, error) {
+func (client *Client) getSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientGetSasDefinitionResponse, error) {
 	result := KeyVaultClientGetSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
 		return KeyVaultClientGetSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
@@ -2679,12 +2670,12 @@ func (client *KeyVaultClient) getSasDefinitionHandleResponse(resp *http.Response
 }
 
 // getSasDefinitionHandleError handles the GetSasDefinition error response.
-func (client *KeyVaultClient) getSasDefinitionHandleError(resp *http.Response) error {
+func (client *Client) getSasDefinitionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2693,12 +2684,11 @@ func (client *KeyVaultClient) getSasDefinitionHandleError(resp *http.Response) e
 
 // GetSasDefinitions - List storage SAS definitions for the given storage account. This operation requires the storage/listsas
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
-// options - KeyVaultClientGetSasDefinitionsOptions contains the optional parameters for the KeyVaultClient.GetSasDefinitions
-// method.
-func (client *KeyVaultClient) GetSasDefinitions(vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetSasDefinitionsOptions) *KeyVaultClientGetSasDefinitionsPager {
+// options - KeyVaultClientGetSasDefinitionsOptions contains the optional parameters for the Client.GetSasDefinitions method.
+func (client *Client) GetSasDefinitions(vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetSasDefinitionsOptions) *KeyVaultClientGetSasDefinitionsPager {
 	return &KeyVaultClientGetSasDefinitionsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2711,7 +2701,7 @@ func (client *KeyVaultClient) GetSasDefinitions(vaultBaseURL string, storageAcco
 }
 
 // getSasDefinitionsCreateRequest creates the GetSasDefinitions request.
-func (client *KeyVaultClient) getSasDefinitionsCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetSasDefinitionsOptions) (*policy.Request, error) {
+func (client *Client) getSasDefinitionsCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetSasDefinitionsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}/sas"
@@ -2734,7 +2724,7 @@ func (client *KeyVaultClient) getSasDefinitionsCreateRequest(ctx context.Context
 }
 
 // getSasDefinitionsHandleResponse handles the GetSasDefinitions response.
-func (client *KeyVaultClient) getSasDefinitionsHandleResponse(resp *http.Response) (KeyVaultClientGetSasDefinitionsResponse, error) {
+func (client *Client) getSasDefinitionsHandleResponse(resp *http.Response) (KeyVaultClientGetSasDefinitionsResponse, error) {
 	result := KeyVaultClientGetSasDefinitionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionListResult); err != nil {
 		return KeyVaultClientGetSasDefinitionsResponse{}, runtime.NewResponseError(err, resp)
@@ -2743,12 +2733,12 @@ func (client *KeyVaultClient) getSasDefinitionsHandleResponse(resp *http.Respons
 }
 
 // getSasDefinitionsHandleError handles the GetSasDefinitions error response.
-func (client *KeyVaultClient) getSasDefinitionsHandleError(resp *http.Response) error {
+func (client *Client) getSasDefinitionsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2757,13 +2747,13 @@ func (client *KeyVaultClient) getSasDefinitionsHandleError(resp *http.Response) 
 
 // GetSecret - The GET operation is applicable to any secret stored in Azure Key Vault. This operation requires the secrets/get
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
 // secretVersion - The version of the secret. This URI fragment is optional. If not specified, the latest version of the secret
 // is returned.
-// options - KeyVaultClientGetSecretOptions contains the optional parameters for the KeyVaultClient.GetSecret method.
-func (client *KeyVaultClient) GetSecret(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string, options *KeyVaultClientGetSecretOptions) (KeyVaultClientGetSecretResponse, error) {
+// options - KeyVaultClientGetSecretOptions contains the optional parameters for the Client.GetSecret method.
+func (client *Client) GetSecret(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string, options *KeyVaultClientGetSecretOptions) (KeyVaultClientGetSecretResponse, error) {
 	req, err := client.getSecretCreateRequest(ctx, vaultBaseURL, secretName, secretVersion, options)
 	if err != nil {
 		return KeyVaultClientGetSecretResponse{}, err
@@ -2779,7 +2769,7 @@ func (client *KeyVaultClient) GetSecret(ctx context.Context, vaultBaseURL string
 }
 
 // getSecretCreateRequest creates the GetSecret request.
-func (client *KeyVaultClient) getSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string, options *KeyVaultClientGetSecretOptions) (*policy.Request, error) {
+func (client *Client) getSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string, options *KeyVaultClientGetSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/secrets/{secret-name}/{secret-version}"
@@ -2803,7 +2793,7 @@ func (client *KeyVaultClient) getSecretCreateRequest(ctx context.Context, vaultB
 }
 
 // getSecretHandleResponse handles the GetSecret response.
-func (client *KeyVaultClient) getSecretHandleResponse(resp *http.Response) (KeyVaultClientGetSecretResponse, error) {
+func (client *Client) getSecretHandleResponse(resp *http.Response) (KeyVaultClientGetSecretResponse, error) {
 	result := KeyVaultClientGetSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return KeyVaultClientGetSecretResponse{}, runtime.NewResponseError(err, resp)
@@ -2812,12 +2802,12 @@ func (client *KeyVaultClient) getSecretHandleResponse(resp *http.Response) (KeyV
 }
 
 // getSecretHandleError handles the GetSecret error response.
-func (client *KeyVaultClient) getSecretHandleError(resp *http.Response) error {
+func (client *Client) getSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2826,12 +2816,11 @@ func (client *KeyVaultClient) getSecretHandleError(resp *http.Response) error {
 
 // GetSecretVersions - The full secret identifier and attributes are provided in the response. No values are returned for
 // the secrets. This operations requires the secrets/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
-// options - KeyVaultClientGetSecretVersionsOptions contains the optional parameters for the KeyVaultClient.GetSecretVersions
-// method.
-func (client *KeyVaultClient) GetSecretVersions(vaultBaseURL string, secretName string, options *KeyVaultClientGetSecretVersionsOptions) *KeyVaultClientGetSecretVersionsPager {
+// options - KeyVaultClientGetSecretVersionsOptions contains the optional parameters for the Client.GetSecretVersions method.
+func (client *Client) GetSecretVersions(vaultBaseURL string, secretName string, options *KeyVaultClientGetSecretVersionsOptions) *KeyVaultClientGetSecretVersionsPager {
 	return &KeyVaultClientGetSecretVersionsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2844,7 +2833,7 @@ func (client *KeyVaultClient) GetSecretVersions(vaultBaseURL string, secretName 
 }
 
 // getSecretVersionsCreateRequest creates the GetSecretVersions request.
-func (client *KeyVaultClient) getSecretVersionsCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientGetSecretVersionsOptions) (*policy.Request, error) {
+func (client *Client) getSecretVersionsCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientGetSecretVersionsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/secrets/{secret-name}/versions"
@@ -2867,7 +2856,7 @@ func (client *KeyVaultClient) getSecretVersionsCreateRequest(ctx context.Context
 }
 
 // getSecretVersionsHandleResponse handles the GetSecretVersions response.
-func (client *KeyVaultClient) getSecretVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetSecretVersionsResponse, error) {
+func (client *Client) getSecretVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetSecretVersionsResponse, error) {
 	result := KeyVaultClientGetSecretVersionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretListResult); err != nil {
 		return KeyVaultClientGetSecretVersionsResponse{}, runtime.NewResponseError(err, resp)
@@ -2876,12 +2865,12 @@ func (client *KeyVaultClient) getSecretVersionsHandleResponse(resp *http.Respons
 }
 
 // getSecretVersionsHandleError handles the GetSecretVersions error response.
-func (client *KeyVaultClient) getSecretVersionsHandleError(resp *http.Response) error {
+func (client *Client) getSecretVersionsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2891,10 +2880,10 @@ func (client *KeyVaultClient) getSecretVersionsHandleError(resp *http.Response) 
 // GetSecrets - The Get Secrets operation is applicable to the entire vault. However, only the base secret identifier and
 // its attributes are provided in the response. Individual secret versions are not listed in the
 // response. This operation requires the secrets/list permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetSecretsOptions contains the optional parameters for the KeyVaultClient.GetSecrets method.
-func (client *KeyVaultClient) GetSecrets(vaultBaseURL string, options *KeyVaultClientGetSecretsOptions) *KeyVaultClientGetSecretsPager {
+// options - KeyVaultClientGetSecretsOptions contains the optional parameters for the Client.GetSecrets method.
+func (client *Client) GetSecrets(vaultBaseURL string, options *KeyVaultClientGetSecretsOptions) *KeyVaultClientGetSecretsPager {
 	return &KeyVaultClientGetSecretsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -2907,7 +2896,7 @@ func (client *KeyVaultClient) GetSecrets(vaultBaseURL string, options *KeyVaultC
 }
 
 // getSecretsCreateRequest creates the GetSecrets request.
-func (client *KeyVaultClient) getSecretsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetSecretsOptions) (*policy.Request, error) {
+func (client *Client) getSecretsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetSecretsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/secrets"
@@ -2926,7 +2915,7 @@ func (client *KeyVaultClient) getSecretsCreateRequest(ctx context.Context, vault
 }
 
 // getSecretsHandleResponse handles the GetSecrets response.
-func (client *KeyVaultClient) getSecretsHandleResponse(resp *http.Response) (KeyVaultClientGetSecretsResponse, error) {
+func (client *Client) getSecretsHandleResponse(resp *http.Response) (KeyVaultClientGetSecretsResponse, error) {
 	result := KeyVaultClientGetSecretsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretListResult); err != nil {
 		return KeyVaultClientGetSecretsResponse{}, runtime.NewResponseError(err, resp)
@@ -2935,12 +2924,12 @@ func (client *KeyVaultClient) getSecretsHandleResponse(resp *http.Response) (Key
 }
 
 // getSecretsHandleError handles the GetSecrets error response.
-func (client *KeyVaultClient) getSecretsHandleError(resp *http.Response) error {
+func (client *Client) getSecretsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -2948,12 +2937,11 @@ func (client *KeyVaultClient) getSecretsHandleError(resp *http.Response) error {
 }
 
 // GetStorageAccount - Gets information about a specified storage account. This operation requires the storage/get permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
-// options - KeyVaultClientGetStorageAccountOptions contains the optional parameters for the KeyVaultClient.GetStorageAccount
-// method.
-func (client *KeyVaultClient) GetStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetStorageAccountOptions) (KeyVaultClientGetStorageAccountResponse, error) {
+// options - KeyVaultClientGetStorageAccountOptions contains the optional parameters for the Client.GetStorageAccount method.
+func (client *Client) GetStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetStorageAccountOptions) (KeyVaultClientGetStorageAccountResponse, error) {
 	req, err := client.getStorageAccountCreateRequest(ctx, vaultBaseURL, storageAccountName, options)
 	if err != nil {
 		return KeyVaultClientGetStorageAccountResponse{}, err
@@ -2969,7 +2957,7 @@ func (client *KeyVaultClient) GetStorageAccount(ctx context.Context, vaultBaseUR
 }
 
 // getStorageAccountCreateRequest creates the GetStorageAccount request.
-func (client *KeyVaultClient) getStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) getStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientGetStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}"
@@ -2989,7 +2977,7 @@ func (client *KeyVaultClient) getStorageAccountCreateRequest(ctx context.Context
 }
 
 // getStorageAccountHandleResponse handles the GetStorageAccount response.
-func (client *KeyVaultClient) getStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientGetStorageAccountResponse, error) {
+func (client *Client) getStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientGetStorageAccountResponse, error) {
 	result := KeyVaultClientGetStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return KeyVaultClientGetStorageAccountResponse{}, runtime.NewResponseError(err, resp)
@@ -2998,12 +2986,12 @@ func (client *KeyVaultClient) getStorageAccountHandleResponse(resp *http.Respons
 }
 
 // getStorageAccountHandleError handles the GetStorageAccount error response.
-func (client *KeyVaultClient) getStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) getStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3012,11 +3000,10 @@ func (client *KeyVaultClient) getStorageAccountHandleError(resp *http.Response) 
 
 // GetStorageAccounts - List storage accounts managed by the specified key vault. This operation requires the storage/list
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
-// options - KeyVaultClientGetStorageAccountsOptions contains the optional parameters for the KeyVaultClient.GetStorageAccounts
-// method.
-func (client *KeyVaultClient) GetStorageAccounts(vaultBaseURL string, options *KeyVaultClientGetStorageAccountsOptions) *KeyVaultClientGetStorageAccountsPager {
+// options - KeyVaultClientGetStorageAccountsOptions contains the optional parameters for the Client.GetStorageAccounts method.
+func (client *Client) GetStorageAccounts(vaultBaseURL string, options *KeyVaultClientGetStorageAccountsOptions) *KeyVaultClientGetStorageAccountsPager {
 	return &KeyVaultClientGetStorageAccountsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -3029,7 +3016,7 @@ func (client *KeyVaultClient) GetStorageAccounts(vaultBaseURL string, options *K
 }
 
 // getStorageAccountsCreateRequest creates the GetStorageAccounts request.
-func (client *KeyVaultClient) getStorageAccountsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetStorageAccountsOptions) (*policy.Request, error) {
+func (client *Client) getStorageAccountsCreateRequest(ctx context.Context, vaultBaseURL string, options *KeyVaultClientGetStorageAccountsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage"
@@ -3048,7 +3035,7 @@ func (client *KeyVaultClient) getStorageAccountsCreateRequest(ctx context.Contex
 }
 
 // getStorageAccountsHandleResponse handles the GetStorageAccounts response.
-func (client *KeyVaultClient) getStorageAccountsHandleResponse(resp *http.Response) (KeyVaultClientGetStorageAccountsResponse, error) {
+func (client *Client) getStorageAccountsHandleResponse(resp *http.Response) (KeyVaultClientGetStorageAccountsResponse, error) {
 	result := KeyVaultClientGetStorageAccountsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageListResult); err != nil {
 		return KeyVaultClientGetStorageAccountsResponse{}, runtime.NewResponseError(err, resp)
@@ -3057,12 +3044,12 @@ func (client *KeyVaultClient) getStorageAccountsHandleResponse(resp *http.Respon
 }
 
 // getStorageAccountsHandleError handles the GetStorageAccounts error response.
-func (client *KeyVaultClient) getStorageAccountsHandleError(resp *http.Response) error {
+func (client *Client) getStorageAccountsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3072,13 +3059,12 @@ func (client *KeyVaultClient) getStorageAccountsHandleError(resp *http.Response)
 // ImportCertificate - Imports an existing valid certificate, containing a private key, into Azure Key Vault. The certificate
 // to be imported can be in either PFX or PEM format. If the certificate is in PEM format the PEM
 // file must contain the key as well as x509 certificates. This operation requires the certificates/import permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
 // parameters - The parameters to import the certificate.
-// options - KeyVaultClientImportCertificateOptions contains the optional parameters for the KeyVaultClient.ImportCertificate
-// method.
-func (client *KeyVaultClient) ImportCertificate(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateImportParameters, options *KeyVaultClientImportCertificateOptions) (KeyVaultClientImportCertificateResponse, error) {
+// options - KeyVaultClientImportCertificateOptions contains the optional parameters for the Client.ImportCertificate method.
+func (client *Client) ImportCertificate(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateImportParameters, options *KeyVaultClientImportCertificateOptions) (KeyVaultClientImportCertificateResponse, error) {
 	req, err := client.importCertificateCreateRequest(ctx, vaultBaseURL, certificateName, parameters, options)
 	if err != nil {
 		return KeyVaultClientImportCertificateResponse{}, err
@@ -3094,7 +3080,7 @@ func (client *KeyVaultClient) ImportCertificate(ctx context.Context, vaultBaseUR
 }
 
 // importCertificateCreateRequest creates the ImportCertificate request.
-func (client *KeyVaultClient) importCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateImportParameters, options *KeyVaultClientImportCertificateOptions) (*policy.Request, error) {
+func (client *Client) importCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateImportParameters, options *KeyVaultClientImportCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/import"
@@ -3114,7 +3100,7 @@ func (client *KeyVaultClient) importCertificateCreateRequest(ctx context.Context
 }
 
 // importCertificateHandleResponse handles the ImportCertificate response.
-func (client *KeyVaultClient) importCertificateHandleResponse(resp *http.Response) (KeyVaultClientImportCertificateResponse, error) {
+func (client *Client) importCertificateHandleResponse(resp *http.Response) (KeyVaultClientImportCertificateResponse, error) {
 	result := KeyVaultClientImportCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return KeyVaultClientImportCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -3123,12 +3109,12 @@ func (client *KeyVaultClient) importCertificateHandleResponse(resp *http.Respons
 }
 
 // importCertificateHandleError handles the ImportCertificate error response.
-func (client *KeyVaultClient) importCertificateHandleError(resp *http.Response) error {
+func (client *Client) importCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3138,12 +3124,12 @@ func (client *KeyVaultClient) importCertificateHandleError(resp *http.Response) 
 // ImportKey - The import key operation may be used to import any key type into an Azure Key Vault. If the named key already
 // exists, Azure Key Vault creates a new version of the key. This operation requires the
 // keys/import permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - Name for the imported key.
 // parameters - The parameters to import a key.
-// options - KeyVaultClientImportKeyOptions contains the optional parameters for the KeyVaultClient.ImportKey method.
-func (client *KeyVaultClient) ImportKey(ctx context.Context, vaultBaseURL string, keyName string, parameters KeyImportParameters, options *KeyVaultClientImportKeyOptions) (KeyVaultClientImportKeyResponse, error) {
+// options - KeyVaultClientImportKeyOptions contains the optional parameters for the Client.ImportKey method.
+func (client *Client) ImportKey(ctx context.Context, vaultBaseURL string, keyName string, parameters KeyImportParameters, options *KeyVaultClientImportKeyOptions) (KeyVaultClientImportKeyResponse, error) {
 	req, err := client.importKeyCreateRequest(ctx, vaultBaseURL, keyName, parameters, options)
 	if err != nil {
 		return KeyVaultClientImportKeyResponse{}, err
@@ -3159,7 +3145,7 @@ func (client *KeyVaultClient) ImportKey(ctx context.Context, vaultBaseURL string
 }
 
 // importKeyCreateRequest creates the ImportKey request.
-func (client *KeyVaultClient) importKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, parameters KeyImportParameters, options *KeyVaultClientImportKeyOptions) (*policy.Request, error) {
+func (client *Client) importKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, parameters KeyImportParameters, options *KeyVaultClientImportKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}"
@@ -3179,7 +3165,7 @@ func (client *KeyVaultClient) importKeyCreateRequest(ctx context.Context, vaultB
 }
 
 // importKeyHandleResponse handles the ImportKey response.
-func (client *KeyVaultClient) importKeyHandleResponse(resp *http.Response) (KeyVaultClientImportKeyResponse, error) {
+func (client *Client) importKeyHandleResponse(resp *http.Response) (KeyVaultClientImportKeyResponse, error) {
 	result := KeyVaultClientImportKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return KeyVaultClientImportKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -3188,12 +3174,12 @@ func (client *KeyVaultClient) importKeyHandleResponse(resp *http.Response) (KeyV
 }
 
 // importKeyHandleError handles the ImportKey error response.
-func (client *KeyVaultClient) importKeyHandleError(resp *http.Response) error {
+func (client *Client) importKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3203,13 +3189,12 @@ func (client *KeyVaultClient) importKeyHandleError(resp *http.Response) error {
 // MergeCertificate - The MergeCertificate operation performs the merging of a certificate or certificate chain with a key
 // pair currently available in the service. This operation requires the certificates/create
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
 // parameters - The parameters to merge certificate.
-// options - KeyVaultClientMergeCertificateOptions contains the optional parameters for the KeyVaultClient.MergeCertificate
-// method.
-func (client *KeyVaultClient) MergeCertificate(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateMergeParameters, options *KeyVaultClientMergeCertificateOptions) (KeyVaultClientMergeCertificateResponse, error) {
+// options - KeyVaultClientMergeCertificateOptions contains the optional parameters for the Client.MergeCertificate method.
+func (client *Client) MergeCertificate(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateMergeParameters, options *KeyVaultClientMergeCertificateOptions) (KeyVaultClientMergeCertificateResponse, error) {
 	req, err := client.mergeCertificateCreateRequest(ctx, vaultBaseURL, certificateName, parameters, options)
 	if err != nil {
 		return KeyVaultClientMergeCertificateResponse{}, err
@@ -3225,7 +3210,7 @@ func (client *KeyVaultClient) MergeCertificate(ctx context.Context, vaultBaseURL
 }
 
 // mergeCertificateCreateRequest creates the MergeCertificate request.
-func (client *KeyVaultClient) mergeCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateMergeParameters, options *KeyVaultClientMergeCertificateOptions) (*policy.Request, error) {
+func (client *Client) mergeCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, parameters CertificateMergeParameters, options *KeyVaultClientMergeCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/pending/merge"
@@ -3245,7 +3230,7 @@ func (client *KeyVaultClient) mergeCertificateCreateRequest(ctx context.Context,
 }
 
 // mergeCertificateHandleResponse handles the MergeCertificate response.
-func (client *KeyVaultClient) mergeCertificateHandleResponse(resp *http.Response) (KeyVaultClientMergeCertificateResponse, error) {
+func (client *Client) mergeCertificateHandleResponse(resp *http.Response) (KeyVaultClientMergeCertificateResponse, error) {
 	result := KeyVaultClientMergeCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return KeyVaultClientMergeCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -3254,12 +3239,12 @@ func (client *KeyVaultClient) mergeCertificateHandleResponse(resp *http.Response
 }
 
 // mergeCertificateHandleError handles the MergeCertificate error response.
-func (client *KeyVaultClient) mergeCertificateHandleError(resp *http.Response) error {
+func (client *Client) mergeCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3269,12 +3254,12 @@ func (client *KeyVaultClient) mergeCertificateHandleError(resp *http.Response) e
 // PurgeDeletedCertificate - The PurgeDeletedCertificate operation performs an irreversible deletion of the specified certificate,
 // without possibility for recovery. The operation is not available if the recovery level does not
 // specify 'Purgeable'. This operation requires the certificate/purge permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate
-// options - KeyVaultClientPurgeDeletedCertificateOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedCertificate
+// options - KeyVaultClientPurgeDeletedCertificateOptions contains the optional parameters for the Client.PurgeDeletedCertificate
 // method.
-func (client *KeyVaultClient) PurgeDeletedCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientPurgeDeletedCertificateOptions) (KeyVaultClientPurgeDeletedCertificateResponse, error) {
+func (client *Client) PurgeDeletedCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientPurgeDeletedCertificateOptions) (KeyVaultClientPurgeDeletedCertificateResponse, error) {
 	req, err := client.purgeDeletedCertificateCreateRequest(ctx, vaultBaseURL, certificateName, options)
 	if err != nil {
 		return KeyVaultClientPurgeDeletedCertificateResponse{}, err
@@ -3290,7 +3275,7 @@ func (client *KeyVaultClient) PurgeDeletedCertificate(ctx context.Context, vault
 }
 
 // purgeDeletedCertificateCreateRequest creates the PurgeDeletedCertificate request.
-func (client *KeyVaultClient) purgeDeletedCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientPurgeDeletedCertificateOptions) (*policy.Request, error) {
+func (client *Client) purgeDeletedCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientPurgeDeletedCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedcertificates/{certificate-name}"
@@ -3310,12 +3295,12 @@ func (client *KeyVaultClient) purgeDeletedCertificateCreateRequest(ctx context.C
 }
 
 // purgeDeletedCertificateHandleError handles the PurgeDeletedCertificate error response.
-func (client *KeyVaultClient) purgeDeletedCertificateHandleError(resp *http.Response) error {
+func (client *Client) purgeDeletedCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3325,12 +3310,11 @@ func (client *KeyVaultClient) purgeDeletedCertificateHandleError(resp *http.Resp
 // PurgeDeletedKey - The Purge Deleted Key operation is applicable for soft-delete enabled vaults. While the operation can
 // be invoked on any vault, it will return an error if invoked on a non soft-delete enabled vault.
 // This operation requires the keys/purge permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key
-// options - KeyVaultClientPurgeDeletedKeyOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedKey
-// method.
-func (client *KeyVaultClient) PurgeDeletedKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientPurgeDeletedKeyOptions) (KeyVaultClientPurgeDeletedKeyResponse, error) {
+// options - KeyVaultClientPurgeDeletedKeyOptions contains the optional parameters for the Client.PurgeDeletedKey method.
+func (client *Client) PurgeDeletedKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientPurgeDeletedKeyOptions) (KeyVaultClientPurgeDeletedKeyResponse, error) {
 	req, err := client.purgeDeletedKeyCreateRequest(ctx, vaultBaseURL, keyName, options)
 	if err != nil {
 		return KeyVaultClientPurgeDeletedKeyResponse{}, err
@@ -3346,7 +3330,7 @@ func (client *KeyVaultClient) PurgeDeletedKey(ctx context.Context, vaultBaseURL 
 }
 
 // purgeDeletedKeyCreateRequest creates the PurgeDeletedKey request.
-func (client *KeyVaultClient) purgeDeletedKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientPurgeDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) purgeDeletedKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientPurgeDeletedKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedkeys/{key-name}"
@@ -3366,12 +3350,12 @@ func (client *KeyVaultClient) purgeDeletedKeyCreateRequest(ctx context.Context, 
 }
 
 // purgeDeletedKeyHandleError handles the PurgeDeletedKey error response.
-func (client *KeyVaultClient) purgeDeletedKeyHandleError(resp *http.Response) error {
+func (client *Client) purgeDeletedKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3381,12 +3365,11 @@ func (client *KeyVaultClient) purgeDeletedKeyHandleError(resp *http.Response) er
 // PurgeDeletedSecret - The purge deleted secret operation removes the secret permanently, without the possibility of recovery.
 // This operation can only be enabled on a soft-delete enabled vault. This operation requires the
 // secrets/purge permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
-// options - KeyVaultClientPurgeDeletedSecretOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedSecret
-// method.
-func (client *KeyVaultClient) PurgeDeletedSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientPurgeDeletedSecretOptions) (KeyVaultClientPurgeDeletedSecretResponse, error) {
+// options - KeyVaultClientPurgeDeletedSecretOptions contains the optional parameters for the Client.PurgeDeletedSecret method.
+func (client *Client) PurgeDeletedSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientPurgeDeletedSecretOptions) (KeyVaultClientPurgeDeletedSecretResponse, error) {
 	req, err := client.purgeDeletedSecretCreateRequest(ctx, vaultBaseURL, secretName, options)
 	if err != nil {
 		return KeyVaultClientPurgeDeletedSecretResponse{}, err
@@ -3402,7 +3385,7 @@ func (client *KeyVaultClient) PurgeDeletedSecret(ctx context.Context, vaultBaseU
 }
 
 // purgeDeletedSecretCreateRequest creates the PurgeDeletedSecret request.
-func (client *KeyVaultClient) purgeDeletedSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientPurgeDeletedSecretOptions) (*policy.Request, error) {
+func (client *Client) purgeDeletedSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientPurgeDeletedSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedsecrets/{secret-name}"
@@ -3422,12 +3405,12 @@ func (client *KeyVaultClient) purgeDeletedSecretCreateRequest(ctx context.Contex
 }
 
 // purgeDeletedSecretHandleError handles the PurgeDeletedSecret error response.
-func (client *KeyVaultClient) purgeDeletedSecretHandleError(resp *http.Response) error {
+func (client *Client) purgeDeletedSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3437,12 +3420,12 @@ func (client *KeyVaultClient) purgeDeletedSecretHandleError(resp *http.Response)
 // PurgeDeletedStorageAccount - The purge deleted storage account operation removes the secret permanently, without the possibility
 // of recovery. This operation can only be performed on a soft-delete enabled vault. This operation
 // requires the storage/purge permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
-// options - KeyVaultClientPurgeDeletedStorageAccountOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedStorageAccount
+// options - KeyVaultClientPurgeDeletedStorageAccountOptions contains the optional parameters for the Client.PurgeDeletedStorageAccount
 // method.
-func (client *KeyVaultClient) PurgeDeletedStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientPurgeDeletedStorageAccountOptions) (KeyVaultClientPurgeDeletedStorageAccountResponse, error) {
+func (client *Client) PurgeDeletedStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientPurgeDeletedStorageAccountOptions) (KeyVaultClientPurgeDeletedStorageAccountResponse, error) {
 	req, err := client.purgeDeletedStorageAccountCreateRequest(ctx, vaultBaseURL, storageAccountName, options)
 	if err != nil {
 		return KeyVaultClientPurgeDeletedStorageAccountResponse{}, err
@@ -3458,7 +3441,7 @@ func (client *KeyVaultClient) PurgeDeletedStorageAccount(ctx context.Context, va
 }
 
 // purgeDeletedStorageAccountCreateRequest creates the PurgeDeletedStorageAccount request.
-func (client *KeyVaultClient) purgeDeletedStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientPurgeDeletedStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) purgeDeletedStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientPurgeDeletedStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedstorage/{storage-account-name}"
@@ -3478,12 +3461,12 @@ func (client *KeyVaultClient) purgeDeletedStorageAccountCreateRequest(ctx contex
 }
 
 // purgeDeletedStorageAccountHandleError handles the PurgeDeletedStorageAccount error response.
-func (client *KeyVaultClient) purgeDeletedStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) purgeDeletedStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3493,12 +3476,12 @@ func (client *KeyVaultClient) purgeDeletedStorageAccountHandleError(resp *http.R
 // RecoverDeletedCertificate - The RecoverDeletedCertificate operation performs the reversal of the Delete operation. The
 // operation is applicable in vaults enabled for soft-delete, and must be issued during the retention interval
 // (available in the deleted certificate's attributes). This operation requires the certificates/recover permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the deleted certificate
-// options - KeyVaultClientRecoverDeletedCertificateOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedCertificate
+// options - KeyVaultClientRecoverDeletedCertificateOptions contains the optional parameters for the Client.RecoverDeletedCertificate
 // method.
-func (client *KeyVaultClient) RecoverDeletedCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientRecoverDeletedCertificateOptions) (KeyVaultClientRecoverDeletedCertificateResponse, error) {
+func (client *Client) RecoverDeletedCertificate(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientRecoverDeletedCertificateOptions) (KeyVaultClientRecoverDeletedCertificateResponse, error) {
 	req, err := client.recoverDeletedCertificateCreateRequest(ctx, vaultBaseURL, certificateName, options)
 	if err != nil {
 		return KeyVaultClientRecoverDeletedCertificateResponse{}, err
@@ -3514,7 +3497,7 @@ func (client *KeyVaultClient) RecoverDeletedCertificate(ctx context.Context, vau
 }
 
 // recoverDeletedCertificateCreateRequest creates the RecoverDeletedCertificate request.
-func (client *KeyVaultClient) recoverDeletedCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientRecoverDeletedCertificateOptions) (*policy.Request, error) {
+func (client *Client) recoverDeletedCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, options *KeyVaultClientRecoverDeletedCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedcertificates/{certificate-name}/recover"
@@ -3534,7 +3517,7 @@ func (client *KeyVaultClient) recoverDeletedCertificateCreateRequest(ctx context
 }
 
 // recoverDeletedCertificateHandleResponse handles the RecoverDeletedCertificate response.
-func (client *KeyVaultClient) recoverDeletedCertificateHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedCertificateResponse, error) {
+func (client *Client) recoverDeletedCertificateHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedCertificateResponse, error) {
 	result := KeyVaultClientRecoverDeletedCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return KeyVaultClientRecoverDeletedCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -3543,12 +3526,12 @@ func (client *KeyVaultClient) recoverDeletedCertificateHandleResponse(resp *http
 }
 
 // recoverDeletedCertificateHandleError handles the RecoverDeletedCertificate error response.
-func (client *KeyVaultClient) recoverDeletedCertificateHandleError(resp *http.Response) error {
+func (client *Client) recoverDeletedCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3559,12 +3542,11 @@ func (client *KeyVaultClient) recoverDeletedCertificateHandleError(resp *http.Re
 // recovers the deleted key back to its latest version under /keys. An attempt to recover an non-deleted
 // key will return an error. Consider this the inverse of the delete operation on soft-delete enabled vaults. This operation
 // requires the keys/recover permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the deleted key.
-// options - KeyVaultClientRecoverDeletedKeyOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedKey
-// method.
-func (client *KeyVaultClient) RecoverDeletedKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientRecoverDeletedKeyOptions) (KeyVaultClientRecoverDeletedKeyResponse, error) {
+// options - KeyVaultClientRecoverDeletedKeyOptions contains the optional parameters for the Client.RecoverDeletedKey method.
+func (client *Client) RecoverDeletedKey(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientRecoverDeletedKeyOptions) (KeyVaultClientRecoverDeletedKeyResponse, error) {
 	req, err := client.recoverDeletedKeyCreateRequest(ctx, vaultBaseURL, keyName, options)
 	if err != nil {
 		return KeyVaultClientRecoverDeletedKeyResponse{}, err
@@ -3580,7 +3562,7 @@ func (client *KeyVaultClient) RecoverDeletedKey(ctx context.Context, vaultBaseUR
 }
 
 // recoverDeletedKeyCreateRequest creates the RecoverDeletedKey request.
-func (client *KeyVaultClient) recoverDeletedKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientRecoverDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) recoverDeletedKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientRecoverDeletedKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedkeys/{key-name}/recover"
@@ -3600,7 +3582,7 @@ func (client *KeyVaultClient) recoverDeletedKeyCreateRequest(ctx context.Context
 }
 
 // recoverDeletedKeyHandleResponse handles the RecoverDeletedKey response.
-func (client *KeyVaultClient) recoverDeletedKeyHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedKeyResponse, error) {
+func (client *Client) recoverDeletedKeyHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedKeyResponse, error) {
 	result := KeyVaultClientRecoverDeletedKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return KeyVaultClientRecoverDeletedKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -3609,12 +3591,12 @@ func (client *KeyVaultClient) recoverDeletedKeyHandleResponse(resp *http.Respons
 }
 
 // recoverDeletedKeyHandleError handles the RecoverDeletedKey error response.
-func (client *KeyVaultClient) recoverDeletedKeyHandleError(resp *http.Response) error {
+func (client *Client) recoverDeletedKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3623,13 +3605,13 @@ func (client *KeyVaultClient) recoverDeletedKeyHandleError(resp *http.Response) 
 
 // RecoverDeletedSasDefinition - Recovers the deleted SAS definition for the specified storage account. This operation can
 // only be performed on a soft-delete enabled vault. This operation requires the storage/recover permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // sasDefinitionName - The name of the SAS definition.
-// options - KeyVaultClientRecoverDeletedSasDefinitionOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedSasDefinition
+// options - KeyVaultClientRecoverDeletedSasDefinitionOptions contains the optional parameters for the Client.RecoverDeletedSasDefinition
 // method.
-func (client *KeyVaultClient) RecoverDeletedSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientRecoverDeletedSasDefinitionOptions) (KeyVaultClientRecoverDeletedSasDefinitionResponse, error) {
+func (client *Client) RecoverDeletedSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientRecoverDeletedSasDefinitionOptions) (KeyVaultClientRecoverDeletedSasDefinitionResponse, error) {
 	req, err := client.recoverDeletedSasDefinitionCreateRequest(ctx, vaultBaseURL, storageAccountName, sasDefinitionName, options)
 	if err != nil {
 		return KeyVaultClientRecoverDeletedSasDefinitionResponse{}, err
@@ -3645,7 +3627,7 @@ func (client *KeyVaultClient) RecoverDeletedSasDefinition(ctx context.Context, v
 }
 
 // recoverDeletedSasDefinitionCreateRequest creates the RecoverDeletedSasDefinition request.
-func (client *KeyVaultClient) recoverDeletedSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientRecoverDeletedSasDefinitionOptions) (*policy.Request, error) {
+func (client *Client) recoverDeletedSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, options *KeyVaultClientRecoverDeletedSasDefinitionOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedstorage/{storage-account-name}/sas/{sas-definition-name}/recover"
@@ -3669,7 +3651,7 @@ func (client *KeyVaultClient) recoverDeletedSasDefinitionCreateRequest(ctx conte
 }
 
 // recoverDeletedSasDefinitionHandleResponse handles the RecoverDeletedSasDefinition response.
-func (client *KeyVaultClient) recoverDeletedSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedSasDefinitionResponse, error) {
+func (client *Client) recoverDeletedSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedSasDefinitionResponse, error) {
 	result := KeyVaultClientRecoverDeletedSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
 		return KeyVaultClientRecoverDeletedSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
@@ -3678,12 +3660,12 @@ func (client *KeyVaultClient) recoverDeletedSasDefinitionHandleResponse(resp *ht
 }
 
 // recoverDeletedSasDefinitionHandleError handles the RecoverDeletedSasDefinition error response.
-func (client *KeyVaultClient) recoverDeletedSasDefinitionHandleError(resp *http.Response) error {
+func (client *Client) recoverDeletedSasDefinitionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3692,12 +3674,12 @@ func (client *KeyVaultClient) recoverDeletedSasDefinitionHandleError(resp *http.
 
 // RecoverDeletedSecret - Recovers the deleted secret in the specified vault. This operation can only be performed on a soft-delete
 // enabled vault. This operation requires the secrets/recover permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the deleted secret.
-// options - KeyVaultClientRecoverDeletedSecretOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedSecret
+// options - KeyVaultClientRecoverDeletedSecretOptions contains the optional parameters for the Client.RecoverDeletedSecret
 // method.
-func (client *KeyVaultClient) RecoverDeletedSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientRecoverDeletedSecretOptions) (KeyVaultClientRecoverDeletedSecretResponse, error) {
+func (client *Client) RecoverDeletedSecret(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientRecoverDeletedSecretOptions) (KeyVaultClientRecoverDeletedSecretResponse, error) {
 	req, err := client.recoverDeletedSecretCreateRequest(ctx, vaultBaseURL, secretName, options)
 	if err != nil {
 		return KeyVaultClientRecoverDeletedSecretResponse{}, err
@@ -3713,7 +3695,7 @@ func (client *KeyVaultClient) RecoverDeletedSecret(ctx context.Context, vaultBas
 }
 
 // recoverDeletedSecretCreateRequest creates the RecoverDeletedSecret request.
-func (client *KeyVaultClient) recoverDeletedSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientRecoverDeletedSecretOptions) (*policy.Request, error) {
+func (client *Client) recoverDeletedSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, options *KeyVaultClientRecoverDeletedSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedsecrets/{secret-name}/recover"
@@ -3733,7 +3715,7 @@ func (client *KeyVaultClient) recoverDeletedSecretCreateRequest(ctx context.Cont
 }
 
 // recoverDeletedSecretHandleResponse handles the RecoverDeletedSecret response.
-func (client *KeyVaultClient) recoverDeletedSecretHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedSecretResponse, error) {
+func (client *Client) recoverDeletedSecretHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedSecretResponse, error) {
 	result := KeyVaultClientRecoverDeletedSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return KeyVaultClientRecoverDeletedSecretResponse{}, runtime.NewResponseError(err, resp)
@@ -3742,12 +3724,12 @@ func (client *KeyVaultClient) recoverDeletedSecretHandleResponse(resp *http.Resp
 }
 
 // recoverDeletedSecretHandleError handles the RecoverDeletedSecret error response.
-func (client *KeyVaultClient) recoverDeletedSecretHandleError(resp *http.Response) error {
+func (client *Client) recoverDeletedSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3756,12 +3738,12 @@ func (client *KeyVaultClient) recoverDeletedSecretHandleError(resp *http.Respons
 
 // RecoverDeletedStorageAccount - Recovers the deleted storage account in the specified vault. This operation can only be
 // performed on a soft-delete enabled vault. This operation requires the storage/recover permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
-// options - KeyVaultClientRecoverDeletedStorageAccountOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedStorageAccount
+// options - KeyVaultClientRecoverDeletedStorageAccountOptions contains the optional parameters for the Client.RecoverDeletedStorageAccount
 // method.
-func (client *KeyVaultClient) RecoverDeletedStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientRecoverDeletedStorageAccountOptions) (KeyVaultClientRecoverDeletedStorageAccountResponse, error) {
+func (client *Client) RecoverDeletedStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientRecoverDeletedStorageAccountOptions) (KeyVaultClientRecoverDeletedStorageAccountResponse, error) {
 	req, err := client.recoverDeletedStorageAccountCreateRequest(ctx, vaultBaseURL, storageAccountName, options)
 	if err != nil {
 		return KeyVaultClientRecoverDeletedStorageAccountResponse{}, err
@@ -3777,7 +3759,7 @@ func (client *KeyVaultClient) RecoverDeletedStorageAccount(ctx context.Context, 
 }
 
 // recoverDeletedStorageAccountCreateRequest creates the RecoverDeletedStorageAccount request.
-func (client *KeyVaultClient) recoverDeletedStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientRecoverDeletedStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) recoverDeletedStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, options *KeyVaultClientRecoverDeletedStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/deletedstorage/{storage-account-name}/recover"
@@ -3797,7 +3779,7 @@ func (client *KeyVaultClient) recoverDeletedStorageAccountCreateRequest(ctx cont
 }
 
 // recoverDeletedStorageAccountHandleResponse handles the RecoverDeletedStorageAccount response.
-func (client *KeyVaultClient) recoverDeletedStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedStorageAccountResponse, error) {
+func (client *Client) recoverDeletedStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedStorageAccountResponse, error) {
 	result := KeyVaultClientRecoverDeletedStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return KeyVaultClientRecoverDeletedStorageAccountResponse{}, runtime.NewResponseError(err, resp)
@@ -3806,12 +3788,12 @@ func (client *KeyVaultClient) recoverDeletedStorageAccountHandleResponse(resp *h
 }
 
 // recoverDeletedStorageAccountHandleError handles the RecoverDeletedStorageAccount error response.
-func (client *KeyVaultClient) recoverDeletedStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) recoverDeletedStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3820,13 +3802,13 @@ func (client *KeyVaultClient) recoverDeletedStorageAccountHandleError(resp *http
 
 // RegenerateStorageAccountKey - Regenerates the specified key value for the given storage account. This operation requires
 // the storage/regeneratekey permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // parameters - The parameters to regenerate storage account key.
-// options - KeyVaultClientRegenerateStorageAccountKeyOptions contains the optional parameters for the KeyVaultClient.RegenerateStorageAccountKey
+// options - KeyVaultClientRegenerateStorageAccountKeyOptions contains the optional parameters for the Client.RegenerateStorageAccountKey
 // method.
-func (client *KeyVaultClient) RegenerateStorageAccountKey(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountRegenerteKeyParameters, options *KeyVaultClientRegenerateStorageAccountKeyOptions) (KeyVaultClientRegenerateStorageAccountKeyResponse, error) {
+func (client *Client) RegenerateStorageAccountKey(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountRegenerteKeyParameters, options *KeyVaultClientRegenerateStorageAccountKeyOptions) (KeyVaultClientRegenerateStorageAccountKeyResponse, error) {
 	req, err := client.regenerateStorageAccountKeyCreateRequest(ctx, vaultBaseURL, storageAccountName, parameters, options)
 	if err != nil {
 		return KeyVaultClientRegenerateStorageAccountKeyResponse{}, err
@@ -3842,7 +3824,7 @@ func (client *KeyVaultClient) RegenerateStorageAccountKey(ctx context.Context, v
 }
 
 // regenerateStorageAccountKeyCreateRequest creates the RegenerateStorageAccountKey request.
-func (client *KeyVaultClient) regenerateStorageAccountKeyCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountRegenerteKeyParameters, options *KeyVaultClientRegenerateStorageAccountKeyOptions) (*policy.Request, error) {
+func (client *Client) regenerateStorageAccountKeyCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountRegenerteKeyParameters, options *KeyVaultClientRegenerateStorageAccountKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}/regeneratekey"
@@ -3862,7 +3844,7 @@ func (client *KeyVaultClient) regenerateStorageAccountKeyCreateRequest(ctx conte
 }
 
 // regenerateStorageAccountKeyHandleResponse handles the RegenerateStorageAccountKey response.
-func (client *KeyVaultClient) regenerateStorageAccountKeyHandleResponse(resp *http.Response) (KeyVaultClientRegenerateStorageAccountKeyResponse, error) {
+func (client *Client) regenerateStorageAccountKeyHandleResponse(resp *http.Response) (KeyVaultClientRegenerateStorageAccountKeyResponse, error) {
 	result := KeyVaultClientRegenerateStorageAccountKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return KeyVaultClientRegenerateStorageAccountKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -3871,12 +3853,12 @@ func (client *KeyVaultClient) regenerateStorageAccountKeyHandleResponse(resp *ht
 }
 
 // regenerateStorageAccountKeyHandleError handles the RegenerateStorageAccountKey error response.
-func (client *KeyVaultClient) regenerateStorageAccountKeyHandleError(resp *http.Response) error {
+func (client *Client) regenerateStorageAccountKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3885,12 +3867,11 @@ func (client *KeyVaultClient) regenerateStorageAccountKeyHandleError(resp *http.
 
 // RestoreCertificate - Restores a backed up certificate, and all its versions, to a vault. This operation requires the certificates/restore
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // parameters - The parameters to restore the certificate.
-// options - KeyVaultClientRestoreCertificateOptions contains the optional parameters for the KeyVaultClient.RestoreCertificate
-// method.
-func (client *KeyVaultClient) RestoreCertificate(ctx context.Context, vaultBaseURL string, parameters CertificateRestoreParameters, options *KeyVaultClientRestoreCertificateOptions) (KeyVaultClientRestoreCertificateResponse, error) {
+// options - KeyVaultClientRestoreCertificateOptions contains the optional parameters for the Client.RestoreCertificate method.
+func (client *Client) RestoreCertificate(ctx context.Context, vaultBaseURL string, parameters CertificateRestoreParameters, options *KeyVaultClientRestoreCertificateOptions) (KeyVaultClientRestoreCertificateResponse, error) {
 	req, err := client.restoreCertificateCreateRequest(ctx, vaultBaseURL, parameters, options)
 	if err != nil {
 		return KeyVaultClientRestoreCertificateResponse{}, err
@@ -3906,7 +3887,7 @@ func (client *KeyVaultClient) RestoreCertificate(ctx context.Context, vaultBaseU
 }
 
 // restoreCertificateCreateRequest creates the RestoreCertificate request.
-func (client *KeyVaultClient) restoreCertificateCreateRequest(ctx context.Context, vaultBaseURL string, parameters CertificateRestoreParameters, options *KeyVaultClientRestoreCertificateOptions) (*policy.Request, error) {
+func (client *Client) restoreCertificateCreateRequest(ctx context.Context, vaultBaseURL string, parameters CertificateRestoreParameters, options *KeyVaultClientRestoreCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/restore"
@@ -3922,7 +3903,7 @@ func (client *KeyVaultClient) restoreCertificateCreateRequest(ctx context.Contex
 }
 
 // restoreCertificateHandleResponse handles the RestoreCertificate response.
-func (client *KeyVaultClient) restoreCertificateHandleResponse(resp *http.Response) (KeyVaultClientRestoreCertificateResponse, error) {
+func (client *Client) restoreCertificateHandleResponse(resp *http.Response) (KeyVaultClientRestoreCertificateResponse, error) {
 	result := KeyVaultClientRestoreCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return KeyVaultClientRestoreCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -3931,12 +3912,12 @@ func (client *KeyVaultClient) restoreCertificateHandleResponse(resp *http.Respon
 }
 
 // restoreCertificateHandleError handles the RestoreCertificate error response.
-func (client *KeyVaultClient) restoreCertificateHandleError(resp *http.Response) error {
+func (client *Client) restoreCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -3952,11 +3933,11 @@ func (client *KeyVaultClient) restoreCertificateHandleError(resp *http.Response)
 // versions and preserve version identifiers. The RESTORE operation is subject to security constraints: The target Key Vault
 // must be owned by the same Microsoft Azure Subscription as the source Key Vault
 // The user must have RESTORE permission in the target Key Vault. This operation requires the keys/restore permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // parameters - The parameters to restore the key.
-// options - KeyVaultClientRestoreKeyOptions contains the optional parameters for the KeyVaultClient.RestoreKey method.
-func (client *KeyVaultClient) RestoreKey(ctx context.Context, vaultBaseURL string, parameters KeyRestoreParameters, options *KeyVaultClientRestoreKeyOptions) (KeyVaultClientRestoreKeyResponse, error) {
+// options - KeyVaultClientRestoreKeyOptions contains the optional parameters for the Client.RestoreKey method.
+func (client *Client) RestoreKey(ctx context.Context, vaultBaseURL string, parameters KeyRestoreParameters, options *KeyVaultClientRestoreKeyOptions) (KeyVaultClientRestoreKeyResponse, error) {
 	req, err := client.restoreKeyCreateRequest(ctx, vaultBaseURL, parameters, options)
 	if err != nil {
 		return KeyVaultClientRestoreKeyResponse{}, err
@@ -3972,7 +3953,7 @@ func (client *KeyVaultClient) RestoreKey(ctx context.Context, vaultBaseURL strin
 }
 
 // restoreKeyCreateRequest creates the RestoreKey request.
-func (client *KeyVaultClient) restoreKeyCreateRequest(ctx context.Context, vaultBaseURL string, parameters KeyRestoreParameters, options *KeyVaultClientRestoreKeyOptions) (*policy.Request, error) {
+func (client *Client) restoreKeyCreateRequest(ctx context.Context, vaultBaseURL string, parameters KeyRestoreParameters, options *KeyVaultClientRestoreKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/restore"
@@ -3988,7 +3969,7 @@ func (client *KeyVaultClient) restoreKeyCreateRequest(ctx context.Context, vault
 }
 
 // restoreKeyHandleResponse handles the RestoreKey response.
-func (client *KeyVaultClient) restoreKeyHandleResponse(resp *http.Response) (KeyVaultClientRestoreKeyResponse, error) {
+func (client *Client) restoreKeyHandleResponse(resp *http.Response) (KeyVaultClientRestoreKeyResponse, error) {
 	result := KeyVaultClientRestoreKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return KeyVaultClientRestoreKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -3997,12 +3978,12 @@ func (client *KeyVaultClient) restoreKeyHandleResponse(resp *http.Response) (Key
 }
 
 // restoreKeyHandleError handles the RestoreKey error response.
-func (client *KeyVaultClient) restoreKeyHandleError(resp *http.Response) error {
+func (client *Client) restoreKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4011,11 +3992,11 @@ func (client *KeyVaultClient) restoreKeyHandleError(resp *http.Response) error {
 
 // RestoreSecret - Restores a backed up secret, and all its versions, to a vault. This operation requires the secrets/restore
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // parameters - The parameters to restore the secret.
-// options - KeyVaultClientRestoreSecretOptions contains the optional parameters for the KeyVaultClient.RestoreSecret method.
-func (client *KeyVaultClient) RestoreSecret(ctx context.Context, vaultBaseURL string, parameters SecretRestoreParameters, options *KeyVaultClientRestoreSecretOptions) (KeyVaultClientRestoreSecretResponse, error) {
+// options - KeyVaultClientRestoreSecretOptions contains the optional parameters for the Client.RestoreSecret method.
+func (client *Client) RestoreSecret(ctx context.Context, vaultBaseURL string, parameters SecretRestoreParameters, options *KeyVaultClientRestoreSecretOptions) (KeyVaultClientRestoreSecretResponse, error) {
 	req, err := client.restoreSecretCreateRequest(ctx, vaultBaseURL, parameters, options)
 	if err != nil {
 		return KeyVaultClientRestoreSecretResponse{}, err
@@ -4031,7 +4012,7 @@ func (client *KeyVaultClient) RestoreSecret(ctx context.Context, vaultBaseURL st
 }
 
 // restoreSecretCreateRequest creates the RestoreSecret request.
-func (client *KeyVaultClient) restoreSecretCreateRequest(ctx context.Context, vaultBaseURL string, parameters SecretRestoreParameters, options *KeyVaultClientRestoreSecretOptions) (*policy.Request, error) {
+func (client *Client) restoreSecretCreateRequest(ctx context.Context, vaultBaseURL string, parameters SecretRestoreParameters, options *KeyVaultClientRestoreSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/secrets/restore"
@@ -4047,7 +4028,7 @@ func (client *KeyVaultClient) restoreSecretCreateRequest(ctx context.Context, va
 }
 
 // restoreSecretHandleResponse handles the RestoreSecret response.
-func (client *KeyVaultClient) restoreSecretHandleResponse(resp *http.Response) (KeyVaultClientRestoreSecretResponse, error) {
+func (client *Client) restoreSecretHandleResponse(resp *http.Response) (KeyVaultClientRestoreSecretResponse, error) {
 	result := KeyVaultClientRestoreSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return KeyVaultClientRestoreSecretResponse{}, runtime.NewResponseError(err, resp)
@@ -4056,12 +4037,12 @@ func (client *KeyVaultClient) restoreSecretHandleResponse(resp *http.Response) (
 }
 
 // restoreSecretHandleError handles the RestoreSecret error response.
-func (client *KeyVaultClient) restoreSecretHandleError(resp *http.Response) error {
+func (client *Client) restoreSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4069,11 +4050,11 @@ func (client *KeyVaultClient) restoreSecretHandleError(resp *http.Response) erro
 }
 
 // RestoreStatus - Returns the status of restore operation
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // jobID - The Job Id returned part of the restore operation
-// options - KeyVaultClientRestoreStatusOptions contains the optional parameters for the KeyVaultClient.RestoreStatus method.
-func (client *KeyVaultClient) RestoreStatus(ctx context.Context, vaultBaseURL string, jobID string, options *KeyVaultClientRestoreStatusOptions) (KeyVaultClientRestoreStatusResponse, error) {
+// options - KeyVaultClientRestoreStatusOptions contains the optional parameters for the Client.RestoreStatus method.
+func (client *Client) RestoreStatus(ctx context.Context, vaultBaseURL string, jobID string, options *KeyVaultClientRestoreStatusOptions) (KeyVaultClientRestoreStatusResponse, error) {
 	req, err := client.restoreStatusCreateRequest(ctx, vaultBaseURL, jobID, options)
 	if err != nil {
 		return KeyVaultClientRestoreStatusResponse{}, err
@@ -4089,7 +4070,7 @@ func (client *KeyVaultClient) RestoreStatus(ctx context.Context, vaultBaseURL st
 }
 
 // restoreStatusCreateRequest creates the RestoreStatus request.
-func (client *KeyVaultClient) restoreStatusCreateRequest(ctx context.Context, vaultBaseURL string, jobID string, options *KeyVaultClientRestoreStatusOptions) (*policy.Request, error) {
+func (client *Client) restoreStatusCreateRequest(ctx context.Context, vaultBaseURL string, jobID string, options *KeyVaultClientRestoreStatusOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/restore/{jobId}/pending"
@@ -4109,7 +4090,7 @@ func (client *KeyVaultClient) restoreStatusCreateRequest(ctx context.Context, va
 }
 
 // restoreStatusHandleResponse handles the RestoreStatus response.
-func (client *KeyVaultClient) restoreStatusHandleResponse(resp *http.Response) (KeyVaultClientRestoreStatusResponse, error) {
+func (client *Client) restoreStatusHandleResponse(resp *http.Response) (KeyVaultClientRestoreStatusResponse, error) {
 	result := KeyVaultClientRestoreStatusResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RestoreOperation); err != nil {
 		return KeyVaultClientRestoreStatusResponse{}, runtime.NewResponseError(err, resp)
@@ -4118,12 +4099,12 @@ func (client *KeyVaultClient) restoreStatusHandleResponse(resp *http.Response) (
 }
 
 // restoreStatusHandleError handles the RestoreStatus error response.
-func (client *KeyVaultClient) restoreStatusHandleError(resp *http.Response) error {
+func (client *Client) restoreStatusHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4131,12 +4112,12 @@ func (client *KeyVaultClient) restoreStatusHandleError(resp *http.Response) erro
 }
 
 // RestoreStorageAccount - Restores a backed up storage account to a vault. This operation requires the storage/restore permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // parameters - The parameters to restore the storage account.
-// options - KeyVaultClientRestoreStorageAccountOptions contains the optional parameters for the KeyVaultClient.RestoreStorageAccount
+// options - KeyVaultClientRestoreStorageAccountOptions contains the optional parameters for the Client.RestoreStorageAccount
 // method.
-func (client *KeyVaultClient) RestoreStorageAccount(ctx context.Context, vaultBaseURL string, parameters StorageRestoreParameters, options *KeyVaultClientRestoreStorageAccountOptions) (KeyVaultClientRestoreStorageAccountResponse, error) {
+func (client *Client) RestoreStorageAccount(ctx context.Context, vaultBaseURL string, parameters StorageRestoreParameters, options *KeyVaultClientRestoreStorageAccountOptions) (KeyVaultClientRestoreStorageAccountResponse, error) {
 	req, err := client.restoreStorageAccountCreateRequest(ctx, vaultBaseURL, parameters, options)
 	if err != nil {
 		return KeyVaultClientRestoreStorageAccountResponse{}, err
@@ -4152,7 +4133,7 @@ func (client *KeyVaultClient) RestoreStorageAccount(ctx context.Context, vaultBa
 }
 
 // restoreStorageAccountCreateRequest creates the RestoreStorageAccount request.
-func (client *KeyVaultClient) restoreStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, parameters StorageRestoreParameters, options *KeyVaultClientRestoreStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) restoreStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, parameters StorageRestoreParameters, options *KeyVaultClientRestoreStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/restore"
@@ -4168,7 +4149,7 @@ func (client *KeyVaultClient) restoreStorageAccountCreateRequest(ctx context.Con
 }
 
 // restoreStorageAccountHandleResponse handles the RestoreStorageAccount response.
-func (client *KeyVaultClient) restoreStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientRestoreStorageAccountResponse, error) {
+func (client *Client) restoreStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientRestoreStorageAccountResponse, error) {
 	result := KeyVaultClientRestoreStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return KeyVaultClientRestoreStorageAccountResponse{}, runtime.NewResponseError(err, resp)
@@ -4177,12 +4158,12 @@ func (client *KeyVaultClient) restoreStorageAccountHandleResponse(resp *http.Res
 }
 
 // restoreStorageAccountHandleError handles the RestoreStorageAccount error response.
-func (client *KeyVaultClient) restoreStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) restoreStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4191,12 +4172,12 @@ func (client *KeyVaultClient) restoreStorageAccountHandleError(resp *http.Respon
 
 // BeginSelectiveKeyRestoreOperation - Restores all key versions of a given key using user supplied SAS token pointing to
 // a previously stored Azure Blob storage backup folder
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key to be restored from the user supplied backup
-// options - KeyVaultClientBeginSelectiveKeyRestoreOperationOptions contains the optional parameters for the KeyVaultClient.BeginSelectiveKeyRestoreOperation
+// options - KeyVaultClientBeginSelectiveKeyRestoreOperationOptions contains the optional parameters for the Client.BeginSelectiveKeyRestoreOperation
 // method.
-func (client *KeyVaultClient) BeginSelectiveKeyRestoreOperation(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBeginSelectiveKeyRestoreOperationOptions) (KeyVaultClientSelectiveKeyRestoreOperationPollerResponse, error) {
+func (client *Client) BeginSelectiveKeyRestoreOperation(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBeginSelectiveKeyRestoreOperationOptions) (KeyVaultClientSelectiveKeyRestoreOperationPollerResponse, error) {
 	resp, err := client.selectiveKeyRestoreOperation(ctx, vaultBaseURL, keyName, options)
 	if err != nil {
 		return KeyVaultClientSelectiveKeyRestoreOperationPollerResponse{}, err
@@ -4204,7 +4185,7 @@ func (client *KeyVaultClient) BeginSelectiveKeyRestoreOperation(ctx context.Cont
 	result := KeyVaultClientSelectiveKeyRestoreOperationPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := runtime.NewPoller("KeyVaultClient.SelectiveKeyRestoreOperation", resp, client.pl, client.selectiveKeyRestoreOperationHandleError)
+	pt, err := runtime.NewPoller("Client.SelectiveKeyRestoreOperation", resp, client.pl, client.selectiveKeyRestoreOperationHandleError)
 	if err != nil {
 		return KeyVaultClientSelectiveKeyRestoreOperationPollerResponse{}, err
 	}
@@ -4216,8 +4197,8 @@ func (client *KeyVaultClient) BeginSelectiveKeyRestoreOperation(ctx context.Cont
 
 // SelectiveKeyRestoreOperation - Restores all key versions of a given key using user supplied SAS token pointing to a previously
 // stored Azure Blob storage backup folder
-// If the operation fails it returns the *KeyVaultError error type.
-func (client *KeyVaultClient) selectiveKeyRestoreOperation(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBeginSelectiveKeyRestoreOperationOptions) (*http.Response, error) {
+// If the operation fails it returns the *Error error type.
+func (client *Client) selectiveKeyRestoreOperation(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBeginSelectiveKeyRestoreOperationOptions) (*http.Response, error) {
 	req, err := client.selectiveKeyRestoreOperationCreateRequest(ctx, vaultBaseURL, keyName, options)
 	if err != nil {
 		return nil, err
@@ -4233,7 +4214,7 @@ func (client *KeyVaultClient) selectiveKeyRestoreOperation(ctx context.Context, 
 }
 
 // selectiveKeyRestoreOperationCreateRequest creates the SelectiveKeyRestoreOperation request.
-func (client *KeyVaultClient) selectiveKeyRestoreOperationCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBeginSelectiveKeyRestoreOperationOptions) (*policy.Request, error) {
+func (client *Client) selectiveKeyRestoreOperationCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, options *KeyVaultClientBeginSelectiveKeyRestoreOperationOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{keyName}/restore"
@@ -4256,12 +4237,12 @@ func (client *KeyVaultClient) selectiveKeyRestoreOperationCreateRequest(ctx cont
 }
 
 // selectiveKeyRestoreOperationHandleError handles the SelectiveKeyRestoreOperation error response.
-func (client *KeyVaultClient) selectiveKeyRestoreOperationHandleError(resp *http.Response) error {
+func (client *Client) selectiveKeyRestoreOperationHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4270,12 +4251,12 @@ func (client *KeyVaultClient) selectiveKeyRestoreOperationHandleError(resp *http
 
 // SetCertificateContacts - Sets the certificate contacts for the specified key vault. This operation requires the certificates/managecontacts
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // contacts - The contacts for the key vault certificate.
-// options - KeyVaultClientSetCertificateContactsOptions contains the optional parameters for the KeyVaultClient.SetCertificateContacts
+// options - KeyVaultClientSetCertificateContactsOptions contains the optional parameters for the Client.SetCertificateContacts
 // method.
-func (client *KeyVaultClient) SetCertificateContacts(ctx context.Context, vaultBaseURL string, contacts Contacts, options *KeyVaultClientSetCertificateContactsOptions) (KeyVaultClientSetCertificateContactsResponse, error) {
+func (client *Client) SetCertificateContacts(ctx context.Context, vaultBaseURL string, contacts Contacts, options *KeyVaultClientSetCertificateContactsOptions) (KeyVaultClientSetCertificateContactsResponse, error) {
 	req, err := client.setCertificateContactsCreateRequest(ctx, vaultBaseURL, contacts, options)
 	if err != nil {
 		return KeyVaultClientSetCertificateContactsResponse{}, err
@@ -4291,7 +4272,7 @@ func (client *KeyVaultClient) SetCertificateContacts(ctx context.Context, vaultB
 }
 
 // setCertificateContactsCreateRequest creates the SetCertificateContacts request.
-func (client *KeyVaultClient) setCertificateContactsCreateRequest(ctx context.Context, vaultBaseURL string, contacts Contacts, options *KeyVaultClientSetCertificateContactsOptions) (*policy.Request, error) {
+func (client *Client) setCertificateContactsCreateRequest(ctx context.Context, vaultBaseURL string, contacts Contacts, options *KeyVaultClientSetCertificateContactsOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/contacts"
@@ -4307,7 +4288,7 @@ func (client *KeyVaultClient) setCertificateContactsCreateRequest(ctx context.Co
 }
 
 // setCertificateContactsHandleResponse handles the SetCertificateContacts response.
-func (client *KeyVaultClient) setCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientSetCertificateContactsResponse, error) {
+func (client *Client) setCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientSetCertificateContactsResponse, error) {
 	result := KeyVaultClientSetCertificateContactsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
 		return KeyVaultClientSetCertificateContactsResponse{}, runtime.NewResponseError(err, resp)
@@ -4316,12 +4297,12 @@ func (client *KeyVaultClient) setCertificateContactsHandleResponse(resp *http.Re
 }
 
 // setCertificateContactsHandleError handles the SetCertificateContacts error response.
-func (client *KeyVaultClient) setCertificateContactsHandleError(resp *http.Response) error {
+func (client *Client) setCertificateContactsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4330,13 +4311,13 @@ func (client *KeyVaultClient) setCertificateContactsHandleError(resp *http.Respo
 
 // SetCertificateIssuer - The SetCertificateIssuer operation adds or updates the specified certificate issuer. This operation
 // requires the certificates/setissuers permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // issuerName - The name of the issuer.
 // parameter - Certificate issuer set parameter.
-// options - KeyVaultClientSetCertificateIssuerOptions contains the optional parameters for the KeyVaultClient.SetCertificateIssuer
+// options - KeyVaultClientSetCertificateIssuerOptions contains the optional parameters for the Client.SetCertificateIssuer
 // method.
-func (client *KeyVaultClient) SetCertificateIssuer(ctx context.Context, vaultBaseURL string, issuerName string, parameter CertificateIssuerSetParameters, options *KeyVaultClientSetCertificateIssuerOptions) (KeyVaultClientSetCertificateIssuerResponse, error) {
+func (client *Client) SetCertificateIssuer(ctx context.Context, vaultBaseURL string, issuerName string, parameter CertificateIssuerSetParameters, options *KeyVaultClientSetCertificateIssuerOptions) (KeyVaultClientSetCertificateIssuerResponse, error) {
 	req, err := client.setCertificateIssuerCreateRequest(ctx, vaultBaseURL, issuerName, parameter, options)
 	if err != nil {
 		return KeyVaultClientSetCertificateIssuerResponse{}, err
@@ -4352,7 +4333,7 @@ func (client *KeyVaultClient) SetCertificateIssuer(ctx context.Context, vaultBas
 }
 
 // setCertificateIssuerCreateRequest creates the SetCertificateIssuer request.
-func (client *KeyVaultClient) setCertificateIssuerCreateRequest(ctx context.Context, vaultBaseURL string, issuerName string, parameter CertificateIssuerSetParameters, options *KeyVaultClientSetCertificateIssuerOptions) (*policy.Request, error) {
+func (client *Client) setCertificateIssuerCreateRequest(ctx context.Context, vaultBaseURL string, issuerName string, parameter CertificateIssuerSetParameters, options *KeyVaultClientSetCertificateIssuerOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/issuers/{issuer-name}"
@@ -4372,7 +4353,7 @@ func (client *KeyVaultClient) setCertificateIssuerCreateRequest(ctx context.Cont
 }
 
 // setCertificateIssuerHandleResponse handles the SetCertificateIssuer response.
-func (client *KeyVaultClient) setCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientSetCertificateIssuerResponse, error) {
+func (client *Client) setCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientSetCertificateIssuerResponse, error) {
 	result := KeyVaultClientSetCertificateIssuerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
 		return KeyVaultClientSetCertificateIssuerResponse{}, runtime.NewResponseError(err, resp)
@@ -4381,12 +4362,12 @@ func (client *KeyVaultClient) setCertificateIssuerHandleResponse(resp *http.Resp
 }
 
 // setCertificateIssuerHandleError handles the SetCertificateIssuer error response.
-func (client *KeyVaultClient) setCertificateIssuerHandleError(resp *http.Response) error {
+func (client *Client) setCertificateIssuerHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4395,14 +4376,13 @@ func (client *KeyVaultClient) setCertificateIssuerHandleError(resp *http.Respons
 
 // SetSasDefinition - Creates or updates a new SAS definition for the specified storage account. This operation requires the
 // storage/setsas permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // sasDefinitionName - The name of the SAS definition.
 // parameters - The parameters to create a SAS definition.
-// options - KeyVaultClientSetSasDefinitionOptions contains the optional parameters for the KeyVaultClient.SetSasDefinition
-// method.
-func (client *KeyVaultClient) SetSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, parameters SasDefinitionCreateParameters, options *KeyVaultClientSetSasDefinitionOptions) (KeyVaultClientSetSasDefinitionResponse, error) {
+// options - KeyVaultClientSetSasDefinitionOptions contains the optional parameters for the Client.SetSasDefinition method.
+func (client *Client) SetSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, parameters SasDefinitionCreateParameters, options *KeyVaultClientSetSasDefinitionOptions) (KeyVaultClientSetSasDefinitionResponse, error) {
 	req, err := client.setSasDefinitionCreateRequest(ctx, vaultBaseURL, storageAccountName, sasDefinitionName, parameters, options)
 	if err != nil {
 		return KeyVaultClientSetSasDefinitionResponse{}, err
@@ -4418,7 +4398,7 @@ func (client *KeyVaultClient) SetSasDefinition(ctx context.Context, vaultBaseURL
 }
 
 // setSasDefinitionCreateRequest creates the SetSasDefinition request.
-func (client *KeyVaultClient) setSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, parameters SasDefinitionCreateParameters, options *KeyVaultClientSetSasDefinitionOptions) (*policy.Request, error) {
+func (client *Client) setSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, parameters SasDefinitionCreateParameters, options *KeyVaultClientSetSasDefinitionOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}/sas/{sas-definition-name}"
@@ -4442,7 +4422,7 @@ func (client *KeyVaultClient) setSasDefinitionCreateRequest(ctx context.Context,
 }
 
 // setSasDefinitionHandleResponse handles the SetSasDefinition response.
-func (client *KeyVaultClient) setSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientSetSasDefinitionResponse, error) {
+func (client *Client) setSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientSetSasDefinitionResponse, error) {
 	result := KeyVaultClientSetSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
 		return KeyVaultClientSetSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
@@ -4451,12 +4431,12 @@ func (client *KeyVaultClient) setSasDefinitionHandleResponse(resp *http.Response
 }
 
 // setSasDefinitionHandleError handles the SetSasDefinition error response.
-func (client *KeyVaultClient) setSasDefinitionHandleError(resp *http.Response) error {
+func (client *Client) setSasDefinitionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4465,12 +4445,12 @@ func (client *KeyVaultClient) setSasDefinitionHandleError(resp *http.Response) e
 
 // SetSecret - The SET operation adds a secret to the Azure Key Vault. If the named secret already exists, Azure Key Vault
 // creates a new version of that secret. This operation requires the secrets/set permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
 // parameters - The parameters for setting the secret.
-// options - KeyVaultClientSetSecretOptions contains the optional parameters for the KeyVaultClient.SetSecret method.
-func (client *KeyVaultClient) SetSecret(ctx context.Context, vaultBaseURL string, secretName string, parameters SecretSetParameters, options *KeyVaultClientSetSecretOptions) (KeyVaultClientSetSecretResponse, error) {
+// options - KeyVaultClientSetSecretOptions contains the optional parameters for the Client.SetSecret method.
+func (client *Client) SetSecret(ctx context.Context, vaultBaseURL string, secretName string, parameters SecretSetParameters, options *KeyVaultClientSetSecretOptions) (KeyVaultClientSetSecretResponse, error) {
 	req, err := client.setSecretCreateRequest(ctx, vaultBaseURL, secretName, parameters, options)
 	if err != nil {
 		return KeyVaultClientSetSecretResponse{}, err
@@ -4486,7 +4466,7 @@ func (client *KeyVaultClient) SetSecret(ctx context.Context, vaultBaseURL string
 }
 
 // setSecretCreateRequest creates the SetSecret request.
-func (client *KeyVaultClient) setSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, parameters SecretSetParameters, options *KeyVaultClientSetSecretOptions) (*policy.Request, error) {
+func (client *Client) setSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, parameters SecretSetParameters, options *KeyVaultClientSetSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/secrets/{secret-name}"
@@ -4506,7 +4486,7 @@ func (client *KeyVaultClient) setSecretCreateRequest(ctx context.Context, vaultB
 }
 
 // setSecretHandleResponse handles the SetSecret response.
-func (client *KeyVaultClient) setSecretHandleResponse(resp *http.Response) (KeyVaultClientSetSecretResponse, error) {
+func (client *Client) setSecretHandleResponse(resp *http.Response) (KeyVaultClientSetSecretResponse, error) {
 	result := KeyVaultClientSetSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return KeyVaultClientSetSecretResponse{}, runtime.NewResponseError(err, resp)
@@ -4515,12 +4495,12 @@ func (client *KeyVaultClient) setSecretHandleResponse(resp *http.Response) (KeyV
 }
 
 // setSecretHandleError handles the SetSecret error response.
-func (client *KeyVaultClient) setSecretHandleError(resp *http.Response) error {
+func (client *Client) setSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4528,13 +4508,12 @@ func (client *KeyVaultClient) setSecretHandleError(resp *http.Response) error {
 }
 
 // SetStorageAccount - Creates or updates a new storage account. This operation requires the storage/set permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // parameters - The parameters to create a storage account.
-// options - KeyVaultClientSetStorageAccountOptions contains the optional parameters for the KeyVaultClient.SetStorageAccount
-// method.
-func (client *KeyVaultClient) SetStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountCreateParameters, options *KeyVaultClientSetStorageAccountOptions) (KeyVaultClientSetStorageAccountResponse, error) {
+// options - KeyVaultClientSetStorageAccountOptions contains the optional parameters for the Client.SetStorageAccount method.
+func (client *Client) SetStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountCreateParameters, options *KeyVaultClientSetStorageAccountOptions) (KeyVaultClientSetStorageAccountResponse, error) {
 	req, err := client.setStorageAccountCreateRequest(ctx, vaultBaseURL, storageAccountName, parameters, options)
 	if err != nil {
 		return KeyVaultClientSetStorageAccountResponse{}, err
@@ -4550,7 +4529,7 @@ func (client *KeyVaultClient) SetStorageAccount(ctx context.Context, vaultBaseUR
 }
 
 // setStorageAccountCreateRequest creates the SetStorageAccount request.
-func (client *KeyVaultClient) setStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountCreateParameters, options *KeyVaultClientSetStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) setStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountCreateParameters, options *KeyVaultClientSetStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}"
@@ -4570,7 +4549,7 @@ func (client *KeyVaultClient) setStorageAccountCreateRequest(ctx context.Context
 }
 
 // setStorageAccountHandleResponse handles the SetStorageAccount response.
-func (client *KeyVaultClient) setStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientSetStorageAccountResponse, error) {
+func (client *Client) setStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientSetStorageAccountResponse, error) {
 	result := KeyVaultClientSetStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return KeyVaultClientSetStorageAccountResponse{}, runtime.NewResponseError(err, resp)
@@ -4579,12 +4558,12 @@ func (client *KeyVaultClient) setStorageAccountHandleResponse(resp *http.Respons
 }
 
 // setStorageAccountHandleError handles the SetStorageAccount error response.
-func (client *KeyVaultClient) setStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) setStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4593,13 +4572,13 @@ func (client *KeyVaultClient) setStorageAccountHandleError(resp *http.Response) 
 
 // Sign - The SIGN operation is applicable to asymmetric and symmetric keys stored in Azure Key Vault since this operation
 // uses the private portion of the key. This operation requires the keys/sign permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
 // keyVersion - The version of the key.
 // parameters - The parameters for the signing operation.
-// options - KeyVaultClientSignOptions contains the optional parameters for the KeyVaultClient.Sign method.
-func (client *KeyVaultClient) Sign(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeySignParameters, options *KeyVaultClientSignOptions) (KeyVaultClientSignResponse, error) {
+// options - KeyVaultClientSignOptions contains the optional parameters for the Client.Sign method.
+func (client *Client) Sign(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeySignParameters, options *KeyVaultClientSignOptions) (KeyVaultClientSignResponse, error) {
 	req, err := client.signCreateRequest(ctx, vaultBaseURL, keyName, keyVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientSignResponse{}, err
@@ -4615,7 +4594,7 @@ func (client *KeyVaultClient) Sign(ctx context.Context, vaultBaseURL string, key
 }
 
 // signCreateRequest creates the Sign request.
-func (client *KeyVaultClient) signCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeySignParameters, options *KeyVaultClientSignOptions) (*policy.Request, error) {
+func (client *Client) signCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeySignParameters, options *KeyVaultClientSignOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/{key-version}/sign"
@@ -4639,7 +4618,7 @@ func (client *KeyVaultClient) signCreateRequest(ctx context.Context, vaultBaseUR
 }
 
 // signHandleResponse handles the Sign response.
-func (client *KeyVaultClient) signHandleResponse(resp *http.Response) (KeyVaultClientSignResponse, error) {
+func (client *Client) signHandleResponse(resp *http.Response) (KeyVaultClientSignResponse, error) {
 	result := KeyVaultClientSignResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return KeyVaultClientSignResponse{}, runtime.NewResponseError(err, resp)
@@ -4648,12 +4627,12 @@ func (client *KeyVaultClient) signHandleResponse(resp *http.Response) (KeyVaultC
 }
 
 // signHandleError handles the Sign error response.
-func (client *KeyVaultClient) signHandleError(resp *http.Response) error {
+func (client *Client) signHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4664,13 +4643,13 @@ func (client *KeyVaultClient) signHandleError(resp *http.Response) error {
 // is the reverse of the WRAP operation. The UNWRAP operation applies to asymmetric and
 // symmetric keys stored in Azure Key Vault since it uses the private portion of the key. This operation requires the keys/unwrapKey
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
 // keyVersion - The version of the key.
 // parameters - The parameters for the key operation.
-// options - KeyVaultClientUnwrapKeyOptions contains the optional parameters for the KeyVaultClient.UnwrapKey method.
-func (client *KeyVaultClient) UnwrapKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientUnwrapKeyOptions) (KeyVaultClientUnwrapKeyResponse, error) {
+// options - KeyVaultClientUnwrapKeyOptions contains the optional parameters for the Client.UnwrapKey method.
+func (client *Client) UnwrapKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientUnwrapKeyOptions) (KeyVaultClientUnwrapKeyResponse, error) {
 	req, err := client.unwrapKeyCreateRequest(ctx, vaultBaseURL, keyName, keyVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientUnwrapKeyResponse{}, err
@@ -4686,7 +4665,7 @@ func (client *KeyVaultClient) UnwrapKey(ctx context.Context, vaultBaseURL string
 }
 
 // unwrapKeyCreateRequest creates the UnwrapKey request.
-func (client *KeyVaultClient) unwrapKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientUnwrapKeyOptions) (*policy.Request, error) {
+func (client *Client) unwrapKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientUnwrapKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/{key-version}/unwrapkey"
@@ -4710,7 +4689,7 @@ func (client *KeyVaultClient) unwrapKeyCreateRequest(ctx context.Context, vaultB
 }
 
 // unwrapKeyHandleResponse handles the UnwrapKey response.
-func (client *KeyVaultClient) unwrapKeyHandleResponse(resp *http.Response) (KeyVaultClientUnwrapKeyResponse, error) {
+func (client *Client) unwrapKeyHandleResponse(resp *http.Response) (KeyVaultClientUnwrapKeyResponse, error) {
 	result := KeyVaultClientUnwrapKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return KeyVaultClientUnwrapKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -4719,12 +4698,12 @@ func (client *KeyVaultClient) unwrapKeyHandleResponse(resp *http.Response) (KeyV
 }
 
 // unwrapKeyHandleError handles the UnwrapKey error response.
-func (client *KeyVaultClient) unwrapKeyHandleError(resp *http.Response) error {
+func (client *Client) unwrapKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4734,14 +4713,13 @@ func (client *KeyVaultClient) unwrapKeyHandleError(resp *http.Response) error {
 // UpdateCertificate - The UpdateCertificate operation applies the specified update on the given certificate; the only elements
 // updated are the certificate's attributes. This operation requires the certificates/update
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate in the given key vault.
 // certificateVersion - The version of the certificate.
 // parameters - The parameters for certificate update.
-// options - KeyVaultClientUpdateCertificateOptions contains the optional parameters for the KeyVaultClient.UpdateCertificate
-// method.
-func (client *KeyVaultClient) UpdateCertificate(ctx context.Context, vaultBaseURL string, certificateName string, certificateVersion string, parameters CertificateUpdateParameters, options *KeyVaultClientUpdateCertificateOptions) (KeyVaultClientUpdateCertificateResponse, error) {
+// options - KeyVaultClientUpdateCertificateOptions contains the optional parameters for the Client.UpdateCertificate method.
+func (client *Client) UpdateCertificate(ctx context.Context, vaultBaseURL string, certificateName string, certificateVersion string, parameters CertificateUpdateParameters, options *KeyVaultClientUpdateCertificateOptions) (KeyVaultClientUpdateCertificateResponse, error) {
 	req, err := client.updateCertificateCreateRequest(ctx, vaultBaseURL, certificateName, certificateVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientUpdateCertificateResponse{}, err
@@ -4757,7 +4735,7 @@ func (client *KeyVaultClient) UpdateCertificate(ctx context.Context, vaultBaseUR
 }
 
 // updateCertificateCreateRequest creates the UpdateCertificate request.
-func (client *KeyVaultClient) updateCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, certificateVersion string, parameters CertificateUpdateParameters, options *KeyVaultClientUpdateCertificateOptions) (*policy.Request, error) {
+func (client *Client) updateCertificateCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, certificateVersion string, parameters CertificateUpdateParameters, options *KeyVaultClientUpdateCertificateOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/{certificate-version}"
@@ -4781,7 +4759,7 @@ func (client *KeyVaultClient) updateCertificateCreateRequest(ctx context.Context
 }
 
 // updateCertificateHandleResponse handles the UpdateCertificate response.
-func (client *KeyVaultClient) updateCertificateHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateResponse, error) {
+func (client *Client) updateCertificateHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateResponse, error) {
 	result := KeyVaultClientUpdateCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return KeyVaultClientUpdateCertificateResponse{}, runtime.NewResponseError(err, resp)
@@ -4790,12 +4768,12 @@ func (client *KeyVaultClient) updateCertificateHandleResponse(resp *http.Respons
 }
 
 // updateCertificateHandleError handles the UpdateCertificate error response.
-func (client *KeyVaultClient) updateCertificateHandleError(resp *http.Response) error {
+func (client *Client) updateCertificateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4804,13 +4782,13 @@ func (client *KeyVaultClient) updateCertificateHandleError(resp *http.Response) 
 
 // UpdateCertificateIssuer - The UpdateCertificateIssuer operation performs an update on the specified certificate issuer
 // entity. This operation requires the certificates/setissuers permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // issuerName - The name of the issuer.
 // parameter - Certificate issuer update parameter.
-// options - KeyVaultClientUpdateCertificateIssuerOptions contains the optional parameters for the KeyVaultClient.UpdateCertificateIssuer
+// options - KeyVaultClientUpdateCertificateIssuerOptions contains the optional parameters for the Client.UpdateCertificateIssuer
 // method.
-func (client *KeyVaultClient) UpdateCertificateIssuer(ctx context.Context, vaultBaseURL string, issuerName string, parameter CertificateIssuerUpdateParameters, options *KeyVaultClientUpdateCertificateIssuerOptions) (KeyVaultClientUpdateCertificateIssuerResponse, error) {
+func (client *Client) UpdateCertificateIssuer(ctx context.Context, vaultBaseURL string, issuerName string, parameter CertificateIssuerUpdateParameters, options *KeyVaultClientUpdateCertificateIssuerOptions) (KeyVaultClientUpdateCertificateIssuerResponse, error) {
 	req, err := client.updateCertificateIssuerCreateRequest(ctx, vaultBaseURL, issuerName, parameter, options)
 	if err != nil {
 		return KeyVaultClientUpdateCertificateIssuerResponse{}, err
@@ -4826,7 +4804,7 @@ func (client *KeyVaultClient) UpdateCertificateIssuer(ctx context.Context, vault
 }
 
 // updateCertificateIssuerCreateRequest creates the UpdateCertificateIssuer request.
-func (client *KeyVaultClient) updateCertificateIssuerCreateRequest(ctx context.Context, vaultBaseURL string, issuerName string, parameter CertificateIssuerUpdateParameters, options *KeyVaultClientUpdateCertificateIssuerOptions) (*policy.Request, error) {
+func (client *Client) updateCertificateIssuerCreateRequest(ctx context.Context, vaultBaseURL string, issuerName string, parameter CertificateIssuerUpdateParameters, options *KeyVaultClientUpdateCertificateIssuerOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/issuers/{issuer-name}"
@@ -4846,7 +4824,7 @@ func (client *KeyVaultClient) updateCertificateIssuerCreateRequest(ctx context.C
 }
 
 // updateCertificateIssuerHandleResponse handles the UpdateCertificateIssuer response.
-func (client *KeyVaultClient) updateCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateIssuerResponse, error) {
+func (client *Client) updateCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateIssuerResponse, error) {
 	result := KeyVaultClientUpdateCertificateIssuerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
 		return KeyVaultClientUpdateCertificateIssuerResponse{}, runtime.NewResponseError(err, resp)
@@ -4855,12 +4833,12 @@ func (client *KeyVaultClient) updateCertificateIssuerHandleResponse(resp *http.R
 }
 
 // updateCertificateIssuerHandleError handles the UpdateCertificateIssuer error response.
-func (client *KeyVaultClient) updateCertificateIssuerHandleError(resp *http.Response) error {
+func (client *Client) updateCertificateIssuerHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4869,13 +4847,13 @@ func (client *KeyVaultClient) updateCertificateIssuerHandleError(resp *http.Resp
 
 // UpdateCertificateOperation - Updates a certificate creation operation that is already in progress. This operation requires
 // the certificates/update permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
 // certificateOperation - The certificate operation response.
-// options - KeyVaultClientUpdateCertificateOperationOptions contains the optional parameters for the KeyVaultClient.UpdateCertificateOperation
+// options - KeyVaultClientUpdateCertificateOperationOptions contains the optional parameters for the Client.UpdateCertificateOperation
 // method.
-func (client *KeyVaultClient) UpdateCertificateOperation(ctx context.Context, vaultBaseURL string, certificateName string, certificateOperation CertificateOperationUpdateParameter, options *KeyVaultClientUpdateCertificateOperationOptions) (KeyVaultClientUpdateCertificateOperationResponse, error) {
+func (client *Client) UpdateCertificateOperation(ctx context.Context, vaultBaseURL string, certificateName string, certificateOperation CertificateOperationUpdateParameter, options *KeyVaultClientUpdateCertificateOperationOptions) (KeyVaultClientUpdateCertificateOperationResponse, error) {
 	req, err := client.updateCertificateOperationCreateRequest(ctx, vaultBaseURL, certificateName, certificateOperation, options)
 	if err != nil {
 		return KeyVaultClientUpdateCertificateOperationResponse{}, err
@@ -4891,7 +4869,7 @@ func (client *KeyVaultClient) UpdateCertificateOperation(ctx context.Context, va
 }
 
 // updateCertificateOperationCreateRequest creates the UpdateCertificateOperation request.
-func (client *KeyVaultClient) updateCertificateOperationCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, certificateOperation CertificateOperationUpdateParameter, options *KeyVaultClientUpdateCertificateOperationOptions) (*policy.Request, error) {
+func (client *Client) updateCertificateOperationCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, certificateOperation CertificateOperationUpdateParameter, options *KeyVaultClientUpdateCertificateOperationOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/pending"
@@ -4911,7 +4889,7 @@ func (client *KeyVaultClient) updateCertificateOperationCreateRequest(ctx contex
 }
 
 // updateCertificateOperationHandleResponse handles the UpdateCertificateOperation response.
-func (client *KeyVaultClient) updateCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateOperationResponse, error) {
+func (client *Client) updateCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateOperationResponse, error) {
 	result := KeyVaultClientUpdateCertificateOperationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
 		return KeyVaultClientUpdateCertificateOperationResponse{}, runtime.NewResponseError(err, resp)
@@ -4920,12 +4898,12 @@ func (client *KeyVaultClient) updateCertificateOperationHandleResponse(resp *htt
 }
 
 // updateCertificateOperationHandleError handles the UpdateCertificateOperation error response.
-func (client *KeyVaultClient) updateCertificateOperationHandleError(resp *http.Response) error {
+func (client *Client) updateCertificateOperationHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4934,13 +4912,13 @@ func (client *KeyVaultClient) updateCertificateOperationHandleError(resp *http.R
 
 // UpdateCertificatePolicy - Set specified members in the certificate policy. Leave others as null. This operation requires
 // the certificates/update permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate in the given vault.
 // certificatePolicy - The policy for the certificate.
-// options - KeyVaultClientUpdateCertificatePolicyOptions contains the optional parameters for the KeyVaultClient.UpdateCertificatePolicy
+// options - KeyVaultClientUpdateCertificatePolicyOptions contains the optional parameters for the Client.UpdateCertificatePolicy
 // method.
-func (client *KeyVaultClient) UpdateCertificatePolicy(ctx context.Context, vaultBaseURL string, certificateName string, certificatePolicy CertificatePolicy, options *KeyVaultClientUpdateCertificatePolicyOptions) (KeyVaultClientUpdateCertificatePolicyResponse, error) {
+func (client *Client) UpdateCertificatePolicy(ctx context.Context, vaultBaseURL string, certificateName string, certificatePolicy CertificatePolicy, options *KeyVaultClientUpdateCertificatePolicyOptions) (KeyVaultClientUpdateCertificatePolicyResponse, error) {
 	req, err := client.updateCertificatePolicyCreateRequest(ctx, vaultBaseURL, certificateName, certificatePolicy, options)
 	if err != nil {
 		return KeyVaultClientUpdateCertificatePolicyResponse{}, err
@@ -4956,7 +4934,7 @@ func (client *KeyVaultClient) UpdateCertificatePolicy(ctx context.Context, vault
 }
 
 // updateCertificatePolicyCreateRequest creates the UpdateCertificatePolicy request.
-func (client *KeyVaultClient) updateCertificatePolicyCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, certificatePolicy CertificatePolicy, options *KeyVaultClientUpdateCertificatePolicyOptions) (*policy.Request, error) {
+func (client *Client) updateCertificatePolicyCreateRequest(ctx context.Context, vaultBaseURL string, certificateName string, certificatePolicy CertificatePolicy, options *KeyVaultClientUpdateCertificatePolicyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/certificates/{certificate-name}/policy"
@@ -4976,7 +4954,7 @@ func (client *KeyVaultClient) updateCertificatePolicyCreateRequest(ctx context.C
 }
 
 // updateCertificatePolicyHandleResponse handles the UpdateCertificatePolicy response.
-func (client *KeyVaultClient) updateCertificatePolicyHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificatePolicyResponse, error) {
+func (client *Client) updateCertificatePolicyHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificatePolicyResponse, error) {
 	result := KeyVaultClientUpdateCertificatePolicyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificatePolicy); err != nil {
 		return KeyVaultClientUpdateCertificatePolicyResponse{}, runtime.NewResponseError(err, resp)
@@ -4985,12 +4963,12 @@ func (client *KeyVaultClient) updateCertificatePolicyHandleResponse(resp *http.R
 }
 
 // updateCertificatePolicyHandleError handles the UpdateCertificatePolicy error response.
-func (client *KeyVaultClient) updateCertificatePolicyHandleError(resp *http.Response) error {
+func (client *Client) updateCertificatePolicyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -4999,13 +4977,13 @@ func (client *KeyVaultClient) updateCertificatePolicyHandleError(resp *http.Resp
 
 // UpdateKey - In order to perform this operation, the key must already exist in the Key Vault. Note: The cryptographic material
 // of a key itself cannot be changed. This operation requires the keys/update permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of key to update.
 // keyVersion - The version of the key to update.
 // parameters - The parameters of the key to update.
-// options - KeyVaultClientUpdateKeyOptions contains the optional parameters for the KeyVaultClient.UpdateKey method.
-func (client *KeyVaultClient) UpdateKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyUpdateParameters, options *KeyVaultClientUpdateKeyOptions) (KeyVaultClientUpdateKeyResponse, error) {
+// options - KeyVaultClientUpdateKeyOptions contains the optional parameters for the Client.UpdateKey method.
+func (client *Client) UpdateKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyUpdateParameters, options *KeyVaultClientUpdateKeyOptions) (KeyVaultClientUpdateKeyResponse, error) {
 	req, err := client.updateKeyCreateRequest(ctx, vaultBaseURL, keyName, keyVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientUpdateKeyResponse{}, err
@@ -5021,7 +4999,7 @@ func (client *KeyVaultClient) UpdateKey(ctx context.Context, vaultBaseURL string
 }
 
 // updateKeyCreateRequest creates the UpdateKey request.
-func (client *KeyVaultClient) updateKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyUpdateParameters, options *KeyVaultClientUpdateKeyOptions) (*policy.Request, error) {
+func (client *Client) updateKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyUpdateParameters, options *KeyVaultClientUpdateKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/{key-version}"
@@ -5045,7 +5023,7 @@ func (client *KeyVaultClient) updateKeyCreateRequest(ctx context.Context, vaultB
 }
 
 // updateKeyHandleResponse handles the UpdateKey response.
-func (client *KeyVaultClient) updateKeyHandleResponse(resp *http.Response) (KeyVaultClientUpdateKeyResponse, error) {
+func (client *Client) updateKeyHandleResponse(resp *http.Response) (KeyVaultClientUpdateKeyResponse, error) {
 	result := KeyVaultClientUpdateKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return KeyVaultClientUpdateKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -5054,12 +5032,12 @@ func (client *KeyVaultClient) updateKeyHandleResponse(resp *http.Response) (KeyV
 }
 
 // updateKeyHandleError handles the UpdateKey error response.
-func (client *KeyVaultClient) updateKeyHandleError(resp *http.Response) error {
+func (client *Client) updateKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -5068,14 +5046,14 @@ func (client *KeyVaultClient) updateKeyHandleError(resp *http.Response) error {
 
 // UpdateSasDefinition - Updates the specified attributes associated with the given SAS definition. This operation requires
 // the storage/setsas permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // sasDefinitionName - The name of the SAS definition.
 // parameters - The parameters to update a SAS definition.
-// options - KeyVaultClientUpdateSasDefinitionOptions contains the optional parameters for the KeyVaultClient.UpdateSasDefinition
+// options - KeyVaultClientUpdateSasDefinitionOptions contains the optional parameters for the Client.UpdateSasDefinition
 // method.
-func (client *KeyVaultClient) UpdateSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, parameters SasDefinitionUpdateParameters, options *KeyVaultClientUpdateSasDefinitionOptions) (KeyVaultClientUpdateSasDefinitionResponse, error) {
+func (client *Client) UpdateSasDefinition(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, parameters SasDefinitionUpdateParameters, options *KeyVaultClientUpdateSasDefinitionOptions) (KeyVaultClientUpdateSasDefinitionResponse, error) {
 	req, err := client.updateSasDefinitionCreateRequest(ctx, vaultBaseURL, storageAccountName, sasDefinitionName, parameters, options)
 	if err != nil {
 		return KeyVaultClientUpdateSasDefinitionResponse{}, err
@@ -5091,7 +5069,7 @@ func (client *KeyVaultClient) UpdateSasDefinition(ctx context.Context, vaultBase
 }
 
 // updateSasDefinitionCreateRequest creates the UpdateSasDefinition request.
-func (client *KeyVaultClient) updateSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, parameters SasDefinitionUpdateParameters, options *KeyVaultClientUpdateSasDefinitionOptions) (*policy.Request, error) {
+func (client *Client) updateSasDefinitionCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, sasDefinitionName string, parameters SasDefinitionUpdateParameters, options *KeyVaultClientUpdateSasDefinitionOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}/sas/{sas-definition-name}"
@@ -5115,7 +5093,7 @@ func (client *KeyVaultClient) updateSasDefinitionCreateRequest(ctx context.Conte
 }
 
 // updateSasDefinitionHandleResponse handles the UpdateSasDefinition response.
-func (client *KeyVaultClient) updateSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientUpdateSasDefinitionResponse, error) {
+func (client *Client) updateSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientUpdateSasDefinitionResponse, error) {
 	result := KeyVaultClientUpdateSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
 		return KeyVaultClientUpdateSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
@@ -5124,12 +5102,12 @@ func (client *KeyVaultClient) updateSasDefinitionHandleResponse(resp *http.Respo
 }
 
 // updateSasDefinitionHandleError handles the UpdateSasDefinition error response.
-func (client *KeyVaultClient) updateSasDefinitionHandleError(resp *http.Response) error {
+func (client *Client) updateSasDefinitionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -5139,13 +5117,13 @@ func (client *KeyVaultClient) updateSasDefinitionHandleError(resp *http.Response
 // UpdateSecret - The UPDATE operation changes specified attributes of an existing stored secret. Attributes that are not
 // specified in the request are left unchanged. The value of a secret itself cannot be changed.
 // This operation requires the secrets/set permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
 // secretVersion - The version of the secret.
 // parameters - The parameters for update secret operation.
-// options - KeyVaultClientUpdateSecretOptions contains the optional parameters for the KeyVaultClient.UpdateSecret method.
-func (client *KeyVaultClient) UpdateSecret(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string, parameters SecretUpdateParameters, options *KeyVaultClientUpdateSecretOptions) (KeyVaultClientUpdateSecretResponse, error) {
+// options - KeyVaultClientUpdateSecretOptions contains the optional parameters for the Client.UpdateSecret method.
+func (client *Client) UpdateSecret(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string, parameters SecretUpdateParameters, options *KeyVaultClientUpdateSecretOptions) (KeyVaultClientUpdateSecretResponse, error) {
 	req, err := client.updateSecretCreateRequest(ctx, vaultBaseURL, secretName, secretVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientUpdateSecretResponse{}, err
@@ -5161,7 +5139,7 @@ func (client *KeyVaultClient) UpdateSecret(ctx context.Context, vaultBaseURL str
 }
 
 // updateSecretCreateRequest creates the UpdateSecret request.
-func (client *KeyVaultClient) updateSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string, parameters SecretUpdateParameters, options *KeyVaultClientUpdateSecretOptions) (*policy.Request, error) {
+func (client *Client) updateSecretCreateRequest(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string, parameters SecretUpdateParameters, options *KeyVaultClientUpdateSecretOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/secrets/{secret-name}/{secret-version}"
@@ -5185,7 +5163,7 @@ func (client *KeyVaultClient) updateSecretCreateRequest(ctx context.Context, vau
 }
 
 // updateSecretHandleResponse handles the UpdateSecret response.
-func (client *KeyVaultClient) updateSecretHandleResponse(resp *http.Response) (KeyVaultClientUpdateSecretResponse, error) {
+func (client *Client) updateSecretHandleResponse(resp *http.Response) (KeyVaultClientUpdateSecretResponse, error) {
 	result := KeyVaultClientUpdateSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return KeyVaultClientUpdateSecretResponse{}, runtime.NewResponseError(err, resp)
@@ -5194,12 +5172,12 @@ func (client *KeyVaultClient) updateSecretHandleResponse(resp *http.Response) (K
 }
 
 // updateSecretHandleError handles the UpdateSecret error response.
-func (client *KeyVaultClient) updateSecretHandleError(resp *http.Response) error {
+func (client *Client) updateSecretHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -5208,13 +5186,13 @@ func (client *KeyVaultClient) updateSecretHandleError(resp *http.Response) error
 
 // UpdateStorageAccount - Updates the specified attributes associated with the given storage account. This operation requires
 // the storage/set/update permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
 // parameters - The parameters to update a storage account.
-// options - KeyVaultClientUpdateStorageAccountOptions contains the optional parameters for the KeyVaultClient.UpdateStorageAccount
+// options - KeyVaultClientUpdateStorageAccountOptions contains the optional parameters for the Client.UpdateStorageAccount
 // method.
-func (client *KeyVaultClient) UpdateStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountUpdateParameters, options *KeyVaultClientUpdateStorageAccountOptions) (KeyVaultClientUpdateStorageAccountResponse, error) {
+func (client *Client) UpdateStorageAccount(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountUpdateParameters, options *KeyVaultClientUpdateStorageAccountOptions) (KeyVaultClientUpdateStorageAccountResponse, error) {
 	req, err := client.updateStorageAccountCreateRequest(ctx, vaultBaseURL, storageAccountName, parameters, options)
 	if err != nil {
 		return KeyVaultClientUpdateStorageAccountResponse{}, err
@@ -5230,7 +5208,7 @@ func (client *KeyVaultClient) UpdateStorageAccount(ctx context.Context, vaultBas
 }
 
 // updateStorageAccountCreateRequest creates the UpdateStorageAccount request.
-func (client *KeyVaultClient) updateStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountUpdateParameters, options *KeyVaultClientUpdateStorageAccountOptions) (*policy.Request, error) {
+func (client *Client) updateStorageAccountCreateRequest(ctx context.Context, vaultBaseURL string, storageAccountName string, parameters StorageAccountUpdateParameters, options *KeyVaultClientUpdateStorageAccountOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/storage/{storage-account-name}"
@@ -5250,7 +5228,7 @@ func (client *KeyVaultClient) updateStorageAccountCreateRequest(ctx context.Cont
 }
 
 // updateStorageAccountHandleResponse handles the UpdateStorageAccount response.
-func (client *KeyVaultClient) updateStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientUpdateStorageAccountResponse, error) {
+func (client *Client) updateStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientUpdateStorageAccountResponse, error) {
 	result := KeyVaultClientUpdateStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return KeyVaultClientUpdateStorageAccountResponse{}, runtime.NewResponseError(err, resp)
@@ -5259,12 +5237,12 @@ func (client *KeyVaultClient) updateStorageAccountHandleResponse(resp *http.Resp
 }
 
 // updateStorageAccountHandleError handles the UpdateStorageAccount error response.
-func (client *KeyVaultClient) updateStorageAccountHandleError(resp *http.Response) error {
+func (client *Client) updateStorageAccountHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -5276,13 +5254,13 @@ func (client *KeyVaultClient) updateStorageAccountHandleError(resp *http.Respons
 // performed using the public portion of the key but this operation is supported as a convenience for callers that only have
 // a key-reference and not the public portion of the key. This operation requires
 // the keys/verify permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
 // keyVersion - The version of the key.
 // parameters - The parameters for verify operations.
-// options - KeyVaultClientVerifyOptions contains the optional parameters for the KeyVaultClient.Verify method.
-func (client *KeyVaultClient) Verify(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyVerifyParameters, options *KeyVaultClientVerifyOptions) (KeyVaultClientVerifyResponse, error) {
+// options - KeyVaultClientVerifyOptions contains the optional parameters for the Client.Verify method.
+func (client *Client) Verify(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyVerifyParameters, options *KeyVaultClientVerifyOptions) (KeyVaultClientVerifyResponse, error) {
 	req, err := client.verifyCreateRequest(ctx, vaultBaseURL, keyName, keyVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientVerifyResponse{}, err
@@ -5298,7 +5276,7 @@ func (client *KeyVaultClient) Verify(ctx context.Context, vaultBaseURL string, k
 }
 
 // verifyCreateRequest creates the Verify request.
-func (client *KeyVaultClient) verifyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyVerifyParameters, options *KeyVaultClientVerifyOptions) (*policy.Request, error) {
+func (client *Client) verifyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyVerifyParameters, options *KeyVaultClientVerifyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/{key-version}/verify"
@@ -5322,7 +5300,7 @@ func (client *KeyVaultClient) verifyCreateRequest(ctx context.Context, vaultBase
 }
 
 // verifyHandleResponse handles the Verify response.
-func (client *KeyVaultClient) verifyHandleResponse(resp *http.Response) (KeyVaultClientVerifyResponse, error) {
+func (client *Client) verifyHandleResponse(resp *http.Response) (KeyVaultClientVerifyResponse, error) {
 	result := KeyVaultClientVerifyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyVerifyResult); err != nil {
 		return KeyVaultClientVerifyResponse{}, runtime.NewResponseError(err, resp)
@@ -5331,12 +5309,12 @@ func (client *KeyVaultClient) verifyHandleResponse(resp *http.Response) (KeyVaul
 }
 
 // verifyHandleError handles the Verify error response.
-func (client *KeyVaultClient) verifyHandleError(resp *http.Response) error {
+func (client *Client) verifyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -5349,13 +5327,13 @@ func (client *KeyVaultClient) verifyHandleError(resp *http.Response) error {
 // key. This operation is supported for asymmetric keys as a convenience for
 // callers that have a key-reference but do not have access to the public key material. This operation requires the keys/wrapKey
 // permission.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
 // keyVersion - The version of the key.
 // parameters - The parameters for wrap operation.
-// options - KeyVaultClientWrapKeyOptions contains the optional parameters for the KeyVaultClient.WrapKey method.
-func (client *KeyVaultClient) WrapKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientWrapKeyOptions) (KeyVaultClientWrapKeyResponse, error) {
+// options - KeyVaultClientWrapKeyOptions contains the optional parameters for the Client.WrapKey method.
+func (client *Client) WrapKey(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientWrapKeyOptions) (KeyVaultClientWrapKeyResponse, error) {
 	req, err := client.wrapKeyCreateRequest(ctx, vaultBaseURL, keyName, keyVersion, parameters, options)
 	if err != nil {
 		return KeyVaultClientWrapKeyResponse{}, err
@@ -5371,7 +5349,7 @@ func (client *KeyVaultClient) WrapKey(ctx context.Context, vaultBaseURL string, 
 }
 
 // wrapKeyCreateRequest creates the WrapKey request.
-func (client *KeyVaultClient) wrapKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientWrapKeyOptions) (*policy.Request, error) {
+func (client *Client) wrapKeyCreateRequest(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientWrapKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", vaultBaseURL)
 	urlPath := "/keys/{key-name}/{key-version}/wrapkey"
@@ -5395,7 +5373,7 @@ func (client *KeyVaultClient) wrapKeyCreateRequest(ctx context.Context, vaultBas
 }
 
 // wrapKeyHandleResponse handles the WrapKey response.
-func (client *KeyVaultClient) wrapKeyHandleResponse(resp *http.Response) (KeyVaultClientWrapKeyResponse, error) {
+func (client *Client) wrapKeyHandleResponse(resp *http.Response) (KeyVaultClientWrapKeyResponse, error) {
 	result := KeyVaultClientWrapKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return KeyVaultClientWrapKeyResponse{}, runtime.NewResponseError(err, resp)
@@ -5404,12 +5382,12 @@ func (client *KeyVaultClient) wrapKeyHandleResponse(resp *http.Response) (KeyVau
 }
 
 // wrapKeyHandleError handles the WrapKey error response.
-func (client *KeyVaultClient) wrapKeyHandleError(resp *http.Response) error {
+func (client *Client) wrapKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
@@ -34,7 +34,7 @@ func NewHSMSecurityDomainClient(pl runtime.Pipeline) *HSMSecurityDomainClient {
 
 // BeginDownload - Retrieves the Security Domain from the managed HSM. Calling this endpoint can be used to activate a provisioned
 // managed HSM resource.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateInfoObject - The Security Domain download operation requires customer to provide N certificates (minimum 3 and
 // maximum 10) containing a public key in JWK format.
@@ -60,7 +60,7 @@ func (client *HSMSecurityDomainClient) BeginDownload(ctx context.Context, vaultB
 
 // Download - Retrieves the Security Domain from the managed HSM. Calling this endpoint can be used to activate a provisioned
 // managed HSM resource.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 func (client *HSMSecurityDomainClient) download(ctx context.Context, vaultBaseURL string, certificateInfoObject CertificateInfoObject, options *HSMSecurityDomainBeginDownloadOptions) (*http.Response, error) {
 	req, err := client.downloadCreateRequest(ctx, vaultBaseURL, certificateInfoObject, options)
 	if err != nil {
@@ -98,7 +98,7 @@ func (client *HSMSecurityDomainClient) downloadHandleError(resp *http.Response) 
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -106,7 +106,7 @@ func (client *HSMSecurityDomainClient) downloadHandleError(resp *http.Response) 
 }
 
 // DownloadPending - Retrieves the Security Domain download operation status
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - HSMSecurityDomainDownloadPendingOptions contains the optional parameters for the HSMSecurityDomainClient.DownloadPending
 // method.
@@ -153,7 +153,7 @@ func (client *HSMSecurityDomainClient) downloadPendingHandleError(resp *http.Res
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -161,7 +161,7 @@ func (client *HSMSecurityDomainClient) downloadPendingHandleError(resp *http.Res
 }
 
 // TransferKey - Retrieve Security Domain transfer key
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - HSMSecurityDomainTransferKeyOptions contains the optional parameters for the HSMSecurityDomainClient.TransferKey
 // method.
@@ -211,7 +211,7 @@ func (client *HSMSecurityDomainClient) transferKeyHandleError(resp *http.Respons
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -219,7 +219,7 @@ func (client *HSMSecurityDomainClient) transferKeyHandleError(resp *http.Respons
 }
 
 // BeginUpload - Restore the provided Security Domain.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // securityDomain - The Security Domain to be restored.
 // options - HSMSecurityDomainBeginUploadOptions contains the optional parameters for the HSMSecurityDomainClient.BeginUpload
@@ -243,7 +243,7 @@ func (client *HSMSecurityDomainClient) BeginUpload(ctx context.Context, vaultBas
 }
 
 // Upload - Restore the provided Security Domain.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 func (client *HSMSecurityDomainClient) upload(ctx context.Context, vaultBaseURL string, securityDomain SecurityDomainObject, options *HSMSecurityDomainBeginUploadOptions) (*http.Response, error) {
 	req, err := client.uploadCreateRequest(ctx, vaultBaseURL, securityDomain, options)
 	if err != nil {
@@ -278,7 +278,7 @@ func (client *HSMSecurityDomainClient) uploadHandleError(resp *http.Response) er
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -286,7 +286,7 @@ func (client *HSMSecurityDomainClient) uploadHandleError(resp *http.Response) er
 }
 
 // UploadPending - Get Security Domain upload operation status
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - HSMSecurityDomainUploadPendingOptions contains the optional parameters for the HSMSecurityDomainClient.UploadPending
 // method.
@@ -333,7 +333,7 @@ func (client *HSMSecurityDomainClient) uploadPendingHandleError(resp *http.Respo
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_generated_models.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_models.go
@@ -626,7 +626,7 @@ type CertificateOperation struct {
 	Csr []byte `json:"csr,omitempty"`
 
 	// Error encountered, if any, during the certificate operation.
-	Error *Error `json:"error,omitempty"`
+	Error *ErrorInfo `json:"error,omitempty"`
 
 	// Parameters for the issuer of the X509 component of a certificate.
 	IssuerParameters *IssuerParameters `json:"issuer,omitempty"`
@@ -1453,13 +1453,27 @@ func (d DeletedStorageListResult) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// Error - The key vault server error.
+// Error - The key vault error exception.
+// Implements the error and azcore.HTTPResponse interfaces.
 type Error struct {
+	raw string
+	// READ-ONLY; The key vault server error.
+	InnerError *ErrorInfo `json:"error,omitempty" azure:"ro"`
+}
+
+// Error implements the error interface for type Error.
+// The contents of the error text are not contractual and subject to change.
+func (e Error) Error() string {
+	return e.raw
+}
+
+// ErrorInfo - The key vault server error.
+type ErrorInfo struct {
 	// READ-ONLY; The error code.
 	Code *string `json:"code,omitempty" azure:"ro"`
 
 	// READ-ONLY; The key vault server error.
-	InnerError *Error `json:"innererror,omitempty" azure:"ro"`
+	InnerError *ErrorInfo `json:"innererror,omitempty" azure:"ro"`
 
 	// READ-ONLY; The error message.
 	Message *string `json:"message,omitempty" azure:"ro"`
@@ -1474,7 +1488,7 @@ type FullBackupOperation struct {
 	EndTime *time.Time `json:"endTime,omitempty"`
 
 	// Error encountered, if any, during the full backup operation.
-	Error *Error `json:"error,omitempty"`
+	Error *ErrorInfo `json:"error,omitempty"`
 
 	// Identifier for the full backup operation.
 	JobID *string `json:"jobId,omitempty"`
@@ -2272,28 +2286,27 @@ func (k KeyUpdateParameters) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// KeyVaultClientBackupCertificateOptions contains the optional parameters for the KeyVaultClient.BackupCertificate method.
+// KeyVaultClientBackupCertificateOptions contains the optional parameters for the Client.BackupCertificate method.
 type KeyVaultClientBackupCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientBackupKeyOptions contains the optional parameters for the KeyVaultClient.BackupKey method.
+// KeyVaultClientBackupKeyOptions contains the optional parameters for the Client.BackupKey method.
 type KeyVaultClientBackupKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientBackupSecretOptions contains the optional parameters for the KeyVaultClient.BackupSecret method.
+// KeyVaultClientBackupSecretOptions contains the optional parameters for the Client.BackupSecret method.
 type KeyVaultClientBackupSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientBackupStorageAccountOptions contains the optional parameters for the KeyVaultClient.BackupStorageAccount
-// method.
+// KeyVaultClientBackupStorageAccountOptions contains the optional parameters for the Client.BackupStorageAccount method.
 type KeyVaultClientBackupStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientBeginFullBackupOptions contains the optional parameters for the KeyVaultClient.BeginFullBackup method.
+// KeyVaultClientBeginFullBackupOptions contains the optional parameters for the Client.BeginFullBackup method.
 type KeyVaultClientBeginFullBackupOptions struct {
 	// Azure blob shared access signature token pointing to a valid Azure blob container where full backup needs to be stored.
 	// This token needs to be valid for at least next 24 hours from the time of making
@@ -2301,133 +2314,125 @@ type KeyVaultClientBeginFullBackupOptions struct {
 	AzureStorageBlobContainerURI *SASTokenParameter
 }
 
-// KeyVaultClientBeginFullRestoreOperationOptions contains the optional parameters for the KeyVaultClient.BeginFullRestoreOperation
+// KeyVaultClientBeginFullRestoreOperationOptions contains the optional parameters for the Client.BeginFullRestoreOperation
 // method.
 type KeyVaultClientBeginFullRestoreOperationOptions struct {
 	// The Azure blob SAS token pointing to a folder where the previous successful full backup was stored
 	RestoreBlobDetails *RestoreOperationParameters
 }
 
-// KeyVaultClientBeginSelectiveKeyRestoreOperationOptions contains the optional parameters for the KeyVaultClient.BeginSelectiveKeyRestoreOperation
+// KeyVaultClientBeginSelectiveKeyRestoreOperationOptions contains the optional parameters for the Client.BeginSelectiveKeyRestoreOperation
 // method.
 type KeyVaultClientBeginSelectiveKeyRestoreOperationOptions struct {
 	// The Azure blob SAS token pointing to a folder where the previous successful full backup was stored
 	RestoreBlobDetails *SelectiveKeyRestoreOperationParameters
 }
 
-// KeyVaultClientCreateCertificateOptions contains the optional parameters for the KeyVaultClient.CreateCertificate method.
+// KeyVaultClientCreateCertificateOptions contains the optional parameters for the Client.CreateCertificate method.
 type KeyVaultClientCreateCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientCreateKeyOptions contains the optional parameters for the KeyVaultClient.CreateKey method.
+// KeyVaultClientCreateKeyOptions contains the optional parameters for the Client.CreateKey method.
 type KeyVaultClientCreateKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDecryptOptions contains the optional parameters for the KeyVaultClient.Decrypt method.
+// KeyVaultClientDecryptOptions contains the optional parameters for the Client.Decrypt method.
 type KeyVaultClientDecryptOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteCertificateContactsOptions contains the optional parameters for the KeyVaultClient.DeleteCertificateContacts
+// KeyVaultClientDeleteCertificateContactsOptions contains the optional parameters for the Client.DeleteCertificateContacts
 // method.
 type KeyVaultClientDeleteCertificateContactsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteCertificateIssuerOptions contains the optional parameters for the KeyVaultClient.DeleteCertificateIssuer
-// method.
+// KeyVaultClientDeleteCertificateIssuerOptions contains the optional parameters for the Client.DeleteCertificateIssuer method.
 type KeyVaultClientDeleteCertificateIssuerOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteCertificateOperationOptions contains the optional parameters for the KeyVaultClient.DeleteCertificateOperation
+// KeyVaultClientDeleteCertificateOperationOptions contains the optional parameters for the Client.DeleteCertificateOperation
 // method.
 type KeyVaultClientDeleteCertificateOperationOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteCertificateOptions contains the optional parameters for the KeyVaultClient.DeleteCertificate method.
+// KeyVaultClientDeleteCertificateOptions contains the optional parameters for the Client.DeleteCertificate method.
 type KeyVaultClientDeleteCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteKeyOptions contains the optional parameters for the KeyVaultClient.DeleteKey method.
+// KeyVaultClientDeleteKeyOptions contains the optional parameters for the Client.DeleteKey method.
 type KeyVaultClientDeleteKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteSasDefinitionOptions contains the optional parameters for the KeyVaultClient.DeleteSasDefinition method.
+// KeyVaultClientDeleteSasDefinitionOptions contains the optional parameters for the Client.DeleteSasDefinition method.
 type KeyVaultClientDeleteSasDefinitionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteSecretOptions contains the optional parameters for the KeyVaultClient.DeleteSecret method.
+// KeyVaultClientDeleteSecretOptions contains the optional parameters for the Client.DeleteSecret method.
 type KeyVaultClientDeleteSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteStorageAccountOptions contains the optional parameters for the KeyVaultClient.DeleteStorageAccount
-// method.
+// KeyVaultClientDeleteStorageAccountOptions contains the optional parameters for the Client.DeleteStorageAccount method.
 type KeyVaultClientDeleteStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientEncryptOptions contains the optional parameters for the KeyVaultClient.Encrypt method.
+// KeyVaultClientEncryptOptions contains the optional parameters for the Client.Encrypt method.
 type KeyVaultClientEncryptOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientFullBackupStatusOptions contains the optional parameters for the KeyVaultClient.FullBackupStatus method.
+// KeyVaultClientFullBackupStatusOptions contains the optional parameters for the Client.FullBackupStatus method.
 type KeyVaultClientFullBackupStatusOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetCertificateContactsOptions contains the optional parameters for the KeyVaultClient.GetCertificateContacts
-// method.
+// KeyVaultClientGetCertificateContactsOptions contains the optional parameters for the Client.GetCertificateContacts method.
 type KeyVaultClientGetCertificateContactsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetCertificateIssuerOptions contains the optional parameters for the KeyVaultClient.GetCertificateIssuer
-// method.
+// KeyVaultClientGetCertificateIssuerOptions contains the optional parameters for the Client.GetCertificateIssuer method.
 type KeyVaultClientGetCertificateIssuerOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetCertificateIssuersOptions contains the optional parameters for the KeyVaultClient.GetCertificateIssuers
-// method.
+// KeyVaultClientGetCertificateIssuersOptions contains the optional parameters for the Client.GetCertificateIssuers method.
 type KeyVaultClientGetCertificateIssuersOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetCertificateOperationOptions contains the optional parameters for the KeyVaultClient.GetCertificateOperation
-// method.
+// KeyVaultClientGetCertificateOperationOptions contains the optional parameters for the Client.GetCertificateOperation method.
 type KeyVaultClientGetCertificateOperationOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetCertificateOptions contains the optional parameters for the KeyVaultClient.GetCertificate method.
+// KeyVaultClientGetCertificateOptions contains the optional parameters for the Client.GetCertificate method.
 type KeyVaultClientGetCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetCertificatePolicyOptions contains the optional parameters for the KeyVaultClient.GetCertificatePolicy
-// method.
+// KeyVaultClientGetCertificatePolicyOptions contains the optional parameters for the Client.GetCertificatePolicy method.
 type KeyVaultClientGetCertificatePolicyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetCertificateVersionsOptions contains the optional parameters for the KeyVaultClient.GetCertificateVersions
-// method.
+// KeyVaultClientGetCertificateVersionsOptions contains the optional parameters for the Client.GetCertificateVersions method.
 type KeyVaultClientGetCertificateVersionsOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetCertificatesOptions contains the optional parameters for the KeyVaultClient.GetCertificates method.
+// KeyVaultClientGetCertificatesOptions contains the optional parameters for the Client.GetCertificates method.
 type KeyVaultClientGetCertificatesOptions struct {
 	// Specifies whether to include certificates which are not completely provisioned.
 	IncludePending *bool
@@ -2435,14 +2440,12 @@ type KeyVaultClientGetCertificatesOptions struct {
 	Maxresults *int32
 }
 
-// KeyVaultClientGetDeletedCertificateOptions contains the optional parameters for the KeyVaultClient.GetDeletedCertificate
-// method.
+// KeyVaultClientGetDeletedCertificateOptions contains the optional parameters for the Client.GetDeletedCertificate method.
 type KeyVaultClientGetDeletedCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetDeletedCertificatesOptions contains the optional parameters for the KeyVaultClient.GetDeletedCertificates
-// method.
+// KeyVaultClientGetDeletedCertificatesOptions contains the optional parameters for the Client.GetDeletedCertificates method.
 type KeyVaultClientGetDeletedCertificatesOptions struct {
 	// Specifies whether to include certificates which are not completely provisioned.
 	IncludePending *bool
@@ -2450,311 +2453,288 @@ type KeyVaultClientGetDeletedCertificatesOptions struct {
 	Maxresults *int32
 }
 
-// KeyVaultClientGetDeletedKeyOptions contains the optional parameters for the KeyVaultClient.GetDeletedKey method.
+// KeyVaultClientGetDeletedKeyOptions contains the optional parameters for the Client.GetDeletedKey method.
 type KeyVaultClientGetDeletedKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetDeletedKeysOptions contains the optional parameters for the KeyVaultClient.GetDeletedKeys method.
+// KeyVaultClientGetDeletedKeysOptions contains the optional parameters for the Client.GetDeletedKeys method.
 type KeyVaultClientGetDeletedKeysOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetDeletedSasDefinitionOptions contains the optional parameters for the KeyVaultClient.GetDeletedSasDefinition
-// method.
+// KeyVaultClientGetDeletedSasDefinitionOptions contains the optional parameters for the Client.GetDeletedSasDefinition method.
 type KeyVaultClientGetDeletedSasDefinitionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetDeletedSasDefinitionsOptions contains the optional parameters for the KeyVaultClient.GetDeletedSasDefinitions
+// KeyVaultClientGetDeletedSasDefinitionsOptions contains the optional parameters for the Client.GetDeletedSasDefinitions
 // method.
 type KeyVaultClientGetDeletedSasDefinitionsOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetDeletedSecretOptions contains the optional parameters for the KeyVaultClient.GetDeletedSecret method.
+// KeyVaultClientGetDeletedSecretOptions contains the optional parameters for the Client.GetDeletedSecret method.
 type KeyVaultClientGetDeletedSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetDeletedSecretsOptions contains the optional parameters for the KeyVaultClient.GetDeletedSecrets method.
+// KeyVaultClientGetDeletedSecretsOptions contains the optional parameters for the Client.GetDeletedSecrets method.
 type KeyVaultClientGetDeletedSecretsOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetDeletedStorageAccountOptions contains the optional parameters for the KeyVaultClient.GetDeletedStorageAccount
+// KeyVaultClientGetDeletedStorageAccountOptions contains the optional parameters for the Client.GetDeletedStorageAccount
 // method.
 type KeyVaultClientGetDeletedStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetDeletedStorageAccountsOptions contains the optional parameters for the KeyVaultClient.GetDeletedStorageAccounts
+// KeyVaultClientGetDeletedStorageAccountsOptions contains the optional parameters for the Client.GetDeletedStorageAccounts
 // method.
 type KeyVaultClientGetDeletedStorageAccountsOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetKeyOptions contains the optional parameters for the KeyVaultClient.GetKey method.
+// KeyVaultClientGetKeyOptions contains the optional parameters for the Client.GetKey method.
 type KeyVaultClientGetKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetKeyVersionsOptions contains the optional parameters for the KeyVaultClient.GetKeyVersions method.
+// KeyVaultClientGetKeyVersionsOptions contains the optional parameters for the Client.GetKeyVersions method.
 type KeyVaultClientGetKeyVersionsOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetKeysOptions contains the optional parameters for the KeyVaultClient.GetKeys method.
+// KeyVaultClientGetKeysOptions contains the optional parameters for the Client.GetKeys method.
 type KeyVaultClientGetKeysOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetSasDefinitionOptions contains the optional parameters for the KeyVaultClient.GetSasDefinition method.
+// KeyVaultClientGetSasDefinitionOptions contains the optional parameters for the Client.GetSasDefinition method.
 type KeyVaultClientGetSasDefinitionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetSasDefinitionsOptions contains the optional parameters for the KeyVaultClient.GetSasDefinitions method.
+// KeyVaultClientGetSasDefinitionsOptions contains the optional parameters for the Client.GetSasDefinitions method.
 type KeyVaultClientGetSasDefinitionsOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetSecretOptions contains the optional parameters for the KeyVaultClient.GetSecret method.
+// KeyVaultClientGetSecretOptions contains the optional parameters for the Client.GetSecret method.
 type KeyVaultClientGetSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetSecretVersionsOptions contains the optional parameters for the KeyVaultClient.GetSecretVersions method.
+// KeyVaultClientGetSecretVersionsOptions contains the optional parameters for the Client.GetSecretVersions method.
 type KeyVaultClientGetSecretVersionsOptions struct {
 	// Maximum number of results to return in a page. If not specified, the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetSecretsOptions contains the optional parameters for the KeyVaultClient.GetSecrets method.
+// KeyVaultClientGetSecretsOptions contains the optional parameters for the Client.GetSecrets method.
 type KeyVaultClientGetSecretsOptions struct {
 	// Maximum number of results to return in a page. If not specified, the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientGetStorageAccountOptions contains the optional parameters for the KeyVaultClient.GetStorageAccount method.
+// KeyVaultClientGetStorageAccountOptions contains the optional parameters for the Client.GetStorageAccount method.
 type KeyVaultClientGetStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetStorageAccountsOptions contains the optional parameters for the KeyVaultClient.GetStorageAccounts method.
+// KeyVaultClientGetStorageAccountsOptions contains the optional parameters for the Client.GetStorageAccounts method.
 type KeyVaultClientGetStorageAccountsOptions struct {
 	// Maximum number of results to return in a page. If not specified the service will return up to 25 results.
 	Maxresults *int32
 }
 
-// KeyVaultClientImportCertificateOptions contains the optional parameters for the KeyVaultClient.ImportCertificate method.
+// KeyVaultClientImportCertificateOptions contains the optional parameters for the Client.ImportCertificate method.
 type KeyVaultClientImportCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientImportKeyOptions contains the optional parameters for the KeyVaultClient.ImportKey method.
+// KeyVaultClientImportKeyOptions contains the optional parameters for the Client.ImportKey method.
 type KeyVaultClientImportKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientMergeCertificateOptions contains the optional parameters for the KeyVaultClient.MergeCertificate method.
+// KeyVaultClientMergeCertificateOptions contains the optional parameters for the Client.MergeCertificate method.
 type KeyVaultClientMergeCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientPurgeDeletedCertificateOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedCertificate
-// method.
+// KeyVaultClientPurgeDeletedCertificateOptions contains the optional parameters for the Client.PurgeDeletedCertificate method.
 type KeyVaultClientPurgeDeletedCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientPurgeDeletedKeyOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedKey method.
+// KeyVaultClientPurgeDeletedKeyOptions contains the optional parameters for the Client.PurgeDeletedKey method.
 type KeyVaultClientPurgeDeletedKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientPurgeDeletedSecretOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedSecret method.
+// KeyVaultClientPurgeDeletedSecretOptions contains the optional parameters for the Client.PurgeDeletedSecret method.
 type KeyVaultClientPurgeDeletedSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientPurgeDeletedStorageAccountOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedStorageAccount
+// KeyVaultClientPurgeDeletedStorageAccountOptions contains the optional parameters for the Client.PurgeDeletedStorageAccount
 // method.
 type KeyVaultClientPurgeDeletedStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRecoverDeletedCertificateOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedCertificate
+// KeyVaultClientRecoverDeletedCertificateOptions contains the optional parameters for the Client.RecoverDeletedCertificate
 // method.
 type KeyVaultClientRecoverDeletedCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRecoverDeletedKeyOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedKey method.
+// KeyVaultClientRecoverDeletedKeyOptions contains the optional parameters for the Client.RecoverDeletedKey method.
 type KeyVaultClientRecoverDeletedKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRecoverDeletedSasDefinitionOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedSasDefinition
+// KeyVaultClientRecoverDeletedSasDefinitionOptions contains the optional parameters for the Client.RecoverDeletedSasDefinition
 // method.
 type KeyVaultClientRecoverDeletedSasDefinitionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRecoverDeletedSecretOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedSecret
-// method.
+// KeyVaultClientRecoverDeletedSecretOptions contains the optional parameters for the Client.RecoverDeletedSecret method.
 type KeyVaultClientRecoverDeletedSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRecoverDeletedStorageAccountOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedStorageAccount
+// KeyVaultClientRecoverDeletedStorageAccountOptions contains the optional parameters for the Client.RecoverDeletedStorageAccount
 // method.
 type KeyVaultClientRecoverDeletedStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRegenerateStorageAccountKeyOptions contains the optional parameters for the KeyVaultClient.RegenerateStorageAccountKey
+// KeyVaultClientRegenerateStorageAccountKeyOptions contains the optional parameters for the Client.RegenerateStorageAccountKey
 // method.
 type KeyVaultClientRegenerateStorageAccountKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRestoreCertificateOptions contains the optional parameters for the KeyVaultClient.RestoreCertificate method.
+// KeyVaultClientRestoreCertificateOptions contains the optional parameters for the Client.RestoreCertificate method.
 type KeyVaultClientRestoreCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRestoreKeyOptions contains the optional parameters for the KeyVaultClient.RestoreKey method.
+// KeyVaultClientRestoreKeyOptions contains the optional parameters for the Client.RestoreKey method.
 type KeyVaultClientRestoreKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRestoreSecretOptions contains the optional parameters for the KeyVaultClient.RestoreSecret method.
+// KeyVaultClientRestoreSecretOptions contains the optional parameters for the Client.RestoreSecret method.
 type KeyVaultClientRestoreSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRestoreStatusOptions contains the optional parameters for the KeyVaultClient.RestoreStatus method.
+// KeyVaultClientRestoreStatusOptions contains the optional parameters for the Client.RestoreStatus method.
 type KeyVaultClientRestoreStatusOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRestoreStorageAccountOptions contains the optional parameters for the KeyVaultClient.RestoreStorageAccount
-// method.
+// KeyVaultClientRestoreStorageAccountOptions contains the optional parameters for the Client.RestoreStorageAccount method.
 type KeyVaultClientRestoreStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientSetCertificateContactsOptions contains the optional parameters for the KeyVaultClient.SetCertificateContacts
-// method.
+// KeyVaultClientSetCertificateContactsOptions contains the optional parameters for the Client.SetCertificateContacts method.
 type KeyVaultClientSetCertificateContactsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientSetCertificateIssuerOptions contains the optional parameters for the KeyVaultClient.SetCertificateIssuer
-// method.
+// KeyVaultClientSetCertificateIssuerOptions contains the optional parameters for the Client.SetCertificateIssuer method.
 type KeyVaultClientSetCertificateIssuerOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientSetSasDefinitionOptions contains the optional parameters for the KeyVaultClient.SetSasDefinition method.
+// KeyVaultClientSetSasDefinitionOptions contains the optional parameters for the Client.SetSasDefinition method.
 type KeyVaultClientSetSasDefinitionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientSetSecretOptions contains the optional parameters for the KeyVaultClient.SetSecret method.
+// KeyVaultClientSetSecretOptions contains the optional parameters for the Client.SetSecret method.
 type KeyVaultClientSetSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientSetStorageAccountOptions contains the optional parameters for the KeyVaultClient.SetStorageAccount method.
+// KeyVaultClientSetStorageAccountOptions contains the optional parameters for the Client.SetStorageAccount method.
 type KeyVaultClientSetStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientSignOptions contains the optional parameters for the KeyVaultClient.Sign method.
+// KeyVaultClientSignOptions contains the optional parameters for the Client.Sign method.
 type KeyVaultClientSignOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUnwrapKeyOptions contains the optional parameters for the KeyVaultClient.UnwrapKey method.
+// KeyVaultClientUnwrapKeyOptions contains the optional parameters for the Client.UnwrapKey method.
 type KeyVaultClientUnwrapKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateCertificateIssuerOptions contains the optional parameters for the KeyVaultClient.UpdateCertificateIssuer
-// method.
+// KeyVaultClientUpdateCertificateIssuerOptions contains the optional parameters for the Client.UpdateCertificateIssuer method.
 type KeyVaultClientUpdateCertificateIssuerOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateCertificateOperationOptions contains the optional parameters for the KeyVaultClient.UpdateCertificateOperation
+// KeyVaultClientUpdateCertificateOperationOptions contains the optional parameters for the Client.UpdateCertificateOperation
 // method.
 type KeyVaultClientUpdateCertificateOperationOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateCertificateOptions contains the optional parameters for the KeyVaultClient.UpdateCertificate method.
+// KeyVaultClientUpdateCertificateOptions contains the optional parameters for the Client.UpdateCertificate method.
 type KeyVaultClientUpdateCertificateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateCertificatePolicyOptions contains the optional parameters for the KeyVaultClient.UpdateCertificatePolicy
-// method.
+// KeyVaultClientUpdateCertificatePolicyOptions contains the optional parameters for the Client.UpdateCertificatePolicy method.
 type KeyVaultClientUpdateCertificatePolicyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateKeyOptions contains the optional parameters for the KeyVaultClient.UpdateKey method.
+// KeyVaultClientUpdateKeyOptions contains the optional parameters for the Client.UpdateKey method.
 type KeyVaultClientUpdateKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateSasDefinitionOptions contains the optional parameters for the KeyVaultClient.UpdateSasDefinition method.
+// KeyVaultClientUpdateSasDefinitionOptions contains the optional parameters for the Client.UpdateSasDefinition method.
 type KeyVaultClientUpdateSasDefinitionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateSecretOptions contains the optional parameters for the KeyVaultClient.UpdateSecret method.
+// KeyVaultClientUpdateSecretOptions contains the optional parameters for the Client.UpdateSecret method.
 type KeyVaultClientUpdateSecretOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateStorageAccountOptions contains the optional parameters for the KeyVaultClient.UpdateStorageAccount
-// method.
+// KeyVaultClientUpdateStorageAccountOptions contains the optional parameters for the Client.UpdateStorageAccount method.
 type KeyVaultClientUpdateStorageAccountOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientVerifyOptions contains the optional parameters for the KeyVaultClient.Verify method.
+// KeyVaultClientVerifyOptions contains the optional parameters for the Client.Verify method.
 type KeyVaultClientVerifyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientWrapKeyOptions contains the optional parameters for the KeyVaultClient.WrapKey method.
+// KeyVaultClientWrapKeyOptions contains the optional parameters for the Client.WrapKey method.
 type KeyVaultClientWrapKeyOptions struct {
 	// placeholder for future optional parameters
-}
-
-// KeyVaultError - The key vault error exception.
-// Implements the error and azcore.HTTPResponse interfaces.
-type KeyVaultError struct {
-	raw string
-	// READ-ONLY; The key vault server error.
-	InnerError *Error `json:"error,omitempty" azure:"ro"`
-}
-
-// Error implements the error interface for type KeyVaultError.
-// The contents of the error text are not contractual and subject to change.
-func (e KeyVaultError) Error() string {
-	return e.raw
 }
 
 // KeyVerifyParameters - The key verify parameters.
@@ -2873,7 +2853,7 @@ type RestoreOperation struct {
 	EndTime *time.Time `json:"endTime,omitempty"`
 
 	// Error encountered, if any, during the restore operation.
-	Error *Error `json:"error,omitempty"`
+	Error *ErrorInfo `json:"error,omitempty"`
 
 	// Identifier for the restore operation.
 	JobID *string `json:"jobId,omitempty"`
@@ -3796,7 +3776,7 @@ type SelectiveKeyRestoreOperation struct {
 	EndTime *time.Time `json:"endTime,omitempty"`
 
 	// Error encountered, if any, during the selective key restore operation.
-	Error *Error `json:"error,omitempty"`
+	Error *ErrorInfo `json:"error,omitempty"`
 
 	// Identifier for the selective key restore operation.
 	JobID *string `json:"jobId,omitempty"`

--- a/test/keyvault/7.2/azkeyvault/zz_generated_pagers.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_pagers.go
@@ -18,7 +18,7 @@ import (
 
 // KeyVaultClientGetCertificateIssuersPager provides operations for iterating over paged responses.
 type KeyVaultClientGetCertificateIssuersPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetCertificateIssuersResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -72,7 +72,7 @@ func (p *KeyVaultClientGetCertificateIssuersPager) PageResponse() KeyVaultClient
 
 // KeyVaultClientGetCertificateVersionsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetCertificateVersionsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetCertificateVersionsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -126,7 +126,7 @@ func (p *KeyVaultClientGetCertificateVersionsPager) PageResponse() KeyVaultClien
 
 // KeyVaultClientGetCertificatesPager provides operations for iterating over paged responses.
 type KeyVaultClientGetCertificatesPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetCertificatesResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -180,7 +180,7 @@ func (p *KeyVaultClientGetCertificatesPager) PageResponse() KeyVaultClientGetCer
 
 // KeyVaultClientGetDeletedCertificatesPager provides operations for iterating over paged responses.
 type KeyVaultClientGetDeletedCertificatesPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetDeletedCertificatesResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -234,7 +234,7 @@ func (p *KeyVaultClientGetDeletedCertificatesPager) PageResponse() KeyVaultClien
 
 // KeyVaultClientGetDeletedKeysPager provides operations for iterating over paged responses.
 type KeyVaultClientGetDeletedKeysPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetDeletedKeysResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -288,7 +288,7 @@ func (p *KeyVaultClientGetDeletedKeysPager) PageResponse() KeyVaultClientGetDele
 
 // KeyVaultClientGetDeletedSasDefinitionsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetDeletedSasDefinitionsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetDeletedSasDefinitionsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -342,7 +342,7 @@ func (p *KeyVaultClientGetDeletedSasDefinitionsPager) PageResponse() KeyVaultCli
 
 // KeyVaultClientGetDeletedSecretsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetDeletedSecretsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetDeletedSecretsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -396,7 +396,7 @@ func (p *KeyVaultClientGetDeletedSecretsPager) PageResponse() KeyVaultClientGetD
 
 // KeyVaultClientGetDeletedStorageAccountsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetDeletedStorageAccountsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetDeletedStorageAccountsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -450,7 +450,7 @@ func (p *KeyVaultClientGetDeletedStorageAccountsPager) PageResponse() KeyVaultCl
 
 // KeyVaultClientGetKeyVersionsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetKeyVersionsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetKeyVersionsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -504,7 +504,7 @@ func (p *KeyVaultClientGetKeyVersionsPager) PageResponse() KeyVaultClientGetKeyV
 
 // KeyVaultClientGetKeysPager provides operations for iterating over paged responses.
 type KeyVaultClientGetKeysPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetKeysResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -558,7 +558,7 @@ func (p *KeyVaultClientGetKeysPager) PageResponse() KeyVaultClientGetKeysRespons
 
 // KeyVaultClientGetSasDefinitionsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetSasDefinitionsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetSasDefinitionsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -612,7 +612,7 @@ func (p *KeyVaultClientGetSasDefinitionsPager) PageResponse() KeyVaultClientGetS
 
 // KeyVaultClientGetSecretVersionsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetSecretVersionsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetSecretVersionsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -666,7 +666,7 @@ func (p *KeyVaultClientGetSecretVersionsPager) PageResponse() KeyVaultClientGetS
 
 // KeyVaultClientGetSecretsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetSecretsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetSecretsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -720,7 +720,7 @@ func (p *KeyVaultClientGetSecretsPager) PageResponse() KeyVaultClientGetSecretsR
 
 // KeyVaultClientGetStorageAccountsPager provides operations for iterating over paged responses.
 type KeyVaultClientGetStorageAccountsPager struct {
-	client    *KeyVaultClient
+	client    *Client
 	current   KeyVaultClientGetStorageAccountsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)

--- a/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
@@ -367,8 +367,8 @@ func (l KeyVaultClientFullBackupPollerResponse) PollUntilDone(ctx context.Contex
 }
 
 // Resume rehydrates a KeyVaultClientFullBackupPollerResponse from the provided client and resume token.
-func (l *KeyVaultClientFullBackupPollerResponse) Resume(ctx context.Context, client *KeyVaultClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("KeyVaultClient.FullBackup", token, client.pl, client.fullBackupHandleError)
+func (l *KeyVaultClientFullBackupPollerResponse) Resume(ctx context.Context, client *Client, token string) error {
+	pt, err := runtime.NewPollerFromResumeToken("Client.FullBackup", token, client.pl, client.fullBackupHandleError)
 	if err != nil {
 		return err
 	}
@@ -430,8 +430,8 @@ func (l KeyVaultClientFullRestoreOperationPollerResponse) PollUntilDone(ctx cont
 }
 
 // Resume rehydrates a KeyVaultClientFullRestoreOperationPollerResponse from the provided client and resume token.
-func (l *KeyVaultClientFullRestoreOperationPollerResponse) Resume(ctx context.Context, client *KeyVaultClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("KeyVaultClient.FullRestoreOperation", token, client.pl, client.fullRestoreOperationHandleError)
+func (l *KeyVaultClientFullRestoreOperationPollerResponse) Resume(ctx context.Context, client *Client, token string) error {
+	pt, err := runtime.NewPollerFromResumeToken("Client.FullRestoreOperation", token, client.pl, client.fullRestoreOperationHandleError)
 	if err != nil {
 		return err
 	}
@@ -1009,8 +1009,8 @@ func (l KeyVaultClientSelectiveKeyRestoreOperationPollerResponse) PollUntilDone(
 }
 
 // Resume rehydrates a KeyVaultClientSelectiveKeyRestoreOperationPollerResponse from the provided client and resume token.
-func (l *KeyVaultClientSelectiveKeyRestoreOperationPollerResponse) Resume(ctx context.Context, client *KeyVaultClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("KeyVaultClient.SelectiveKeyRestoreOperation", token, client.pl, client.selectiveKeyRestoreOperationHandleError)
+func (l *KeyVaultClientSelectiveKeyRestoreOperationPollerResponse) Resume(ctx context.Context, client *Client, token string) error {
+	pt, err := runtime.NewPollerFromResumeToken("Client.SelectiveKeyRestoreOperation", token, client.pl, client.selectiveKeyRestoreOperationHandleError)
 	if err != nil {
 		return err
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
@@ -35,7 +35,7 @@ func NewRoleAssignmentsClient(pl runtime.Pipeline) *RoleAssignmentsClient {
 }
 
 // Create - Creates a role assignment.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role assignment to create.
 // roleAssignmentName - The name of the role assignment to create. It can be any valid GUID.
@@ -92,7 +92,7 @@ func (client *RoleAssignmentsClient) createHandleError(resp *http.Response) erro
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -100,7 +100,7 @@ func (client *RoleAssignmentsClient) createHandleError(resp *http.Response) erro
 }
 
 // Delete - Deletes a role assignment.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role assignment to delete.
 // roleAssignmentName - The name of the role assignment to delete.
@@ -156,7 +156,7 @@ func (client *RoleAssignmentsClient) deleteHandleError(resp *http.Response) erro
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -164,7 +164,7 @@ func (client *RoleAssignmentsClient) deleteHandleError(resp *http.Response) erro
 }
 
 // Get - Get the specified role assignment.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role assignment.
 // roleAssignmentName - The name of the role assignment to get.
@@ -220,7 +220,7 @@ func (client *RoleAssignmentsClient) getHandleError(resp *http.Response) error {
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -228,7 +228,7 @@ func (client *RoleAssignmentsClient) getHandleError(resp *http.Response) error {
 }
 
 // ListForScope - Gets role assignments for a scope.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role assignments.
 // options - RoleAssignmentsListForScopeOptions contains the optional parameters for the RoleAssignmentsClient.ListForScope
@@ -280,7 +280,7 @@ func (client *RoleAssignmentsClient) listForScopeHandleError(resp *http.Response
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
@@ -35,7 +35,7 @@ func NewRoleDefinitionsClient(pl runtime.Pipeline) *RoleDefinitionsClient {
 }
 
 // CreateOrUpdate - Creates or updates a custom role definition.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role definition to create or update. Managed HSM only supports '/'.
 // roleDefinitionName - The name of the role definition to create or update. It can be any valid GUID.
@@ -93,7 +93,7 @@ func (client *RoleDefinitionsClient) createOrUpdateHandleError(resp *http.Respon
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -101,7 +101,7 @@ func (client *RoleDefinitionsClient) createOrUpdateHandleError(resp *http.Respon
 }
 
 // Delete - Deletes a custom role definition.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role definition to delete. Managed HSM only supports '/'.
 // roleDefinitionName - The name (GUID) of the role definition to delete.
@@ -157,7 +157,7 @@ func (client *RoleDefinitionsClient) deleteHandleError(resp *http.Response) erro
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -165,7 +165,7 @@ func (client *RoleDefinitionsClient) deleteHandleError(resp *http.Response) erro
 }
 
 // Get - Get the specified role definition.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role definition to get. Managed HSM only supports '/'.
 // roleDefinitionName - The name of the role definition to get.
@@ -221,7 +221,7 @@ func (client *RoleDefinitionsClient) getHandleError(resp *http.Response) error {
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -229,7 +229,7 @@ func (client *RoleDefinitionsClient) getHandleError(resp *http.Response) error {
 }
 
 // List - Get all role definitions that are applicable at scope and above.
-// If the operation fails it returns the *KeyVaultError error type.
+// If the operation fails it returns the *Error error type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role definition.
 // options - RoleDefinitionsListOptions contains the optional parameters for the RoleDefinitionsClient.List method.
@@ -280,7 +280,7 @@ func (client *RoleDefinitionsClient) listHandleError(resp *http.Response) error 
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := KeyVaultError{raw: string(body)}
+	errType := Error{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}

--- a/test/maps/azalias/zz_generated_client.go
+++ b/test/maps/azalias/zz_generated_client.go
@@ -18,24 +18,24 @@ import (
 	"strings"
 )
 
-type aliasClient struct {
+type client struct {
 	endpoint   string
 	apiVersion *string
 	pl         runtime.Pipeline
 }
 
-// newAliasClient creates a new instance of aliasClient with the specified values.
+// newClient creates a new instance of client with the specified values.
 // geography - This parameter specifies where the Azure Maps Creator resource is located. Valid values are us and eu.
 // apiVersion - Api Version. Specifying any value will set the value to 2.0.
 // pl - the pipeline used for sending requests and handling responses.
-func newAliasClient(geography *Geography, apiVersion *string, pl runtime.Pipeline) *aliasClient {
+func newClient(geography *Geography, apiVersion *string, pl runtime.Pipeline) *client {
 	hostURL := "https://{geography}.atlas.microsoft.com"
 	if geography == nil {
 		defaultValue := GeographyUs
 		geography = &defaultValue
 	}
 	hostURL = strings.ReplaceAll(hostURL, "{geography}", string(*geography))
-	client := &aliasClient{
+	client := &client{
 		endpoint:   hostURL,
 		apiVersion: apiVersion,
 		pl:         pl,
@@ -58,8 +58,8 @@ func newAliasClient(geography *Geography, apiVersion *string, pl runtime.Pipelin
 // "e89aebb9-70a3-8fe1-32bb-1fbd0c725f14", "lastUpdatedTimestamp":
 // "2020-02-13T21:19:22.123Z" }
 // If the operation fails it returns a generic error.
-// options - AliasCreateOptions contains the optional parameters for the aliasClient.Create method.
-func (client *aliasClient) Create(ctx context.Context, options *AliasCreateOptions) (AliasCreateResponse, error) {
+// options - AliasCreateOptions contains the optional parameters for the client.Create method.
+func (client *client) Create(ctx context.Context, options *AliasCreateOptions) (AliasCreateResponse, error) {
 	req, err := client.createCreateRequest(ctx, options)
 	if err != nil {
 		return AliasCreateResponse{}, err
@@ -75,7 +75,7 @@ func (client *aliasClient) Create(ctx context.Context, options *AliasCreateOptio
 }
 
 // createCreateRequest creates the Create request.
-func (client *aliasClient) createCreateRequest(ctx context.Context, options *AliasCreateOptions) (*policy.Request, error) {
+func (client *client) createCreateRequest(ctx context.Context, options *AliasCreateOptions) (*policy.Request, error) {
 	urlPath := "/aliases"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -99,7 +99,7 @@ func (client *aliasClient) createCreateRequest(ctx context.Context, options *Ali
 }
 
 // createHandleResponse handles the Create response.
-func (client *aliasClient) createHandleResponse(resp *http.Response) (AliasCreateResponse, error) {
+func (client *client) createHandleResponse(resp *http.Response) (AliasCreateResponse, error) {
 	result := AliasCreateResponse{RawResponse: resp}
 	if val := resp.Header.Get("Access-Control-Expose-Headers"); val != "" {
 		result.AccessControlExposeHeaders = &val
@@ -111,7 +111,7 @@ func (client *aliasClient) createHandleResponse(resp *http.Response) (AliasCreat
 }
 
 // createHandleError handles the Create error response.
-func (client *aliasClient) createHandleError(resp *http.Response) error {
+func (client *client) createHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -141,21 +141,21 @@ func (client *aliasClient) createHandleError(resp *http.Response) error {
 // "creatorDataItemId": null, "lastUpdatedTimestamp":
 // "2020-02-18T19:53:33.123Z" } ] }
 // If the operation fails it returns a generic error.
-// options - AliasListOptions contains the optional parameters for the aliasClient.List method.
-func (client *aliasClient) List(options *AliasListOptions) *AliasListPager {
+// options - AliasListOptions contains the optional parameters for the client.List method.
+func (client *client) List(options *AliasListOptions) *AliasListPager {
 	return &AliasListPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, options)
 		},
-		advancer: func(ctx context.Context, resp AliasListResponseEnvelope) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.AliasListResponse.NextLink)
+		advancer: func(ctx context.Context, resp AliasListResponse) (*policy.Request, error) {
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.ListResponse.NextLink)
 		},
 	}
 }
 
 // listCreateRequest creates the List request.
-func (client *aliasClient) listCreateRequest(ctx context.Context, options *AliasListOptions) (*policy.Request, error) {
+func (client *client) listCreateRequest(ctx context.Context, options *AliasListOptions) (*policy.Request, error) {
 	urlPath := "/aliases"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -176,16 +176,16 @@ func (client *aliasClient) listCreateRequest(ctx context.Context, options *Alias
 }
 
 // listHandleResponse handles the List response.
-func (client *aliasClient) listHandleResponse(resp *http.Response) (AliasListResponseEnvelope, error) {
-	result := AliasListResponseEnvelope{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.AliasListResponse); err != nil {
-		return AliasListResponseEnvelope{}, runtime.NewResponseError(err, resp)
+func (client *client) listHandleResponse(resp *http.Response) (AliasListResponse, error) {
+	result := AliasListResponse{RawResponse: resp}
+	if err := runtime.UnmarshalAsJSON(resp, &result.ListResponse); err != nil {
+		return AliasListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *aliasClient) listHandleError(resp *http.Response) error {
+func (client *client) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/maps/azalias/zz_generated_models.go
+++ b/test/maps/azalias/zz_generated_models.go
@@ -15,48 +15,16 @@ import (
 	"time"
 )
 
-// AliasCreateOptions contains the optional parameters for the aliasClient.Create method.
+// AliasCreateOptions contains the optional parameters for the client.Create method.
 type AliasCreateOptions struct {
 	// The unique id that references a creator data item to be aliased.
 	CreatorDataItemID *string
 	GroupBy           []SomethingCount
 }
 
-// AliasListItem - Detailed information for the alias.
-type AliasListItem struct {
-	// READ-ONLY; The id for the alias.
-	AliasID *string `json:"aliasId,omitempty" azure:"ro"`
-
-	// READ-ONLY; The created timestamp for the alias.
-	CreatedTimestamp *string `json:"createdTimestamp,omitempty" azure:"ro"`
-
-	// READ-ONLY; The id for the creator data item that this alias references (could be null if the alias has not been assigned).
-	CreatorDataItemID *string `json:"creatorDataItemId,omitempty" azure:"ro"`
-
-	// READ-ONLY; The timestamp of the last time the alias was assigned.
-	LastUpdatedTimestamp *string `json:"lastUpdatedTimestamp,omitempty" azure:"ro"`
-}
-
-// AliasListOptions contains the optional parameters for the aliasClient.List method.
+// AliasListOptions contains the optional parameters for the client.List method.
 type AliasListOptions struct {
 	GroupBy []LogMetricsGroupBy
-}
-
-// AliasListResponse - The response model for the List API. Returns a list of all the previously created aliases.
-type AliasListResponse struct {
-	// READ-ONLY; A list of all the previously created aliases.
-	Aliases []*AliasListItem `json:"aliases,omitempty" azure:"ro"`
-
-	// READ-ONLY; If present, the location of the next page of data.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type AliasListResponse.
-func (a AliasListResponse) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "aliases", a.Aliases)
-	populate(objectMap, "nextLink", a.NextLink)
-	return json.Marshal(objectMap)
 }
 
 // AliasesCreateResponse - The response model for the Alias Create API for the case when the alias was successfully created.
@@ -240,6 +208,38 @@ func (g *GeoJSONObjectNamedCollection) UnmarshalJSON(data []byte) error {
 		}
 	}
 	return nil
+}
+
+// ListItem - Detailed information for the alias.
+type ListItem struct {
+	// READ-ONLY; The id for the alias.
+	AliasID *string `json:"aliasId,omitempty" azure:"ro"`
+
+	// READ-ONLY; The created timestamp for the alias.
+	CreatedTimestamp *string `json:"createdTimestamp,omitempty" azure:"ro"`
+
+	// READ-ONLY; The id for the creator data item that this alias references (could be null if the alias has not been assigned).
+	CreatorDataItemID *string `json:"creatorDataItemId,omitempty" azure:"ro"`
+
+	// READ-ONLY; The timestamp of the last time the alias was assigned.
+	LastUpdatedTimestamp *string `json:"lastUpdatedTimestamp,omitempty" azure:"ro"`
+}
+
+// ListResponse - The response model for the List API. Returns a list of all the previously created aliases.
+type ListResponse struct {
+	// READ-ONLY; A list of all the previously created aliases.
+	Aliases []*ListItem `json:"aliases,omitempty" azure:"ro"`
+
+	// READ-ONLY; If present, the location of the next page of data.
+	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListResponse.
+func (l ListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aliases", l.Aliases)
+	populate(objectMap, "nextLink", l.NextLink)
+	return json.Marshal(objectMap)
 }
 
 // ScheduleCreateOrUpdateProperties - The parameters supplied to the create or update schedule operation.

--- a/test/maps/azalias/zz_generated_pagers.go
+++ b/test/maps/azalias/zz_generated_pagers.go
@@ -18,11 +18,11 @@ import (
 
 // AliasListPager provides operations for iterating over paged responses.
 type AliasListPager struct {
-	client    *aliasClient
-	current   AliasListResponseEnvelope
+	client    *client
+	current   AliasListResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
-	advancer  func(context.Context, AliasListResponseEnvelope) (*policy.Request, error)
+	advancer  func(context.Context, AliasListResponse) (*policy.Request, error)
 }
 
 // Err returns the last error encountered while paging.
@@ -36,7 +36,7 @@ func (p *AliasListPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.AliasListResponse.NextLink == nil || len(*p.current.AliasListResponse.NextLink) == 0 {
+		if p.current.ListResponse.NextLink == nil || len(*p.current.ListResponse.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -65,7 +65,7 @@ func (p *AliasListPager) NextPage(ctx context.Context) bool {
 	return true
 }
 
-// PageResponse returns the current AliasListResponseEnvelope page.
-func (p *AliasListPager) PageResponse() AliasListResponseEnvelope {
+// PageResponse returns the current AliasListResponse page.
+func (p *AliasListPager) PageResponse() AliasListResponse {
 	return p.current
 }

--- a/test/maps/azalias/zz_generated_response_types.go
+++ b/test/maps/azalias/zz_generated_response_types.go
@@ -24,8 +24,8 @@ type AliasCreateResult struct {
 	AccessControlExposeHeaders *string
 }
 
-// AliasListResponseEnvelope contains the response from method Alias.List.
-type AliasListResponseEnvelope struct {
+// AliasListResponse contains the response from method Alias.List.
+type AliasListResponse struct {
 	AliasListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -33,5 +33,5 @@ type AliasListResponseEnvelope struct {
 
 // AliasListResult contains the result from method Alias.List.
 type AliasListResult struct {
-	AliasListResponse
+	ListResponse
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaceipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaceipconfigurations_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkInterfaceIPConfigurationsClient contains the methods for the NetworkInterfaceIPConfigurations group.
-// Don't use this type directly, use NewNetworkInterfaceIPConfigurationsClient() instead.
-type NetworkInterfaceIPConfigurationsClient struct {
+// InterfaceIPConfigurationsClient contains the methods for the NetworkInterfaceIPConfigurations group.
+// Don't use this type directly, use NewInterfaceIPConfigurationsClient() instead.
+type InterfaceIPConfigurationsClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkInterfaceIPConfigurationsClient creates a new instance of NetworkInterfaceIPConfigurationsClient with the specified values.
+// NewInterfaceIPConfigurationsClient creates a new instance of InterfaceIPConfigurationsClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkInterfaceIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkInterfaceIPConfigurationsClient {
+func NewInterfaceIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *InterfaceIPConfigurationsClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkInterfaceIPConfigurationsClient(subscriptionID string, credential
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkInterfaceIPConfigurationsClient{
+	client := &InterfaceIPConfigurationsClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -56,9 +56,9 @@ func NewNetworkInterfaceIPConfigurationsClient(subscriptionID string, credential
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
 // ipConfigurationName - The name of the ip configuration name.
-// options - NetworkInterfaceIPConfigurationsGetOptions contains the optional parameters for the NetworkInterfaceIPConfigurationsClient.Get
+// options - NetworkInterfaceIPConfigurationsGetOptions contains the optional parameters for the InterfaceIPConfigurationsClient.Get
 // method.
-func (client *NetworkInterfaceIPConfigurationsClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfaceIPConfigurationsGetOptions) (NetworkInterfaceIPConfigurationsGetResponse, error) {
+func (client *InterfaceIPConfigurationsClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfaceIPConfigurationsGetOptions) (NetworkInterfaceIPConfigurationsGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, resourceGroupName, networkInterfaceName, ipConfigurationName, options)
 	if err != nil {
 		return NetworkInterfaceIPConfigurationsGetResponse{}, err
@@ -74,7 +74,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) Get(ctx context.Context, r
 }
 
 // getCreateRequest creates the Get request.
-func (client *NetworkInterfaceIPConfigurationsClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfaceIPConfigurationsGetOptions) (*policy.Request, error) {
+func (client *InterfaceIPConfigurationsClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfaceIPConfigurationsGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -104,16 +104,16 @@ func (client *NetworkInterfaceIPConfigurationsClient) getCreateRequest(ctx conte
 }
 
 // getHandleResponse handles the Get response.
-func (client *NetworkInterfaceIPConfigurationsClient) getHandleResponse(resp *http.Response) (NetworkInterfaceIPConfigurationsGetResponse, error) {
+func (client *InterfaceIPConfigurationsClient) getHandleResponse(resp *http.Response) (NetworkInterfaceIPConfigurationsGetResponse, error) {
 	result := NetworkInterfaceIPConfigurationsGetResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceIPConfiguration); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceIPConfiguration); err != nil {
 		return NetworkInterfaceIPConfigurationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getHandleError handles the Get error response.
-func (client *NetworkInterfaceIPConfigurationsClient) getHandleError(resp *http.Response) error {
+func (client *InterfaceIPConfigurationsClient) getHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -129,22 +129,22 @@ func (client *NetworkInterfaceIPConfigurationsClient) getHandleError(resp *http.
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfaceIPConfigurationsListOptions contains the optional parameters for the NetworkInterfaceIPConfigurationsClient.List
+// options - NetworkInterfaceIPConfigurationsListOptions contains the optional parameters for the InterfaceIPConfigurationsClient.List
 // method.
-func (client *NetworkInterfaceIPConfigurationsClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceIPConfigurationsListOptions) *NetworkInterfaceIPConfigurationsListPager {
+func (client *InterfaceIPConfigurationsClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceIPConfigurationsListOptions) *NetworkInterfaceIPConfigurationsListPager {
 	return &NetworkInterfaceIPConfigurationsListPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkInterfaceIPConfigurationsListResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceIPConfigurationListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceIPConfigurationListResult.NextLink)
 		},
 	}
 }
 
 // listCreateRequest creates the List request.
-func (client *NetworkInterfaceIPConfigurationsClient) listCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceIPConfigurationsListOptions) (*policy.Request, error) {
+func (client *InterfaceIPConfigurationsClient) listCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceIPConfigurationsListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -170,16 +170,16 @@ func (client *NetworkInterfaceIPConfigurationsClient) listCreateRequest(ctx cont
 }
 
 // listHandleResponse handles the List response.
-func (client *NetworkInterfaceIPConfigurationsClient) listHandleResponse(resp *http.Response) (NetworkInterfaceIPConfigurationsListResponse, error) {
+func (client *InterfaceIPConfigurationsClient) listHandleResponse(resp *http.Response) (NetworkInterfaceIPConfigurationsListResponse, error) {
 	result := NetworkInterfaceIPConfigurationsListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceIPConfigurationListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceIPConfigurationListResult); err != nil {
 		return NetworkInterfaceIPConfigurationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *NetworkInterfaceIPConfigurationsClient) listHandleError(resp *http.Response) error {
+func (client *InterfaceIPConfigurationsClient) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaceloadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaceloadbalancers_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkInterfaceLoadBalancersClient contains the methods for the NetworkInterfaceLoadBalancers group.
-// Don't use this type directly, use NewNetworkInterfaceLoadBalancersClient() instead.
-type NetworkInterfaceLoadBalancersClient struct {
+// InterfaceLoadBalancersClient contains the methods for the NetworkInterfaceLoadBalancers group.
+// Don't use this type directly, use NewInterfaceLoadBalancersClient() instead.
+type InterfaceLoadBalancersClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkInterfaceLoadBalancersClient creates a new instance of NetworkInterfaceLoadBalancersClient with the specified values.
+// NewInterfaceLoadBalancersClient creates a new instance of InterfaceLoadBalancersClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkInterfaceLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkInterfaceLoadBalancersClient {
+func NewInterfaceLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *InterfaceLoadBalancersClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkInterfaceLoadBalancersClient(subscriptionID string, credential az
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkInterfaceLoadBalancersClient{
+	client := &InterfaceLoadBalancersClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -55,22 +55,22 @@ func NewNetworkInterfaceLoadBalancersClient(subscriptionID string, credential az
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfaceLoadBalancersListOptions contains the optional parameters for the NetworkInterfaceLoadBalancersClient.List
+// options - NetworkInterfaceLoadBalancersListOptions contains the optional parameters for the InterfaceLoadBalancersClient.List
 // method.
-func (client *NetworkInterfaceLoadBalancersClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceLoadBalancersListOptions) *NetworkInterfaceLoadBalancersListPager {
+func (client *InterfaceLoadBalancersClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceLoadBalancersListOptions) *NetworkInterfaceLoadBalancersListPager {
 	return &NetworkInterfaceLoadBalancersListPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkInterfaceLoadBalancersListResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceLoadBalancerListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceLoadBalancerListResult.NextLink)
 		},
 	}
 }
 
 // listCreateRequest creates the List request.
-func (client *NetworkInterfaceLoadBalancersClient) listCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceLoadBalancersListOptions) (*policy.Request, error) {
+func (client *InterfaceLoadBalancersClient) listCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceLoadBalancersListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/loadBalancers"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -96,16 +96,16 @@ func (client *NetworkInterfaceLoadBalancersClient) listCreateRequest(ctx context
 }
 
 // listHandleResponse handles the List response.
-func (client *NetworkInterfaceLoadBalancersClient) listHandleResponse(resp *http.Response) (NetworkInterfaceLoadBalancersListResponse, error) {
+func (client *InterfaceLoadBalancersClient) listHandleResponse(resp *http.Response) (NetworkInterfaceLoadBalancersListResponse, error) {
 	result := NetworkInterfaceLoadBalancersListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceLoadBalancerListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceLoadBalancerListResult); err != nil {
 		return NetworkInterfaceLoadBalancersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *NetworkInterfaceLoadBalancersClient) listHandleError(resp *http.Response) error {
+func (client *InterfaceLoadBalancersClient) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaces_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkInterfacesClient contains the methods for the NetworkInterfaces group.
-// Don't use this type directly, use NewNetworkInterfacesClient() instead.
-type NetworkInterfacesClient struct {
+// InterfacesClient contains the methods for the NetworkInterfaces group.
+// Don't use this type directly, use NewInterfacesClient() instead.
+type InterfacesClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkInterfacesClient creates a new instance of NetworkInterfacesClient with the specified values.
+// NewInterfacesClient creates a new instance of InterfacesClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkInterfacesClient {
+func NewInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *InterfacesClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkInterfacesClient(subscriptionID string, credential azcore.TokenCr
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkInterfacesClient{
+	client := &InterfacesClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -56,9 +56,9 @@ func NewNetworkInterfacesClient(subscriptionID string, credential azcore.TokenCr
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
 // parameters - Parameters supplied to the create or update network interface operation.
-// options - NetworkInterfacesBeginCreateOrUpdateOptions contains the optional parameters for the NetworkInterfacesClient.BeginCreateOrUpdate
+// options - NetworkInterfacesBeginCreateOrUpdateOptions contains the optional parameters for the InterfacesClient.BeginCreateOrUpdate
 // method.
-func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface, options *NetworkInterfacesBeginCreateOrUpdateOptions) (NetworkInterfacesCreateOrUpdatePollerResponse, error) {
+func (client *InterfacesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters Interface, options *NetworkInterfacesBeginCreateOrUpdateOptions) (NetworkInterfacesCreateOrUpdatePollerResponse, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkInterfaceName, parameters, options)
 	if err != nil {
 		return NetworkInterfacesCreateOrUpdatePollerResponse{}, err
@@ -66,7 +66,7 @@ func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, 
 	result := NetworkInterfacesCreateOrUpdatePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkInterfacesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl, client.createOrUpdateHandleError)
+	pt, err := armruntime.NewPoller("InterfacesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl, client.createOrUpdateHandleError)
 	if err != nil {
 		return NetworkInterfacesCreateOrUpdatePollerResponse{}, err
 	}
@@ -78,7 +78,7 @@ func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, 
 
 // CreateOrUpdate - Creates or updates a network interface.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkInterfacesClient) createOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface, options *NetworkInterfacesBeginCreateOrUpdateOptions) (*http.Response, error) {
+func (client *InterfacesClient) createOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters Interface, options *NetworkInterfacesBeginCreateOrUpdateOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateCreateRequest(ctx, resourceGroupName, networkInterfaceName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (client *NetworkInterfacesClient) createOrUpdate(ctx context.Context, resou
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkInterfacesClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface, options *NetworkInterfacesBeginCreateOrUpdateOptions) (*policy.Request, error) {
+func (client *InterfacesClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters Interface, options *NetworkInterfacesBeginCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -120,7 +120,7 @@ func (client *NetworkInterfacesClient) createOrUpdateCreateRequest(ctx context.C
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
-func (client *NetworkInterfacesClient) createOrUpdateHandleError(resp *http.Response) error {
+func (client *InterfacesClient) createOrUpdateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -136,9 +136,8 @@ func (client *NetworkInterfacesClient) createOrUpdateHandleError(resp *http.Resp
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfacesBeginDeleteOptions contains the optional parameters for the NetworkInterfacesClient.BeginDelete
-// method.
-func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginDeleteOptions) (NetworkInterfacesDeletePollerResponse, error) {
+// options - NetworkInterfacesBeginDeleteOptions contains the optional parameters for the InterfacesClient.BeginDelete method.
+func (client *InterfacesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginDeleteOptions) (NetworkInterfacesDeletePollerResponse, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return NetworkInterfacesDeletePollerResponse{}, err
@@ -146,7 +145,7 @@ func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resource
 	result := NetworkInterfacesDeletePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkInterfacesClient.Delete", "location", resp, client.pl, client.deleteHandleError)
+	pt, err := armruntime.NewPoller("InterfacesClient.Delete", "location", resp, client.pl, client.deleteHandleError)
 	if err != nil {
 		return NetworkInterfacesDeletePollerResponse{}, err
 	}
@@ -158,7 +157,7 @@ func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resource
 
 // Delete - Deletes the specified network interface.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkInterfacesClient) deleteOperation(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginDeleteOptions) (*http.Response, error) {
+func (client *InterfacesClient) deleteOperation(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginDeleteOptions) (*http.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
@@ -174,7 +173,7 @@ func (client *NetworkInterfacesClient) deleteOperation(ctx context.Context, reso
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *NetworkInterfacesClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginDeleteOptions) (*policy.Request, error) {
+func (client *InterfacesClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -200,7 +199,7 @@ func (client *NetworkInterfacesClient) deleteCreateRequest(ctx context.Context, 
 }
 
 // deleteHandleError handles the Delete error response.
-func (client *NetworkInterfacesClient) deleteHandleError(resp *http.Response) error {
+func (client *InterfacesClient) deleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -216,8 +215,8 @@ func (client *NetworkInterfacesClient) deleteHandleError(resp *http.Response) er
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfacesGetOptions contains the optional parameters for the NetworkInterfacesClient.Get method.
-func (client *NetworkInterfacesClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetOptions) (NetworkInterfacesGetResponse, error) {
+// options - NetworkInterfacesGetOptions contains the optional parameters for the InterfacesClient.Get method.
+func (client *InterfacesClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetOptions) (NetworkInterfacesGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return NetworkInterfacesGetResponse{}, err
@@ -233,7 +232,7 @@ func (client *NetworkInterfacesClient) Get(ctx context.Context, resourceGroupNam
 }
 
 // getCreateRequest creates the Get request.
-func (client *NetworkInterfacesClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetOptions) (*policy.Request, error) {
+func (client *InterfacesClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -262,16 +261,16 @@ func (client *NetworkInterfacesClient) getCreateRequest(ctx context.Context, res
 }
 
 // getHandleResponse handles the Get response.
-func (client *NetworkInterfacesClient) getHandleResponse(resp *http.Response) (NetworkInterfacesGetResponse, error) {
+func (client *InterfacesClient) getHandleResponse(resp *http.Response) (NetworkInterfacesGetResponse, error) {
 	result := NetworkInterfacesGetResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterface); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
 		return NetworkInterfacesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getHandleError handles the Get error response.
-func (client *NetworkInterfacesClient) getHandleError(resp *http.Response) error {
+func (client *InterfacesClient) getHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -287,9 +286,9 @@ func (client *NetworkInterfacesClient) getHandleError(resp *http.Response) error
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfacesBeginGetEffectiveRouteTableOptions contains the optional parameters for the NetworkInterfacesClient.BeginGetEffectiveRouteTable
+// options - NetworkInterfacesBeginGetEffectiveRouteTableOptions contains the optional parameters for the InterfacesClient.BeginGetEffectiveRouteTable
 // method.
-func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginGetEffectiveRouteTableOptions) (NetworkInterfacesGetEffectiveRouteTablePollerResponse, error) {
+func (client *InterfacesClient) BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginGetEffectiveRouteTableOptions) (NetworkInterfacesGetEffectiveRouteTablePollerResponse, error) {
 	resp, err := client.getEffectiveRouteTable(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return NetworkInterfacesGetEffectiveRouteTablePollerResponse{}, err
@@ -297,7 +296,7 @@ func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.C
 	result := NetworkInterfacesGetEffectiveRouteTablePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkInterfacesClient.GetEffectiveRouteTable", "location", resp, client.pl, client.getEffectiveRouteTableHandleError)
+	pt, err := armruntime.NewPoller("InterfacesClient.GetEffectiveRouteTable", "location", resp, client.pl, client.getEffectiveRouteTableHandleError)
 	if err != nil {
 		return NetworkInterfacesGetEffectiveRouteTablePollerResponse{}, err
 	}
@@ -309,7 +308,7 @@ func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.C
 
 // GetEffectiveRouteTable - Gets all route tables applied to a network interface.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkInterfacesClient) getEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginGetEffectiveRouteTableOptions) (*http.Response, error) {
+func (client *InterfacesClient) getEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginGetEffectiveRouteTableOptions) (*http.Response, error) {
 	req, err := client.getEffectiveRouteTableCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
@@ -325,7 +324,7 @@ func (client *NetworkInterfacesClient) getEffectiveRouteTable(ctx context.Contex
 }
 
 // getEffectiveRouteTableCreateRequest creates the GetEffectiveRouteTable request.
-func (client *NetworkInterfacesClient) getEffectiveRouteTableCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginGetEffectiveRouteTableOptions) (*policy.Request, error) {
+func (client *InterfacesClient) getEffectiveRouteTableCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginGetEffectiveRouteTableOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveRouteTable"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -351,7 +350,7 @@ func (client *NetworkInterfacesClient) getEffectiveRouteTableCreateRequest(ctx c
 }
 
 // getEffectiveRouteTableHandleError handles the GetEffectiveRouteTable error response.
-func (client *NetworkInterfacesClient) getEffectiveRouteTableHandleError(resp *http.Response) error {
+func (client *InterfacesClient) getEffectiveRouteTableHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -371,9 +370,9 @@ func (client *NetworkInterfacesClient) getEffectiveRouteTableHandleError(resp *h
 // virtualmachineIndex - The virtual machine index.
 // networkInterfaceName - The name of the network interface.
 // ipConfigurationName - The name of the ip configuration.
-// options - NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions contains the optional parameters for the NetworkInterfacesClient.GetVirtualMachineScaleSetIPConfiguration
+// options - NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions contains the optional parameters for the InterfacesClient.GetVirtualMachineScaleSetIPConfiguration
 // method.
-func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse, error) {
+func (client *InterfacesClient) GetVirtualMachineScaleSetIPConfiguration(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse, error) {
 	req, err := client.getVirtualMachineScaleSetIPConfigurationCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName, options)
 	if err != nil {
 		return NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse{}, err
@@ -389,7 +388,7 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(
 }
 
 // getVirtualMachineScaleSetIPConfigurationCreateRequest creates the GetVirtualMachineScaleSetIPConfiguration request.
-func (client *NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*policy.Request, error) {
+func (client *InterfacesClient) getVirtualMachineScaleSetIPConfigurationCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -430,16 +429,16 @@ func (client *NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationC
 }
 
 // getVirtualMachineScaleSetIPConfigurationHandleResponse handles the GetVirtualMachineScaleSetIPConfiguration response.
-func (client *NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationHandleResponse(resp *http.Response) (NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse, error) {
+func (client *InterfacesClient) getVirtualMachineScaleSetIPConfigurationHandleResponse(resp *http.Response) (NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse, error) {
 	result := NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceIPConfiguration); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceIPConfiguration); err != nil {
 		return NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getVirtualMachineScaleSetIPConfigurationHandleError handles the GetVirtualMachineScaleSetIPConfiguration error response.
-func (client *NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationHandleError(resp *http.Response) error {
+func (client *InterfacesClient) getVirtualMachineScaleSetIPConfigurationHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -457,9 +456,9 @@ func (client *NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationH
 // virtualMachineScaleSetName - The name of the virtual machine scale set.
 // virtualmachineIndex - The virtual machine index.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions contains the optional parameters for the NetworkInterfacesClient.GetVirtualMachineScaleSetNetworkInterface
+// options - NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions contains the optional parameters for the InterfacesClient.GetVirtualMachineScaleSetNetworkInterface
 // method.
-func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse, error) {
+func (client *InterfacesClient) GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse, error) {
 	req, err := client.getVirtualMachineScaleSetNetworkInterfaceCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, options)
 	if err != nil {
 		return NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse{}, err
@@ -475,7 +474,7 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 }
 
 // getVirtualMachineScaleSetNetworkInterfaceCreateRequest creates the GetVirtualMachineScaleSetNetworkInterface request.
-func (client *NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterfaceCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*policy.Request, error) {
+func (client *InterfacesClient) getVirtualMachineScaleSetNetworkInterfaceCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -512,16 +511,16 @@ func (client *NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterface
 }
 
 // getVirtualMachineScaleSetNetworkInterfaceHandleResponse handles the GetVirtualMachineScaleSetNetworkInterface response.
-func (client *NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp *http.Response) (NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse, error) {
+func (client *InterfacesClient) getVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp *http.Response) (NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse, error) {
 	result := NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterface); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
 		return NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getVirtualMachineScaleSetNetworkInterfaceHandleError handles the GetVirtualMachineScaleSetNetworkInterface error response.
-func (client *NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterfaceHandleError(resp *http.Response) error {
+func (client *InterfacesClient) getVirtualMachineScaleSetNetworkInterfaceHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -536,21 +535,21 @@ func (client *NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterface
 // List - Gets all network interfaces in a resource group.
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
-// options - NetworkInterfacesListOptions contains the optional parameters for the NetworkInterfacesClient.List method.
-func (client *NetworkInterfacesClient) List(resourceGroupName string, options *NetworkInterfacesListOptions) *NetworkInterfacesListPager {
+// options - NetworkInterfacesListOptions contains the optional parameters for the InterfacesClient.List method.
+func (client *InterfacesClient) List(resourceGroupName string, options *NetworkInterfacesListOptions) *NetworkInterfacesListPager {
 	return &NetworkInterfacesListPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, resourceGroupName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkInterfacesListResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceListResult.NextLink)
 		},
 	}
 }
 
 // listCreateRequest creates the List request.
-func (client *NetworkInterfacesClient) listCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkInterfacesListOptions) (*policy.Request, error) {
+func (client *InterfacesClient) listCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkInterfacesListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -572,16 +571,16 @@ func (client *NetworkInterfacesClient) listCreateRequest(ctx context.Context, re
 }
 
 // listHandleResponse handles the List response.
-func (client *NetworkInterfacesClient) listHandleResponse(resp *http.Response) (NetworkInterfacesListResponse, error) {
+func (client *InterfacesClient) listHandleResponse(resp *http.Response) (NetworkInterfacesListResponse, error) {
 	result := NetworkInterfacesListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return NetworkInterfacesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *NetworkInterfacesClient) listHandleError(resp *http.Response) error {
+func (client *InterfacesClient) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -595,21 +594,21 @@ func (client *NetworkInterfacesClient) listHandleError(resp *http.Response) erro
 
 // ListAll - Gets all network interfaces in a subscription.
 // If the operation fails it returns the *CloudError error type.
-// options - NetworkInterfacesListAllOptions contains the optional parameters for the NetworkInterfacesClient.ListAll method.
-func (client *NetworkInterfacesClient) ListAll(options *NetworkInterfacesListAllOptions) *NetworkInterfacesListAllPager {
+// options - NetworkInterfacesListAllOptions contains the optional parameters for the InterfacesClient.ListAll method.
+func (client *InterfacesClient) ListAll(options *NetworkInterfacesListAllOptions) *NetworkInterfacesListAllPager {
 	return &NetworkInterfacesListAllPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listAllCreateRequest(ctx, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkInterfacesListAllResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceListResult.NextLink)
 		},
 	}
 }
 
 // listAllCreateRequest creates the ListAll request.
-func (client *NetworkInterfacesClient) listAllCreateRequest(ctx context.Context, options *NetworkInterfacesListAllOptions) (*policy.Request, error) {
+func (client *InterfacesClient) listAllCreateRequest(ctx context.Context, options *NetworkInterfacesListAllOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkInterfaces"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -627,16 +626,16 @@ func (client *NetworkInterfacesClient) listAllCreateRequest(ctx context.Context,
 }
 
 // listAllHandleResponse handles the ListAll response.
-func (client *NetworkInterfacesClient) listAllHandleResponse(resp *http.Response) (NetworkInterfacesListAllResponse, error) {
+func (client *InterfacesClient) listAllHandleResponse(resp *http.Response) (NetworkInterfacesListAllResponse, error) {
 	result := NetworkInterfacesListAllResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return NetworkInterfacesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listAllHandleError handles the ListAll error response.
-func (client *NetworkInterfacesClient) listAllHandleError(resp *http.Response) error {
+func (client *InterfacesClient) listAllHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -652,9 +651,9 @@ func (client *NetworkInterfacesClient) listAllHandleError(resp *http.Response) e
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions contains the optional parameters for the NetworkInterfacesClient.BeginListEffectiveNetworkSecurityGroups
+// options - NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions contains the optional parameters for the InterfacesClient.BeginListEffectiveNetworkSecurityGroups
 // method.
-func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions) (NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse, error) {
+func (client *InterfacesClient) BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions) (NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse, error) {
 	resp, err := client.listEffectiveNetworkSecurityGroups(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse{}, err
@@ -662,7 +661,7 @@ func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(c
 	result := NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkInterfacesClient.ListEffectiveNetworkSecurityGroups", "location", resp, client.pl, client.listEffectiveNetworkSecurityGroupsHandleError)
+	pt, err := armruntime.NewPoller("InterfacesClient.ListEffectiveNetworkSecurityGroups", "location", resp, client.pl, client.listEffectiveNetworkSecurityGroupsHandleError)
 	if err != nil {
 		return NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse{}, err
 	}
@@ -674,7 +673,7 @@ func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(c
 
 // ListEffectiveNetworkSecurityGroups - Gets all network security groups applied to a network interface.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkInterfacesClient) listEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions) (*http.Response, error) {
+func (client *InterfacesClient) listEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions) (*http.Response, error) {
 	req, err := client.listEffectiveNetworkSecurityGroupsCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
@@ -690,7 +689,7 @@ func (client *NetworkInterfacesClient) listEffectiveNetworkSecurityGroups(ctx co
 }
 
 // listEffectiveNetworkSecurityGroupsCreateRequest creates the ListEffectiveNetworkSecurityGroups request.
-func (client *NetworkInterfacesClient) listEffectiveNetworkSecurityGroupsCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions) (*policy.Request, error) {
+func (client *InterfacesClient) listEffectiveNetworkSecurityGroupsCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveNetworkSecurityGroups"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -716,7 +715,7 @@ func (client *NetworkInterfacesClient) listEffectiveNetworkSecurityGroupsCreateR
 }
 
 // listEffectiveNetworkSecurityGroupsHandleError handles the ListEffectiveNetworkSecurityGroups error response.
-func (client *NetworkInterfacesClient) listEffectiveNetworkSecurityGroupsHandleError(resp *http.Response) error {
+func (client *InterfacesClient) listEffectiveNetworkSecurityGroupsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -735,22 +734,22 @@ func (client *NetworkInterfacesClient) listEffectiveNetworkSecurityGroupsHandleE
 // virtualMachineScaleSetName - The name of the virtual machine scale set.
 // virtualmachineIndex - The virtual machine index.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions contains the optional parameters for the NetworkInterfacesClient.ListVirtualMachineScaleSetIPConfigurations
+// options - NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions contains the optional parameters for the InterfacesClient.ListVirtualMachineScaleSetIPConfigurations
 // method.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurations(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsPager {
+func (client *InterfacesClient) ListVirtualMachineScaleSetIPConfigurations(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsPager {
 	return &NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceIPConfigurationListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceIPConfigurationListResult.NextLink)
 		},
 	}
 }
 
 // listVirtualMachineScaleSetIPConfigurationsCreateRequest creates the ListVirtualMachineScaleSetIPConfigurations request.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) (*policy.Request, error) {
+func (client *InterfacesClient) listVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipConfigurations"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -787,16 +786,16 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetIPConfiguration
 }
 
 // listVirtualMachineScaleSetIPConfigurationsHandleResponse handles the ListVirtualMachineScaleSetIPConfigurations response.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetIPConfigurationsHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse, error) {
+func (client *InterfacesClient) listVirtualMachineScaleSetIPConfigurationsHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse, error) {
 	result := NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceIPConfigurationListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceIPConfigurationListResult); err != nil {
 		return NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listVirtualMachineScaleSetIPConfigurationsHandleError handles the ListVirtualMachineScaleSetIPConfigurations error response.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetIPConfigurationsHandleError(resp *http.Response) error {
+func (client *InterfacesClient) listVirtualMachineScaleSetIPConfigurationsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -813,21 +812,21 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetIPConfiguration
 // resourceGroupName - The name of the resource group.
 // virtualMachineScaleSetName - The name of the virtual machine scale set.
 // options - NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions contains the optional parameters for the
-// NetworkInterfacesClient.ListVirtualMachineScaleSetNetworkInterfaces method.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, options *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions) *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesPager {
+// InterfacesClient.ListVirtualMachineScaleSetNetworkInterfaces method.
+func (client *InterfacesClient) ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, options *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions) *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesPager {
 	return &NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceListResult.NextLink)
 		},
 	}
 }
 
 // listVirtualMachineScaleSetNetworkInterfacesCreateRequest creates the ListVirtualMachineScaleSetNetworkInterfaces request.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, options *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions) (*policy.Request, error) {
+func (client *InterfacesClient) listVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, options *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/networkInterfaces"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -853,16 +852,16 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterfac
 }
 
 // listVirtualMachineScaleSetNetworkInterfacesHandleResponse handles the ListVirtualMachineScaleSetNetworkInterfaces response.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterfacesHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse, error) {
+func (client *InterfacesClient) listVirtualMachineScaleSetNetworkInterfacesHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse, error) {
 	result := NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listVirtualMachineScaleSetNetworkInterfacesHandleError handles the ListVirtualMachineScaleSetNetworkInterfaces error response.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterfacesHandleError(resp *http.Response) error {
+func (client *InterfacesClient) listVirtualMachineScaleSetNetworkInterfacesHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -881,21 +880,21 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterfac
 // virtualMachineScaleSetName - The name of the virtual machine scale set.
 // virtualmachineIndex - The virtual machine index.
 // options - NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions contains the optional parameters for the
-// NetworkInterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfaces method.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, options *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions) *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesPager {
+// InterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfaces method.
+func (client *InterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, options *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions) *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesPager {
 	return &NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceListResult.NextLink)
 		},
 	}
 }
 
 // listVirtualMachineScaleSetVMNetworkInterfacesCreateRequest creates the ListVirtualMachineScaleSetVMNetworkInterfaces request.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, options *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions) (*policy.Request, error) {
+func (client *InterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, options *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -925,16 +924,16 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterf
 }
 
 // listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse handles the ListVirtualMachineScaleSetVMNetworkInterfaces response.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse, error) {
+func (client *InterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse, error) {
 	result := NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listVirtualMachineScaleSetVMNetworkInterfacesHandleError handles the ListVirtualMachineScaleSetVMNetworkInterfaces error response.
-func (client *NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesHandleError(resp *http.Response) error {
+func (client *InterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -951,9 +950,8 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterf
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
 // parameters - Parameters supplied to update network interface tags.
-// options - NetworkInterfacesUpdateTagsOptions contains the optional parameters for the NetworkInterfacesClient.UpdateTags
-// method.
-func (client *NetworkInterfacesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject, options *NetworkInterfacesUpdateTagsOptions) (NetworkInterfacesUpdateTagsResponse, error) {
+// options - NetworkInterfacesUpdateTagsOptions contains the optional parameters for the InterfacesClient.UpdateTags method.
+func (client *InterfacesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject, options *NetworkInterfacesUpdateTagsOptions) (NetworkInterfacesUpdateTagsResponse, error) {
 	req, err := client.updateTagsCreateRequest(ctx, resourceGroupName, networkInterfaceName, parameters, options)
 	if err != nil {
 		return NetworkInterfacesUpdateTagsResponse{}, err
@@ -969,7 +967,7 @@ func (client *NetworkInterfacesClient) UpdateTags(ctx context.Context, resourceG
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkInterfacesClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject, options *NetworkInterfacesUpdateTagsOptions) (*policy.Request, error) {
+func (client *InterfacesClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject, options *NetworkInterfacesUpdateTagsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -995,16 +993,16 @@ func (client *NetworkInterfacesClient) updateTagsCreateRequest(ctx context.Conte
 }
 
 // updateTagsHandleResponse handles the UpdateTags response.
-func (client *NetworkInterfacesClient) updateTagsHandleResponse(resp *http.Response) (NetworkInterfacesUpdateTagsResponse, error) {
+func (client *InterfacesClient) updateTagsHandleResponse(resp *http.Response) (NetworkInterfacesUpdateTagsResponse, error) {
 	result := NetworkInterfacesUpdateTagsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterface); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
 		return NetworkInterfacesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.
-func (client *NetworkInterfacesClient) updateTagsHandleError(resp *http.Response) error {
+func (client *InterfacesClient) updateTagsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfacetapconfigurations_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkInterfaceTapConfigurationsClient contains the methods for the NetworkInterfaceTapConfigurations group.
-// Don't use this type directly, use NewNetworkInterfaceTapConfigurationsClient() instead.
-type NetworkInterfaceTapConfigurationsClient struct {
+// InterfaceTapConfigurationsClient contains the methods for the NetworkInterfaceTapConfigurations group.
+// Don't use this type directly, use NewInterfaceTapConfigurationsClient() instead.
+type InterfaceTapConfigurationsClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkInterfaceTapConfigurationsClient creates a new instance of NetworkInterfaceTapConfigurationsClient with the specified values.
+// NewInterfaceTapConfigurationsClient creates a new instance of InterfaceTapConfigurationsClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkInterfaceTapConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkInterfaceTapConfigurationsClient {
+func NewInterfaceTapConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *InterfaceTapConfigurationsClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkInterfaceTapConfigurationsClient(subscriptionID string, credentia
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkInterfaceTapConfigurationsClient{
+	client := &InterfaceTapConfigurationsClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -57,9 +57,9 @@ func NewNetworkInterfaceTapConfigurationsClient(subscriptionID string, credentia
 // networkInterfaceName - The name of the network interface.
 // tapConfigurationName - The name of the tap configuration.
 // tapConfigurationParameters - Parameters supplied to the create or update tap configuration operation.
-// options - NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions contains the optional parameters for the NetworkInterfaceTapConfigurationsClient.BeginCreateOrUpdate
+// options - NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions contains the optional parameters for the InterfaceTapConfigurationsClient.BeginCreateOrUpdate
 // method.
-func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions) (NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse, error) {
+func (client *InterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters InterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions) (NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, tapConfigurationParameters, options)
 	if err != nil {
 		return NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse{}, err
@@ -67,7 +67,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx c
 	result := NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkInterfaceTapConfigurationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl, client.createOrUpdateHandleError)
+	pt, err := armruntime.NewPoller("InterfaceTapConfigurationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl, client.createOrUpdateHandleError)
 	if err != nil {
 		return NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse{}, err
 	}
@@ -79,7 +79,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx c
 
 // CreateOrUpdate - Creates or updates a Tap configuration in the specified NetworkInterface.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions) (*http.Response, error) {
+func (client *InterfaceTapConfigurationsClient) createOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters InterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, tapConfigurationParameters, options)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdate(ctx contex
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions) (*policy.Request, error) {
+func (client *InterfaceTapConfigurationsClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters InterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -125,7 +125,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdateCreateReque
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
-func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdateHandleError(resp *http.Response) error {
+func (client *InterfaceTapConfigurationsClient) createOrUpdateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -142,9 +142,9 @@ func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdateHandleError
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
 // tapConfigurationName - The name of the tap configuration.
-// options - NetworkInterfaceTapConfigurationsBeginDeleteOptions contains the optional parameters for the NetworkInterfaceTapConfigurationsClient.BeginDelete
+// options - NetworkInterfaceTapConfigurationsBeginDeleteOptions contains the optional parameters for the InterfaceTapConfigurationsClient.BeginDelete
 // method.
-func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsBeginDeleteOptions) (NetworkInterfaceTapConfigurationsDeletePollerResponse, error) {
+func (client *InterfaceTapConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsBeginDeleteOptions) (NetworkInterfaceTapConfigurationsDeletePollerResponse, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, options)
 	if err != nil {
 		return NetworkInterfaceTapConfigurationsDeletePollerResponse{}, err
@@ -152,7 +152,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.C
 	result := NetworkInterfaceTapConfigurationsDeletePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkInterfaceTapConfigurationsClient.Delete", "location", resp, client.pl, client.deleteHandleError)
+	pt, err := armruntime.NewPoller("InterfaceTapConfigurationsClient.Delete", "location", resp, client.pl, client.deleteHandleError)
 	if err != nil {
 		return NetworkInterfaceTapConfigurationsDeletePollerResponse{}, err
 	}
@@ -164,7 +164,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.C
 
 // Delete - Deletes the specified tap configuration from the NetworkInterface.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkInterfaceTapConfigurationsClient) deleteOperation(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsBeginDeleteOptions) (*http.Response, error) {
+func (client *InterfaceTapConfigurationsClient) deleteOperation(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsBeginDeleteOptions) (*http.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, options)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) deleteOperation(ctx conte
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *NetworkInterfaceTapConfigurationsClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsBeginDeleteOptions) (*policy.Request, error) {
+func (client *InterfaceTapConfigurationsClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -210,7 +210,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) deleteCreateRequest(ctx c
 }
 
 // deleteHandleError handles the Delete error response.
-func (client *NetworkInterfaceTapConfigurationsClient) deleteHandleError(resp *http.Response) error {
+func (client *InterfaceTapConfigurationsClient) deleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -227,9 +227,9 @@ func (client *NetworkInterfaceTapConfigurationsClient) deleteHandleError(resp *h
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
 // tapConfigurationName - The name of the tap configuration.
-// options - NetworkInterfaceTapConfigurationsGetOptions contains the optional parameters for the NetworkInterfaceTapConfigurationsClient.Get
+// options - NetworkInterfaceTapConfigurationsGetOptions contains the optional parameters for the InterfaceTapConfigurationsClient.Get
 // method.
-func (client *NetworkInterfaceTapConfigurationsClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsGetOptions) (NetworkInterfaceTapConfigurationsGetResponse, error) {
+func (client *InterfaceTapConfigurationsClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsGetOptions) (NetworkInterfaceTapConfigurationsGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, options)
 	if err != nil {
 		return NetworkInterfaceTapConfigurationsGetResponse{}, err
@@ -245,7 +245,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) Get(ctx context.Context, 
 }
 
 // getCreateRequest creates the Get request.
-func (client *NetworkInterfaceTapConfigurationsClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsGetOptions) (*policy.Request, error) {
+func (client *InterfaceTapConfigurationsClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -275,16 +275,16 @@ func (client *NetworkInterfaceTapConfigurationsClient) getCreateRequest(ctx cont
 }
 
 // getHandleResponse handles the Get response.
-func (client *NetworkInterfaceTapConfigurationsClient) getHandleResponse(resp *http.Response) (NetworkInterfaceTapConfigurationsGetResponse, error) {
+func (client *InterfaceTapConfigurationsClient) getHandleResponse(resp *http.Response) (NetworkInterfaceTapConfigurationsGetResponse, error) {
 	result := NetworkInterfaceTapConfigurationsGetResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceTapConfiguration); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceTapConfiguration); err != nil {
 		return NetworkInterfaceTapConfigurationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getHandleError handles the Get error response.
-func (client *NetworkInterfaceTapConfigurationsClient) getHandleError(resp *http.Response) error {
+func (client *InterfaceTapConfigurationsClient) getHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -300,22 +300,22 @@ func (client *NetworkInterfaceTapConfigurationsClient) getHandleError(resp *http
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
-// options - NetworkInterfaceTapConfigurationsListOptions contains the optional parameters for the NetworkInterfaceTapConfigurationsClient.List
+// options - NetworkInterfaceTapConfigurationsListOptions contains the optional parameters for the InterfaceTapConfigurationsClient.List
 // method.
-func (client *NetworkInterfaceTapConfigurationsClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceTapConfigurationsListOptions) *NetworkInterfaceTapConfigurationsListPager {
+func (client *InterfaceTapConfigurationsClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceTapConfigurationsListOptions) *NetworkInterfaceTapConfigurationsListPager {
 	return &NetworkInterfaceTapConfigurationsListPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkInterfaceTapConfigurationsListResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceTapConfigurationListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceTapConfigurationListResult.NextLink)
 		},
 	}
 }
 
 // listCreateRequest creates the List request.
-func (client *NetworkInterfaceTapConfigurationsClient) listCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceTapConfigurationsListOptions) (*policy.Request, error) {
+func (client *InterfaceTapConfigurationsClient) listCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceTapConfigurationsListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -341,16 +341,16 @@ func (client *NetworkInterfaceTapConfigurationsClient) listCreateRequest(ctx con
 }
 
 // listHandleResponse handles the List response.
-func (client *NetworkInterfaceTapConfigurationsClient) listHandleResponse(resp *http.Response) (NetworkInterfaceTapConfigurationsListResponse, error) {
+func (client *InterfaceTapConfigurationsClient) listHandleResponse(resp *http.Response) (NetworkInterfaceTapConfigurationsListResponse, error) {
 	result := NetworkInterfaceTapConfigurationsListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceTapConfigurationListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceTapConfigurationListResult); err != nil {
 		return NetworkInterfaceTapConfigurationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *NetworkInterfaceTapConfigurationsClient) listHandleError(resp *http.Response) error {
+func (client *InterfaceTapConfigurationsClient) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
@@ -64,7 +64,7 @@ func (client *LoadBalancerNetworkInterfacesClient) List(resourceGroupName string
 			return client.listCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 		},
 		advancer: func(ctx context.Context, resp LoadBalancerNetworkInterfacesListResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.InterfaceListResult.NextLink)
 		},
 	}
 }
@@ -98,7 +98,7 @@ func (client *LoadBalancerNetworkInterfacesClient) listCreateRequest(ctx context
 // listHandleResponse handles the List response.
 func (client *LoadBalancerNetworkInterfacesClient) listHandleResponse(resp *http.Response) (LoadBalancerNetworkInterfacesListResponse, error) {
 	result := LoadBalancerNetworkInterfacesListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return LoadBalancerNetworkInterfacesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil

--- a/test/network/2020-03-01/armnetwork/zz_generated_management_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_management_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkManagementClient contains the methods for the NetworkManagementClient group.
-// Don't use this type directly, use NewNetworkManagementClient() instead.
-type NetworkManagementClient struct {
+// ManagementClient contains the methods for the NetworkManagementClient group.
+// Don't use this type directly, use NewManagementClient() instead.
+type ManagementClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkManagementClient creates a new instance of NetworkManagementClient with the specified values.
+// NewManagementClient creates a new instance of ManagementClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkManagementClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkManagementClient {
+func NewManagementClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *ManagementClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkManagementClient(subscriptionID string, credential azcore.TokenCr
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkManagementClient{
+	client := &ManagementClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -55,9 +55,9 @@ func NewNetworkManagementClient(subscriptionID string, credential azcore.TokenCr
 // If the operation fails it returns the *CloudError error type.
 // location - The location of the domain name.
 // domainNameLabel - The domain name to be verified. It must conform to the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$.
-// options - NetworkManagementClientCheckDNSNameAvailabilityOptions contains the optional parameters for the NetworkManagementClient.CheckDNSNameAvailability
+// options - NetworkManagementClientCheckDNSNameAvailabilityOptions contains the optional parameters for the ManagementClient.CheckDNSNameAvailability
 // method.
-func (client *NetworkManagementClient) CheckDNSNameAvailability(ctx context.Context, location string, domainNameLabel string, options *NetworkManagementClientCheckDNSNameAvailabilityOptions) (NetworkManagementClientCheckDNSNameAvailabilityResponse, error) {
+func (client *ManagementClient) CheckDNSNameAvailability(ctx context.Context, location string, domainNameLabel string, options *NetworkManagementClientCheckDNSNameAvailabilityOptions) (NetworkManagementClientCheckDNSNameAvailabilityResponse, error) {
 	req, err := client.checkDNSNameAvailabilityCreateRequest(ctx, location, domainNameLabel, options)
 	if err != nil {
 		return NetworkManagementClientCheckDNSNameAvailabilityResponse{}, err
@@ -73,7 +73,7 @@ func (client *NetworkManagementClient) CheckDNSNameAvailability(ctx context.Cont
 }
 
 // checkDNSNameAvailabilityCreateRequest creates the CheckDNSNameAvailability request.
-func (client *NetworkManagementClient) checkDNSNameAvailabilityCreateRequest(ctx context.Context, location string, domainNameLabel string, options *NetworkManagementClientCheckDNSNameAvailabilityOptions) (*policy.Request, error) {
+func (client *ManagementClient) checkDNSNameAvailabilityCreateRequest(ctx context.Context, location string, domainNameLabel string, options *NetworkManagementClientCheckDNSNameAvailabilityOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/CheckDnsNameAvailability"
 	if location == "" {
 		return nil, errors.New("parameter location cannot be empty")
@@ -96,7 +96,7 @@ func (client *NetworkManagementClient) checkDNSNameAvailabilityCreateRequest(ctx
 }
 
 // checkDNSNameAvailabilityHandleResponse handles the CheckDNSNameAvailability response.
-func (client *NetworkManagementClient) checkDNSNameAvailabilityHandleResponse(resp *http.Response) (NetworkManagementClientCheckDNSNameAvailabilityResponse, error) {
+func (client *ManagementClient) checkDNSNameAvailabilityHandleResponse(resp *http.Response) (NetworkManagementClientCheckDNSNameAvailabilityResponse, error) {
 	result := NetworkManagementClientCheckDNSNameAvailabilityResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DNSNameAvailabilityResult); err != nil {
 		return NetworkManagementClientCheckDNSNameAvailabilityResponse{}, runtime.NewResponseError(err, resp)
@@ -105,7 +105,7 @@ func (client *NetworkManagementClient) checkDNSNameAvailabilityHandleResponse(re
 }
 
 // checkDNSNameAvailabilityHandleError handles the CheckDNSNameAvailability error response.
-func (client *NetworkManagementClient) checkDNSNameAvailabilityHandleError(resp *http.Response) error {
+func (client *ManagementClient) checkDNSNameAvailabilityHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -122,9 +122,9 @@ func (client *NetworkManagementClient) checkDNSNameAvailabilityHandleError(resp 
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
 // bslRequest - Post request for all the Bastion Shareable Link endpoints.
-// options - NetworkManagementClientBeginDeleteBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.BeginDeleteBastionShareableLink
+// options - NetworkManagementClientBeginDeleteBastionShareableLinkOptions contains the optional parameters for the ManagementClient.BeginDeleteBastionShareableLink
 // method.
-func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginDeleteBastionShareableLinkOptions) (NetworkManagementClientDeleteBastionShareableLinkPollerResponse, error) {
+func (client *ManagementClient) BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginDeleteBastionShareableLinkOptions) (NetworkManagementClientDeleteBastionShareableLinkPollerResponse, error) {
 	resp, err := client.deleteBastionShareableLink(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
 		return NetworkManagementClientDeleteBastionShareableLinkPollerResponse{}, err
@@ -132,7 +132,7 @@ func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx conte
 	result := NetworkManagementClientDeleteBastionShareableLinkPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkManagementClient.DeleteBastionShareableLink", "location", resp, client.pl, client.deleteBastionShareableLinkHandleError)
+	pt, err := armruntime.NewPoller("ManagementClient.DeleteBastionShareableLink", "location", resp, client.pl, client.deleteBastionShareableLinkHandleError)
 	if err != nil {
 		return NetworkManagementClientDeleteBastionShareableLinkPollerResponse{}, err
 	}
@@ -144,7 +144,7 @@ func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx conte
 
 // DeleteBastionShareableLink - Deletes the Bastion Shareable Links for all the VMs specified in the request.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkManagementClient) deleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginDeleteBastionShareableLinkOptions) (*http.Response, error) {
+func (client *ManagementClient) deleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginDeleteBastionShareableLinkOptions) (*http.Response, error) {
 	req, err := client.deleteBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
 		return nil, err
@@ -160,7 +160,7 @@ func (client *NetworkManagementClient) deleteBastionShareableLink(ctx context.Co
 }
 
 // deleteBastionShareableLinkCreateRequest creates the DeleteBastionShareableLink request.
-func (client *NetworkManagementClient) deleteBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginDeleteBastionShareableLinkOptions) (*policy.Request, error) {
+func (client *ManagementClient) deleteBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginDeleteBastionShareableLinkOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/deleteShareableLinks"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -186,7 +186,7 @@ func (client *NetworkManagementClient) deleteBastionShareableLinkCreateRequest(c
 }
 
 // deleteBastionShareableLinkHandleError handles the DeleteBastionShareableLink error response.
-func (client *NetworkManagementClient) deleteBastionShareableLinkHandleError(resp *http.Response) error {
+func (client *ManagementClient) deleteBastionShareableLinkHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -203,9 +203,9 @@ func (client *NetworkManagementClient) deleteBastionShareableLinkHandleError(res
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
 // sessionIDs - The list of sessionids to disconnect.
-// options - NetworkManagementClientDisconnectActiveSessionsOptions contains the optional parameters for the NetworkManagementClient.DisconnectActiveSessions
+// options - NetworkManagementClientDisconnectActiveSessionsOptions contains the optional parameters for the ManagementClient.DisconnectActiveSessions
 // method.
-func (client *NetworkManagementClient) DisconnectActiveSessions(resourceGroupName string, bastionHostName string, sessionIDs SessionIDs, options *NetworkManagementClientDisconnectActiveSessionsOptions) *NetworkManagementClientDisconnectActiveSessionsPager {
+func (client *ManagementClient) DisconnectActiveSessions(resourceGroupName string, bastionHostName string, sessionIDs SessionIDs, options *NetworkManagementClientDisconnectActiveSessionsOptions) *NetworkManagementClientDisconnectActiveSessionsPager {
 	return &NetworkManagementClientDisconnectActiveSessionsPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -218,7 +218,7 @@ func (client *NetworkManagementClient) DisconnectActiveSessions(resourceGroupNam
 }
 
 // disconnectActiveSessionsCreateRequest creates the DisconnectActiveSessions request.
-func (client *NetworkManagementClient) disconnectActiveSessionsCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, sessionIDs SessionIDs, options *NetworkManagementClientDisconnectActiveSessionsOptions) (*policy.Request, error) {
+func (client *ManagementClient) disconnectActiveSessionsCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, sessionIDs SessionIDs, options *NetworkManagementClientDisconnectActiveSessionsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/disconnectActiveSessions"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -244,7 +244,7 @@ func (client *NetworkManagementClient) disconnectActiveSessionsCreateRequest(ctx
 }
 
 // disconnectActiveSessionsHandleResponse handles the DisconnectActiveSessions response.
-func (client *NetworkManagementClient) disconnectActiveSessionsHandleResponse(resp *http.Response) (NetworkManagementClientDisconnectActiveSessionsResponse, error) {
+func (client *ManagementClient) disconnectActiveSessionsHandleResponse(resp *http.Response) (NetworkManagementClientDisconnectActiveSessionsResponse, error) {
 	result := NetworkManagementClientDisconnectActiveSessionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionSessionDeleteResult); err != nil {
 		return NetworkManagementClientDisconnectActiveSessionsResponse{}, runtime.NewResponseError(err, resp)
@@ -253,7 +253,7 @@ func (client *NetworkManagementClient) disconnectActiveSessionsHandleResponse(re
 }
 
 // disconnectActiveSessionsHandleError handles the DisconnectActiveSessions error response.
-func (client *NetworkManagementClient) disconnectActiveSessionsHandleError(resp *http.Response) error {
+func (client *ManagementClient) disconnectActiveSessionsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -272,8 +272,8 @@ func (client *NetworkManagementClient) disconnectActiveSessionsHandleError(resp 
 // virtualWANName - The name of the VirtualWAN whose associated VpnServerConfigurations is needed.
 // vpnClientParams - Parameters supplied to the generate VirtualWan VPN profile generation operation.
 // options - NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions contains the optional parameters
-// for the NetworkManagementClient.BeginGeneratevirtualwanvpnserverconfigurationvpnprofile method.
-func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWANName string, vpnClientParams VirtualWanVPNProfileParameters, options *NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse, error) {
+// for the ManagementClient.BeginGeneratevirtualwanvpnserverconfigurationvpnprofile method.
+func (client *ManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWANName string, vpnClientParams VirtualWanVPNProfileParameters, options *NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse, error) {
 	resp, err := client.generatevirtualwanvpnserverconfigurationvpnprofile(ctx, resourceGroupName, virtualWANName, vpnClientParams, options)
 	if err != nil {
 		return NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{}, err
@@ -281,7 +281,7 @@ func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigura
 	result := NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", "location", resp, client.pl, client.generatevirtualwanvpnserverconfigurationvpnprofileHandleError)
+	pt, err := armruntime.NewPoller("ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", "location", resp, client.pl, client.generatevirtualwanvpnserverconfigurationvpnprofileHandleError)
 	if err != nil {
 		return NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{}, err
 	}
@@ -294,7 +294,7 @@ func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigura
 // Generatevirtualwanvpnserverconfigurationvpnprofile - Generates a unique VPN profile for P2S clients for VirtualWan and
 // associated VpnServerConfiguration combination in the specified resource group.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWANName string, vpnClientParams VirtualWanVPNProfileParameters, options *NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*http.Response, error) {
+func (client *ManagementClient) generatevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWANName string, vpnClientParams VirtualWanVPNProfileParameters, options *NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*http.Response, error) {
 	req, err := client.generatevirtualwanvpnserverconfigurationvpnprofileCreateRequest(ctx, resourceGroupName, virtualWANName, vpnClientParams, options)
 	if err != nil {
 		return nil, err
@@ -310,7 +310,7 @@ func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationv
 }
 
 // generatevirtualwanvpnserverconfigurationvpnprofileCreateRequest creates the Generatevirtualwanvpnserverconfigurationvpnprofile request.
-func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationvpnprofileCreateRequest(ctx context.Context, resourceGroupName string, virtualWANName string, vpnClientParams VirtualWanVPNProfileParameters, options *NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*policy.Request, error) {
+func (client *ManagementClient) generatevirtualwanvpnserverconfigurationvpnprofileCreateRequest(ctx context.Context, resourceGroupName string, virtualWANName string, vpnClientParams VirtualWanVPNProfileParameters, options *NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/GenerateVpnProfile"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -336,7 +336,7 @@ func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationv
 }
 
 // generatevirtualwanvpnserverconfigurationvpnprofileHandleError handles the Generatevirtualwanvpnserverconfigurationvpnprofile error response.
-func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationvpnprofileHandleError(resp *http.Response) error {
+func (client *ManagementClient) generatevirtualwanvpnserverconfigurationvpnprofileHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -352,9 +352,9 @@ func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationv
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
-// options - NetworkManagementClientBeginGetActiveSessionsOptions contains the optional parameters for the NetworkManagementClient.BeginGetActiveSessions
+// options - NetworkManagementClientBeginGetActiveSessionsOptions contains the optional parameters for the ManagementClient.BeginGetActiveSessions
 // method.
-func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientBeginGetActiveSessionsOptions) (NetworkManagementClientGetActiveSessionsPollerResponse, error) {
+func (client *ManagementClient) BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientBeginGetActiveSessionsOptions) (NetworkManagementClientGetActiveSessionsPollerResponse, error) {
 	resp, err := client.getActiveSessions(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
 		return NetworkManagementClientGetActiveSessionsPollerResponse{}, err
@@ -362,7 +362,7 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 	result := NetworkManagementClientGetActiveSessionsPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkManagementClient.GetActiveSessions", "location", resp, client.pl, client.getActiveSessionsHandleError)
+	pt, err := armruntime.NewPoller("ManagementClient.GetActiveSessions", "location", resp, client.pl, client.getActiveSessionsHandleError)
 	if err != nil {
 		return NetworkManagementClientGetActiveSessionsPollerResponse{}, err
 	}
@@ -375,7 +375,7 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 
 // GetActiveSessions - Returns the list of currently active sessions on the Bastion.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkManagementClient) getActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientBeginGetActiveSessionsOptions) (*http.Response, error) {
+func (client *ManagementClient) getActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientBeginGetActiveSessionsOptions) (*http.Response, error) {
 	req, err := client.getActiveSessionsCreateRequest(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
 		return nil, err
@@ -391,7 +391,7 @@ func (client *NetworkManagementClient) getActiveSessions(ctx context.Context, re
 }
 
 // getActiveSessionsCreateRequest creates the GetActiveSessions request.
-func (client *NetworkManagementClient) getActiveSessionsCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientBeginGetActiveSessionsOptions) (*policy.Request, error) {
+func (client *ManagementClient) getActiveSessionsCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientBeginGetActiveSessionsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getActiveSessions"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -417,7 +417,7 @@ func (client *NetworkManagementClient) getActiveSessionsCreateRequest(ctx contex
 }
 
 // getActiveSessionsHandleResponse handles the GetActiveSessions response.
-func (client *NetworkManagementClient) getActiveSessionsHandleResponse(resp *http.Response) (NetworkManagementClientGetActiveSessionsResponse, error) {
+func (client *ManagementClient) getActiveSessionsHandleResponse(resp *http.Response) (NetworkManagementClientGetActiveSessionsResponse, error) {
 	result := NetworkManagementClientGetActiveSessionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionActiveSessionListResult); err != nil {
 		return NetworkManagementClientGetActiveSessionsResponse{}, runtime.NewResponseError(err, resp)
@@ -426,7 +426,7 @@ func (client *NetworkManagementClient) getActiveSessionsHandleResponse(resp *htt
 }
 
 // getActiveSessionsHandleError handles the GetActiveSessions error response.
-func (client *NetworkManagementClient) getActiveSessionsHandleError(resp *http.Response) error {
+func (client *ManagementClient) getActiveSessionsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -443,9 +443,9 @@ func (client *NetworkManagementClient) getActiveSessionsHandleError(resp *http.R
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
 // bslRequest - Post request for all the Bastion Shareable Link endpoints.
-// options - NetworkManagementClientGetBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.GetBastionShareableLink
+// options - NetworkManagementClientGetBastionShareableLinkOptions contains the optional parameters for the ManagementClient.GetBastionShareableLink
 // method.
-func (client *NetworkManagementClient) GetBastionShareableLink(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientGetBastionShareableLinkOptions) *NetworkManagementClientGetBastionShareableLinkPager {
+func (client *ManagementClient) GetBastionShareableLink(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientGetBastionShareableLinkOptions) *NetworkManagementClientGetBastionShareableLinkPager {
 	return &NetworkManagementClientGetBastionShareableLinkPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
@@ -458,7 +458,7 @@ func (client *NetworkManagementClient) GetBastionShareableLink(resourceGroupName
 }
 
 // getBastionShareableLinkCreateRequest creates the GetBastionShareableLink request.
-func (client *NetworkManagementClient) getBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientGetBastionShareableLinkOptions) (*policy.Request, error) {
+func (client *ManagementClient) getBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientGetBastionShareableLinkOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getShareableLinks"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -484,7 +484,7 @@ func (client *NetworkManagementClient) getBastionShareableLinkCreateRequest(ctx 
 }
 
 // getBastionShareableLinkHandleResponse handles the GetBastionShareableLink response.
-func (client *NetworkManagementClient) getBastionShareableLinkHandleResponse(resp *http.Response) (NetworkManagementClientGetBastionShareableLinkResponse, error) {
+func (client *ManagementClient) getBastionShareableLinkHandleResponse(resp *http.Response) (NetworkManagementClientGetBastionShareableLinkResponse, error) {
 	result := NetworkManagementClientGetBastionShareableLinkResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionShareableLinkListResult); err != nil {
 		return NetworkManagementClientGetBastionShareableLinkResponse{}, runtime.NewResponseError(err, resp)
@@ -493,7 +493,7 @@ func (client *NetworkManagementClient) getBastionShareableLinkHandleResponse(res
 }
 
 // getBastionShareableLinkHandleError handles the GetBastionShareableLink error response.
-func (client *NetworkManagementClient) getBastionShareableLinkHandleError(resp *http.Response) error {
+func (client *ManagementClient) getBastionShareableLinkHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -510,9 +510,9 @@ func (client *NetworkManagementClient) getBastionShareableLinkHandleError(resp *
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
 // bslRequest - Post request for all the Bastion Shareable Link endpoints.
-// options - NetworkManagementClientBeginPutBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.BeginPutBastionShareableLink
+// options - NetworkManagementClientBeginPutBastionShareableLinkOptions contains the optional parameters for the ManagementClient.BeginPutBastionShareableLink
 // method.
-func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginPutBastionShareableLinkOptions) (NetworkManagementClientPutBastionShareableLinkPollerResponse, error) {
+func (client *ManagementClient) BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginPutBastionShareableLinkOptions) (NetworkManagementClientPutBastionShareableLinkPollerResponse, error) {
 	resp, err := client.putBastionShareableLink(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
 		return NetworkManagementClientPutBastionShareableLinkPollerResponse{}, err
@@ -520,7 +520,7 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 	result := NetworkManagementClientPutBastionShareableLinkPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkManagementClient.PutBastionShareableLink", "location", resp, client.pl, client.putBastionShareableLinkHandleError)
+	pt, err := armruntime.NewPoller("ManagementClient.PutBastionShareableLink", "location", resp, client.pl, client.putBastionShareableLinkHandleError)
 	if err != nil {
 		return NetworkManagementClientPutBastionShareableLinkPollerResponse{}, err
 	}
@@ -533,7 +533,7 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 
 // PutBastionShareableLink - Creates a Bastion Shareable Links for all the VMs specified in the request.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkManagementClient) putBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginPutBastionShareableLinkOptions) (*http.Response, error) {
+func (client *ManagementClient) putBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginPutBastionShareableLinkOptions) (*http.Response, error) {
 	req, err := client.putBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
 		return nil, err
@@ -549,7 +549,7 @@ func (client *NetworkManagementClient) putBastionShareableLink(ctx context.Conte
 }
 
 // putBastionShareableLinkCreateRequest creates the PutBastionShareableLink request.
-func (client *NetworkManagementClient) putBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginPutBastionShareableLinkOptions) (*policy.Request, error) {
+func (client *ManagementClient) putBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientBeginPutBastionShareableLinkOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/createShareableLinks"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -575,7 +575,7 @@ func (client *NetworkManagementClient) putBastionShareableLinkCreateRequest(ctx 
 }
 
 // putBastionShareableLinkHandleResponse handles the PutBastionShareableLink response.
-func (client *NetworkManagementClient) putBastionShareableLinkHandleResponse(resp *http.Response) (NetworkManagementClientPutBastionShareableLinkResponse, error) {
+func (client *ManagementClient) putBastionShareableLinkHandleResponse(resp *http.Response) (NetworkManagementClientPutBastionShareableLinkResponse, error) {
 	result := NetworkManagementClientPutBastionShareableLinkResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionShareableLinkListResult); err != nil {
 		return NetworkManagementClientPutBastionShareableLinkResponse{}, runtime.NewResponseError(err, resp)
@@ -584,7 +584,7 @@ func (client *NetworkManagementClient) putBastionShareableLinkHandleResponse(res
 }
 
 // putBastionShareableLinkHandleError handles the PutBastionShareableLink error response.
-func (client *NetworkManagementClient) putBastionShareableLinkHandleError(resp *http.Response) error {
+func (client *ManagementClient) putBastionShareableLinkHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -600,9 +600,9 @@ func (client *NetworkManagementClient) putBastionShareableLinkHandleError(resp *
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The resource group name.
 // virtualWANName - The name of the VirtualWAN for which supported security providers are needed.
-// options - NetworkManagementClientSupportedSecurityProvidersOptions contains the optional parameters for the NetworkManagementClient.SupportedSecurityProviders
+// options - NetworkManagementClientSupportedSecurityProvidersOptions contains the optional parameters for the ManagementClient.SupportedSecurityProviders
 // method.
-func (client *NetworkManagementClient) SupportedSecurityProviders(ctx context.Context, resourceGroupName string, virtualWANName string, options *NetworkManagementClientSupportedSecurityProvidersOptions) (NetworkManagementClientSupportedSecurityProvidersResponse, error) {
+func (client *ManagementClient) SupportedSecurityProviders(ctx context.Context, resourceGroupName string, virtualWANName string, options *NetworkManagementClientSupportedSecurityProvidersOptions) (NetworkManagementClientSupportedSecurityProvidersResponse, error) {
 	req, err := client.supportedSecurityProvidersCreateRequest(ctx, resourceGroupName, virtualWANName, options)
 	if err != nil {
 		return NetworkManagementClientSupportedSecurityProvidersResponse{}, err
@@ -618,7 +618,7 @@ func (client *NetworkManagementClient) SupportedSecurityProviders(ctx context.Co
 }
 
 // supportedSecurityProvidersCreateRequest creates the SupportedSecurityProviders request.
-func (client *NetworkManagementClient) supportedSecurityProvidersCreateRequest(ctx context.Context, resourceGroupName string, virtualWANName string, options *NetworkManagementClientSupportedSecurityProvidersOptions) (*policy.Request, error) {
+func (client *ManagementClient) supportedSecurityProvidersCreateRequest(ctx context.Context, resourceGroupName string, virtualWANName string, options *NetworkManagementClientSupportedSecurityProvidersOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/supportedSecurityProviders"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -644,7 +644,7 @@ func (client *NetworkManagementClient) supportedSecurityProvidersCreateRequest(c
 }
 
 // supportedSecurityProvidersHandleResponse handles the SupportedSecurityProviders response.
-func (client *NetworkManagementClient) supportedSecurityProvidersHandleResponse(resp *http.Response) (NetworkManagementClientSupportedSecurityProvidersResponse, error) {
+func (client *ManagementClient) supportedSecurityProvidersHandleResponse(resp *http.Response) (NetworkManagementClientSupportedSecurityProvidersResponse, error) {
 	result := NetworkManagementClientSupportedSecurityProvidersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualWanSecurityProviders); err != nil {
 		return NetworkManagementClientSupportedSecurityProvidersResponse{}, runtime.NewResponseError(err, resp)
@@ -653,7 +653,7 @@ func (client *NetworkManagementClient) supportedSecurityProvidersHandleResponse(
 }
 
 // supportedSecurityProvidersHandleError handles the SupportedSecurityProviders error response.
-func (client *NetworkManagementClient) supportedSecurityProvidersHandleError(resp *http.Response) error {
+func (client *ManagementClient) supportedSecurityProvidersHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -225,7 +225,7 @@ type ApplicationGatewayBackendAddressPoolPropertiesFormat struct {
 	BackendAddresses []*ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
 
 	// READ-ONLY; Collection of references to IPs defined in network interfaces.
-	BackendIPConfigurations []*NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
+	BackendIPConfigurations []*InterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the backend address pool resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -401,7 +401,7 @@ type ApplicationGatewayBackendHealthServer struct {
 	HealthProbeLog *string `json:"healthProbeLog,omitempty"`
 
 	// Reference to IP configuration of backend server.
-	IPConfiguration *NetworkInterfaceIPConfiguration `json:"ipConfiguration,omitempty"`
+	IPConfiguration *InterfaceIPConfiguration `json:"ipConfiguration,omitempty"`
 }
 
 // ApplicationGatewayConnectionDraining - Connection draining allows open connections to a backend server to be active for
@@ -2890,7 +2890,7 @@ func (b BackendAddressPool) MarshalJSON() ([]byte, error) {
 // BackendAddressPoolPropertiesFormat - Properties of the backend address pool.
 type BackendAddressPoolPropertiesFormat struct {
 	// READ-ONLY; An array of references to IP addresses defined in network interfaces.
-	BackendIPConfigurations []*NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
+	BackendIPConfigurations []*InterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to load balancing rules that use this backend address pool.
 	LoadBalancingRules []*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
@@ -3339,6 +3339,68 @@ type Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentit
 
 	// READ-ONLY; The principal id of user assigned identity.
 	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+}
+
+// ConfigurationDiagnosticParameters - Parameters to get network configuration diagnostic.
+type ConfigurationDiagnosticParameters struct {
+	// REQUIRED; List of network configuration diagnostic profiles.
+	Profiles []*ConfigurationDiagnosticProfile `json:"profiles,omitempty"`
+
+	// REQUIRED; The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface,
+	// VMSS/NetworkInterface and Application Gateway.
+	TargetResourceID *string `json:"targetResourceId,omitempty"`
+
+	// Verbosity level.
+	VerbosityLevel *VerbosityLevel `json:"verbosityLevel,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConfigurationDiagnosticParameters.
+func (c ConfigurationDiagnosticParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "profiles", c.Profiles)
+	populate(objectMap, "targetResourceId", c.TargetResourceID)
+	populate(objectMap, "verbosityLevel", c.VerbosityLevel)
+	return json.Marshal(objectMap)
+}
+
+// ConfigurationDiagnosticProfile - Parameters to compare with network configuration.
+type ConfigurationDiagnosticProfile struct {
+	// REQUIRED; Traffic destination. Accepted values are: '*', IP Address/CIDR, Service Tag.
+	Destination *string `json:"destination,omitempty"`
+
+	// REQUIRED; Traffic destination port. Accepted values are '*' and a single port in the range (0 - 65535).
+	DestinationPort *string `json:"destinationPort,omitempty"`
+
+	// REQUIRED; The direction of the traffic.
+	Direction *Direction `json:"direction,omitempty"`
+
+	// REQUIRED; Protocol to be verified on. Accepted values are '*', TCP, UDP.
+	Protocol *string `json:"protocol,omitempty"`
+
+	// REQUIRED; Traffic source. Accepted values are '*', IP Address/CIDR, Service Tag.
+	Source *string `json:"source,omitempty"`
+}
+
+// ConfigurationDiagnosticResponse - Results of network configuration diagnostic on the target resource.
+type ConfigurationDiagnosticResponse struct {
+	// READ-ONLY; List of network configuration diagnostic results.
+	Results []*ConfigurationDiagnosticResult `json:"results,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConfigurationDiagnosticResponse.
+func (c ConfigurationDiagnosticResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "results", c.Results)
+	return json.Marshal(objectMap)
+}
+
+// ConfigurationDiagnosticResult - Network configuration diagnostic result corresponded to provided traffic query.
+type ConfigurationDiagnosticResult struct {
+	// Network security group result.
+	NetworkSecurityGroupResult *SecurityGroupResult `json:"networkSecurityGroupResult,omitempty"`
+
+	// Network configuration diagnostic profile.
+	Profile *ConfigurationDiagnosticProfile `json:"profile,omitempty"`
 }
 
 // ConnectionMonitor - Parameters that define the operation to create a connection monitor.
@@ -4752,7 +4814,7 @@ type EvaluatedNetworkSecurityGroup struct {
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty"`
 
 	// READ-ONLY; List of network security rules evaluation results.
-	RulesEvaluationResult []*NetworkSecurityRulesEvaluationResult `json:"rulesEvaluationResult,omitempty" azure:"ro"`
+	RulesEvaluationResult []*SecurityRulesEvaluationResult `json:"rulesEvaluationResult,omitempty" azure:"ro"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type EvaluatedNetworkSecurityGroup.
@@ -7580,7 +7642,7 @@ type InboundNatRulePropertiesFormat struct {
 
 	// READ-ONLY; A reference to a private IP address defined on a network interface of a VM. Traffic sent to the frontend port
 	// of each of the frontend IP configurations is forwarded to the backend IP.
-	BackendIPConfiguration *NetworkInterfaceIPConfiguration `json:"backendIPConfiguration,omitempty" azure:"ro"`
+	BackendIPConfiguration *InterfaceIPConfiguration `json:"backendIPConfiguration,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the inbound NAT rule resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -7606,6 +7668,371 @@ type InboundNatRulesGetOptions struct {
 // InboundNatRulesListOptions contains the optional parameters for the InboundNatRulesClient.List method.
 type InboundNatRulesListOptions struct {
 	// placeholder for future optional parameters
+}
+
+// IntentPolicy - Network Intent Policy resource.
+type IntentPolicy struct {
+	Resource
+	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
+	Etag *string `json:"etag,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IntentPolicy.
+func (i IntentPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	i.Resource.marshalInternal(objectMap)
+	populate(objectMap, "etag", i.Etag)
+	return json.Marshal(objectMap)
+}
+
+// IntentPolicyConfiguration - Details of NetworkIntentPolicyConfiguration for PrepareNetworkPoliciesRequest.
+type IntentPolicyConfiguration struct {
+	// The name of the Network Intent Policy for storing in target subscription.
+	NetworkIntentPolicyName *string `json:"networkIntentPolicyName,omitempty"`
+
+	// Source network intent policy.
+	SourceNetworkIntentPolicy *IntentPolicy `json:"sourceNetworkIntentPolicy,omitempty"`
+}
+
+// Interface - A network interface in a resource group.
+type Interface struct {
+	Resource
+	// Properties of the network interface.
+	Properties *InterfacePropertiesFormat `json:"properties,omitempty"`
+
+	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
+	Etag *string `json:"etag,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Interface.
+func (i Interface) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	i.Resource.marshalInternal(objectMap)
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "properties", i.Properties)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceAssociation - Network interface and its custom security rules.
+type InterfaceAssociation struct {
+	// Collection of custom security rules.
+	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
+
+	// READ-ONLY; Network interface ID.
+	ID *string `json:"id,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceAssociation.
+func (i InterfaceAssociation) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", i.ID)
+	populate(objectMap, "securityRules", i.SecurityRules)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceDNSSettings - DNS settings of a network interface.
+type InterfaceDNSSettings struct {
+	// List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS'
+	// value cannot be combined with other IPs, it must be the only value in dnsServers
+	// collection.
+	DNSServers []*string `json:"dnsServers,omitempty"`
+
+	// Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.
+	InternalDNSNameLabel *string `json:"internalDnsNameLabel,omitempty"`
+
+	// READ-ONLY; If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers
+	// from all NICs that are part of the Availability Set. This property is what is
+	// configured on each of those VMs.
+	AppliedDNSServers []*string `json:"appliedDnsServers,omitempty" azure:"ro"`
+
+	// READ-ONLY; Even if internalDnsNameLabel is not specified, a DNS entry is created for the primary NIC of the VM. This DNS
+	// name can be constructed by concatenating the VM name with the value of
+	// internalDomainNameSuffix.
+	InternalDomainNameSuffix *string `json:"internalDomainNameSuffix,omitempty" azure:"ro"`
+
+	// READ-ONLY; Fully qualified DNS name supporting internal communications between VMs in the same virtual network.
+	InternalFqdn *string `json:"internalFqdn,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceDNSSettings.
+func (i InterfaceDNSSettings) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "appliedDnsServers", i.AppliedDNSServers)
+	populate(objectMap, "dnsServers", i.DNSServers)
+	populate(objectMap, "internalDnsNameLabel", i.InternalDNSNameLabel)
+	populate(objectMap, "internalDomainNameSuffix", i.InternalDomainNameSuffix)
+	populate(objectMap, "internalFqdn", i.InternalFqdn)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceIPConfiguration - IPConfiguration in a network interface.
+type InterfaceIPConfiguration struct {
+	SubResource
+	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
+	Name *string `json:"name,omitempty"`
+
+	// Network interface IP configuration properties.
+	Properties *InterfaceIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+
+	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
+	Etag *string `json:"etag,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceIPConfiguration.
+func (i InterfaceIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	i.SubResource.marshalInternal(objectMap)
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "name", i.Name)
+	populate(objectMap, "properties", i.Properties)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceIPConfigurationListResult - Response for list ip configurations API service call.
+type InterfaceIPConfigurationListResult struct {
+	// A list of ip configurations.
+	Value []*InterfaceIPConfiguration `json:"value,omitempty"`
+
+	// READ-ONLY; The URL to get the next set of results.
+	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceIPConfigurationListResult.
+func (i InterfaceIPConfigurationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceIPConfigurationPrivateLinkConnectionProperties - PrivateLinkConnection properties for the network interface.
+type InterfaceIPConfigurationPrivateLinkConnectionProperties struct {
+	// READ-ONLY; List of FQDNs for current private link connection.
+	Fqdns []*string `json:"fqdns,omitempty" azure:"ro"`
+
+	// READ-ONLY; The group ID for current private link connection.
+	GroupID *string `json:"groupId,omitempty" azure:"ro"`
+
+	// READ-ONLY; The required member name for current private link connection.
+	RequiredMemberName *string `json:"requiredMemberName,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceIPConfigurationPrivateLinkConnectionProperties.
+func (i InterfaceIPConfigurationPrivateLinkConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "fqdns", i.Fqdns)
+	populate(objectMap, "groupId", i.GroupID)
+	populate(objectMap, "requiredMemberName", i.RequiredMemberName)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceIPConfigurationPropertiesFormat - Properties of IP configuration.
+type InterfaceIPConfigurationPropertiesFormat struct {
+	// The reference to ApplicationGatewayBackendAddressPool resource.
+	ApplicationGatewayBackendAddressPools []*ApplicationGatewayBackendAddressPool `json:"applicationGatewayBackendAddressPools,omitempty"`
+
+	// Application security groups in which the IP configuration is included.
+	ApplicationSecurityGroups []*ApplicationSecurityGroup `json:"applicationSecurityGroups,omitempty"`
+
+	// The reference to LoadBalancerBackendAddressPool resource.
+	LoadBalancerBackendAddressPools []*BackendAddressPool `json:"loadBalancerBackendAddressPools,omitempty"`
+
+	// A list of references of LoadBalancerInboundNatRules.
+	LoadBalancerInboundNatRules []*InboundNatRule `json:"loadBalancerInboundNatRules,omitempty"`
+
+	// Whether this is a primary customer address on the network interface.
+	Primary *bool `json:"primary,omitempty"`
+
+	// Private IP address of the IP configuration.
+	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+
+	// Whether the specific IP configuration is IPv4 or IPv6. Default is IPv4.
+	PrivateIPAddressVersion *IPVersion `json:"privateIPAddressVersion,omitempty"`
+
+	// The private IP address allocation method.
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+
+	// Public IP address bound to the IP configuration.
+	PublicIPAddress *PublicIPAddress `json:"publicIPAddress,omitempty"`
+
+	// Subnet bound to the IP configuration.
+	Subnet *Subnet `json:"subnet,omitempty"`
+
+	// The reference to Virtual Network Taps.
+	VirtualNetworkTaps []*VirtualNetworkTap `json:"virtualNetworkTaps,omitempty"`
+
+	// READ-ONLY; PrivateLinkConnection properties for the network interface.
+	PrivateLinkConnectionProperties *InterfaceIPConfigurationPrivateLinkConnectionProperties `json:"privateLinkConnectionProperties,omitempty" azure:"ro"`
+
+	// READ-ONLY; The provisioning state of the network interface IP configuration.
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceIPConfigurationPropertiesFormat.
+func (i InterfaceIPConfigurationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "applicationGatewayBackendAddressPools", i.ApplicationGatewayBackendAddressPools)
+	populate(objectMap, "applicationSecurityGroups", i.ApplicationSecurityGroups)
+	populate(objectMap, "loadBalancerBackendAddressPools", i.LoadBalancerBackendAddressPools)
+	populate(objectMap, "loadBalancerInboundNatRules", i.LoadBalancerInboundNatRules)
+	populate(objectMap, "primary", i.Primary)
+	populate(objectMap, "privateIPAddress", i.PrivateIPAddress)
+	populate(objectMap, "privateIPAddressVersion", i.PrivateIPAddressVersion)
+	populate(objectMap, "privateIPAllocationMethod", i.PrivateIPAllocationMethod)
+	populate(objectMap, "privateLinkConnectionProperties", i.PrivateLinkConnectionProperties)
+	populate(objectMap, "provisioningState", i.ProvisioningState)
+	populate(objectMap, "publicIPAddress", i.PublicIPAddress)
+	populate(objectMap, "subnet", i.Subnet)
+	populate(objectMap, "virtualNetworkTaps", i.VirtualNetworkTaps)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceListResult - Response for the ListNetworkInterface API service call.
+type InterfaceListResult struct {
+	// A list of network interfaces in a resource group.
+	Value []*Interface `json:"value,omitempty"`
+
+	// READ-ONLY; The URL to get the next set of results.
+	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceListResult.
+func (i InterfaceListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceLoadBalancerListResult - Response for list ip configurations API service call.
+type InterfaceLoadBalancerListResult struct {
+	// A list of load balancers.
+	Value []*LoadBalancer `json:"value,omitempty"`
+
+	// READ-ONLY; The URL to get the next set of results.
+	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceLoadBalancerListResult.
+func (i InterfaceLoadBalancerListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
+}
+
+// InterfacePropertiesFormat - NetworkInterface properties.
+type InterfacePropertiesFormat struct {
+	// The DNS settings in network interface.
+	DNSSettings *InterfaceDNSSettings `json:"dnsSettings,omitempty"`
+
+	// If the network interface is accelerated networking enabled.
+	EnableAcceleratedNetworking *bool `json:"enableAcceleratedNetworking,omitempty"`
+
+	// Indicates whether IP forwarding is enabled on this network interface.
+	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
+
+	// A list of IPConfigurations of the network interface.
+	IPConfigurations []*InterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
+
+	// The reference to the NetworkSecurityGroup resource.
+	NetworkSecurityGroup *SecurityGroup `json:"networkSecurityGroup,omitempty"`
+
+	// READ-ONLY; A list of references to linked BareMetal resources.
+	HostedWorkloads []*string `json:"hostedWorkloads,omitempty" azure:"ro"`
+
+	// READ-ONLY; The MAC address of the network interface.
+	MacAddress *string `json:"macAddress,omitempty" azure:"ro"`
+
+	// READ-ONLY; Whether this is a primary network interface on a virtual machine.
+	Primary *bool `json:"primary,omitempty" azure:"ro"`
+
+	// READ-ONLY; A reference to the private endpoint to which the network interface is linked.
+	PrivateEndpoint *PrivateEndpoint `json:"privateEndpoint,omitempty" azure:"ro"`
+
+	// READ-ONLY; The provisioning state of the network interface resource.
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+
+	// READ-ONLY; The resource GUID property of the network interface resource.
+	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+
+	// READ-ONLY; A list of TapConfigurations of the network interface.
+	TapConfigurations []*InterfaceTapConfiguration `json:"tapConfigurations,omitempty" azure:"ro"`
+
+	// READ-ONLY; The reference to a virtual machine.
+	VirtualMachine *SubResource `json:"virtualMachine,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfacePropertiesFormat.
+func (i InterfacePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsSettings", i.DNSSettings)
+	populate(objectMap, "enableAcceleratedNetworking", i.EnableAcceleratedNetworking)
+	populate(objectMap, "enableIPForwarding", i.EnableIPForwarding)
+	populate(objectMap, "hostedWorkloads", i.HostedWorkloads)
+	populate(objectMap, "ipConfigurations", i.IPConfigurations)
+	populate(objectMap, "macAddress", i.MacAddress)
+	populate(objectMap, "networkSecurityGroup", i.NetworkSecurityGroup)
+	populate(objectMap, "primary", i.Primary)
+	populate(objectMap, "privateEndpoint", i.PrivateEndpoint)
+	populate(objectMap, "provisioningState", i.ProvisioningState)
+	populate(objectMap, "resourceGuid", i.ResourceGUID)
+	populate(objectMap, "tapConfigurations", i.TapConfigurations)
+	populate(objectMap, "virtualMachine", i.VirtualMachine)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceTapConfiguration - Tap configuration in a Network Interface.
+type InterfaceTapConfiguration struct {
+	SubResource
+	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
+	Name *string `json:"name,omitempty"`
+
+	// Properties of the Virtual Network Tap configuration.
+	Properties *InterfaceTapConfigurationPropertiesFormat `json:"properties,omitempty"`
+
+	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
+	Etag *string `json:"etag,omitempty" azure:"ro"`
+
+	// READ-ONLY; Sub Resource type.
+	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceTapConfiguration.
+func (i InterfaceTapConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	i.SubResource.marshalInternal(objectMap)
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "name", i.Name)
+	populate(objectMap, "properties", i.Properties)
+	populate(objectMap, "type", i.Type)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceTapConfigurationListResult - Response for list tap configurations API service call.
+type InterfaceTapConfigurationListResult struct {
+	// A list of tap configurations.
+	Value []*InterfaceTapConfiguration `json:"value,omitempty"`
+
+	// READ-ONLY; The URL to get the next set of results.
+	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InterfaceTapConfigurationListResult.
+func (i InterfaceTapConfigurationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
+}
+
+// InterfaceTapConfigurationPropertiesFormat - Properties of Virtual Network Tap configuration.
+type InterfaceTapConfigurationPropertiesFormat struct {
+	// The reference to the Virtual Network Tap resource.
+	VirtualNetworkTap *VirtualNetworkTap `json:"virtualNetworkTap,omitempty"`
+
+	// READ-ONLY; The provisioning state of the network interface tap configuration resource.
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 }
 
 // ListHubVirtualNetworkConnectionsResult - List of HubVirtualNetworkConnections and a URL nextLink to get the next set of
@@ -8639,1156 +9066,364 @@ func (n *NatRuleCondition) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// NetworkConfigurationDiagnosticParameters - Parameters to get network configuration diagnostic.
-type NetworkConfigurationDiagnosticParameters struct {
-	// REQUIRED; List of network configuration diagnostic profiles.
-	Profiles []*NetworkConfigurationDiagnosticProfile `json:"profiles,omitempty"`
-
-	// REQUIRED; The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface,
-	// VMSS/NetworkInterface and Application Gateway.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
-
-	// Verbosity level.
-	VerbosityLevel *VerbosityLevel `json:"verbosityLevel,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkConfigurationDiagnosticParameters.
-func (n NetworkConfigurationDiagnosticParameters) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "profiles", n.Profiles)
-	populate(objectMap, "targetResourceId", n.TargetResourceID)
-	populate(objectMap, "verbosityLevel", n.VerbosityLevel)
-	return json.Marshal(objectMap)
-}
-
-// NetworkConfigurationDiagnosticProfile - Parameters to compare with network configuration.
-type NetworkConfigurationDiagnosticProfile struct {
-	// REQUIRED; Traffic destination. Accepted values are: '*', IP Address/CIDR, Service Tag.
-	Destination *string `json:"destination,omitempty"`
-
-	// REQUIRED; Traffic destination port. Accepted values are '*' and a single port in the range (0 - 65535).
-	DestinationPort *string `json:"destinationPort,omitempty"`
-
-	// REQUIRED; The direction of the traffic.
-	Direction *Direction `json:"direction,omitempty"`
-
-	// REQUIRED; Protocol to be verified on. Accepted values are '*', TCP, UDP.
-	Protocol *string `json:"protocol,omitempty"`
-
-	// REQUIRED; Traffic source. Accepted values are '*', IP Address/CIDR, Service Tag.
-	Source *string `json:"source,omitempty"`
-}
-
-// NetworkConfigurationDiagnosticResponse - Results of network configuration diagnostic on the target resource.
-type NetworkConfigurationDiagnosticResponse struct {
-	// READ-ONLY; List of network configuration diagnostic results.
-	Results []*NetworkConfigurationDiagnosticResult `json:"results,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkConfigurationDiagnosticResponse.
-func (n NetworkConfigurationDiagnosticResponse) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "results", n.Results)
-	return json.Marshal(objectMap)
-}
-
-// NetworkConfigurationDiagnosticResult - Network configuration diagnostic result corresponded to provided traffic query.
-type NetworkConfigurationDiagnosticResult struct {
-	// Network security group result.
-	NetworkSecurityGroupResult *NetworkSecurityGroupResult `json:"networkSecurityGroupResult,omitempty"`
-
-	// Network configuration diagnostic profile.
-	Profile *NetworkConfigurationDiagnosticProfile `json:"profile,omitempty"`
-}
-
-// NetworkIntentPolicy - Network Intent Policy resource.
-type NetworkIntentPolicy struct {
-	Resource
-	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkIntentPolicy.
-func (n NetworkIntentPolicy) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.Resource.marshalInternal(objectMap)
-	populate(objectMap, "etag", n.Etag)
-	return json.Marshal(objectMap)
-}
-
-// NetworkIntentPolicyConfiguration - Details of NetworkIntentPolicyConfiguration for PrepareNetworkPoliciesRequest.
-type NetworkIntentPolicyConfiguration struct {
-	// The name of the Network Intent Policy for storing in target subscription.
-	NetworkIntentPolicyName *string `json:"networkIntentPolicyName,omitempty"`
-
-	// Source network intent policy.
-	SourceNetworkIntentPolicy *NetworkIntentPolicy `json:"sourceNetworkIntentPolicy,omitempty"`
-}
-
-// NetworkInterface - A network interface in a resource group.
-type NetworkInterface struct {
-	Resource
-	// Properties of the network interface.
-	Properties *NetworkInterfacePropertiesFormat `json:"properties,omitempty"`
-
-	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterface.
-func (n NetworkInterface) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.Resource.marshalInternal(objectMap)
-	populate(objectMap, "etag", n.Etag)
-	populate(objectMap, "properties", n.Properties)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceAssociation - Network interface and its custom security rules.
-type NetworkInterfaceAssociation struct {
-	// Collection of custom security rules.
-	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
-
-	// READ-ONLY; Network interface ID.
-	ID *string `json:"id,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceAssociation.
-func (n NetworkInterfaceAssociation) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "id", n.ID)
-	populate(objectMap, "securityRules", n.SecurityRules)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceDNSSettings - DNS settings of a network interface.
-type NetworkInterfaceDNSSettings struct {
-	// List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS'
-	// value cannot be combined with other IPs, it must be the only value in dnsServers
-	// collection.
-	DNSServers []*string `json:"dnsServers,omitempty"`
-
-	// Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.
-	InternalDNSNameLabel *string `json:"internalDnsNameLabel,omitempty"`
-
-	// READ-ONLY; If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers
-	// from all NICs that are part of the Availability Set. This property is what is
-	// configured on each of those VMs.
-	AppliedDNSServers []*string `json:"appliedDnsServers,omitempty" azure:"ro"`
-
-	// READ-ONLY; Even if internalDnsNameLabel is not specified, a DNS entry is created for the primary NIC of the VM. This DNS
-	// name can be constructed by concatenating the VM name with the value of
-	// internalDomainNameSuffix.
-	InternalDomainNameSuffix *string `json:"internalDomainNameSuffix,omitempty" azure:"ro"`
-
-	// READ-ONLY; Fully qualified DNS name supporting internal communications between VMs in the same virtual network.
-	InternalFqdn *string `json:"internalFqdn,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceDNSSettings.
-func (n NetworkInterfaceDNSSettings) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "appliedDnsServers", n.AppliedDNSServers)
-	populate(objectMap, "dnsServers", n.DNSServers)
-	populate(objectMap, "internalDnsNameLabel", n.InternalDNSNameLabel)
-	populate(objectMap, "internalDomainNameSuffix", n.InternalDomainNameSuffix)
-	populate(objectMap, "internalFqdn", n.InternalFqdn)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceIPConfiguration - IPConfiguration in a network interface.
-type NetworkInterfaceIPConfiguration struct {
-	SubResource
-	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
-
-	// Network interface IP configuration properties.
-	Properties *NetworkInterfaceIPConfigurationPropertiesFormat `json:"properties,omitempty"`
-
-	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceIPConfiguration.
-func (n NetworkInterfaceIPConfiguration) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.SubResource.marshalInternal(objectMap)
-	populate(objectMap, "etag", n.Etag)
-	populate(objectMap, "name", n.Name)
-	populate(objectMap, "properties", n.Properties)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceIPConfigurationListResult - Response for list ip configurations API service call.
-type NetworkInterfaceIPConfigurationListResult struct {
-	// A list of ip configurations.
-	Value []*NetworkInterfaceIPConfiguration `json:"value,omitempty"`
-
-	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceIPConfigurationListResult.
-func (n NetworkInterfaceIPConfigurationListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "nextLink", n.NextLink)
-	populate(objectMap, "value", n.Value)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties - PrivateLinkConnection properties for the network interface.
-type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties struct {
-	// READ-ONLY; List of FQDNs for current private link connection.
-	Fqdns []*string `json:"fqdns,omitempty" azure:"ro"`
-
-	// READ-ONLY; The group ID for current private link connection.
-	GroupID *string `json:"groupId,omitempty" azure:"ro"`
-
-	// READ-ONLY; The required member name for current private link connection.
-	RequiredMemberName *string `json:"requiredMemberName,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties.
-func (n NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "fqdns", n.Fqdns)
-	populate(objectMap, "groupId", n.GroupID)
-	populate(objectMap, "requiredMemberName", n.RequiredMemberName)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceIPConfigurationPropertiesFormat - Properties of IP configuration.
-type NetworkInterfaceIPConfigurationPropertiesFormat struct {
-	// The reference to ApplicationGatewayBackendAddressPool resource.
-	ApplicationGatewayBackendAddressPools []*ApplicationGatewayBackendAddressPool `json:"applicationGatewayBackendAddressPools,omitempty"`
-
-	// Application security groups in which the IP configuration is included.
-	ApplicationSecurityGroups []*ApplicationSecurityGroup `json:"applicationSecurityGroups,omitempty"`
-
-	// The reference to LoadBalancerBackendAddressPool resource.
-	LoadBalancerBackendAddressPools []*BackendAddressPool `json:"loadBalancerBackendAddressPools,omitempty"`
-
-	// A list of references of LoadBalancerInboundNatRules.
-	LoadBalancerInboundNatRules []*InboundNatRule `json:"loadBalancerInboundNatRules,omitempty"`
-
-	// Whether this is a primary customer address on the network interface.
-	Primary *bool `json:"primary,omitempty"`
-
-	// Private IP address of the IP configuration.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
-
-	// Whether the specific IP configuration is IPv4 or IPv6. Default is IPv4.
-	PrivateIPAddressVersion *IPVersion `json:"privateIPAddressVersion,omitempty"`
-
-	// The private IP address allocation method.
-	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
-
-	// Public IP address bound to the IP configuration.
-	PublicIPAddress *PublicIPAddress `json:"publicIPAddress,omitempty"`
-
-	// Subnet bound to the IP configuration.
-	Subnet *Subnet `json:"subnet,omitempty"`
-
-	// The reference to Virtual Network Taps.
-	VirtualNetworkTaps []*VirtualNetworkTap `json:"virtualNetworkTaps,omitempty"`
-
-	// READ-ONLY; PrivateLinkConnection properties for the network interface.
-	PrivateLinkConnectionProperties *NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties `json:"privateLinkConnectionProperties,omitempty" azure:"ro"`
-
-	// READ-ONLY; The provisioning state of the network interface IP configuration.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceIPConfigurationPropertiesFormat.
-func (n NetworkInterfaceIPConfigurationPropertiesFormat) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "applicationGatewayBackendAddressPools", n.ApplicationGatewayBackendAddressPools)
-	populate(objectMap, "applicationSecurityGroups", n.ApplicationSecurityGroups)
-	populate(objectMap, "loadBalancerBackendAddressPools", n.LoadBalancerBackendAddressPools)
-	populate(objectMap, "loadBalancerInboundNatRules", n.LoadBalancerInboundNatRules)
-	populate(objectMap, "primary", n.Primary)
-	populate(objectMap, "privateIPAddress", n.PrivateIPAddress)
-	populate(objectMap, "privateIPAddressVersion", n.PrivateIPAddressVersion)
-	populate(objectMap, "privateIPAllocationMethod", n.PrivateIPAllocationMethod)
-	populate(objectMap, "privateLinkConnectionProperties", n.PrivateLinkConnectionProperties)
-	populate(objectMap, "provisioningState", n.ProvisioningState)
-	populate(objectMap, "publicIPAddress", n.PublicIPAddress)
-	populate(objectMap, "subnet", n.Subnet)
-	populate(objectMap, "virtualNetworkTaps", n.VirtualNetworkTaps)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceIPConfigurationsGetOptions contains the optional parameters for the NetworkInterfaceIPConfigurationsClient.Get
+// NetworkInterfaceIPConfigurationsGetOptions contains the optional parameters for the InterfaceIPConfigurationsClient.Get
 // method.
 type NetworkInterfaceIPConfigurationsGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfaceIPConfigurationsListOptions contains the optional parameters for the NetworkInterfaceIPConfigurationsClient.List
+// NetworkInterfaceIPConfigurationsListOptions contains the optional parameters for the InterfaceIPConfigurationsClient.List
 // method.
 type NetworkInterfaceIPConfigurationsListOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfaceListResult - Response for the ListNetworkInterface API service call.
-type NetworkInterfaceListResult struct {
-	// A list of network interfaces in a resource group.
-	Value []*NetworkInterface `json:"value,omitempty"`
-
-	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceListResult.
-func (n NetworkInterfaceListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "nextLink", n.NextLink)
-	populate(objectMap, "value", n.Value)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceLoadBalancerListResult - Response for list ip configurations API service call.
-type NetworkInterfaceLoadBalancerListResult struct {
-	// A list of load balancers.
-	Value []*LoadBalancer `json:"value,omitempty"`
-
-	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceLoadBalancerListResult.
-func (n NetworkInterfaceLoadBalancerListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "nextLink", n.NextLink)
-	populate(objectMap, "value", n.Value)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceLoadBalancersListOptions contains the optional parameters for the NetworkInterfaceLoadBalancersClient.List
-// method.
+// NetworkInterfaceLoadBalancersListOptions contains the optional parameters for the InterfaceLoadBalancersClient.List method.
 type NetworkInterfaceLoadBalancersListOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacePropertiesFormat - NetworkInterface properties.
-type NetworkInterfacePropertiesFormat struct {
-	// The DNS settings in network interface.
-	DNSSettings *NetworkInterfaceDNSSettings `json:"dnsSettings,omitempty"`
-
-	// If the network interface is accelerated networking enabled.
-	EnableAcceleratedNetworking *bool `json:"enableAcceleratedNetworking,omitempty"`
-
-	// Indicates whether IP forwarding is enabled on this network interface.
-	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
-
-	// A list of IPConfigurations of the network interface.
-	IPConfigurations []*NetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
-
-	// The reference to the NetworkSecurityGroup resource.
-	NetworkSecurityGroup *NetworkSecurityGroup `json:"networkSecurityGroup,omitempty"`
-
-	// READ-ONLY; A list of references to linked BareMetal resources.
-	HostedWorkloads []*string `json:"hostedWorkloads,omitempty" azure:"ro"`
-
-	// READ-ONLY; The MAC address of the network interface.
-	MacAddress *string `json:"macAddress,omitempty" azure:"ro"`
-
-	// READ-ONLY; Whether this is a primary network interface on a virtual machine.
-	Primary *bool `json:"primary,omitempty" azure:"ro"`
-
-	// READ-ONLY; A reference to the private endpoint to which the network interface is linked.
-	PrivateEndpoint *PrivateEndpoint `json:"privateEndpoint,omitempty" azure:"ro"`
-
-	// READ-ONLY; The provisioning state of the network interface resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
-
-	// READ-ONLY; The resource GUID property of the network interface resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
-
-	// READ-ONLY; A list of TapConfigurations of the network interface.
-	TapConfigurations []*NetworkInterfaceTapConfiguration `json:"tapConfigurations,omitempty" azure:"ro"`
-
-	// READ-ONLY; The reference to a virtual machine.
-	VirtualMachine *SubResource `json:"virtualMachine,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfacePropertiesFormat.
-func (n NetworkInterfacePropertiesFormat) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "dnsSettings", n.DNSSettings)
-	populate(objectMap, "enableAcceleratedNetworking", n.EnableAcceleratedNetworking)
-	populate(objectMap, "enableIPForwarding", n.EnableIPForwarding)
-	populate(objectMap, "hostedWorkloads", n.HostedWorkloads)
-	populate(objectMap, "ipConfigurations", n.IPConfigurations)
-	populate(objectMap, "macAddress", n.MacAddress)
-	populate(objectMap, "networkSecurityGroup", n.NetworkSecurityGroup)
-	populate(objectMap, "primary", n.Primary)
-	populate(objectMap, "privateEndpoint", n.PrivateEndpoint)
-	populate(objectMap, "provisioningState", n.ProvisioningState)
-	populate(objectMap, "resourceGuid", n.ResourceGUID)
-	populate(objectMap, "tapConfigurations", n.TapConfigurations)
-	populate(objectMap, "virtualMachine", n.VirtualMachine)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceTapConfiguration - Tap configuration in a Network Interface.
-type NetworkInterfaceTapConfiguration struct {
-	SubResource
-	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
-
-	// Properties of the Virtual Network Tap configuration.
-	Properties *NetworkInterfaceTapConfigurationPropertiesFormat `json:"properties,omitempty"`
-
-	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
-
-	// READ-ONLY; Sub Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceTapConfiguration.
-func (n NetworkInterfaceTapConfiguration) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.SubResource.marshalInternal(objectMap)
-	populate(objectMap, "etag", n.Etag)
-	populate(objectMap, "name", n.Name)
-	populate(objectMap, "properties", n.Properties)
-	populate(objectMap, "type", n.Type)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceTapConfigurationListResult - Response for list tap configurations API service call.
-type NetworkInterfaceTapConfigurationListResult struct {
-	// A list of tap configurations.
-	Value []*NetworkInterfaceTapConfiguration `json:"value,omitempty"`
-
-	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceTapConfigurationListResult.
-func (n NetworkInterfaceTapConfigurationListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "nextLink", n.NextLink)
-	populate(objectMap, "value", n.Value)
-	return json.Marshal(objectMap)
-}
-
-// NetworkInterfaceTapConfigurationPropertiesFormat - Properties of Virtual Network Tap configuration.
-type NetworkInterfaceTapConfigurationPropertiesFormat struct {
-	// The reference to the Virtual Network Tap resource.
-	VirtualNetworkTap *VirtualNetworkTap `json:"virtualNetworkTap,omitempty"`
-
-	// READ-ONLY; The provisioning state of the network interface tap configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
-}
-
-// NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions contains the optional parameters for the NetworkInterfaceTapConfigurationsClient.BeginCreateOrUpdate
+// NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions contains the optional parameters for the InterfaceTapConfigurationsClient.BeginCreateOrUpdate
 // method.
 type NetworkInterfaceTapConfigurationsBeginCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfaceTapConfigurationsBeginDeleteOptions contains the optional parameters for the NetworkInterfaceTapConfigurationsClient.BeginDelete
+// NetworkInterfaceTapConfigurationsBeginDeleteOptions contains the optional parameters for the InterfaceTapConfigurationsClient.BeginDelete
 // method.
 type NetworkInterfaceTapConfigurationsBeginDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfaceTapConfigurationsGetOptions contains the optional parameters for the NetworkInterfaceTapConfigurationsClient.Get
+// NetworkInterfaceTapConfigurationsGetOptions contains the optional parameters for the InterfaceTapConfigurationsClient.Get
 // method.
 type NetworkInterfaceTapConfigurationsGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfaceTapConfigurationsListOptions contains the optional parameters for the NetworkInterfaceTapConfigurationsClient.List
+// NetworkInterfaceTapConfigurationsListOptions contains the optional parameters for the InterfaceTapConfigurationsClient.List
 // method.
 type NetworkInterfaceTapConfigurationsListOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesBeginCreateOrUpdateOptions contains the optional parameters for the NetworkInterfacesClient.BeginCreateOrUpdate
+// NetworkInterfacesBeginCreateOrUpdateOptions contains the optional parameters for the InterfacesClient.BeginCreateOrUpdate
 // method.
 type NetworkInterfacesBeginCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesBeginDeleteOptions contains the optional parameters for the NetworkInterfacesClient.BeginDelete method.
+// NetworkInterfacesBeginDeleteOptions contains the optional parameters for the InterfacesClient.BeginDelete method.
 type NetworkInterfacesBeginDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesBeginGetEffectiveRouteTableOptions contains the optional parameters for the NetworkInterfacesClient.BeginGetEffectiveRouteTable
+// NetworkInterfacesBeginGetEffectiveRouteTableOptions contains the optional parameters for the InterfacesClient.BeginGetEffectiveRouteTable
 // method.
 type NetworkInterfacesBeginGetEffectiveRouteTableOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions contains the optional parameters for the NetworkInterfacesClient.BeginListEffectiveNetworkSecurityGroups
+// NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions contains the optional parameters for the InterfacesClient.BeginListEffectiveNetworkSecurityGroups
 // method.
 type NetworkInterfacesBeginListEffectiveNetworkSecurityGroupsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesGetOptions contains the optional parameters for the NetworkInterfacesClient.Get method.
+// NetworkInterfacesGetOptions contains the optional parameters for the InterfacesClient.Get method.
 type NetworkInterfacesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
 }
 
-// NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions contains the optional parameters for the NetworkInterfacesClient.GetVirtualMachineScaleSetIPConfiguration
+// NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions contains the optional parameters for the InterfacesClient.GetVirtualMachineScaleSetIPConfiguration
 // method.
 type NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions struct {
 	// Expands referenced resources.
 	Expand *string
 }
 
-// NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions contains the optional parameters for the NetworkInterfacesClient.GetVirtualMachineScaleSetNetworkInterface
+// NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions contains the optional parameters for the InterfacesClient.GetVirtualMachineScaleSetNetworkInterface
 // method.
 type NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions struct {
 	// Expands referenced resources.
 	Expand *string
 }
 
-// NetworkInterfacesListAllOptions contains the optional parameters for the NetworkInterfacesClient.ListAll method.
+// NetworkInterfacesListAllOptions contains the optional parameters for the InterfacesClient.ListAll method.
 type NetworkInterfacesListAllOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesListOptions contains the optional parameters for the NetworkInterfacesClient.List method.
+// NetworkInterfacesListOptions contains the optional parameters for the InterfacesClient.List method.
 type NetworkInterfacesListOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions contains the optional parameters for the NetworkInterfacesClient.ListVirtualMachineScaleSetIPConfigurations
+// NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions contains the optional parameters for the InterfacesClient.ListVirtualMachineScaleSetIPConfigurations
 // method.
 type NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions struct {
 	// Expands referenced resources.
 	Expand *string
 }
 
-// NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions contains the optional parameters for the NetworkInterfacesClient.ListVirtualMachineScaleSetNetworkInterfaces
+// NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions contains the optional parameters for the InterfacesClient.ListVirtualMachineScaleSetNetworkInterfaces
 // method.
 type NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions contains the optional parameters for the NetworkInterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfaces
+// NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions contains the optional parameters for the InterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfaces
 // method.
 type NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkInterfacesUpdateTagsOptions contains the optional parameters for the NetworkInterfacesClient.UpdateTags method.
+// NetworkInterfacesUpdateTagsOptions contains the optional parameters for the InterfacesClient.UpdateTags method.
 type NetworkInterfacesUpdateTagsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkManagementClientBeginDeleteBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.BeginDeleteBastionShareableLink
+// NetworkManagementClientBeginDeleteBastionShareableLinkOptions contains the optional parameters for the ManagementClient.BeginDeleteBastionShareableLink
 // method.
 type NetworkManagementClientBeginDeleteBastionShareableLinkOptions struct {
 	// placeholder for future optional parameters
 }
 
 // NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions contains the optional parameters
-// for the NetworkManagementClient.BeginGeneratevirtualwanvpnserverconfigurationvpnprofile method.
+// for the ManagementClient.BeginGeneratevirtualwanvpnserverconfigurationvpnprofile method.
 type NetworkManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkManagementClientBeginGetActiveSessionsOptions contains the optional parameters for the NetworkManagementClient.BeginGetActiveSessions
+// NetworkManagementClientBeginGetActiveSessionsOptions contains the optional parameters for the ManagementClient.BeginGetActiveSessions
 // method.
 type NetworkManagementClientBeginGetActiveSessionsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkManagementClientBeginPutBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.BeginPutBastionShareableLink
+// NetworkManagementClientBeginPutBastionShareableLinkOptions contains the optional parameters for the ManagementClient.BeginPutBastionShareableLink
 // method.
 type NetworkManagementClientBeginPutBastionShareableLinkOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkManagementClientCheckDNSNameAvailabilityOptions contains the optional parameters for the NetworkManagementClient.CheckDNSNameAvailability
+// NetworkManagementClientCheckDNSNameAvailabilityOptions contains the optional parameters for the ManagementClient.CheckDNSNameAvailability
 // method.
 type NetworkManagementClientCheckDNSNameAvailabilityOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkManagementClientDisconnectActiveSessionsOptions contains the optional parameters for the NetworkManagementClient.DisconnectActiveSessions
+// NetworkManagementClientDisconnectActiveSessionsOptions contains the optional parameters for the ManagementClient.DisconnectActiveSessions
 // method.
 type NetworkManagementClientDisconnectActiveSessionsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkManagementClientGetBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.GetBastionShareableLink
+// NetworkManagementClientGetBastionShareableLinkOptions contains the optional parameters for the ManagementClient.GetBastionShareableLink
 // method.
 type NetworkManagementClientGetBastionShareableLinkOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkManagementClientSupportedSecurityProvidersOptions contains the optional parameters for the NetworkManagementClient.SupportedSecurityProviders
+// NetworkManagementClientSupportedSecurityProvidersOptions contains the optional parameters for the ManagementClient.SupportedSecurityProviders
 // method.
 type NetworkManagementClientSupportedSecurityProvidersOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkProfile - Network profile resource.
-type NetworkProfile struct {
-	Resource
-	// Network profile properties.
-	Properties *NetworkProfilePropertiesFormat `json:"properties,omitempty"`
-
-	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkProfile.
-func (n NetworkProfile) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.Resource.marshalInternal(objectMap)
-	populate(objectMap, "etag", n.Etag)
-	populate(objectMap, "properties", n.Properties)
-	return json.Marshal(objectMap)
-}
-
-// NetworkProfileListResult - Response for ListNetworkProfiles API service call.
-type NetworkProfileListResult struct {
-	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
-
-	// A list of network profiles that exist in a resource group.
-	Value []*NetworkProfile `json:"value,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkProfileListResult.
-func (n NetworkProfileListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "nextLink", n.NextLink)
-	populate(objectMap, "value", n.Value)
-	return json.Marshal(objectMap)
-}
-
-// NetworkProfilePropertiesFormat - Network profile properties.
-type NetworkProfilePropertiesFormat struct {
-	// List of chid container network interface configurations.
-	ContainerNetworkInterfaceConfigurations []*ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfigurations,omitempty"`
-
-	// READ-ONLY; List of child container network interfaces.
-	ContainerNetworkInterfaces []*ContainerNetworkInterface `json:"containerNetworkInterfaces,omitempty" azure:"ro"`
-
-	// READ-ONLY; The provisioning state of the network profile resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
-
-	// READ-ONLY; The resource GUID property of the network profile resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkProfilePropertiesFormat.
-func (n NetworkProfilePropertiesFormat) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "containerNetworkInterfaceConfigurations", n.ContainerNetworkInterfaceConfigurations)
-	populate(objectMap, "containerNetworkInterfaces", n.ContainerNetworkInterfaces)
-	populate(objectMap, "provisioningState", n.ProvisioningState)
-	populate(objectMap, "resourceGuid", n.ResourceGUID)
-	return json.Marshal(objectMap)
-}
-
-// NetworkProfilesBeginDeleteOptions contains the optional parameters for the NetworkProfilesClient.BeginDelete method.
+// NetworkProfilesBeginDeleteOptions contains the optional parameters for the ProfilesClient.BeginDelete method.
 type NetworkProfilesBeginDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkProfilesCreateOrUpdateOptions contains the optional parameters for the NetworkProfilesClient.CreateOrUpdate method.
+// NetworkProfilesCreateOrUpdateOptions contains the optional parameters for the ProfilesClient.CreateOrUpdate method.
 type NetworkProfilesCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkProfilesGetOptions contains the optional parameters for the NetworkProfilesClient.Get method.
+// NetworkProfilesGetOptions contains the optional parameters for the ProfilesClient.Get method.
 type NetworkProfilesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
 }
 
-// NetworkProfilesListAllOptions contains the optional parameters for the NetworkProfilesClient.ListAll method.
+// NetworkProfilesListAllOptions contains the optional parameters for the ProfilesClient.ListAll method.
 type NetworkProfilesListAllOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkProfilesListOptions contains the optional parameters for the NetworkProfilesClient.List method.
+// NetworkProfilesListOptions contains the optional parameters for the ProfilesClient.List method.
 type NetworkProfilesListOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkProfilesUpdateTagsOptions contains the optional parameters for the NetworkProfilesClient.UpdateTags method.
+// NetworkProfilesUpdateTagsOptions contains the optional parameters for the ProfilesClient.UpdateTags method.
 type NetworkProfilesUpdateTagsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkRuleCondition - Rule condition of type network.
-type NetworkRuleCondition struct {
-	FirewallPolicyRuleCondition
-	// List of destination IP addresses or Service Tags.
-	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
-
-	// List of destination IpGroups for this rule.
-	DestinationIPGroups []*string `json:"destinationIpGroups,omitempty"`
-
-	// List of destination ports.
-	DestinationPorts []*string `json:"destinationPorts,omitempty"`
-
-	// Array of FirewallPolicyRuleConditionNetworkProtocols.
-	IPProtocols []*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
-
-	// List of source IP addresses for this rule.
-	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
-
-	// List of source IpGroups for this rule.
-	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkRuleCondition.
-func (n NetworkRuleCondition) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.FirewallPolicyRuleCondition.marshalInternal(objectMap, FirewallPolicyRuleConditionTypeNetworkRuleCondition)
-	populate(objectMap, "destinationAddresses", n.DestinationAddresses)
-	populate(objectMap, "destinationIpGroups", n.DestinationIPGroups)
-	populate(objectMap, "destinationPorts", n.DestinationPorts)
-	populate(objectMap, "ipProtocols", n.IPProtocols)
-	populate(objectMap, "sourceAddresses", n.SourceAddresses)
-	populate(objectMap, "sourceIpGroups", n.SourceIPGroups)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type NetworkRuleCondition.
-func (n *NetworkRuleCondition) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return err
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "destinationAddresses":
-			err = unpopulate(val, &n.DestinationAddresses)
-			delete(rawMsg, key)
-		case "destinationIpGroups":
-			err = unpopulate(val, &n.DestinationIPGroups)
-			delete(rawMsg, key)
-		case "destinationPorts":
-			err = unpopulate(val, &n.DestinationPorts)
-			delete(rawMsg, key)
-		case "ipProtocols":
-			err = unpopulate(val, &n.IPProtocols)
-			delete(rawMsg, key)
-		case "sourceAddresses":
-			err = unpopulate(val, &n.SourceAddresses)
-			delete(rawMsg, key)
-		case "sourceIpGroups":
-			err = unpopulate(val, &n.SourceIPGroups)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	if err := n.FirewallPolicyRuleCondition.unmarshalInternal(rawMsg); err != nil {
-		return err
-	}
-	return nil
-}
-
-// NetworkSecurityGroup resource.
-type NetworkSecurityGroup struct {
-	Resource
-	// Properties of the network security group.
-	Properties *NetworkSecurityGroupPropertiesFormat `json:"properties,omitempty"`
-
-	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkSecurityGroup.
-func (n NetworkSecurityGroup) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.Resource.marshalInternal(objectMap)
-	populate(objectMap, "etag", n.Etag)
-	populate(objectMap, "properties", n.Properties)
-	return json.Marshal(objectMap)
-}
-
-// NetworkSecurityGroupListResult - Response for ListNetworkSecurityGroups API service call.
-type NetworkSecurityGroupListResult struct {
-	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
-
-	// A list of NetworkSecurityGroup resources.
-	Value []*NetworkSecurityGroup `json:"value,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkSecurityGroupListResult.
-func (n NetworkSecurityGroupListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "nextLink", n.NextLink)
-	populate(objectMap, "value", n.Value)
-	return json.Marshal(objectMap)
-}
-
-// NetworkSecurityGroupPropertiesFormat - Network Security Group resource.
-type NetworkSecurityGroupPropertiesFormat struct {
-	// A collection of security rules of the network security group.
-	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
-
-	// READ-ONLY; The default security rules of network security group.
-	DefaultSecurityRules []*SecurityRule `json:"defaultSecurityRules,omitempty" azure:"ro"`
-
-	// READ-ONLY; A collection of references to flow log resources.
-	FlowLogs []*FlowLog `json:"flowLogs,omitempty" azure:"ro"`
-
-	// READ-ONLY; A collection of references to network interfaces.
-	NetworkInterfaces []*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
-
-	// READ-ONLY; The provisioning state of the network security group resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
-
-	// READ-ONLY; The resource GUID property of the network security group resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
-
-	// READ-ONLY; A collection of references to subnets.
-	Subnets []*Subnet `json:"subnets,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkSecurityGroupPropertiesFormat.
-func (n NetworkSecurityGroupPropertiesFormat) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "defaultSecurityRules", n.DefaultSecurityRules)
-	populate(objectMap, "flowLogs", n.FlowLogs)
-	populate(objectMap, "networkInterfaces", n.NetworkInterfaces)
-	populate(objectMap, "provisioningState", n.ProvisioningState)
-	populate(objectMap, "resourceGuid", n.ResourceGUID)
-	populate(objectMap, "securityRules", n.SecurityRules)
-	populate(objectMap, "subnets", n.Subnets)
-	return json.Marshal(objectMap)
-}
-
-// NetworkSecurityGroupResult - Network configuration diagnostic result corresponded provided traffic query.
-type NetworkSecurityGroupResult struct {
-	// The network traffic is allowed or denied.
-	SecurityRuleAccessResult *SecurityRuleAccess `json:"securityRuleAccessResult,omitempty"`
-
-	// READ-ONLY; List of results network security groups diagnostic.
-	EvaluatedNetworkSecurityGroups []*EvaluatedNetworkSecurityGroup `json:"evaluatedNetworkSecurityGroups,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkSecurityGroupResult.
-func (n NetworkSecurityGroupResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "evaluatedNetworkSecurityGroups", n.EvaluatedNetworkSecurityGroups)
-	populate(objectMap, "securityRuleAccessResult", n.SecurityRuleAccessResult)
-	return json.Marshal(objectMap)
-}
-
-// NetworkSecurityGroupsBeginCreateOrUpdateOptions contains the optional parameters for the NetworkSecurityGroupsClient.BeginCreateOrUpdate
+// NetworkSecurityGroupsBeginCreateOrUpdateOptions contains the optional parameters for the SecurityGroupsClient.BeginCreateOrUpdate
 // method.
 type NetworkSecurityGroupsBeginCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkSecurityGroupsBeginDeleteOptions contains the optional parameters for the NetworkSecurityGroupsClient.BeginDelete
-// method.
+// NetworkSecurityGroupsBeginDeleteOptions contains the optional parameters for the SecurityGroupsClient.BeginDelete method.
 type NetworkSecurityGroupsBeginDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkSecurityGroupsGetOptions contains the optional parameters for the NetworkSecurityGroupsClient.Get method.
+// NetworkSecurityGroupsGetOptions contains the optional parameters for the SecurityGroupsClient.Get method.
 type NetworkSecurityGroupsGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
 }
 
-// NetworkSecurityGroupsListAllOptions contains the optional parameters for the NetworkSecurityGroupsClient.ListAll method.
+// NetworkSecurityGroupsListAllOptions contains the optional parameters for the SecurityGroupsClient.ListAll method.
 type NetworkSecurityGroupsListAllOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkSecurityGroupsListOptions contains the optional parameters for the NetworkSecurityGroupsClient.List method.
+// NetworkSecurityGroupsListOptions contains the optional parameters for the SecurityGroupsClient.List method.
 type NetworkSecurityGroupsListOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkSecurityGroupsUpdateTagsOptions contains the optional parameters for the NetworkSecurityGroupsClient.UpdateTags
-// method.
+// NetworkSecurityGroupsUpdateTagsOptions contains the optional parameters for the SecurityGroupsClient.UpdateTags method.
 type NetworkSecurityGroupsUpdateTagsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkSecurityRulesEvaluationResult - Network security rules evaluation result.
-type NetworkSecurityRulesEvaluationResult struct {
-	// Value indicating whether destination is matched.
-	DestinationMatched *bool `json:"destinationMatched,omitempty"`
-
-	// Value indicating whether destination port is matched.
-	DestinationPortMatched *bool `json:"destinationPortMatched,omitempty"`
-
-	// Name of the network security rule.
-	Name *string `json:"name,omitempty"`
-
-	// Value indicating whether protocol is matched.
-	ProtocolMatched *bool `json:"protocolMatched,omitempty"`
-
-	// Value indicating whether source is matched.
-	SourceMatched *bool `json:"sourceMatched,omitempty"`
-
-	// Value indicating whether source port is matched.
-	SourcePortMatched *bool `json:"sourcePortMatched,omitempty"`
-}
-
-// NetworkVirtualAppliance Resource.
-type NetworkVirtualAppliance struct {
-	Resource
-	// The service principal that has read access to cloud-init and config blob.
-	Identity *ManagedServiceIdentity `json:"identity,omitempty"`
-
-	// Properties of the Network Virtual Appliance.
-	Properties *NetworkVirtualAppliancePropertiesFormat `json:"properties,omitempty"`
-
-	// Network Virtual Appliance SKU.
-	SKU *VirtualApplianceSKUProperties `json:"sku,omitempty"`
-
-	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkVirtualAppliance.
-func (n NetworkVirtualAppliance) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.Resource.marshalInternal(objectMap)
-	populate(objectMap, "etag", n.Etag)
-	populate(objectMap, "identity", n.Identity)
-	populate(objectMap, "properties", n.Properties)
-	populate(objectMap, "sku", n.SKU)
-	return json.Marshal(objectMap)
-}
-
-// NetworkVirtualApplianceListResult - Response for ListNetworkVirtualAppliances API service call.
-type NetworkVirtualApplianceListResult struct {
-	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
-
-	// List of Network Virtual Appliances.
-	Value []*NetworkVirtualAppliance `json:"value,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkVirtualApplianceListResult.
-func (n NetworkVirtualApplianceListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "nextLink", n.NextLink)
-	populate(objectMap, "value", n.Value)
-	return json.Marshal(objectMap)
-}
-
-// NetworkVirtualAppliancePropertiesFormat - Network Virtual Appliance definition.
-type NetworkVirtualAppliancePropertiesFormat struct {
-	// BootStrapConfigurationBlob storage URLs.
-	BootStrapConfigurationBlob []*string `json:"bootStrapConfigurationBlob,omitempty"`
-
-	// CloudInitConfigurationBlob storage URLs.
-	CloudInitConfigurationBlob []*string `json:"cloudInitConfigurationBlob,omitempty"`
-
-	// VirtualAppliance ASN.
-	VirtualApplianceAsn *int64 `json:"virtualApplianceAsn,omitempty"`
-
-	// The Virtual Hub where Network Virtual Appliance is being deployed.
-	VirtualHub *SubResource `json:"virtualHub,omitempty"`
-
-	// READ-ONLY; The provisioning state of the resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
-
-	// READ-ONLY; List of Virtual Appliance Network Interfaces.
-	VirtualApplianceNics []*VirtualApplianceNicProperties `json:"virtualApplianceNics,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkVirtualAppliancePropertiesFormat.
-func (n NetworkVirtualAppliancePropertiesFormat) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "bootStrapConfigurationBlob", n.BootStrapConfigurationBlob)
-	populate(objectMap, "cloudInitConfigurationBlob", n.CloudInitConfigurationBlob)
-	populate(objectMap, "provisioningState", n.ProvisioningState)
-	populate(objectMap, "virtualApplianceAsn", n.VirtualApplianceAsn)
-	populate(objectMap, "virtualApplianceNics", n.VirtualApplianceNics)
-	populate(objectMap, "virtualHub", n.VirtualHub)
-	return json.Marshal(objectMap)
-}
-
-// NetworkVirtualAppliancesBeginCreateOrUpdateOptions contains the optional parameters for the NetworkVirtualAppliancesClient.BeginCreateOrUpdate
+// NetworkVirtualAppliancesBeginCreateOrUpdateOptions contains the optional parameters for the VirtualAppliancesClient.BeginCreateOrUpdate
 // method.
 type NetworkVirtualAppliancesBeginCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkVirtualAppliancesBeginDeleteOptions contains the optional parameters for the NetworkVirtualAppliancesClient.BeginDelete
+// NetworkVirtualAppliancesBeginDeleteOptions contains the optional parameters for the VirtualAppliancesClient.BeginDelete
 // method.
 type NetworkVirtualAppliancesBeginDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkVirtualAppliancesGetOptions contains the optional parameters for the NetworkVirtualAppliancesClient.Get method.
+// NetworkVirtualAppliancesGetOptions contains the optional parameters for the VirtualAppliancesClient.Get method.
 type NetworkVirtualAppliancesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
 }
 
-// NetworkVirtualAppliancesListByResourceGroupOptions contains the optional parameters for the NetworkVirtualAppliancesClient.ListByResourceGroup
+// NetworkVirtualAppliancesListByResourceGroupOptions contains the optional parameters for the VirtualAppliancesClient.ListByResourceGroup
 // method.
 type NetworkVirtualAppliancesListByResourceGroupOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkVirtualAppliancesListOptions contains the optional parameters for the NetworkVirtualAppliancesClient.List method.
+// NetworkVirtualAppliancesListOptions contains the optional parameters for the VirtualAppliancesClient.List method.
 type NetworkVirtualAppliancesListOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkVirtualAppliancesUpdateTagsOptions contains the optional parameters for the NetworkVirtualAppliancesClient.UpdateTags
-// method.
+// NetworkVirtualAppliancesUpdateTagsOptions contains the optional parameters for the VirtualAppliancesClient.UpdateTags method.
 type NetworkVirtualAppliancesUpdateTagsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatcher - Network watcher in a resource group.
-type NetworkWatcher struct {
-	Resource
-	// Properties of the network watcher.
-	Properties *NetworkWatcherPropertiesFormat `json:"properties,omitempty"`
-
-	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkWatcher.
-func (n NetworkWatcher) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	n.Resource.marshalInternal(objectMap)
-	populate(objectMap, "etag", n.Etag)
-	populate(objectMap, "properties", n.Properties)
-	return json.Marshal(objectMap)
-}
-
-// NetworkWatcherListResult - Response for ListNetworkWatchers API service call.
-type NetworkWatcherListResult struct {
-	// List of network watcher resources.
-	Value []*NetworkWatcher `json:"value,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type NetworkWatcherListResult.
-func (n NetworkWatcherListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", n.Value)
-	return json.Marshal(objectMap)
-}
-
-// NetworkWatcherPropertiesFormat - The network watcher properties.
-type NetworkWatcherPropertiesFormat struct {
-	// READ-ONLY; The provisioning state of the network watcher resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
-}
-
-// NetworkWatchersBeginCheckConnectivityOptions contains the optional parameters for the NetworkWatchersClient.BeginCheckConnectivity
+// NetworkWatchersBeginCheckConnectivityOptions contains the optional parameters for the WatchersClient.BeginCheckConnectivity
 // method.
 type NetworkWatchersBeginCheckConnectivityOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginDeleteOptions contains the optional parameters for the NetworkWatchersClient.BeginDelete method.
+// NetworkWatchersBeginDeleteOptions contains the optional parameters for the WatchersClient.BeginDelete method.
 type NetworkWatchersBeginDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginGetAzureReachabilityReportOptions contains the optional parameters for the NetworkWatchersClient.BeginGetAzureReachabilityReport
+// NetworkWatchersBeginGetAzureReachabilityReportOptions contains the optional parameters for the WatchersClient.BeginGetAzureReachabilityReport
 // method.
 type NetworkWatchersBeginGetAzureReachabilityReportOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginGetFlowLogStatusOptions contains the optional parameters for the NetworkWatchersClient.BeginGetFlowLogStatus
+// NetworkWatchersBeginGetFlowLogStatusOptions contains the optional parameters for the WatchersClient.BeginGetFlowLogStatus
 // method.
 type NetworkWatchersBeginGetFlowLogStatusOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions contains the optional parameters for the NetworkWatchersClient.BeginGetNetworkConfigurationDiagnostic
+// NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions contains the optional parameters for the WatchersClient.BeginGetNetworkConfigurationDiagnostic
 // method.
 type NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginGetNextHopOptions contains the optional parameters for the NetworkWatchersClient.BeginGetNextHop method.
+// NetworkWatchersBeginGetNextHopOptions contains the optional parameters for the WatchersClient.BeginGetNextHop method.
 type NetworkWatchersBeginGetNextHopOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginGetTroubleshootingOptions contains the optional parameters for the NetworkWatchersClient.BeginGetTroubleshooting
+// NetworkWatchersBeginGetTroubleshootingOptions contains the optional parameters for the WatchersClient.BeginGetTroubleshooting
 // method.
 type NetworkWatchersBeginGetTroubleshootingOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginGetTroubleshootingResultOptions contains the optional parameters for the NetworkWatchersClient.BeginGetTroubleshootingResult
+// NetworkWatchersBeginGetTroubleshootingResultOptions contains the optional parameters for the WatchersClient.BeginGetTroubleshootingResult
 // method.
 type NetworkWatchersBeginGetTroubleshootingResultOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginGetVMSecurityRulesOptions contains the optional parameters for the NetworkWatchersClient.BeginGetVMSecurityRules
+// NetworkWatchersBeginGetVMSecurityRulesOptions contains the optional parameters for the WatchersClient.BeginGetVMSecurityRules
 // method.
 type NetworkWatchersBeginGetVMSecurityRulesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginListAvailableProvidersOptions contains the optional parameters for the NetworkWatchersClient.BeginListAvailableProviders
+// NetworkWatchersBeginListAvailableProvidersOptions contains the optional parameters for the WatchersClient.BeginListAvailableProviders
 // method.
 type NetworkWatchersBeginListAvailableProvidersOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginSetFlowLogConfigurationOptions contains the optional parameters for the NetworkWatchersClient.BeginSetFlowLogConfiguration
+// NetworkWatchersBeginSetFlowLogConfigurationOptions contains the optional parameters for the WatchersClient.BeginSetFlowLogConfiguration
 // method.
 type NetworkWatchersBeginSetFlowLogConfigurationOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersBeginVerifyIPFlowOptions contains the optional parameters for the NetworkWatchersClient.BeginVerifyIPFlow
-// method.
+// NetworkWatchersBeginVerifyIPFlowOptions contains the optional parameters for the WatchersClient.BeginVerifyIPFlow method.
 type NetworkWatchersBeginVerifyIPFlowOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersCreateOrUpdateOptions contains the optional parameters for the NetworkWatchersClient.CreateOrUpdate method.
+// NetworkWatchersCreateOrUpdateOptions contains the optional parameters for the WatchersClient.CreateOrUpdate method.
 type NetworkWatchersCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersGetOptions contains the optional parameters for the NetworkWatchersClient.Get method.
+// NetworkWatchersGetOptions contains the optional parameters for the WatchersClient.Get method.
 type NetworkWatchersGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersGetTopologyOptions contains the optional parameters for the NetworkWatchersClient.GetTopology method.
+// NetworkWatchersGetTopologyOptions contains the optional parameters for the WatchersClient.GetTopology method.
 type NetworkWatchersGetTopologyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersListAllOptions contains the optional parameters for the NetworkWatchersClient.ListAll method.
+// NetworkWatchersListAllOptions contains the optional parameters for the WatchersClient.ListAll method.
 type NetworkWatchersListAllOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersListOptions contains the optional parameters for the NetworkWatchersClient.List method.
+// NetworkWatchersListOptions contains the optional parameters for the WatchersClient.List method.
 type NetworkWatchersListOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NetworkWatchersUpdateTagsOptions contains the optional parameters for the NetworkWatchersClient.UpdateTags method.
+// NetworkWatchersUpdateTagsOptions contains the optional parameters for the WatchersClient.UpdateTags method.
 type NetworkWatchersUpdateTagsOptions struct {
 	// placeholder for future optional parameters
 }
@@ -10542,7 +10177,7 @@ type PolicySettings struct {
 // PrepareNetworkPoliciesRequest - Details of PrepareNetworkPolicies for Subnet.
 type PrepareNetworkPoliciesRequest struct {
 	// A list of NetworkIntentPolicyConfiguration.
-	NetworkIntentPolicyConfigurations []*NetworkIntentPolicyConfiguration `json:"networkIntentPolicyConfigurations,omitempty"`
+	NetworkIntentPolicyConfigurations []*IntentPolicyConfiguration `json:"networkIntentPolicyConfigurations,omitempty"`
 
 	// The name of the service for which subnet is being prepared for.
 	ServiceName *string `json:"serviceName,omitempty"`
@@ -10772,7 +10407,7 @@ type PrivateEndpointProperties struct {
 	Subnet *Subnet `json:"subnet,omitempty"`
 
 	// READ-ONLY; An array of references to the network interfaces created for this private endpoint.
-	NetworkInterfaces []*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces []*Interface `json:"networkInterfaces,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the private endpoint resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -10995,7 +10630,7 @@ type PrivateLinkServiceProperties struct {
 	Alias *string `json:"alias,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to the network interfaces created for this private link service.
-	NetworkInterfaces []*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces []*Interface `json:"networkInterfaces,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of list about connections to the private endpoint.
 	PrivateEndpointConnections []*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty" azure:"ro"`
@@ -11182,6 +10817,67 @@ func (p ProbePropertiesFormat) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "protocol", p.Protocol)
 	populate(objectMap, "provisioningState", p.ProvisioningState)
 	populate(objectMap, "requestPath", p.RequestPath)
+	return json.Marshal(objectMap)
+}
+
+// Profile - Network profile resource.
+type Profile struct {
+	Resource
+	// Network profile properties.
+	Properties *ProfilePropertiesFormat `json:"properties,omitempty"`
+
+	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
+	Etag *string `json:"etag,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Profile.
+func (p Profile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	p.Resource.marshalInternal(objectMap)
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
+}
+
+// ProfileListResult - Response for ListNetworkProfiles API service call.
+type ProfileListResult struct {
+	// The URL to get the next set of results.
+	NextLink *string `json:"nextLink,omitempty"`
+
+	// A list of network profiles that exist in a resource group.
+	Value []*Profile `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ProfileListResult.
+func (p ProfileListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
+}
+
+// ProfilePropertiesFormat - Network profile properties.
+type ProfilePropertiesFormat struct {
+	// List of chid container network interface configurations.
+	ContainerNetworkInterfaceConfigurations []*ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfigurations,omitempty"`
+
+	// READ-ONLY; List of child container network interfaces.
+	ContainerNetworkInterfaces []*ContainerNetworkInterface `json:"containerNetworkInterfaces,omitempty" azure:"ro"`
+
+	// READ-ONLY; The provisioning state of the network profile resource.
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+
+	// READ-ONLY; The resource GUID property of the network profile resource.
+	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ProfilePropertiesFormat.
+func (p ProfilePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "containerNetworkInterfaceConfigurations", p.ContainerNetworkInterfaceConfigurations)
+	populate(objectMap, "containerNetworkInterfaces", p.ContainerNetworkInterfaces)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	populate(objectMap, "resourceGuid", p.ResourceGUID)
 	return json.Marshal(objectMap)
 }
 
@@ -12032,6 +11728,115 @@ type RoutesListOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RuleCondition - Rule condition of type network.
+type RuleCondition struct {
+	FirewallPolicyRuleCondition
+	// List of destination IP addresses or Service Tags.
+	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
+
+	// List of destination IpGroups for this rule.
+	DestinationIPGroups []*string `json:"destinationIpGroups,omitempty"`
+
+	// List of destination ports.
+	DestinationPorts []*string `json:"destinationPorts,omitempty"`
+
+	// Array of FirewallPolicyRuleConditionNetworkProtocols.
+	IPProtocols []*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
+
+	// List of source IP addresses for this rule.
+	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
+
+	// List of source IpGroups for this rule.
+	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RuleCondition.
+func (r RuleCondition) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	r.FirewallPolicyRuleCondition.marshalInternal(objectMap, FirewallPolicyRuleConditionTypeNetworkRuleCondition)
+	populate(objectMap, "destinationAddresses", r.DestinationAddresses)
+	populate(objectMap, "destinationIpGroups", r.DestinationIPGroups)
+	populate(objectMap, "destinationPorts", r.DestinationPorts)
+	populate(objectMap, "ipProtocols", r.IPProtocols)
+	populate(objectMap, "sourceAddresses", r.SourceAddresses)
+	populate(objectMap, "sourceIpGroups", r.SourceIPGroups)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type RuleCondition.
+func (r *RuleCondition) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "destinationAddresses":
+			err = unpopulate(val, &r.DestinationAddresses)
+			delete(rawMsg, key)
+		case "destinationIpGroups":
+			err = unpopulate(val, &r.DestinationIPGroups)
+			delete(rawMsg, key)
+		case "destinationPorts":
+			err = unpopulate(val, &r.DestinationPorts)
+			delete(rawMsg, key)
+		case "ipProtocols":
+			err = unpopulate(val, &r.IPProtocols)
+			delete(rawMsg, key)
+		case "sourceAddresses":
+			err = unpopulate(val, &r.SourceAddresses)
+			delete(rawMsg, key)
+		case "sourceIpGroups":
+			err = unpopulate(val, &r.SourceIPGroups)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	if err := r.FirewallPolicyRuleCondition.unmarshalInternal(rawMsg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SecurityGroup - NetworkSecurityGroup resource.
+type SecurityGroup struct {
+	Resource
+	// Properties of the network security group.
+	Properties *SecurityGroupPropertiesFormat `json:"properties,omitempty"`
+
+	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
+	Etag *string `json:"etag,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SecurityGroup.
+func (s SecurityGroup) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	s.Resource.marshalInternal(objectMap)
+	populate(objectMap, "etag", s.Etag)
+	populate(objectMap, "properties", s.Properties)
+	return json.Marshal(objectMap)
+}
+
+// SecurityGroupListResult - Response for ListNetworkSecurityGroups API service call.
+type SecurityGroupListResult struct {
+	// The URL to get the next set of results.
+	NextLink *string `json:"nextLink,omitempty"`
+
+	// A list of NetworkSecurityGroup resources.
+	Value []*SecurityGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SecurityGroupListResult.
+func (s SecurityGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
+}
+
 // SecurityGroupNetworkInterface - Network interface and all its associated security rules.
 type SecurityGroupNetworkInterface struct {
 	// ID of the network interface.
@@ -12039,6 +11844,60 @@ type SecurityGroupNetworkInterface struct {
 
 	// All security rules associated with the network interface.
 	SecurityRuleAssociations *SecurityRuleAssociations `json:"securityRuleAssociations,omitempty"`
+}
+
+// SecurityGroupPropertiesFormat - Network Security Group resource.
+type SecurityGroupPropertiesFormat struct {
+	// A collection of security rules of the network security group.
+	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
+
+	// READ-ONLY; The default security rules of network security group.
+	DefaultSecurityRules []*SecurityRule `json:"defaultSecurityRules,omitempty" azure:"ro"`
+
+	// READ-ONLY; A collection of references to flow log resources.
+	FlowLogs []*FlowLog `json:"flowLogs,omitempty" azure:"ro"`
+
+	// READ-ONLY; A collection of references to network interfaces.
+	NetworkInterfaces []*Interface `json:"networkInterfaces,omitempty" azure:"ro"`
+
+	// READ-ONLY; The provisioning state of the network security group resource.
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+
+	// READ-ONLY; The resource GUID property of the network security group resource.
+	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+
+	// READ-ONLY; A collection of references to subnets.
+	Subnets []*Subnet `json:"subnets,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SecurityGroupPropertiesFormat.
+func (s SecurityGroupPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "defaultSecurityRules", s.DefaultSecurityRules)
+	populate(objectMap, "flowLogs", s.FlowLogs)
+	populate(objectMap, "networkInterfaces", s.NetworkInterfaces)
+	populate(objectMap, "provisioningState", s.ProvisioningState)
+	populate(objectMap, "resourceGuid", s.ResourceGUID)
+	populate(objectMap, "securityRules", s.SecurityRules)
+	populate(objectMap, "subnets", s.Subnets)
+	return json.Marshal(objectMap)
+}
+
+// SecurityGroupResult - Network configuration diagnostic result corresponded provided traffic query.
+type SecurityGroupResult struct {
+	// The network traffic is allowed or denied.
+	SecurityRuleAccessResult *SecurityRuleAccess `json:"securityRuleAccessResult,omitempty"`
+
+	// READ-ONLY; List of results network security groups diagnostic.
+	EvaluatedNetworkSecurityGroups []*EvaluatedNetworkSecurityGroup `json:"evaluatedNetworkSecurityGroups,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SecurityGroupResult.
+func (s SecurityGroupResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "evaluatedNetworkSecurityGroups", s.EvaluatedNetworkSecurityGroups)
+	populate(objectMap, "securityRuleAccessResult", s.SecurityRuleAccessResult)
+	return json.Marshal(objectMap)
 }
 
 // SecurityGroupViewParameters - Parameters that define the VM to check security groups for.
@@ -12177,7 +12036,7 @@ type SecurityRuleAssociations struct {
 	EffectiveSecurityRules []*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
 
 	// Network interface and it's custom security rules.
-	NetworkInterfaceAssociation *NetworkInterfaceAssociation `json:"networkInterfaceAssociation,omitempty"`
+	NetworkInterfaceAssociation *InterfaceAssociation `json:"networkInterfaceAssociation,omitempty"`
 
 	// Subnet and it's custom security rules.
 	SubnetAssociation *SubnetAssociation `json:"subnetAssociation,omitempty"`
@@ -12298,6 +12157,27 @@ type SecurityRulesBeginCreateOrUpdateOptions struct {
 // SecurityRulesBeginDeleteOptions contains the optional parameters for the SecurityRulesClient.BeginDelete method.
 type SecurityRulesBeginDeleteOptions struct {
 	// placeholder for future optional parameters
+}
+
+// SecurityRulesEvaluationResult - Network security rules evaluation result.
+type SecurityRulesEvaluationResult struct {
+	// Value indicating whether destination is matched.
+	DestinationMatched *bool `json:"destinationMatched,omitempty"`
+
+	// Value indicating whether destination port is matched.
+	DestinationPortMatched *bool `json:"destinationPortMatched,omitempty"`
+
+	// Name of the network security rule.
+	Name *string `json:"name,omitempty"`
+
+	// Value indicating whether protocol is matched.
+	ProtocolMatched *bool `json:"protocolMatched,omitempty"`
+
+	// Value indicating whether source is matched.
+	SourceMatched *bool `json:"sourceMatched,omitempty"`
+
+	// Value indicating whether source port is matched.
+	SourcePortMatched *bool `json:"sourcePortMatched,omitempty"`
 }
 
 // SecurityRulesGetOptions contains the optional parameters for the SecurityRulesClient.Get method.
@@ -12796,7 +12676,7 @@ type SubnetPropertiesFormat struct {
 	NatGateway *SubResource `json:"natGateway,omitempty"`
 
 	// The reference to the NetworkSecurityGroup resource.
-	NetworkSecurityGroup *NetworkSecurityGroup `json:"networkSecurityGroup,omitempty"`
+	NetworkSecurityGroup *SecurityGroup `json:"networkSecurityGroup,omitempty"`
 
 	// Enable or Disable apply network policies on private end point in the subnet.
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty"`
@@ -14226,6 +14106,50 @@ type VerificationIPFlowResult struct {
 	RuleName *string `json:"ruleName,omitempty"`
 }
 
+// VirtualAppliance - NetworkVirtualAppliance Resource.
+type VirtualAppliance struct {
+	Resource
+	// The service principal that has read access to cloud-init and config blob.
+	Identity *ManagedServiceIdentity `json:"identity,omitempty"`
+
+	// Properties of the Network Virtual Appliance.
+	Properties *VirtualAppliancePropertiesFormat `json:"properties,omitempty"`
+
+	// Network Virtual Appliance SKU.
+	SKU *VirtualApplianceSKUProperties `json:"sku,omitempty"`
+
+	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
+	Etag *string `json:"etag,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualAppliance.
+func (v VirtualAppliance) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	v.Resource.marshalInternal(objectMap)
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "identity", v.Identity)
+	populate(objectMap, "properties", v.Properties)
+	populate(objectMap, "sku", v.SKU)
+	return json.Marshal(objectMap)
+}
+
+// VirtualApplianceListResult - Response for ListNetworkVirtualAppliances API service call.
+type VirtualApplianceListResult struct {
+	// URL to get the next set of results.
+	NextLink *string `json:"nextLink,omitempty"`
+
+	// List of Network Virtual Appliances.
+	Value []*VirtualAppliance `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualApplianceListResult.
+func (v VirtualApplianceListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
+}
+
 // VirtualApplianceNicProperties - Network Virtual Appliance NIC properties.
 type VirtualApplianceNicProperties struct {
 	// READ-ONLY; NIC name.
@@ -14236,6 +14160,39 @@ type VirtualApplianceNicProperties struct {
 
 	// READ-ONLY; Public IP address.
 	PublicIPAddress *string `json:"publicIpAddress,omitempty" azure:"ro"`
+}
+
+// VirtualAppliancePropertiesFormat - Network Virtual Appliance definition.
+type VirtualAppliancePropertiesFormat struct {
+	// BootStrapConfigurationBlob storage URLs.
+	BootStrapConfigurationBlob []*string `json:"bootStrapConfigurationBlob,omitempty"`
+
+	// CloudInitConfigurationBlob storage URLs.
+	CloudInitConfigurationBlob []*string `json:"cloudInitConfigurationBlob,omitempty"`
+
+	// VirtualAppliance ASN.
+	VirtualApplianceAsn *int64 `json:"virtualApplianceAsn,omitempty"`
+
+	// The Virtual Hub where Network Virtual Appliance is being deployed.
+	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+
+	// READ-ONLY; The provisioning state of the resource.
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+
+	// READ-ONLY; List of Virtual Appliance Network Interfaces.
+	VirtualApplianceNics []*VirtualApplianceNicProperties `json:"virtualApplianceNics,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualAppliancePropertiesFormat.
+func (v VirtualAppliancePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bootStrapConfigurationBlob", v.BootStrapConfigurationBlob)
+	populate(objectMap, "cloudInitConfigurationBlob", v.CloudInitConfigurationBlob)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "virtualApplianceAsn", v.VirtualApplianceAsn)
+	populate(objectMap, "virtualApplianceNics", v.VirtualApplianceNics)
+	populate(objectMap, "virtualHub", v.VirtualHub)
+	return json.Marshal(objectMap)
 }
 
 // VirtualApplianceSKUProperties - Network Virtual Appliance Sku Properties.
@@ -15364,13 +15321,13 @@ type VirtualNetworkTapPropertiesFormat struct {
 	DestinationLoadBalancerFrontEndIPConfiguration *FrontendIPConfiguration `json:"destinationLoadBalancerFrontEndIPConfiguration,omitempty"`
 
 	// The reference to the private IP Address of the collector nic that will receive the tap.
-	DestinationNetworkInterfaceIPConfiguration *NetworkInterfaceIPConfiguration `json:"destinationNetworkInterfaceIPConfiguration,omitempty"`
+	DestinationNetworkInterfaceIPConfiguration *InterfaceIPConfiguration `json:"destinationNetworkInterfaceIPConfiguration,omitempty"`
 
 	// The VXLAN destination port that will receive the tapped traffic.
 	DestinationPort *int32 `json:"destinationPort,omitempty"`
 
 	// READ-ONLY; Specifies the list of resource IDs for the network interface IP configuration that needs to be tapped.
-	NetworkInterfaceTapConfigurations []*NetworkInterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty" azure:"ro"`
+	NetworkInterfaceTapConfigurations []*InterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the virtual network tap resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -15790,6 +15747,44 @@ type VirtualWansListOptions struct {
 // VirtualWansUpdateTagsOptions contains the optional parameters for the VirtualWansClient.UpdateTags method.
 type VirtualWansUpdateTagsOptions struct {
 	// placeholder for future optional parameters
+}
+
+// Watcher - Network watcher in a resource group.
+type Watcher struct {
+	Resource
+	// Properties of the network watcher.
+	Properties *WatcherPropertiesFormat `json:"properties,omitempty"`
+
+	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
+	Etag *string `json:"etag,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Watcher.
+func (w Watcher) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	w.Resource.marshalInternal(objectMap)
+	populate(objectMap, "etag", w.Etag)
+	populate(objectMap, "properties", w.Properties)
+	return json.Marshal(objectMap)
+}
+
+// WatcherListResult - Response for ListNetworkWatchers API service call.
+type WatcherListResult struct {
+	// List of network watcher resources.
+	Value []*Watcher `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WatcherListResult.
+func (w WatcherListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", w.Value)
+	return json.Marshal(objectMap)
+}
+
+// WatcherPropertiesFormat - The network watcher properties.
+type WatcherPropertiesFormat struct {
+	// READ-ONLY; The provisioning state of the network watcher resource.
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 }
 
 // WebApplicationFirewallCustomRule - Defines contents of a web application rule.

--- a/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
@@ -2574,7 +2574,7 @@ func (p *LoadBalancerNetworkInterfacesListPager) NextPage(ctx context.Context) b
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceListResult.NextLink == nil || len(*p.current.NetworkInterfaceListResult.NextLink) == 0 {
+		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -2988,7 +2988,7 @@ func (p *NatGatewaysListPager) PageResponse() NatGatewaysListResponse {
 
 // NetworkInterfaceIPConfigurationsListPager provides operations for iterating over paged responses.
 type NetworkInterfaceIPConfigurationsListPager struct {
-	client    *NetworkInterfaceIPConfigurationsClient
+	client    *InterfaceIPConfigurationsClient
 	current   NetworkInterfaceIPConfigurationsListResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3006,7 +3006,7 @@ func (p *NetworkInterfaceIPConfigurationsListPager) NextPage(ctx context.Context
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceIPConfigurationListResult.NextLink == nil || len(*p.current.NetworkInterfaceIPConfigurationListResult.NextLink) == 0 {
+		if p.current.InterfaceIPConfigurationListResult.NextLink == nil || len(*p.current.InterfaceIPConfigurationListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3042,7 +3042,7 @@ func (p *NetworkInterfaceIPConfigurationsListPager) PageResponse() NetworkInterf
 
 // NetworkInterfaceLoadBalancersListPager provides operations for iterating over paged responses.
 type NetworkInterfaceLoadBalancersListPager struct {
-	client    *NetworkInterfaceLoadBalancersClient
+	client    *InterfaceLoadBalancersClient
 	current   NetworkInterfaceLoadBalancersListResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3060,7 +3060,7 @@ func (p *NetworkInterfaceLoadBalancersListPager) NextPage(ctx context.Context) b
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceLoadBalancerListResult.NextLink == nil || len(*p.current.NetworkInterfaceLoadBalancerListResult.NextLink) == 0 {
+		if p.current.InterfaceLoadBalancerListResult.NextLink == nil || len(*p.current.InterfaceLoadBalancerListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3096,7 +3096,7 @@ func (p *NetworkInterfaceLoadBalancersListPager) PageResponse() NetworkInterface
 
 // NetworkInterfaceTapConfigurationsListPager provides operations for iterating over paged responses.
 type NetworkInterfaceTapConfigurationsListPager struct {
-	client    *NetworkInterfaceTapConfigurationsClient
+	client    *InterfaceTapConfigurationsClient
 	current   NetworkInterfaceTapConfigurationsListResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3114,7 +3114,7 @@ func (p *NetworkInterfaceTapConfigurationsListPager) NextPage(ctx context.Contex
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceTapConfigurationListResult.NextLink == nil || len(*p.current.NetworkInterfaceTapConfigurationListResult.NextLink) == 0 {
+		if p.current.InterfaceTapConfigurationListResult.NextLink == nil || len(*p.current.InterfaceTapConfigurationListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3150,7 +3150,7 @@ func (p *NetworkInterfaceTapConfigurationsListPager) PageResponse() NetworkInter
 
 // NetworkInterfacesListAllPager provides operations for iterating over paged responses.
 type NetworkInterfacesListAllPager struct {
-	client    *NetworkInterfacesClient
+	client    *InterfacesClient
 	current   NetworkInterfacesListAllResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3168,7 +3168,7 @@ func (p *NetworkInterfacesListAllPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceListResult.NextLink == nil || len(*p.current.NetworkInterfaceListResult.NextLink) == 0 {
+		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3204,7 +3204,7 @@ func (p *NetworkInterfacesListAllPager) PageResponse() NetworkInterfacesListAllR
 
 // NetworkInterfacesListPager provides operations for iterating over paged responses.
 type NetworkInterfacesListPager struct {
-	client    *NetworkInterfacesClient
+	client    *InterfacesClient
 	current   NetworkInterfacesListResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3222,7 +3222,7 @@ func (p *NetworkInterfacesListPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceListResult.NextLink == nil || len(*p.current.NetworkInterfaceListResult.NextLink) == 0 {
+		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3258,7 +3258,7 @@ func (p *NetworkInterfacesListPager) PageResponse() NetworkInterfacesListRespons
 
 // NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsPager provides operations for iterating over paged responses.
 type NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsPager struct {
-	client    *NetworkInterfacesClient
+	client    *InterfacesClient
 	current   NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3276,7 +3276,7 @@ func (p *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsPager) NextP
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceIPConfigurationListResult.NextLink == nil || len(*p.current.NetworkInterfaceIPConfigurationListResult.NextLink) == 0 {
+		if p.current.InterfaceIPConfigurationListResult.NextLink == nil || len(*p.current.InterfaceIPConfigurationListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3312,7 +3312,7 @@ func (p *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsPager) PageR
 
 // NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesPager provides operations for iterating over paged responses.
 type NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesPager struct {
-	client    *NetworkInterfacesClient
+	client    *InterfacesClient
 	current   NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3330,7 +3330,7 @@ func (p *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesPager) Next
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceListResult.NextLink == nil || len(*p.current.NetworkInterfaceListResult.NextLink) == 0 {
+		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3366,7 +3366,7 @@ func (p *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesPager) Page
 
 // NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesPager provides operations for iterating over paged responses.
 type NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesPager struct {
-	client    *NetworkInterfacesClient
+	client    *InterfacesClient
 	current   NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3384,7 +3384,7 @@ func (p *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesPager) Ne
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkInterfaceListResult.NextLink == nil || len(*p.current.NetworkInterfaceListResult.NextLink) == 0 {
+		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3420,7 +3420,7 @@ func (p *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesPager) Pa
 
 // NetworkManagementClientDisconnectActiveSessionsPager provides operations for iterating over paged responses.
 type NetworkManagementClientDisconnectActiveSessionsPager struct {
-	client    *NetworkManagementClient
+	client    *ManagementClient
 	current   NetworkManagementClientDisconnectActiveSessionsResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3474,7 +3474,7 @@ func (p *NetworkManagementClientDisconnectActiveSessionsPager) PageResponse() Ne
 
 // NetworkManagementClientGetActiveSessionsPager provides operations for iterating over paged responses.
 type NetworkManagementClientGetActiveSessionsPager struct {
-	client  *NetworkManagementClient
+	client  *ManagementClient
 	current NetworkManagementClientGetActiveSessionsResponse
 	err     error
 	second  bool
@@ -3526,7 +3526,7 @@ func (p *NetworkManagementClientGetActiveSessionsPager) PageResponse() NetworkMa
 
 // NetworkManagementClientGetBastionShareableLinkPager provides operations for iterating over paged responses.
 type NetworkManagementClientGetBastionShareableLinkPager struct {
-	client    *NetworkManagementClient
+	client    *ManagementClient
 	current   NetworkManagementClientGetBastionShareableLinkResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3580,7 +3580,7 @@ func (p *NetworkManagementClientGetBastionShareableLinkPager) PageResponse() Net
 
 // NetworkManagementClientPutBastionShareableLinkPager provides operations for iterating over paged responses.
 type NetworkManagementClientPutBastionShareableLinkPager struct {
-	client  *NetworkManagementClient
+	client  *ManagementClient
 	current NetworkManagementClientPutBastionShareableLinkResponse
 	err     error
 	second  bool
@@ -3632,7 +3632,7 @@ func (p *NetworkManagementClientPutBastionShareableLinkPager) PageResponse() Net
 
 // NetworkProfilesListAllPager provides operations for iterating over paged responses.
 type NetworkProfilesListAllPager struct {
-	client    *NetworkProfilesClient
+	client    *ProfilesClient
 	current   NetworkProfilesListAllResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3650,7 +3650,7 @@ func (p *NetworkProfilesListAllPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkProfileListResult.NextLink == nil || len(*p.current.NetworkProfileListResult.NextLink) == 0 {
+		if p.current.ProfileListResult.NextLink == nil || len(*p.current.ProfileListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3686,7 +3686,7 @@ func (p *NetworkProfilesListAllPager) PageResponse() NetworkProfilesListAllRespo
 
 // NetworkProfilesListPager provides operations for iterating over paged responses.
 type NetworkProfilesListPager struct {
-	client    *NetworkProfilesClient
+	client    *ProfilesClient
 	current   NetworkProfilesListResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3704,7 +3704,7 @@ func (p *NetworkProfilesListPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkProfileListResult.NextLink == nil || len(*p.current.NetworkProfileListResult.NextLink) == 0 {
+		if p.current.ProfileListResult.NextLink == nil || len(*p.current.ProfileListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3740,7 +3740,7 @@ func (p *NetworkProfilesListPager) PageResponse() NetworkProfilesListResponse {
 
 // NetworkSecurityGroupsListAllPager provides operations for iterating over paged responses.
 type NetworkSecurityGroupsListAllPager struct {
-	client    *NetworkSecurityGroupsClient
+	client    *SecurityGroupsClient
 	current   NetworkSecurityGroupsListAllResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3758,7 +3758,7 @@ func (p *NetworkSecurityGroupsListAllPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkSecurityGroupListResult.NextLink == nil || len(*p.current.NetworkSecurityGroupListResult.NextLink) == 0 {
+		if p.current.SecurityGroupListResult.NextLink == nil || len(*p.current.SecurityGroupListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3794,7 +3794,7 @@ func (p *NetworkSecurityGroupsListAllPager) PageResponse() NetworkSecurityGroups
 
 // NetworkSecurityGroupsListPager provides operations for iterating over paged responses.
 type NetworkSecurityGroupsListPager struct {
-	client    *NetworkSecurityGroupsClient
+	client    *SecurityGroupsClient
 	current   NetworkSecurityGroupsListResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3812,7 +3812,7 @@ func (p *NetworkSecurityGroupsListPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkSecurityGroupListResult.NextLink == nil || len(*p.current.NetworkSecurityGroupListResult.NextLink) == 0 {
+		if p.current.SecurityGroupListResult.NextLink == nil || len(*p.current.SecurityGroupListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3848,7 +3848,7 @@ func (p *NetworkSecurityGroupsListPager) PageResponse() NetworkSecurityGroupsLis
 
 // NetworkVirtualAppliancesListByResourceGroupPager provides operations for iterating over paged responses.
 type NetworkVirtualAppliancesListByResourceGroupPager struct {
-	client    *NetworkVirtualAppliancesClient
+	client    *VirtualAppliancesClient
 	current   NetworkVirtualAppliancesListByResourceGroupResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3866,7 +3866,7 @@ func (p *NetworkVirtualAppliancesListByResourceGroupPager) NextPage(ctx context.
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkVirtualApplianceListResult.NextLink == nil || len(*p.current.NetworkVirtualApplianceListResult.NextLink) == 0 {
+		if p.current.VirtualApplianceListResult.NextLink == nil || len(*p.current.VirtualApplianceListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)
@@ -3902,7 +3902,7 @@ func (p *NetworkVirtualAppliancesListByResourceGroupPager) PageResponse() Networ
 
 // NetworkVirtualAppliancesListPager provides operations for iterating over paged responses.
 type NetworkVirtualAppliancesListPager struct {
-	client    *NetworkVirtualAppliancesClient
+	client    *VirtualAppliancesClient
 	current   NetworkVirtualAppliancesListResponse
 	err       error
 	requester func(context.Context) (*policy.Request, error)
@@ -3920,7 +3920,7 @@ func (p *NetworkVirtualAppliancesListPager) NextPage(ctx context.Context) bool {
 	var req *policy.Request
 	var err error
 	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.NetworkVirtualApplianceListResult.NextLink == nil || len(*p.current.NetworkVirtualApplianceListResult.NextLink) == 0 {
+		if p.current.VirtualApplianceListResult.NextLink == nil || len(*p.current.VirtualApplianceListResult.NextLink) == 0 {
 			return false
 		}
 		req, err = p.advancer(ctx, p.current)

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -2752,7 +2752,7 @@ func (p *NetworkInterfaceTapConfigurationsCreateOrUpdatePoller) Poll(ctx context
 // If the final GET succeeded then the final NetworkInterfaceTapConfigurationsCreateOrUpdateResponse will be returned.
 func (p *NetworkInterfaceTapConfigurationsCreateOrUpdatePoller) FinalResponse(ctx context.Context) (NetworkInterfaceTapConfigurationsCreateOrUpdateResponse, error) {
 	respType := NetworkInterfaceTapConfigurationsCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.NetworkInterfaceTapConfiguration)
+	resp, err := p.pt.FinalResponse(ctx, &respType.InterfaceTapConfiguration)
 	if err != nil {
 		return NetworkInterfaceTapConfigurationsCreateOrUpdateResponse{}, err
 	}
@@ -2838,7 +2838,7 @@ func (p *NetworkInterfacesCreateOrUpdatePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final NetworkInterfacesCreateOrUpdateResponse will be returned.
 func (p *NetworkInterfacesCreateOrUpdatePoller) FinalResponse(ctx context.Context) (NetworkInterfacesCreateOrUpdateResponse, error) {
 	respType := NetworkInterfacesCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.NetworkInterface)
+	resp, err := p.pt.FinalResponse(ctx, &respType.Interface)
 	if err != nil {
 		return NetworkInterfacesCreateOrUpdateResponse{}, err
 	}
@@ -3070,7 +3070,7 @@ func (p *NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofi
 // NetworkManagementClientGetActiveSessionsPoller provides polling facilities until the operation reaches a terminal state.
 type NetworkManagementClientGetActiveSessionsPoller struct {
 	pt     *azcore.Poller
-	client *NetworkManagementClient
+	client *ManagementClient
 }
 
 // Done returns true if the LRO has reached a terminal state.
@@ -3112,7 +3112,7 @@ func (p *NetworkManagementClientGetActiveSessionsPoller) ResumeToken() (string, 
 // NetworkManagementClientPutBastionShareableLinkPoller provides polling facilities until the operation reaches a terminal state.
 type NetworkManagementClientPutBastionShareableLinkPoller struct {
 	pt     *azcore.Poller
-	client *NetworkManagementClient
+	client *ManagementClient
 }
 
 // Done returns true if the LRO has reached a terminal state.
@@ -3223,7 +3223,7 @@ func (p *NetworkSecurityGroupsCreateOrUpdatePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final NetworkSecurityGroupsCreateOrUpdateResponse will be returned.
 func (p *NetworkSecurityGroupsCreateOrUpdatePoller) FinalResponse(ctx context.Context) (NetworkSecurityGroupsCreateOrUpdateResponse, error) {
 	respType := NetworkSecurityGroupsCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.NetworkSecurityGroup)
+	resp, err := p.pt.FinalResponse(ctx, &respType.SecurityGroup)
 	if err != nil {
 		return NetworkSecurityGroupsCreateOrUpdateResponse{}, err
 	}
@@ -3309,7 +3309,7 @@ func (p *NetworkVirtualAppliancesCreateOrUpdatePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final NetworkVirtualAppliancesCreateOrUpdateResponse will be returned.
 func (p *NetworkVirtualAppliancesCreateOrUpdatePoller) FinalResponse(ctx context.Context) (NetworkVirtualAppliancesCreateOrUpdateResponse, error) {
 	respType := NetworkVirtualAppliancesCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.NetworkVirtualAppliance)
+	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualAppliance)
 	if err != nil {
 		return NetworkVirtualAppliancesCreateOrUpdateResponse{}, err
 	}
@@ -3567,7 +3567,7 @@ func (p *NetworkWatchersGetNetworkConfigurationDiagnosticPoller) Poll(ctx contex
 // If the final GET succeeded then the final NetworkWatchersGetNetworkConfigurationDiagnosticResponse will be returned.
 func (p *NetworkWatchersGetNetworkConfigurationDiagnosticPoller) FinalResponse(ctx context.Context) (NetworkWatchersGetNetworkConfigurationDiagnosticResponse, error) {
 	respType := NetworkWatchersGetNetworkConfigurationDiagnosticResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.NetworkConfigurationDiagnosticResponse)
+	resp, err := p.pt.FinalResponse(ctx, &respType.ConfigurationDiagnosticResponse)
 	if err != nil {
 		return NetworkWatchersGetNetworkConfigurationDiagnosticResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_polymorphic_helpers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_polymorphic_helpers.go
@@ -83,7 +83,7 @@ func unmarshalFirewallPolicyRuleConditionClassification(rawMsg json.RawMessage) 
 	case string(FirewallPolicyRuleConditionTypeNatRuleCondition):
 		b = &NatRuleCondition{}
 	case string(FirewallPolicyRuleConditionTypeNetworkRuleCondition):
-		b = &NetworkRuleCondition{}
+		b = &RuleCondition{}
 	default:
 		b = &FirewallPolicyRuleCondition{}
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_profiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_profiles_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkProfilesClient contains the methods for the NetworkProfiles group.
-// Don't use this type directly, use NewNetworkProfilesClient() instead.
-type NetworkProfilesClient struct {
+// ProfilesClient contains the methods for the NetworkProfiles group.
+// Don't use this type directly, use NewProfilesClient() instead.
+type ProfilesClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkProfilesClient creates a new instance of NetworkProfilesClient with the specified values.
+// NewProfilesClient creates a new instance of ProfilesClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkProfilesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkProfilesClient {
+func NewProfilesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *ProfilesClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkProfilesClient(subscriptionID string, credential azcore.TokenCred
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkProfilesClient{
+	client := &ProfilesClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -56,9 +56,8 @@ func NewNetworkProfilesClient(subscriptionID string, credential azcore.TokenCred
 // resourceGroupName - The name of the resource group.
 // networkProfileName - The name of the network profile.
 // parameters - Parameters supplied to the create or update network profile operation.
-// options - NetworkProfilesCreateOrUpdateOptions contains the optional parameters for the NetworkProfilesClient.CreateOrUpdate
-// method.
-func (client *NetworkProfilesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkProfileName string, parameters NetworkProfile, options *NetworkProfilesCreateOrUpdateOptions) (NetworkProfilesCreateOrUpdateResponse, error) {
+// options - NetworkProfilesCreateOrUpdateOptions contains the optional parameters for the ProfilesClient.CreateOrUpdate method.
+func (client *ProfilesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkProfileName string, parameters Profile, options *NetworkProfilesCreateOrUpdateOptions) (NetworkProfilesCreateOrUpdateResponse, error) {
 	req, err := client.createOrUpdateCreateRequest(ctx, resourceGroupName, networkProfileName, parameters, options)
 	if err != nil {
 		return NetworkProfilesCreateOrUpdateResponse{}, err
@@ -74,7 +73,7 @@ func (client *NetworkProfilesClient) CreateOrUpdate(ctx context.Context, resourc
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkProfilesClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, parameters NetworkProfile, options *NetworkProfilesCreateOrUpdateOptions) (*policy.Request, error) {
+func (client *ProfilesClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, parameters Profile, options *NetworkProfilesCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -100,16 +99,16 @@ func (client *NetworkProfilesClient) createOrUpdateCreateRequest(ctx context.Con
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *NetworkProfilesClient) createOrUpdateHandleResponse(resp *http.Response) (NetworkProfilesCreateOrUpdateResponse, error) {
+func (client *ProfilesClient) createOrUpdateHandleResponse(resp *http.Response) (NetworkProfilesCreateOrUpdateResponse, error) {
 	result := NetworkProfilesCreateOrUpdateResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfile); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Profile); err != nil {
 		return NetworkProfilesCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
-func (client *NetworkProfilesClient) createOrUpdateHandleError(resp *http.Response) error {
+func (client *ProfilesClient) createOrUpdateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -125,9 +124,8 @@ func (client *NetworkProfilesClient) createOrUpdateHandleError(resp *http.Respon
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkProfileName - The name of the NetworkProfile.
-// options - NetworkProfilesBeginDeleteOptions contains the optional parameters for the NetworkProfilesClient.BeginDelete
-// method.
-func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesBeginDeleteOptions) (NetworkProfilesDeletePollerResponse, error) {
+// options - NetworkProfilesBeginDeleteOptions contains the optional parameters for the ProfilesClient.BeginDelete method.
+func (client *ProfilesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesBeginDeleteOptions) (NetworkProfilesDeletePollerResponse, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkProfileName, options)
 	if err != nil {
 		return NetworkProfilesDeletePollerResponse{}, err
@@ -135,7 +133,7 @@ func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGr
 	result := NetworkProfilesDeletePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkProfilesClient.Delete", "location", resp, client.pl, client.deleteHandleError)
+	pt, err := armruntime.NewPoller("ProfilesClient.Delete", "location", resp, client.pl, client.deleteHandleError)
 	if err != nil {
 		return NetworkProfilesDeletePollerResponse{}, err
 	}
@@ -147,7 +145,7 @@ func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGr
 
 // Delete - Deletes the specified network profile.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkProfilesClient) deleteOperation(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesBeginDeleteOptions) (*http.Response, error) {
+func (client *ProfilesClient) deleteOperation(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesBeginDeleteOptions) (*http.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, resourceGroupName, networkProfileName, options)
 	if err != nil {
 		return nil, err
@@ -163,7 +161,7 @@ func (client *NetworkProfilesClient) deleteOperation(ctx context.Context, resour
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *NetworkProfilesClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesBeginDeleteOptions) (*policy.Request, error) {
+func (client *ProfilesClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -189,7 +187,7 @@ func (client *NetworkProfilesClient) deleteCreateRequest(ctx context.Context, re
 }
 
 // deleteHandleError handles the Delete error response.
-func (client *NetworkProfilesClient) deleteHandleError(resp *http.Response) error {
+func (client *ProfilesClient) deleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -205,8 +203,8 @@ func (client *NetworkProfilesClient) deleteHandleError(resp *http.Response) erro
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkProfileName - The name of the public IP prefix.
-// options - NetworkProfilesGetOptions contains the optional parameters for the NetworkProfilesClient.Get method.
-func (client *NetworkProfilesClient) Get(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesGetOptions) (NetworkProfilesGetResponse, error) {
+// options - NetworkProfilesGetOptions contains the optional parameters for the ProfilesClient.Get method.
+func (client *ProfilesClient) Get(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesGetOptions) (NetworkProfilesGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, resourceGroupName, networkProfileName, options)
 	if err != nil {
 		return NetworkProfilesGetResponse{}, err
@@ -222,7 +220,7 @@ func (client *NetworkProfilesClient) Get(ctx context.Context, resourceGroupName 
 }
 
 // getCreateRequest creates the Get request.
-func (client *NetworkProfilesClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesGetOptions) (*policy.Request, error) {
+func (client *ProfilesClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -251,16 +249,16 @@ func (client *NetworkProfilesClient) getCreateRequest(ctx context.Context, resou
 }
 
 // getHandleResponse handles the Get response.
-func (client *NetworkProfilesClient) getHandleResponse(resp *http.Response) (NetworkProfilesGetResponse, error) {
+func (client *ProfilesClient) getHandleResponse(resp *http.Response) (NetworkProfilesGetResponse, error) {
 	result := NetworkProfilesGetResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfile); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Profile); err != nil {
 		return NetworkProfilesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getHandleError handles the Get error response.
-func (client *NetworkProfilesClient) getHandleError(resp *http.Response) error {
+func (client *ProfilesClient) getHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -275,21 +273,21 @@ func (client *NetworkProfilesClient) getHandleError(resp *http.Response) error {
 // List - Gets all network profiles in a resource group.
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
-// options - NetworkProfilesListOptions contains the optional parameters for the NetworkProfilesClient.List method.
-func (client *NetworkProfilesClient) List(resourceGroupName string, options *NetworkProfilesListOptions) *NetworkProfilesListPager {
+// options - NetworkProfilesListOptions contains the optional parameters for the ProfilesClient.List method.
+func (client *ProfilesClient) List(resourceGroupName string, options *NetworkProfilesListOptions) *NetworkProfilesListPager {
 	return &NetworkProfilesListPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, resourceGroupName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkProfilesListResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkProfileListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.ProfileListResult.NextLink)
 		},
 	}
 }
 
 // listCreateRequest creates the List request.
-func (client *NetworkProfilesClient) listCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkProfilesListOptions) (*policy.Request, error) {
+func (client *ProfilesClient) listCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkProfilesListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -311,16 +309,16 @@ func (client *NetworkProfilesClient) listCreateRequest(ctx context.Context, reso
 }
 
 // listHandleResponse handles the List response.
-func (client *NetworkProfilesClient) listHandleResponse(resp *http.Response) (NetworkProfilesListResponse, error) {
+func (client *ProfilesClient) listHandleResponse(resp *http.Response) (NetworkProfilesListResponse, error) {
 	result := NetworkProfilesListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfileListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.ProfileListResult); err != nil {
 		return NetworkProfilesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *NetworkProfilesClient) listHandleError(resp *http.Response) error {
+func (client *ProfilesClient) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -334,21 +332,21 @@ func (client *NetworkProfilesClient) listHandleError(resp *http.Response) error 
 
 // ListAll - Gets all the network profiles in a subscription.
 // If the operation fails it returns the *CloudError error type.
-// options - NetworkProfilesListAllOptions contains the optional parameters for the NetworkProfilesClient.ListAll method.
-func (client *NetworkProfilesClient) ListAll(options *NetworkProfilesListAllOptions) *NetworkProfilesListAllPager {
+// options - NetworkProfilesListAllOptions contains the optional parameters for the ProfilesClient.ListAll method.
+func (client *ProfilesClient) ListAll(options *NetworkProfilesListAllOptions) *NetworkProfilesListAllPager {
 	return &NetworkProfilesListAllPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listAllCreateRequest(ctx, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkProfilesListAllResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkProfileListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.ProfileListResult.NextLink)
 		},
 	}
 }
 
 // listAllCreateRequest creates the ListAll request.
-func (client *NetworkProfilesClient) listAllCreateRequest(ctx context.Context, options *NetworkProfilesListAllOptions) (*policy.Request, error) {
+func (client *ProfilesClient) listAllCreateRequest(ctx context.Context, options *NetworkProfilesListAllOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkProfiles"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -366,16 +364,16 @@ func (client *NetworkProfilesClient) listAllCreateRequest(ctx context.Context, o
 }
 
 // listAllHandleResponse handles the ListAll response.
-func (client *NetworkProfilesClient) listAllHandleResponse(resp *http.Response) (NetworkProfilesListAllResponse, error) {
+func (client *ProfilesClient) listAllHandleResponse(resp *http.Response) (NetworkProfilesListAllResponse, error) {
 	result := NetworkProfilesListAllResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfileListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.ProfileListResult); err != nil {
 		return NetworkProfilesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listAllHandleError handles the ListAll error response.
-func (client *NetworkProfilesClient) listAllHandleError(resp *http.Response) error {
+func (client *ProfilesClient) listAllHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -392,8 +390,8 @@ func (client *NetworkProfilesClient) listAllHandleError(resp *http.Response) err
 // resourceGroupName - The name of the resource group.
 // networkProfileName - The name of the network profile.
 // parameters - Parameters supplied to update network profile tags.
-// options - NetworkProfilesUpdateTagsOptions contains the optional parameters for the NetworkProfilesClient.UpdateTags method.
-func (client *NetworkProfilesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject, options *NetworkProfilesUpdateTagsOptions) (NetworkProfilesUpdateTagsResponse, error) {
+// options - NetworkProfilesUpdateTagsOptions contains the optional parameters for the ProfilesClient.UpdateTags method.
+func (client *ProfilesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject, options *NetworkProfilesUpdateTagsOptions) (NetworkProfilesUpdateTagsResponse, error) {
 	req, err := client.updateTagsCreateRequest(ctx, resourceGroupName, networkProfileName, parameters, options)
 	if err != nil {
 		return NetworkProfilesUpdateTagsResponse{}, err
@@ -409,7 +407,7 @@ func (client *NetworkProfilesClient) UpdateTags(ctx context.Context, resourceGro
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkProfilesClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject, options *NetworkProfilesUpdateTagsOptions) (*policy.Request, error) {
+func (client *ProfilesClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject, options *NetworkProfilesUpdateTagsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -435,16 +433,16 @@ func (client *NetworkProfilesClient) updateTagsCreateRequest(ctx context.Context
 }
 
 // updateTagsHandleResponse handles the UpdateTags response.
-func (client *NetworkProfilesClient) updateTagsHandleResponse(resp *http.Response) (NetworkProfilesUpdateTagsResponse, error) {
+func (client *ProfilesClient) updateTagsHandleResponse(resp *http.Response) (NetworkProfilesUpdateTagsResponse, error) {
 	result := NetworkProfilesUpdateTagsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfile); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Profile); err != nil {
 		return NetworkProfilesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.
-func (client *NetworkProfilesClient) updateTagsHandleError(resp *http.Response) error {
+func (client *ProfilesClient) updateTagsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
@@ -4019,7 +4019,7 @@ type LoadBalancerNetworkInterfacesListResponse struct {
 
 // LoadBalancerNetworkInterfacesListResult contains the result from method LoadBalancerNetworkInterfaces.List.
 type LoadBalancerNetworkInterfacesListResult struct {
-	NetworkInterfaceListResult
+	InterfaceListResult
 }
 
 // LoadBalancerOutboundRulesGetResponse contains the response from method LoadBalancerOutboundRules.Get.
@@ -4505,7 +4505,7 @@ type NetworkInterfaceIPConfigurationsGetResponse struct {
 
 // NetworkInterfaceIPConfigurationsGetResult contains the result from method NetworkInterfaceIPConfigurations.Get.
 type NetworkInterfaceIPConfigurationsGetResult struct {
-	NetworkInterfaceIPConfiguration
+	InterfaceIPConfiguration
 }
 
 // NetworkInterfaceIPConfigurationsListResponse contains the response from method NetworkInterfaceIPConfigurations.List.
@@ -4517,7 +4517,7 @@ type NetworkInterfaceIPConfigurationsListResponse struct {
 
 // NetworkInterfaceIPConfigurationsListResult contains the result from method NetworkInterfaceIPConfigurations.List.
 type NetworkInterfaceIPConfigurationsListResult struct {
-	NetworkInterfaceIPConfigurationListResult
+	InterfaceIPConfigurationListResult
 }
 
 // NetworkInterfaceLoadBalancersListResponse contains the response from method NetworkInterfaceLoadBalancers.List.
@@ -4529,7 +4529,7 @@ type NetworkInterfaceLoadBalancersListResponse struct {
 
 // NetworkInterfaceLoadBalancersListResult contains the result from method NetworkInterfaceLoadBalancers.List.
 type NetworkInterfaceLoadBalancersListResult struct {
-	NetworkInterfaceLoadBalancerListResult
+	InterfaceLoadBalancerListResult
 }
 
 // NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse contains the response from method NetworkInterfaceTapConfigurations.CreateOrUpdate.
@@ -4546,7 +4546,7 @@ type NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NetworkInterfaceTapConfigurationsCreateOrUpdateResponse, error) {
 	respType := NetworkInterfaceTapConfigurationsCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NetworkInterfaceTapConfiguration)
+	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.InterfaceTapConfiguration)
 	if err != nil {
 		return respType, err
 	}
@@ -4555,8 +4555,8 @@ func (l NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse) PollUntil
 }
 
 // Resume rehydrates a NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *NetworkInterfaceTapConfigurationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkInterfaceTapConfigurationsClient.CreateOrUpdate", token, client.pl, client.createOrUpdateHandleError)
+func (l *NetworkInterfaceTapConfigurationsCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *InterfaceTapConfigurationsClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.CreateOrUpdate", token, client.pl, client.createOrUpdateHandleError)
 	if err != nil {
 		return err
 	}
@@ -4581,7 +4581,7 @@ type NetworkInterfaceTapConfigurationsCreateOrUpdateResponse struct {
 
 // NetworkInterfaceTapConfigurationsCreateOrUpdateResult contains the result from method NetworkInterfaceTapConfigurations.CreateOrUpdate.
 type NetworkInterfaceTapConfigurationsCreateOrUpdateResult struct {
-	NetworkInterfaceTapConfiguration
+	InterfaceTapConfiguration
 }
 
 // NetworkInterfaceTapConfigurationsDeletePollerResponse contains the response from method NetworkInterfaceTapConfigurations.Delete.
@@ -4607,8 +4607,8 @@ func (l NetworkInterfaceTapConfigurationsDeletePollerResponse) PollUntilDone(ctx
 }
 
 // Resume rehydrates a NetworkInterfaceTapConfigurationsDeletePollerResponse from the provided client and resume token.
-func (l *NetworkInterfaceTapConfigurationsDeletePollerResponse) Resume(ctx context.Context, client *NetworkInterfaceTapConfigurationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkInterfaceTapConfigurationsClient.Delete", token, client.pl, client.deleteHandleError)
+func (l *NetworkInterfaceTapConfigurationsDeletePollerResponse) Resume(ctx context.Context, client *InterfaceTapConfigurationsClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.Delete", token, client.pl, client.deleteHandleError)
 	if err != nil {
 		return err
 	}
@@ -4639,7 +4639,7 @@ type NetworkInterfaceTapConfigurationsGetResponse struct {
 
 // NetworkInterfaceTapConfigurationsGetResult contains the result from method NetworkInterfaceTapConfigurations.Get.
 type NetworkInterfaceTapConfigurationsGetResult struct {
-	NetworkInterfaceTapConfiguration
+	InterfaceTapConfiguration
 }
 
 // NetworkInterfaceTapConfigurationsListResponse contains the response from method NetworkInterfaceTapConfigurations.List.
@@ -4651,7 +4651,7 @@ type NetworkInterfaceTapConfigurationsListResponse struct {
 
 // NetworkInterfaceTapConfigurationsListResult contains the result from method NetworkInterfaceTapConfigurations.List.
 type NetworkInterfaceTapConfigurationsListResult struct {
-	NetworkInterfaceTapConfigurationListResult
+	InterfaceTapConfigurationListResult
 }
 
 // NetworkInterfacesCreateOrUpdatePollerResponse contains the response from method NetworkInterfaces.CreateOrUpdate.
@@ -4668,7 +4668,7 @@ type NetworkInterfacesCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l NetworkInterfacesCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NetworkInterfacesCreateOrUpdateResponse, error) {
 	respType := NetworkInterfacesCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NetworkInterface)
+	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Interface)
 	if err != nil {
 		return respType, err
 	}
@@ -4677,8 +4677,8 @@ func (l NetworkInterfacesCreateOrUpdatePollerResponse) PollUntilDone(ctx context
 }
 
 // Resume rehydrates a NetworkInterfacesCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *NetworkInterfacesCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *NetworkInterfacesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkInterfacesClient.CreateOrUpdate", token, client.pl, client.createOrUpdateHandleError)
+func (l *NetworkInterfacesCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *InterfacesClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("InterfacesClient.CreateOrUpdate", token, client.pl, client.createOrUpdateHandleError)
 	if err != nil {
 		return err
 	}
@@ -4703,7 +4703,7 @@ type NetworkInterfacesCreateOrUpdateResponse struct {
 
 // NetworkInterfacesCreateOrUpdateResult contains the result from method NetworkInterfaces.CreateOrUpdate.
 type NetworkInterfacesCreateOrUpdateResult struct {
-	NetworkInterface
+	Interface
 }
 
 // NetworkInterfacesDeletePollerResponse contains the response from method NetworkInterfaces.Delete.
@@ -4729,8 +4729,8 @@ func (l NetworkInterfacesDeletePollerResponse) PollUntilDone(ctx context.Context
 }
 
 // Resume rehydrates a NetworkInterfacesDeletePollerResponse from the provided client and resume token.
-func (l *NetworkInterfacesDeletePollerResponse) Resume(ctx context.Context, client *NetworkInterfacesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkInterfacesClient.Delete", token, client.pl, client.deleteHandleError)
+func (l *NetworkInterfacesDeletePollerResponse) Resume(ctx context.Context, client *InterfacesClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("InterfacesClient.Delete", token, client.pl, client.deleteHandleError)
 	if err != nil {
 		return err
 	}
@@ -4775,8 +4775,8 @@ func (l NetworkInterfacesGetEffectiveRouteTablePollerResponse) PollUntilDone(ctx
 }
 
 // Resume rehydrates a NetworkInterfacesGetEffectiveRouteTablePollerResponse from the provided client and resume token.
-func (l *NetworkInterfacesGetEffectiveRouteTablePollerResponse) Resume(ctx context.Context, client *NetworkInterfacesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkInterfacesClient.GetEffectiveRouteTable", token, client.pl, client.getEffectiveRouteTableHandleError)
+func (l *NetworkInterfacesGetEffectiveRouteTablePollerResponse) Resume(ctx context.Context, client *InterfacesClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("InterfacesClient.GetEffectiveRouteTable", token, client.pl, client.getEffectiveRouteTableHandleError)
 	if err != nil {
 		return err
 	}
@@ -4813,7 +4813,7 @@ type NetworkInterfacesGetResponse struct {
 
 // NetworkInterfacesGetResult contains the result from method NetworkInterfaces.Get.
 type NetworkInterfacesGetResult struct {
-	NetworkInterface
+	Interface
 }
 
 // NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse contains the response from method NetworkInterfaces.GetVirtualMachineScaleSetIPConfiguration.
@@ -4825,7 +4825,7 @@ type NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse struct {
 
 // NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResult contains the result from method NetworkInterfaces.GetVirtualMachineScaleSetIPConfiguration.
 type NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResult struct {
-	NetworkInterfaceIPConfiguration
+	InterfaceIPConfiguration
 }
 
 // NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse contains the response from method NetworkInterfaces.GetVirtualMachineScaleSetNetworkInterface.
@@ -4837,7 +4837,7 @@ type NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse struct {
 
 // NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResult contains the result from method NetworkInterfaces.GetVirtualMachineScaleSetNetworkInterface.
 type NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResult struct {
-	NetworkInterface
+	Interface
 }
 
 // NetworkInterfacesListAllResponse contains the response from method NetworkInterfaces.ListAll.
@@ -4849,7 +4849,7 @@ type NetworkInterfacesListAllResponse struct {
 
 // NetworkInterfacesListAllResult contains the result from method NetworkInterfaces.ListAll.
 type NetworkInterfacesListAllResult struct {
-	NetworkInterfaceListResult
+	InterfaceListResult
 }
 
 // NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse contains the response from method NetworkInterfaces.ListEffectiveNetworkSecurityGroups.
@@ -4876,8 +4876,8 @@ func (l NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse) PollU
 
 // Resume rehydrates a NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse from the provided client and resume
 // token.
-func (l *NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse) Resume(ctx context.Context, client *NetworkInterfacesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkInterfacesClient.ListEffectiveNetworkSecurityGroups", token, client.pl, client.listEffectiveNetworkSecurityGroupsHandleError)
+func (l *NetworkInterfacesListEffectiveNetworkSecurityGroupsPollerResponse) Resume(ctx context.Context, client *InterfacesClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("InterfacesClient.ListEffectiveNetworkSecurityGroups", token, client.pl, client.listEffectiveNetworkSecurityGroupsHandleError)
 	if err != nil {
 		return err
 	}
@@ -4914,7 +4914,7 @@ type NetworkInterfacesListResponse struct {
 
 // NetworkInterfacesListResult contains the result from method NetworkInterfaces.List.
 type NetworkInterfacesListResult struct {
-	NetworkInterfaceListResult
+	InterfaceListResult
 }
 
 // NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse contains the response from method NetworkInterfaces.ListVirtualMachineScaleSetIPConfigurations.
@@ -4926,7 +4926,7 @@ type NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse struct 
 
 // NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResult contains the result from method NetworkInterfaces.ListVirtualMachineScaleSetIPConfigurations.
 type NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResult struct {
-	NetworkInterfaceIPConfigurationListResult
+	InterfaceIPConfigurationListResult
 }
 
 // NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse contains the response from method NetworkInterfaces.ListVirtualMachineScaleSetNetworkInterfaces.
@@ -4938,7 +4938,7 @@ type NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse struct
 
 // NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResult contains the result from method NetworkInterfaces.ListVirtualMachineScaleSetNetworkInterfaces.
 type NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResult struct {
-	NetworkInterfaceListResult
+	InterfaceListResult
 }
 
 // NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse contains the response from method NetworkInterfaces.ListVirtualMachineScaleSetVMNetworkInterfaces.
@@ -4950,7 +4950,7 @@ type NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse stru
 
 // NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResult contains the result from method NetworkInterfaces.ListVirtualMachineScaleSetVMNetworkInterfaces.
 type NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResult struct {
-	NetworkInterfaceListResult
+	InterfaceListResult
 }
 
 // NetworkInterfacesUpdateTagsResponse contains the response from method NetworkInterfaces.UpdateTags.
@@ -4962,7 +4962,7 @@ type NetworkInterfacesUpdateTagsResponse struct {
 
 // NetworkInterfacesUpdateTagsResult contains the result from method NetworkInterfaces.UpdateTags.
 type NetworkInterfacesUpdateTagsResult struct {
-	NetworkInterface
+	Interface
 }
 
 // NetworkManagementClientCheckDNSNameAvailabilityResponse contains the response from method NetworkManagementClient.CheckDNSNameAvailability.
@@ -5001,8 +5001,8 @@ func (l NetworkManagementClientDeleteBastionShareableLinkPollerResponse) PollUnt
 
 // Resume rehydrates a NetworkManagementClientDeleteBastionShareableLinkPollerResponse from the provided client and resume
 // token.
-func (l *NetworkManagementClientDeleteBastionShareableLinkPollerResponse) Resume(ctx context.Context, client *NetworkManagementClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkManagementClient.DeleteBastionShareableLink", token, client.pl, client.deleteBastionShareableLinkHandleError)
+func (l *NetworkManagementClientDeleteBastionShareableLinkPollerResponse) Resume(ctx context.Context, client *ManagementClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("ManagementClient.DeleteBastionShareableLink", token, client.pl, client.deleteBastionShareableLinkHandleError)
 	if err != nil {
 		return err
 	}
@@ -5061,8 +5061,8 @@ func (l NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofil
 
 // Resume rehydrates a NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse from the provided
 // client and resume token.
-func (l *NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse) Resume(ctx context.Context, client *NetworkManagementClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", token, client.pl, client.generatevirtualwanvpnserverconfigurationvpnprofileHandleError)
+func (l *NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse) Resume(ctx context.Context, client *ManagementClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", token, client.pl, client.generatevirtualwanvpnserverconfigurationvpnprofileHandleError)
 	if err != nil {
 		return err
 	}
@@ -5114,8 +5114,8 @@ func (l NetworkManagementClientGetActiveSessionsPollerResponse) PollUntilDone(ct
 }
 
 // Resume rehydrates a NetworkManagementClientGetActiveSessionsPollerResponse from the provided client and resume token.
-func (l *NetworkManagementClientGetActiveSessionsPollerResponse) Resume(ctx context.Context, client *NetworkManagementClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkManagementClient.GetActiveSessions", token, client.pl, client.getActiveSessionsHandleError)
+func (l *NetworkManagementClientGetActiveSessionsPollerResponse) Resume(ctx context.Context, client *ManagementClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("ManagementClient.GetActiveSessions", token, client.pl, client.getActiveSessionsHandleError)
 	if err != nil {
 		return err
 	}
@@ -5180,8 +5180,8 @@ func (l NetworkManagementClientPutBastionShareableLinkPollerResponse) PollUntilD
 }
 
 // Resume rehydrates a NetworkManagementClientPutBastionShareableLinkPollerResponse from the provided client and resume token.
-func (l *NetworkManagementClientPutBastionShareableLinkPollerResponse) Resume(ctx context.Context, client *NetworkManagementClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkManagementClient.PutBastionShareableLink", token, client.pl, client.putBastionShareableLinkHandleError)
+func (l *NetworkManagementClientPutBastionShareableLinkPollerResponse) Resume(ctx context.Context, client *ManagementClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("ManagementClient.PutBastionShareableLink", token, client.pl, client.putBastionShareableLinkHandleError)
 	if err != nil {
 		return err
 	}
@@ -5231,7 +5231,7 @@ type NetworkProfilesCreateOrUpdateResponse struct {
 
 // NetworkProfilesCreateOrUpdateResult contains the result from method NetworkProfiles.CreateOrUpdate.
 type NetworkProfilesCreateOrUpdateResult struct {
-	NetworkProfile
+	Profile
 }
 
 // NetworkProfilesDeletePollerResponse contains the response from method NetworkProfiles.Delete.
@@ -5257,8 +5257,8 @@ func (l NetworkProfilesDeletePollerResponse) PollUntilDone(ctx context.Context, 
 }
 
 // Resume rehydrates a NetworkProfilesDeletePollerResponse from the provided client and resume token.
-func (l *NetworkProfilesDeletePollerResponse) Resume(ctx context.Context, client *NetworkProfilesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkProfilesClient.Delete", token, client.pl, client.deleteHandleError)
+func (l *NetworkProfilesDeletePollerResponse) Resume(ctx context.Context, client *ProfilesClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("ProfilesClient.Delete", token, client.pl, client.deleteHandleError)
 	if err != nil {
 		return err
 	}
@@ -5289,7 +5289,7 @@ type NetworkProfilesGetResponse struct {
 
 // NetworkProfilesGetResult contains the result from method NetworkProfiles.Get.
 type NetworkProfilesGetResult struct {
-	NetworkProfile
+	Profile
 }
 
 // NetworkProfilesListAllResponse contains the response from method NetworkProfiles.ListAll.
@@ -5301,7 +5301,7 @@ type NetworkProfilesListAllResponse struct {
 
 // NetworkProfilesListAllResult contains the result from method NetworkProfiles.ListAll.
 type NetworkProfilesListAllResult struct {
-	NetworkProfileListResult
+	ProfileListResult
 }
 
 // NetworkProfilesListResponse contains the response from method NetworkProfiles.List.
@@ -5313,7 +5313,7 @@ type NetworkProfilesListResponse struct {
 
 // NetworkProfilesListResult contains the result from method NetworkProfiles.List.
 type NetworkProfilesListResult struct {
-	NetworkProfileListResult
+	ProfileListResult
 }
 
 // NetworkProfilesUpdateTagsResponse contains the response from method NetworkProfiles.UpdateTags.
@@ -5325,7 +5325,7 @@ type NetworkProfilesUpdateTagsResponse struct {
 
 // NetworkProfilesUpdateTagsResult contains the result from method NetworkProfiles.UpdateTags.
 type NetworkProfilesUpdateTagsResult struct {
-	NetworkProfile
+	Profile
 }
 
 // NetworkSecurityGroupsCreateOrUpdatePollerResponse contains the response from method NetworkSecurityGroups.CreateOrUpdate.
@@ -5342,7 +5342,7 @@ type NetworkSecurityGroupsCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l NetworkSecurityGroupsCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NetworkSecurityGroupsCreateOrUpdateResponse, error) {
 	respType := NetworkSecurityGroupsCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NetworkSecurityGroup)
+	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityGroup)
 	if err != nil {
 		return respType, err
 	}
@@ -5351,8 +5351,8 @@ func (l NetworkSecurityGroupsCreateOrUpdatePollerResponse) PollUntilDone(ctx con
 }
 
 // Resume rehydrates a NetworkSecurityGroupsCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *NetworkSecurityGroupsCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *NetworkSecurityGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkSecurityGroupsClient.CreateOrUpdate", token, client.pl, client.createOrUpdateHandleError)
+func (l *NetworkSecurityGroupsCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *SecurityGroupsClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("SecurityGroupsClient.CreateOrUpdate", token, client.pl, client.createOrUpdateHandleError)
 	if err != nil {
 		return err
 	}
@@ -5377,7 +5377,7 @@ type NetworkSecurityGroupsCreateOrUpdateResponse struct {
 
 // NetworkSecurityGroupsCreateOrUpdateResult contains the result from method NetworkSecurityGroups.CreateOrUpdate.
 type NetworkSecurityGroupsCreateOrUpdateResult struct {
-	NetworkSecurityGroup
+	SecurityGroup
 }
 
 // NetworkSecurityGroupsDeletePollerResponse contains the response from method NetworkSecurityGroups.Delete.
@@ -5403,8 +5403,8 @@ func (l NetworkSecurityGroupsDeletePollerResponse) PollUntilDone(ctx context.Con
 }
 
 // Resume rehydrates a NetworkSecurityGroupsDeletePollerResponse from the provided client and resume token.
-func (l *NetworkSecurityGroupsDeletePollerResponse) Resume(ctx context.Context, client *NetworkSecurityGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkSecurityGroupsClient.Delete", token, client.pl, client.deleteHandleError)
+func (l *NetworkSecurityGroupsDeletePollerResponse) Resume(ctx context.Context, client *SecurityGroupsClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("SecurityGroupsClient.Delete", token, client.pl, client.deleteHandleError)
 	if err != nil {
 		return err
 	}
@@ -5435,7 +5435,7 @@ type NetworkSecurityGroupsGetResponse struct {
 
 // NetworkSecurityGroupsGetResult contains the result from method NetworkSecurityGroups.Get.
 type NetworkSecurityGroupsGetResult struct {
-	NetworkSecurityGroup
+	SecurityGroup
 }
 
 // NetworkSecurityGroupsListAllResponse contains the response from method NetworkSecurityGroups.ListAll.
@@ -5447,7 +5447,7 @@ type NetworkSecurityGroupsListAllResponse struct {
 
 // NetworkSecurityGroupsListAllResult contains the result from method NetworkSecurityGroups.ListAll.
 type NetworkSecurityGroupsListAllResult struct {
-	NetworkSecurityGroupListResult
+	SecurityGroupListResult
 }
 
 // NetworkSecurityGroupsListResponse contains the response from method NetworkSecurityGroups.List.
@@ -5459,7 +5459,7 @@ type NetworkSecurityGroupsListResponse struct {
 
 // NetworkSecurityGroupsListResult contains the result from method NetworkSecurityGroups.List.
 type NetworkSecurityGroupsListResult struct {
-	NetworkSecurityGroupListResult
+	SecurityGroupListResult
 }
 
 // NetworkSecurityGroupsUpdateTagsResponse contains the response from method NetworkSecurityGroups.UpdateTags.
@@ -5471,7 +5471,7 @@ type NetworkSecurityGroupsUpdateTagsResponse struct {
 
 // NetworkSecurityGroupsUpdateTagsResult contains the result from method NetworkSecurityGroups.UpdateTags.
 type NetworkSecurityGroupsUpdateTagsResult struct {
-	NetworkSecurityGroup
+	SecurityGroup
 }
 
 // NetworkVirtualAppliancesCreateOrUpdatePollerResponse contains the response from method NetworkVirtualAppliances.CreateOrUpdate.
@@ -5488,7 +5488,7 @@ type NetworkVirtualAppliancesCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l NetworkVirtualAppliancesCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NetworkVirtualAppliancesCreateOrUpdateResponse, error) {
 	respType := NetworkVirtualAppliancesCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NetworkVirtualAppliance)
+	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualAppliance)
 	if err != nil {
 		return respType, err
 	}
@@ -5497,8 +5497,8 @@ func (l NetworkVirtualAppliancesCreateOrUpdatePollerResponse) PollUntilDone(ctx 
 }
 
 // Resume rehydrates a NetworkVirtualAppliancesCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *NetworkVirtualAppliancesCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *NetworkVirtualAppliancesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkVirtualAppliancesClient.CreateOrUpdate", token, client.pl, client.createOrUpdateHandleError)
+func (l *NetworkVirtualAppliancesCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualAppliancesClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.CreateOrUpdate", token, client.pl, client.createOrUpdateHandleError)
 	if err != nil {
 		return err
 	}
@@ -5523,7 +5523,7 @@ type NetworkVirtualAppliancesCreateOrUpdateResponse struct {
 
 // NetworkVirtualAppliancesCreateOrUpdateResult contains the result from method NetworkVirtualAppliances.CreateOrUpdate.
 type NetworkVirtualAppliancesCreateOrUpdateResult struct {
-	NetworkVirtualAppliance
+	VirtualAppliance
 }
 
 // NetworkVirtualAppliancesDeletePollerResponse contains the response from method NetworkVirtualAppliances.Delete.
@@ -5549,8 +5549,8 @@ func (l NetworkVirtualAppliancesDeletePollerResponse) PollUntilDone(ctx context.
 }
 
 // Resume rehydrates a NetworkVirtualAppliancesDeletePollerResponse from the provided client and resume token.
-func (l *NetworkVirtualAppliancesDeletePollerResponse) Resume(ctx context.Context, client *NetworkVirtualAppliancesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkVirtualAppliancesClient.Delete", token, client.pl, client.deleteHandleError)
+func (l *NetworkVirtualAppliancesDeletePollerResponse) Resume(ctx context.Context, client *VirtualAppliancesClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.Delete", token, client.pl, client.deleteHandleError)
 	if err != nil {
 		return err
 	}
@@ -5581,7 +5581,7 @@ type NetworkVirtualAppliancesGetResponse struct {
 
 // NetworkVirtualAppliancesGetResult contains the result from method NetworkVirtualAppliances.Get.
 type NetworkVirtualAppliancesGetResult struct {
-	NetworkVirtualAppliance
+	VirtualAppliance
 }
 
 // NetworkVirtualAppliancesListByResourceGroupResponse contains the response from method NetworkVirtualAppliances.ListByResourceGroup.
@@ -5593,7 +5593,7 @@ type NetworkVirtualAppliancesListByResourceGroupResponse struct {
 
 // NetworkVirtualAppliancesListByResourceGroupResult contains the result from method NetworkVirtualAppliances.ListByResourceGroup.
 type NetworkVirtualAppliancesListByResourceGroupResult struct {
-	NetworkVirtualApplianceListResult
+	VirtualApplianceListResult
 }
 
 // NetworkVirtualAppliancesListResponse contains the response from method NetworkVirtualAppliances.List.
@@ -5605,7 +5605,7 @@ type NetworkVirtualAppliancesListResponse struct {
 
 // NetworkVirtualAppliancesListResult contains the result from method NetworkVirtualAppliances.List.
 type NetworkVirtualAppliancesListResult struct {
-	NetworkVirtualApplianceListResult
+	VirtualApplianceListResult
 }
 
 // NetworkVirtualAppliancesUpdateTagsResponse contains the response from method NetworkVirtualAppliances.UpdateTags.
@@ -5617,7 +5617,7 @@ type NetworkVirtualAppliancesUpdateTagsResponse struct {
 
 // NetworkVirtualAppliancesUpdateTagsResult contains the result from method NetworkVirtualAppliances.UpdateTags.
 type NetworkVirtualAppliancesUpdateTagsResult struct {
-	NetworkVirtualAppliance
+	VirtualAppliance
 }
 
 // NetworkWatchersCheckConnectivityPollerResponse contains the response from method NetworkWatchers.CheckConnectivity.
@@ -5643,8 +5643,8 @@ func (l NetworkWatchersCheckConnectivityPollerResponse) PollUntilDone(ctx contex
 }
 
 // Resume rehydrates a NetworkWatchersCheckConnectivityPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersCheckConnectivityPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.CheckConnectivity", token, client.pl, client.checkConnectivityHandleError)
+func (l *NetworkWatchersCheckConnectivityPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.CheckConnectivity", token, client.pl, client.checkConnectivityHandleError)
 	if err != nil {
 		return err
 	}
@@ -5681,7 +5681,7 @@ type NetworkWatchersCreateOrUpdateResponse struct {
 
 // NetworkWatchersCreateOrUpdateResult contains the result from method NetworkWatchers.CreateOrUpdate.
 type NetworkWatchersCreateOrUpdateResult struct {
-	NetworkWatcher
+	Watcher
 }
 
 // NetworkWatchersDeletePollerResponse contains the response from method NetworkWatchers.Delete.
@@ -5707,8 +5707,8 @@ func (l NetworkWatchersDeletePollerResponse) PollUntilDone(ctx context.Context, 
 }
 
 // Resume rehydrates a NetworkWatchersDeletePollerResponse from the provided client and resume token.
-func (l *NetworkWatchersDeletePollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.Delete", token, client.pl, client.deleteHandleError)
+func (l *NetworkWatchersDeletePollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.Delete", token, client.pl, client.deleteHandleError)
 	if err != nil {
 		return err
 	}
@@ -5753,8 +5753,8 @@ func (l NetworkWatchersGetAzureReachabilityReportPollerResponse) PollUntilDone(c
 }
 
 // Resume rehydrates a NetworkWatchersGetAzureReachabilityReportPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersGetAzureReachabilityReportPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.GetAzureReachabilityReport", token, client.pl, client.getAzureReachabilityReportHandleError)
+func (l *NetworkWatchersGetAzureReachabilityReportPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetAzureReachabilityReport", token, client.pl, client.getAzureReachabilityReportHandleError)
 	if err != nil {
 		return err
 	}
@@ -5805,8 +5805,8 @@ func (l NetworkWatchersGetFlowLogStatusPollerResponse) PollUntilDone(ctx context
 }
 
 // Resume rehydrates a NetworkWatchersGetFlowLogStatusPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersGetFlowLogStatusPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.GetFlowLogStatus", token, client.pl, client.getFlowLogStatusHandleError)
+func (l *NetworkWatchersGetFlowLogStatusPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetFlowLogStatus", token, client.pl, client.getFlowLogStatusHandleError)
 	if err != nil {
 		return err
 	}
@@ -5848,7 +5848,7 @@ type NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NetworkWatchersGetNetworkConfigurationDiagnosticResponse, error) {
 	respType := NetworkWatchersGetNetworkConfigurationDiagnosticResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NetworkConfigurationDiagnosticResponse)
+	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConfigurationDiagnosticResponse)
 	if err != nil {
 		return respType, err
 	}
@@ -5858,8 +5858,8 @@ func (l NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse) PollUnti
 
 // Resume rehydrates a NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse from the provided client and resume
 // token.
-func (l *NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.GetNetworkConfigurationDiagnostic", token, client.pl, client.getNetworkConfigurationDiagnosticHandleError)
+func (l *NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetNetworkConfigurationDiagnostic", token, client.pl, client.getNetworkConfigurationDiagnosticHandleError)
 	if err != nil {
 		return err
 	}
@@ -5884,7 +5884,7 @@ type NetworkWatchersGetNetworkConfigurationDiagnosticResponse struct {
 
 // NetworkWatchersGetNetworkConfigurationDiagnosticResult contains the result from method NetworkWatchers.GetNetworkConfigurationDiagnostic.
 type NetworkWatchersGetNetworkConfigurationDiagnosticResult struct {
-	NetworkConfigurationDiagnosticResponse
+	ConfigurationDiagnosticResponse
 }
 
 // NetworkWatchersGetNextHopPollerResponse contains the response from method NetworkWatchers.GetNextHop.
@@ -5910,8 +5910,8 @@ func (l NetworkWatchersGetNextHopPollerResponse) PollUntilDone(ctx context.Conte
 }
 
 // Resume rehydrates a NetworkWatchersGetNextHopPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersGetNextHopPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.GetNextHop", token, client.pl, client.getNextHopHandleError)
+func (l *NetworkWatchersGetNextHopPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetNextHop", token, client.pl, client.getNextHopHandleError)
 	if err != nil {
 		return err
 	}
@@ -5948,7 +5948,7 @@ type NetworkWatchersGetResponse struct {
 
 // NetworkWatchersGetResult contains the result from method NetworkWatchers.Get.
 type NetworkWatchersGetResult struct {
-	NetworkWatcher
+	Watcher
 }
 
 // NetworkWatchersGetTopologyResponse contains the response from method NetworkWatchers.GetTopology.
@@ -5986,8 +5986,8 @@ func (l NetworkWatchersGetTroubleshootingPollerResponse) PollUntilDone(ctx conte
 }
 
 // Resume rehydrates a NetworkWatchersGetTroubleshootingPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersGetTroubleshootingPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.GetTroubleshooting", token, client.pl, client.getTroubleshootingHandleError)
+func (l *NetworkWatchersGetTroubleshootingPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshooting", token, client.pl, client.getTroubleshootingHandleError)
 	if err != nil {
 		return err
 	}
@@ -6038,8 +6038,8 @@ func (l NetworkWatchersGetTroubleshootingResultPollerResponse) PollUntilDone(ctx
 }
 
 // Resume rehydrates a NetworkWatchersGetTroubleshootingResultPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersGetTroubleshootingResultPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.GetTroubleshootingResult", token, client.pl, client.getTroubleshootingResultHandleError)
+func (l *NetworkWatchersGetTroubleshootingResultPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshootingResult", token, client.pl, client.getTroubleshootingResultHandleError)
 	if err != nil {
 		return err
 	}
@@ -6090,8 +6090,8 @@ func (l NetworkWatchersGetVMSecurityRulesPollerResponse) PollUntilDone(ctx conte
 }
 
 // Resume rehydrates a NetworkWatchersGetVMSecurityRulesPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersGetVMSecurityRulesPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.GetVMSecurityRules", token, client.pl, client.getVMSecurityRulesHandleError)
+func (l *NetworkWatchersGetVMSecurityRulesPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetVMSecurityRules", token, client.pl, client.getVMSecurityRulesHandleError)
 	if err != nil {
 		return err
 	}
@@ -6128,7 +6128,7 @@ type NetworkWatchersListAllResponse struct {
 
 // NetworkWatchersListAllResult contains the result from method NetworkWatchers.ListAll.
 type NetworkWatchersListAllResult struct {
-	NetworkWatcherListResult
+	WatcherListResult
 }
 
 // NetworkWatchersListAvailableProvidersPollerResponse contains the response from method NetworkWatchers.ListAvailableProviders.
@@ -6154,8 +6154,8 @@ func (l NetworkWatchersListAvailableProvidersPollerResponse) PollUntilDone(ctx c
 }
 
 // Resume rehydrates a NetworkWatchersListAvailableProvidersPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersListAvailableProvidersPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.ListAvailableProviders", token, client.pl, client.listAvailableProvidersHandleError)
+func (l *NetworkWatchersListAvailableProvidersPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.ListAvailableProviders", token, client.pl, client.listAvailableProvidersHandleError)
 	if err != nil {
 		return err
 	}
@@ -6192,7 +6192,7 @@ type NetworkWatchersListResponse struct {
 
 // NetworkWatchersListResult contains the result from method NetworkWatchers.List.
 type NetworkWatchersListResult struct {
-	NetworkWatcherListResult
+	WatcherListResult
 }
 
 // NetworkWatchersSetFlowLogConfigurationPollerResponse contains the response from method NetworkWatchers.SetFlowLogConfiguration.
@@ -6218,8 +6218,8 @@ func (l NetworkWatchersSetFlowLogConfigurationPollerResponse) PollUntilDone(ctx 
 }
 
 // Resume rehydrates a NetworkWatchersSetFlowLogConfigurationPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersSetFlowLogConfigurationPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.SetFlowLogConfiguration", token, client.pl, client.setFlowLogConfigurationHandleError)
+func (l *NetworkWatchersSetFlowLogConfigurationPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.SetFlowLogConfiguration", token, client.pl, client.setFlowLogConfigurationHandleError)
 	if err != nil {
 		return err
 	}
@@ -6256,7 +6256,7 @@ type NetworkWatchersUpdateTagsResponse struct {
 
 // NetworkWatchersUpdateTagsResult contains the result from method NetworkWatchers.UpdateTags.
 type NetworkWatchersUpdateTagsResult struct {
-	NetworkWatcher
+	Watcher
 }
 
 // NetworkWatchersVerifyIPFlowPollerResponse contains the response from method NetworkWatchers.VerifyIPFlow.
@@ -6282,8 +6282,8 @@ func (l NetworkWatchersVerifyIPFlowPollerResponse) PollUntilDone(ctx context.Con
 }
 
 // Resume rehydrates a NetworkWatchersVerifyIPFlowPollerResponse from the provided client and resume token.
-func (l *NetworkWatchersVerifyIPFlowPollerResponse) Resume(ctx context.Context, client *NetworkWatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NetworkWatchersClient.VerifyIPFlow", token, client.pl, client.verifyIPFlowHandleError)
+func (l *NetworkWatchersVerifyIPFlowPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
+	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.VerifyIPFlow", token, client.pl, client.verifyIPFlowHandleError)
 	if err != nil {
 		return err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitygroups_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkSecurityGroupsClient contains the methods for the NetworkSecurityGroups group.
-// Don't use this type directly, use NewNetworkSecurityGroupsClient() instead.
-type NetworkSecurityGroupsClient struct {
+// SecurityGroupsClient contains the methods for the NetworkSecurityGroups group.
+// Don't use this type directly, use NewSecurityGroupsClient() instead.
+type SecurityGroupsClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkSecurityGroupsClient creates a new instance of NetworkSecurityGroupsClient with the specified values.
+// NewSecurityGroupsClient creates a new instance of SecurityGroupsClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkSecurityGroupsClient {
+func NewSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *SecurityGroupsClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkSecurityGroupsClient(subscriptionID string, credential azcore.Tok
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkSecurityGroupsClient{
+	client := &SecurityGroupsClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -56,9 +56,9 @@ func NewNetworkSecurityGroupsClient(subscriptionID string, credential azcore.Tok
 // resourceGroupName - The name of the resource group.
 // networkSecurityGroupName - The name of the network security group.
 // parameters - Parameters supplied to the create or update network security group operation.
-// options - NetworkSecurityGroupsBeginCreateOrUpdateOptions contains the optional parameters for the NetworkSecurityGroupsClient.BeginCreateOrUpdate
+// options - NetworkSecurityGroupsBeginCreateOrUpdateOptions contains the optional parameters for the SecurityGroupsClient.BeginCreateOrUpdate
 // method.
-func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup, options *NetworkSecurityGroupsBeginCreateOrUpdateOptions) (NetworkSecurityGroupsCreateOrUpdatePollerResponse, error) {
+func (client *SecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, options *NetworkSecurityGroupsBeginCreateOrUpdateOptions) (NetworkSecurityGroupsCreateOrUpdatePollerResponse, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkSecurityGroupName, parameters, options)
 	if err != nil {
 		return NetworkSecurityGroupsCreateOrUpdatePollerResponse{}, err
@@ -66,7 +66,7 @@ func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Conte
 	result := NetworkSecurityGroupsCreateOrUpdatePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkSecurityGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl, client.createOrUpdateHandleError)
+	pt, err := armruntime.NewPoller("SecurityGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl, client.createOrUpdateHandleError)
 	if err != nil {
 		return NetworkSecurityGroupsCreateOrUpdatePollerResponse{}, err
 	}
@@ -78,7 +78,7 @@ func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Conte
 
 // CreateOrUpdate - Creates or updates a network security group in the specified resource group.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkSecurityGroupsClient) createOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup, options *NetworkSecurityGroupsBeginCreateOrUpdateOptions) (*http.Response, error) {
+func (client *SecurityGroupsClient) createOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, options *NetworkSecurityGroupsBeginCreateOrUpdateOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (client *NetworkSecurityGroupsClient) createOrUpdate(ctx context.Context, r
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkSecurityGroupsClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup, options *NetworkSecurityGroupsBeginCreateOrUpdateOptions) (*policy.Request, error) {
+func (client *SecurityGroupsClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, options *NetworkSecurityGroupsBeginCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -120,7 +120,7 @@ func (client *NetworkSecurityGroupsClient) createOrUpdateCreateRequest(ctx conte
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
-func (client *NetworkSecurityGroupsClient) createOrUpdateHandleError(resp *http.Response) error {
+func (client *SecurityGroupsClient) createOrUpdateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -136,9 +136,9 @@ func (client *NetworkSecurityGroupsClient) createOrUpdateHandleError(resp *http.
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkSecurityGroupName - The name of the network security group.
-// options - NetworkSecurityGroupsBeginDeleteOptions contains the optional parameters for the NetworkSecurityGroupsClient.BeginDelete
+// options - NetworkSecurityGroupsBeginDeleteOptions contains the optional parameters for the SecurityGroupsClient.BeginDelete
 // method.
-func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsBeginDeleteOptions) (NetworkSecurityGroupsDeletePollerResponse, error) {
+func (client *SecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsBeginDeleteOptions) (NetworkSecurityGroupsDeletePollerResponse, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkSecurityGroupName, options)
 	if err != nil {
 		return NetworkSecurityGroupsDeletePollerResponse{}, err
@@ -146,7 +146,7 @@ func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, reso
 	result := NetworkSecurityGroupsDeletePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkSecurityGroupsClient.Delete", "location", resp, client.pl, client.deleteHandleError)
+	pt, err := armruntime.NewPoller("SecurityGroupsClient.Delete", "location", resp, client.pl, client.deleteHandleError)
 	if err != nil {
 		return NetworkSecurityGroupsDeletePollerResponse{}, err
 	}
@@ -158,7 +158,7 @@ func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, reso
 
 // Delete - Deletes the specified network security group.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkSecurityGroupsClient) deleteOperation(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsBeginDeleteOptions) (*http.Response, error) {
+func (client *SecurityGroupsClient) deleteOperation(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsBeginDeleteOptions) (*http.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, options)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func (client *NetworkSecurityGroupsClient) deleteOperation(ctx context.Context, 
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *NetworkSecurityGroupsClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsBeginDeleteOptions) (*policy.Request, error) {
+func (client *SecurityGroupsClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -200,7 +200,7 @@ func (client *NetworkSecurityGroupsClient) deleteCreateRequest(ctx context.Conte
 }
 
 // deleteHandleError handles the Delete error response.
-func (client *NetworkSecurityGroupsClient) deleteHandleError(resp *http.Response) error {
+func (client *SecurityGroupsClient) deleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -216,8 +216,8 @@ func (client *NetworkSecurityGroupsClient) deleteHandleError(resp *http.Response
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkSecurityGroupName - The name of the network security group.
-// options - NetworkSecurityGroupsGetOptions contains the optional parameters for the NetworkSecurityGroupsClient.Get method.
-func (client *NetworkSecurityGroupsClient) Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsGetOptions) (NetworkSecurityGroupsGetResponse, error) {
+// options - NetworkSecurityGroupsGetOptions contains the optional parameters for the SecurityGroupsClient.Get method.
+func (client *SecurityGroupsClient) Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsGetOptions) (NetworkSecurityGroupsGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, options)
 	if err != nil {
 		return NetworkSecurityGroupsGetResponse{}, err
@@ -233,7 +233,7 @@ func (client *NetworkSecurityGroupsClient) Get(ctx context.Context, resourceGrou
 }
 
 // getCreateRequest creates the Get request.
-func (client *NetworkSecurityGroupsClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsGetOptions) (*policy.Request, error) {
+func (client *SecurityGroupsClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -262,16 +262,16 @@ func (client *NetworkSecurityGroupsClient) getCreateRequest(ctx context.Context,
 }
 
 // getHandleResponse handles the Get response.
-func (client *NetworkSecurityGroupsClient) getHandleResponse(resp *http.Response) (NetworkSecurityGroupsGetResponse, error) {
+func (client *SecurityGroupsClient) getHandleResponse(resp *http.Response) (NetworkSecurityGroupsGetResponse, error) {
 	result := NetworkSecurityGroupsGetResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSecurityGroup); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityGroup); err != nil {
 		return NetworkSecurityGroupsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getHandleError handles the Get error response.
-func (client *NetworkSecurityGroupsClient) getHandleError(resp *http.Response) error {
+func (client *SecurityGroupsClient) getHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -286,21 +286,21 @@ func (client *NetworkSecurityGroupsClient) getHandleError(resp *http.Response) e
 // List - Gets all network security groups in a resource group.
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
-// options - NetworkSecurityGroupsListOptions contains the optional parameters for the NetworkSecurityGroupsClient.List method.
-func (client *NetworkSecurityGroupsClient) List(resourceGroupName string, options *NetworkSecurityGroupsListOptions) *NetworkSecurityGroupsListPager {
+// options - NetworkSecurityGroupsListOptions contains the optional parameters for the SecurityGroupsClient.List method.
+func (client *SecurityGroupsClient) List(resourceGroupName string, options *NetworkSecurityGroupsListOptions) *NetworkSecurityGroupsListPager {
 	return &NetworkSecurityGroupsListPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, resourceGroupName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkSecurityGroupsListResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkSecurityGroupListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.SecurityGroupListResult.NextLink)
 		},
 	}
 }
 
 // listCreateRequest creates the List request.
-func (client *NetworkSecurityGroupsClient) listCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkSecurityGroupsListOptions) (*policy.Request, error) {
+func (client *SecurityGroupsClient) listCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkSecurityGroupsListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -322,16 +322,16 @@ func (client *NetworkSecurityGroupsClient) listCreateRequest(ctx context.Context
 }
 
 // listHandleResponse handles the List response.
-func (client *NetworkSecurityGroupsClient) listHandleResponse(resp *http.Response) (NetworkSecurityGroupsListResponse, error) {
+func (client *SecurityGroupsClient) listHandleResponse(resp *http.Response) (NetworkSecurityGroupsListResponse, error) {
 	result := NetworkSecurityGroupsListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSecurityGroupListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityGroupListResult); err != nil {
 		return NetworkSecurityGroupsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *NetworkSecurityGroupsClient) listHandleError(resp *http.Response) error {
+func (client *SecurityGroupsClient) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -345,22 +345,21 @@ func (client *NetworkSecurityGroupsClient) listHandleError(resp *http.Response) 
 
 // ListAll - Gets all network security groups in a subscription.
 // If the operation fails it returns the *CloudError error type.
-// options - NetworkSecurityGroupsListAllOptions contains the optional parameters for the NetworkSecurityGroupsClient.ListAll
-// method.
-func (client *NetworkSecurityGroupsClient) ListAll(options *NetworkSecurityGroupsListAllOptions) *NetworkSecurityGroupsListAllPager {
+// options - NetworkSecurityGroupsListAllOptions contains the optional parameters for the SecurityGroupsClient.ListAll method.
+func (client *SecurityGroupsClient) ListAll(options *NetworkSecurityGroupsListAllOptions) *NetworkSecurityGroupsListAllPager {
 	return &NetworkSecurityGroupsListAllPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listAllCreateRequest(ctx, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkSecurityGroupsListAllResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkSecurityGroupListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.SecurityGroupListResult.NextLink)
 		},
 	}
 }
 
 // listAllCreateRequest creates the ListAll request.
-func (client *NetworkSecurityGroupsClient) listAllCreateRequest(ctx context.Context, options *NetworkSecurityGroupsListAllOptions) (*policy.Request, error) {
+func (client *SecurityGroupsClient) listAllCreateRequest(ctx context.Context, options *NetworkSecurityGroupsListAllOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityGroups"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -378,16 +377,16 @@ func (client *NetworkSecurityGroupsClient) listAllCreateRequest(ctx context.Cont
 }
 
 // listAllHandleResponse handles the ListAll response.
-func (client *NetworkSecurityGroupsClient) listAllHandleResponse(resp *http.Response) (NetworkSecurityGroupsListAllResponse, error) {
+func (client *SecurityGroupsClient) listAllHandleResponse(resp *http.Response) (NetworkSecurityGroupsListAllResponse, error) {
 	result := NetworkSecurityGroupsListAllResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSecurityGroupListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityGroupListResult); err != nil {
 		return NetworkSecurityGroupsListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listAllHandleError handles the ListAll error response.
-func (client *NetworkSecurityGroupsClient) listAllHandleError(resp *http.Response) error {
+func (client *SecurityGroupsClient) listAllHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -404,9 +403,9 @@ func (client *NetworkSecurityGroupsClient) listAllHandleError(resp *http.Respons
 // resourceGroupName - The name of the resource group.
 // networkSecurityGroupName - The name of the network security group.
 // parameters - Parameters supplied to update network security group tags.
-// options - NetworkSecurityGroupsUpdateTagsOptions contains the optional parameters for the NetworkSecurityGroupsClient.UpdateTags
+// options - NetworkSecurityGroupsUpdateTagsOptions contains the optional parameters for the SecurityGroupsClient.UpdateTags
 // method.
-func (client *NetworkSecurityGroupsClient) UpdateTags(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject, options *NetworkSecurityGroupsUpdateTagsOptions) (NetworkSecurityGroupsUpdateTagsResponse, error) {
+func (client *SecurityGroupsClient) UpdateTags(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject, options *NetworkSecurityGroupsUpdateTagsOptions) (NetworkSecurityGroupsUpdateTagsResponse, error) {
 	req, err := client.updateTagsCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, parameters, options)
 	if err != nil {
 		return NetworkSecurityGroupsUpdateTagsResponse{}, err
@@ -422,7 +421,7 @@ func (client *NetworkSecurityGroupsClient) UpdateTags(ctx context.Context, resou
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkSecurityGroupsClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject, options *NetworkSecurityGroupsUpdateTagsOptions) (*policy.Request, error) {
+func (client *SecurityGroupsClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject, options *NetworkSecurityGroupsUpdateTagsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -448,16 +447,16 @@ func (client *NetworkSecurityGroupsClient) updateTagsCreateRequest(ctx context.C
 }
 
 // updateTagsHandleResponse handles the UpdateTags response.
-func (client *NetworkSecurityGroupsClient) updateTagsHandleResponse(resp *http.Response) (NetworkSecurityGroupsUpdateTagsResponse, error) {
+func (client *SecurityGroupsClient) updateTagsHandleResponse(resp *http.Response) (NetworkSecurityGroupsUpdateTagsResponse, error) {
 	result := NetworkSecurityGroupsUpdateTagsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSecurityGroup); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityGroup); err != nil {
 		return NetworkSecurityGroupsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.
-func (client *NetworkSecurityGroupsClient) updateTagsHandleError(resp *http.Response) error {
+func (client *SecurityGroupsClient) updateTagsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualappliances_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkVirtualAppliancesClient contains the methods for the NetworkVirtualAppliances group.
-// Don't use this type directly, use NewNetworkVirtualAppliancesClient() instead.
-type NetworkVirtualAppliancesClient struct {
+// VirtualAppliancesClient contains the methods for the NetworkVirtualAppliances group.
+// Don't use this type directly, use NewVirtualAppliancesClient() instead.
+type VirtualAppliancesClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkVirtualAppliancesClient creates a new instance of NetworkVirtualAppliancesClient with the specified values.
+// NewVirtualAppliancesClient creates a new instance of VirtualAppliancesClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkVirtualAppliancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkVirtualAppliancesClient {
+func NewVirtualAppliancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *VirtualAppliancesClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkVirtualAppliancesClient(subscriptionID string, credential azcore.
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkVirtualAppliancesClient{
+	client := &VirtualAppliancesClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -56,9 +56,9 @@ func NewNetworkVirtualAppliancesClient(subscriptionID string, credential azcore.
 // resourceGroupName - The name of the resource group.
 // networkVirtualApplianceName - The name of Network Virtual Appliance.
 // parameters - Parameters supplied to the create or update Network Virtual Appliance.
-// options - NetworkVirtualAppliancesBeginCreateOrUpdateOptions contains the optional parameters for the NetworkVirtualAppliancesClient.BeginCreateOrUpdate
+// options - NetworkVirtualAppliancesBeginCreateOrUpdateOptions contains the optional parameters for the VirtualAppliancesClient.BeginCreateOrUpdate
 // method.
-func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance, options *NetworkVirtualAppliancesBeginCreateOrUpdateOptions) (NetworkVirtualAppliancesCreateOrUpdatePollerResponse, error) {
+func (client *VirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters VirtualAppliance, options *NetworkVirtualAppliancesBeginCreateOrUpdateOptions) (NetworkVirtualAppliancesCreateOrUpdatePollerResponse, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkVirtualApplianceName, parameters, options)
 	if err != nil {
 		return NetworkVirtualAppliancesCreateOrUpdatePollerResponse{}, err
@@ -66,7 +66,7 @@ func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Co
 	result := NetworkVirtualAppliancesCreateOrUpdatePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkVirtualAppliancesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl, client.createOrUpdateHandleError)
+	pt, err := armruntime.NewPoller("VirtualAppliancesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl, client.createOrUpdateHandleError)
 	if err != nil {
 		return NetworkVirtualAppliancesCreateOrUpdatePollerResponse{}, err
 	}
@@ -78,7 +78,7 @@ func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Co
 
 // CreateOrUpdate - Creates or updates the specified Network Virtual Appliance.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkVirtualAppliancesClient) createOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance, options *NetworkVirtualAppliancesBeginCreateOrUpdateOptions) (*http.Response, error) {
+func (client *VirtualAppliancesClient) createOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters VirtualAppliance, options *NetworkVirtualAppliancesBeginCreateOrUpdateOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (client *NetworkVirtualAppliancesClient) createOrUpdate(ctx context.Context
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkVirtualAppliancesClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance, options *NetworkVirtualAppliancesBeginCreateOrUpdateOptions) (*policy.Request, error) {
+func (client *VirtualAppliancesClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters VirtualAppliance, options *NetworkVirtualAppliancesBeginCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -120,7 +120,7 @@ func (client *NetworkVirtualAppliancesClient) createOrUpdateCreateRequest(ctx co
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
-func (client *NetworkVirtualAppliancesClient) createOrUpdateHandleError(resp *http.Response) error {
+func (client *VirtualAppliancesClient) createOrUpdateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -136,9 +136,9 @@ func (client *NetworkVirtualAppliancesClient) createOrUpdateHandleError(resp *ht
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkVirtualApplianceName - The name of Network Virtual Appliance.
-// options - NetworkVirtualAppliancesBeginDeleteOptions contains the optional parameters for the NetworkVirtualAppliancesClient.BeginDelete
+// options - NetworkVirtualAppliancesBeginDeleteOptions contains the optional parameters for the VirtualAppliancesClient.BeginDelete
 // method.
-func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesBeginDeleteOptions) (NetworkVirtualAppliancesDeletePollerResponse, error) {
+func (client *VirtualAppliancesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesBeginDeleteOptions) (NetworkVirtualAppliancesDeletePollerResponse, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkVirtualApplianceName, options)
 	if err != nil {
 		return NetworkVirtualAppliancesDeletePollerResponse{}, err
@@ -146,7 +146,7 @@ func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, r
 	result := NetworkVirtualAppliancesDeletePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkVirtualAppliancesClient.Delete", "location", resp, client.pl, client.deleteHandleError)
+	pt, err := armruntime.NewPoller("VirtualAppliancesClient.Delete", "location", resp, client.pl, client.deleteHandleError)
 	if err != nil {
 		return NetworkVirtualAppliancesDeletePollerResponse{}, err
 	}
@@ -158,7 +158,7 @@ func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, r
 
 // Delete - Deletes the specified Network Virtual Appliance.
 // If the operation fails it returns the *CloudError error type.
-func (client *NetworkVirtualAppliancesClient) deleteOperation(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesBeginDeleteOptions) (*http.Response, error) {
+func (client *VirtualAppliancesClient) deleteOperation(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesBeginDeleteOptions) (*http.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, options)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func (client *NetworkVirtualAppliancesClient) deleteOperation(ctx context.Contex
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *NetworkVirtualAppliancesClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesBeginDeleteOptions) (*policy.Request, error) {
+func (client *VirtualAppliancesClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -200,7 +200,7 @@ func (client *NetworkVirtualAppliancesClient) deleteCreateRequest(ctx context.Co
 }
 
 // deleteHandleError handles the Delete error response.
-func (client *NetworkVirtualAppliancesClient) deleteHandleError(resp *http.Response) error {
+func (client *VirtualAppliancesClient) deleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -216,9 +216,8 @@ func (client *NetworkVirtualAppliancesClient) deleteHandleError(resp *http.Respo
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
 // networkVirtualApplianceName - The name of Network Virtual Appliance.
-// options - NetworkVirtualAppliancesGetOptions contains the optional parameters for the NetworkVirtualAppliancesClient.Get
-// method.
-func (client *NetworkVirtualAppliancesClient) Get(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesGetOptions) (NetworkVirtualAppliancesGetResponse, error) {
+// options - NetworkVirtualAppliancesGetOptions contains the optional parameters for the VirtualAppliancesClient.Get method.
+func (client *VirtualAppliancesClient) Get(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesGetOptions) (NetworkVirtualAppliancesGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, options)
 	if err != nil {
 		return NetworkVirtualAppliancesGetResponse{}, err
@@ -234,7 +233,7 @@ func (client *NetworkVirtualAppliancesClient) Get(ctx context.Context, resourceG
 }
 
 // getCreateRequest creates the Get request.
-func (client *NetworkVirtualAppliancesClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesGetOptions) (*policy.Request, error) {
+func (client *VirtualAppliancesClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -263,16 +262,16 @@ func (client *NetworkVirtualAppliancesClient) getCreateRequest(ctx context.Conte
 }
 
 // getHandleResponse handles the Get response.
-func (client *NetworkVirtualAppliancesClient) getHandleResponse(resp *http.Response) (NetworkVirtualAppliancesGetResponse, error) {
+func (client *VirtualAppliancesClient) getHandleResponse(resp *http.Response) (NetworkVirtualAppliancesGetResponse, error) {
 	result := NetworkVirtualAppliancesGetResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkVirtualAppliance); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualAppliance); err != nil {
 		return NetworkVirtualAppliancesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getHandleError handles the Get error response.
-func (client *NetworkVirtualAppliancesClient) getHandleError(resp *http.Response) error {
+func (client *VirtualAppliancesClient) getHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -286,22 +285,21 @@ func (client *NetworkVirtualAppliancesClient) getHandleError(resp *http.Response
 
 // List - Gets all Network Virtual Appliances in a subscription.
 // If the operation fails it returns the *CloudError error type.
-// options - NetworkVirtualAppliancesListOptions contains the optional parameters for the NetworkVirtualAppliancesClient.List
-// method.
-func (client *NetworkVirtualAppliancesClient) List(options *NetworkVirtualAppliancesListOptions) *NetworkVirtualAppliancesListPager {
+// options - NetworkVirtualAppliancesListOptions contains the optional parameters for the VirtualAppliancesClient.List method.
+func (client *VirtualAppliancesClient) List(options *NetworkVirtualAppliancesListOptions) *NetworkVirtualAppliancesListPager {
 	return &NetworkVirtualAppliancesListPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkVirtualAppliancesListResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkVirtualApplianceListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.VirtualApplianceListResult.NextLink)
 		},
 	}
 }
 
 // listCreateRequest creates the List request.
-func (client *NetworkVirtualAppliancesClient) listCreateRequest(ctx context.Context, options *NetworkVirtualAppliancesListOptions) (*policy.Request, error) {
+func (client *VirtualAppliancesClient) listCreateRequest(ctx context.Context, options *NetworkVirtualAppliancesListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkVirtualAppliances"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -319,16 +317,16 @@ func (client *NetworkVirtualAppliancesClient) listCreateRequest(ctx context.Cont
 }
 
 // listHandleResponse handles the List response.
-func (client *NetworkVirtualAppliancesClient) listHandleResponse(resp *http.Response) (NetworkVirtualAppliancesListResponse, error) {
+func (client *VirtualAppliancesClient) listHandleResponse(resp *http.Response) (NetworkVirtualAppliancesListResponse, error) {
 	result := NetworkVirtualAppliancesListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkVirtualApplianceListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualApplianceListResult); err != nil {
 		return NetworkVirtualAppliancesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *NetworkVirtualAppliancesClient) listHandleError(resp *http.Response) error {
+func (client *VirtualAppliancesClient) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -343,22 +341,22 @@ func (client *NetworkVirtualAppliancesClient) listHandleError(resp *http.Respons
 // ListByResourceGroup - Lists all Network Virtual Appliances in a resource group.
 // If the operation fails it returns the *CloudError error type.
 // resourceGroupName - The name of the resource group.
-// options - NetworkVirtualAppliancesListByResourceGroupOptions contains the optional parameters for the NetworkVirtualAppliancesClient.ListByResourceGroup
+// options - NetworkVirtualAppliancesListByResourceGroupOptions contains the optional parameters for the VirtualAppliancesClient.ListByResourceGroup
 // method.
-func (client *NetworkVirtualAppliancesClient) ListByResourceGroup(resourceGroupName string, options *NetworkVirtualAppliancesListByResourceGroupOptions) *NetworkVirtualAppliancesListByResourceGroupPager {
+func (client *VirtualAppliancesClient) ListByResourceGroup(resourceGroupName string, options *NetworkVirtualAppliancesListByResourceGroupOptions) *NetworkVirtualAppliancesListByResourceGroupPager {
 	return &NetworkVirtualAppliancesListByResourceGroupPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
 			return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		advancer: func(ctx context.Context, resp NetworkVirtualAppliancesListByResourceGroupResponse) (*policy.Request, error) {
-			return runtime.NewRequest(ctx, http.MethodGet, *resp.NetworkVirtualApplianceListResult.NextLink)
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.VirtualApplianceListResult.NextLink)
 		},
 	}
 }
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *NetworkVirtualAppliancesClient) listByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkVirtualAppliancesListByResourceGroupOptions) (*policy.Request, error) {
+func (client *VirtualAppliancesClient) listByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkVirtualAppliancesListByResourceGroupOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -380,16 +378,16 @@ func (client *NetworkVirtualAppliancesClient) listByResourceGroupCreateRequest(c
 }
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
-func (client *NetworkVirtualAppliancesClient) listByResourceGroupHandleResponse(resp *http.Response) (NetworkVirtualAppliancesListByResourceGroupResponse, error) {
+func (client *VirtualAppliancesClient) listByResourceGroupHandleResponse(resp *http.Response) (NetworkVirtualAppliancesListByResourceGroupResponse, error) {
 	result := NetworkVirtualAppliancesListByResourceGroupResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkVirtualApplianceListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualApplianceListResult); err != nil {
 		return NetworkVirtualAppliancesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
-func (client *NetworkVirtualAppliancesClient) listByResourceGroupHandleError(resp *http.Response) error {
+func (client *VirtualAppliancesClient) listByResourceGroupHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -406,9 +404,9 @@ func (client *NetworkVirtualAppliancesClient) listByResourceGroupHandleError(res
 // resourceGroupName - The resource group name of Network Virtual Appliance.
 // networkVirtualApplianceName - The name of Network Virtual Appliance being updated.
 // parameters - Parameters supplied to Update Network Virtual Appliance Tags.
-// options - NetworkVirtualAppliancesUpdateTagsOptions contains the optional parameters for the NetworkVirtualAppliancesClient.UpdateTags
+// options - NetworkVirtualAppliancesUpdateTagsOptions contains the optional parameters for the VirtualAppliancesClient.UpdateTags
 // method.
-func (client *NetworkVirtualAppliancesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject, options *NetworkVirtualAppliancesUpdateTagsOptions) (NetworkVirtualAppliancesUpdateTagsResponse, error) {
+func (client *VirtualAppliancesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject, options *NetworkVirtualAppliancesUpdateTagsOptions) (NetworkVirtualAppliancesUpdateTagsResponse, error) {
 	req, err := client.updateTagsCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, parameters, options)
 	if err != nil {
 		return NetworkVirtualAppliancesUpdateTagsResponse{}, err
@@ -424,7 +422,7 @@ func (client *NetworkVirtualAppliancesClient) UpdateTags(ctx context.Context, re
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkVirtualAppliancesClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject, options *NetworkVirtualAppliancesUpdateTagsOptions) (*policy.Request, error) {
+func (client *VirtualAppliancesClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject, options *NetworkVirtualAppliancesUpdateTagsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -450,16 +448,16 @@ func (client *NetworkVirtualAppliancesClient) updateTagsCreateRequest(ctx contex
 }
 
 // updateTagsHandleResponse handles the UpdateTags response.
-func (client *NetworkVirtualAppliancesClient) updateTagsHandleResponse(resp *http.Response) (NetworkVirtualAppliancesUpdateTagsResponse, error) {
+func (client *VirtualAppliancesClient) updateTagsHandleResponse(resp *http.Response) (NetworkVirtualAppliancesUpdateTagsResponse, error) {
 	result := NetworkVirtualAppliancesUpdateTagsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkVirtualAppliance); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualAppliance); err != nil {
 		return NetworkVirtualAppliancesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.
-func (client *NetworkVirtualAppliancesClient) updateTagsHandleError(resp *http.Response) error {
+func (client *VirtualAppliancesClient) updateTagsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 )
 
-// NetworkWatchersClient contains the methods for the NetworkWatchers group.
-// Don't use this type directly, use NewNetworkWatchersClient() instead.
-type NetworkWatchersClient struct {
+// WatchersClient contains the methods for the NetworkWatchers group.
+// Don't use this type directly, use NewWatchersClient() instead.
+type WatchersClient struct {
 	host           string
 	subscriptionID string
 	pl             runtime.Pipeline
 }
 
-// NewNetworkWatchersClient creates a new instance of NetworkWatchersClient with the specified values.
+// NewWatchersClient creates a new instance of WatchersClient with the specified values.
 // subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 // ID forms part of the URI for every service call.
 // credential - used to authorize requests. Usually a credential from azidentity.
 // options - pass nil to accept the default values.
-func NewNetworkWatchersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *NetworkWatchersClient {
+func NewWatchersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) *WatchersClient {
 	cp := arm.ClientOptions{}
 	if options != nil {
 		cp = *options
@@ -43,7 +43,7 @@ func NewNetworkWatchersClient(subscriptionID string, credential azcore.TokenCred
 	if len(cp.Host) == 0 {
 		cp.Host = arm.AzurePublicCloud
 	}
-	client := &NetworkWatchersClient{
+	client := &WatchersClient{
 		subscriptionID: subscriptionID,
 		host:           string(cp.Host),
 		pl:             armruntime.NewPipeline(module, version, credential, &cp),
@@ -57,9 +57,9 @@ func NewNetworkWatchersClient(subscriptionID string, credential azcore.TokenCred
 // resourceGroupName - The name of the network watcher resource group.
 // networkWatcherName - The name of the network watcher resource.
 // parameters - Parameters that determine how the connectivity check will be performed.
-// options - NetworkWatchersBeginCheckConnectivityOptions contains the optional parameters for the NetworkWatchersClient.BeginCheckConnectivity
+// options - NetworkWatchersBeginCheckConnectivityOptions contains the optional parameters for the WatchersClient.BeginCheckConnectivity
 // method.
-func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersBeginCheckConnectivityOptions) (NetworkWatchersCheckConnectivityPollerResponse, error) {
+func (client *WatchersClient) BeginCheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersBeginCheckConnectivityOptions) (NetworkWatchersCheckConnectivityPollerResponse, error) {
 	resp, err := client.checkConnectivity(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersCheckConnectivityPollerResponse{}, err
@@ -67,7 +67,7 @@ func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context,
 	result := NetworkWatchersCheckConnectivityPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.CheckConnectivity", "location", resp, client.pl, client.checkConnectivityHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.CheckConnectivity", "location", resp, client.pl, client.checkConnectivityHandleError)
 	if err != nil {
 		return NetworkWatchersCheckConnectivityPollerResponse{}, err
 	}
@@ -80,7 +80,7 @@ func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context,
 // CheckConnectivity - Verifies the possibility of establishing a direct TCP connection from a virtual machine to a given
 // endpoint including another VM or an arbitrary remote server.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) checkConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersBeginCheckConnectivityOptions) (*http.Response, error) {
+func (client *WatchersClient) checkConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersBeginCheckConnectivityOptions) (*http.Response, error) {
 	req, err := client.checkConnectivityCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (client *NetworkWatchersClient) checkConnectivity(ctx context.Context, reso
 }
 
 // checkConnectivityCreateRequest creates the CheckConnectivity request.
-func (client *NetworkWatchersClient) checkConnectivityCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersBeginCheckConnectivityOptions) (*policy.Request, error) {
+func (client *WatchersClient) checkConnectivityCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersBeginCheckConnectivityOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectivityCheck"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -122,7 +122,7 @@ func (client *NetworkWatchersClient) checkConnectivityCreateRequest(ctx context.
 }
 
 // checkConnectivityHandleError handles the CheckConnectivity error response.
-func (client *NetworkWatchersClient) checkConnectivityHandleError(resp *http.Response) error {
+func (client *WatchersClient) checkConnectivityHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -139,9 +139,8 @@ func (client *NetworkWatchersClient) checkConnectivityHandleError(resp *http.Res
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
 // parameters - Parameters that define the network watcher resource.
-// options - NetworkWatchersCreateOrUpdateOptions contains the optional parameters for the NetworkWatchersClient.CreateOrUpdate
-// method.
-func (client *NetworkWatchersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkWatcher, options *NetworkWatchersCreateOrUpdateOptions) (NetworkWatchersCreateOrUpdateResponse, error) {
+// options - NetworkWatchersCreateOrUpdateOptions contains the optional parameters for the WatchersClient.CreateOrUpdate method.
+func (client *WatchersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters Watcher, options *NetworkWatchersCreateOrUpdateOptions) (NetworkWatchersCreateOrUpdateResponse, error) {
 	req, err := client.createOrUpdateCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersCreateOrUpdateResponse{}, err
@@ -157,7 +156,7 @@ func (client *NetworkWatchersClient) CreateOrUpdate(ctx context.Context, resourc
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkWatchersClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkWatcher, options *NetworkWatchersCreateOrUpdateOptions) (*policy.Request, error) {
+func (client *WatchersClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters Watcher, options *NetworkWatchersCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -183,16 +182,16 @@ func (client *NetworkWatchersClient) createOrUpdateCreateRequest(ctx context.Con
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *NetworkWatchersClient) createOrUpdateHandleResponse(resp *http.Response) (NetworkWatchersCreateOrUpdateResponse, error) {
+func (client *WatchersClient) createOrUpdateHandleResponse(resp *http.Response) (NetworkWatchersCreateOrUpdateResponse, error) {
 	result := NetworkWatchersCreateOrUpdateResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcher); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Watcher); err != nil {
 		return NetworkWatchersCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
-func (client *NetworkWatchersClient) createOrUpdateHandleError(resp *http.Response) error {
+func (client *WatchersClient) createOrUpdateHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -208,9 +207,8 @@ func (client *NetworkWatchersClient) createOrUpdateHandleError(resp *http.Respon
 // If the operation fails it returns the *ErrorResponse error type.
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
-// options - NetworkWatchersBeginDeleteOptions contains the optional parameters for the NetworkWatchersClient.BeginDelete
-// method.
-func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersBeginDeleteOptions) (NetworkWatchersDeletePollerResponse, error) {
+// options - NetworkWatchersBeginDeleteOptions contains the optional parameters for the WatchersClient.BeginDelete method.
+func (client *WatchersClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersBeginDeleteOptions) (NetworkWatchersDeletePollerResponse, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
 		return NetworkWatchersDeletePollerResponse{}, err
@@ -218,7 +216,7 @@ func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGr
 	result := NetworkWatchersDeletePollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.Delete", "location", resp, client.pl, client.deleteHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.Delete", "location", resp, client.pl, client.deleteHandleError)
 	if err != nil {
 		return NetworkWatchersDeletePollerResponse{}, err
 	}
@@ -230,7 +228,7 @@ func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGr
 
 // Delete - Deletes the specified network watcher resource.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) deleteOperation(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersBeginDeleteOptions) (*http.Response, error) {
+func (client *WatchersClient) deleteOperation(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersBeginDeleteOptions) (*http.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
 		return nil, err
@@ -246,7 +244,7 @@ func (client *NetworkWatchersClient) deleteOperation(ctx context.Context, resour
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *NetworkWatchersClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersBeginDeleteOptions) (*policy.Request, error) {
+func (client *WatchersClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -272,7 +270,7 @@ func (client *NetworkWatchersClient) deleteCreateRequest(ctx context.Context, re
 }
 
 // deleteHandleError handles the Delete error response.
-func (client *NetworkWatchersClient) deleteHandleError(resp *http.Response) error {
+func (client *WatchersClient) deleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -288,8 +286,8 @@ func (client *NetworkWatchersClient) deleteHandleError(resp *http.Response) erro
 // If the operation fails it returns the *ErrorResponse error type.
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
-// options - NetworkWatchersGetOptions contains the optional parameters for the NetworkWatchersClient.Get method.
-func (client *NetworkWatchersClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersGetOptions) (NetworkWatchersGetResponse, error) {
+// options - NetworkWatchersGetOptions contains the optional parameters for the WatchersClient.Get method.
+func (client *WatchersClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersGetOptions) (NetworkWatchersGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
 		return NetworkWatchersGetResponse{}, err
@@ -305,7 +303,7 @@ func (client *NetworkWatchersClient) Get(ctx context.Context, resourceGroupName 
 }
 
 // getCreateRequest creates the Get request.
-func (client *NetworkWatchersClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersGetOptions) (*policy.Request, error) {
+func (client *WatchersClient) getCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -331,16 +329,16 @@ func (client *NetworkWatchersClient) getCreateRequest(ctx context.Context, resou
 }
 
 // getHandleResponse handles the Get response.
-func (client *NetworkWatchersClient) getHandleResponse(resp *http.Response) (NetworkWatchersGetResponse, error) {
+func (client *WatchersClient) getHandleResponse(resp *http.Response) (NetworkWatchersGetResponse, error) {
 	result := NetworkWatchersGetResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcher); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Watcher); err != nil {
 		return NetworkWatchersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getHandleError handles the Get error response.
-func (client *NetworkWatchersClient) getHandleError(resp *http.Response) error {
+func (client *WatchersClient) getHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -358,9 +356,9 @@ func (client *NetworkWatchersClient) getHandleError(resp *http.Response) error {
 // resourceGroupName - The name of the network watcher resource group.
 // networkWatcherName - The name of the network watcher resource.
 // parameters - Parameters that determine Azure reachability report configuration.
-// options - NetworkWatchersBeginGetAzureReachabilityReportOptions contains the optional parameters for the NetworkWatchersClient.BeginGetAzureReachabilityReport
+// options - NetworkWatchersBeginGetAzureReachabilityReportOptions contains the optional parameters for the WatchersClient.BeginGetAzureReachabilityReport
 // method.
-func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersBeginGetAzureReachabilityReportOptions) (NetworkWatchersGetAzureReachabilityReportPollerResponse, error) {
+func (client *WatchersClient) BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersBeginGetAzureReachabilityReportOptions) (NetworkWatchersGetAzureReachabilityReportPollerResponse, error) {
 	resp, err := client.getAzureReachabilityReport(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersGetAzureReachabilityReportPollerResponse{}, err
@@ -368,7 +366,7 @@ func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context
 	result := NetworkWatchersGetAzureReachabilityReportPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.GetAzureReachabilityReport", "location", resp, client.pl, client.getAzureReachabilityReportHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.GetAzureReachabilityReport", "location", resp, client.pl, client.getAzureReachabilityReportHandleError)
 	if err != nil {
 		return NetworkWatchersGetAzureReachabilityReportPollerResponse{}, err
 	}
@@ -381,7 +379,7 @@ func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context
 // GetAzureReachabilityReport - NOTE: This feature is currently in preview and still being tested for stability. Gets the
 // relative latency score for internet service providers from a specified location to Azure regions.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) getAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersBeginGetAzureReachabilityReportOptions) (*http.Response, error) {
+func (client *WatchersClient) getAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersBeginGetAzureReachabilityReportOptions) (*http.Response, error) {
 	req, err := client.getAzureReachabilityReportCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -397,7 +395,7 @@ func (client *NetworkWatchersClient) getAzureReachabilityReport(ctx context.Cont
 }
 
 // getAzureReachabilityReportCreateRequest creates the GetAzureReachabilityReport request.
-func (client *NetworkWatchersClient) getAzureReachabilityReportCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersBeginGetAzureReachabilityReportOptions) (*policy.Request, error) {
+func (client *WatchersClient) getAzureReachabilityReportCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersBeginGetAzureReachabilityReportOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/azureReachabilityReport"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -423,7 +421,7 @@ func (client *NetworkWatchersClient) getAzureReachabilityReportCreateRequest(ctx
 }
 
 // getAzureReachabilityReportHandleError handles the GetAzureReachabilityReport error response.
-func (client *NetworkWatchersClient) getAzureReachabilityReportHandleError(resp *http.Response) error {
+func (client *WatchersClient) getAzureReachabilityReportHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -440,9 +438,9 @@ func (client *NetworkWatchersClient) getAzureReachabilityReportHandleError(resp 
 // resourceGroupName - The name of the network watcher resource group.
 // networkWatcherName - The name of the network watcher resource.
 // parameters - Parameters that define a resource to query flow log and traffic analytics (optional) status.
-// options - NetworkWatchersBeginGetFlowLogStatusOptions contains the optional parameters for the NetworkWatchersClient.BeginGetFlowLogStatus
+// options - NetworkWatchersBeginGetFlowLogStatusOptions contains the optional parameters for the WatchersClient.BeginGetFlowLogStatus
 // method.
-func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersBeginGetFlowLogStatusOptions) (NetworkWatchersGetFlowLogStatusPollerResponse, error) {
+func (client *WatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersBeginGetFlowLogStatusOptions) (NetworkWatchersGetFlowLogStatusPollerResponse, error) {
 	resp, err := client.getFlowLogStatus(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersGetFlowLogStatusPollerResponse{}, err
@@ -450,7 +448,7 @@ func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, 
 	result := NetworkWatchersGetFlowLogStatusPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.GetFlowLogStatus", "location", resp, client.pl, client.getFlowLogStatusHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.GetFlowLogStatus", "location", resp, client.pl, client.getFlowLogStatusHandleError)
 	if err != nil {
 		return NetworkWatchersGetFlowLogStatusPollerResponse{}, err
 	}
@@ -462,7 +460,7 @@ func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, 
 
 // GetFlowLogStatus - Queries status of flow log and traffic analytics (optional) on a specified resource.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) getFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersBeginGetFlowLogStatusOptions) (*http.Response, error) {
+func (client *WatchersClient) getFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersBeginGetFlowLogStatusOptions) (*http.Response, error) {
 	req, err := client.getFlowLogStatusCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -478,7 +476,7 @@ func (client *NetworkWatchersClient) getFlowLogStatus(ctx context.Context, resou
 }
 
 // getFlowLogStatusCreateRequest creates the GetFlowLogStatus request.
-func (client *NetworkWatchersClient) getFlowLogStatusCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersBeginGetFlowLogStatusOptions) (*policy.Request, error) {
+func (client *WatchersClient) getFlowLogStatusCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersBeginGetFlowLogStatusOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryFlowLogStatus"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -504,7 +502,7 @@ func (client *NetworkWatchersClient) getFlowLogStatusCreateRequest(ctx context.C
 }
 
 // getFlowLogStatusHandleError handles the GetFlowLogStatus error response.
-func (client *NetworkWatchersClient) getFlowLogStatusHandleError(resp *http.Response) error {
+func (client *WatchersClient) getFlowLogStatusHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -525,9 +523,9 @@ func (client *NetworkWatchersClient) getFlowLogStatusHandleError(resp *http.Resp
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
 // parameters - Parameters to get network configuration diagnostic.
-// options - NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions contains the optional parameters for the NetworkWatchersClient.BeginGetNetworkConfigurationDiagnostic
+// options - NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions contains the optional parameters for the WatchersClient.BeginGetNetworkConfigurationDiagnostic
 // method.
-func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters, options *NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions) (NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse, error) {
+func (client *WatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConfigurationDiagnosticParameters, options *NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions) (NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse, error) {
 	resp, err := client.getNetworkConfigurationDiagnostic(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse{}, err
@@ -535,7 +533,7 @@ func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx 
 	result := NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.GetNetworkConfigurationDiagnostic", "location", resp, client.pl, client.getNetworkConfigurationDiagnosticHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.GetNetworkConfigurationDiagnostic", "location", resp, client.pl, client.getNetworkConfigurationDiagnosticHandleError)
 	if err != nil {
 		return NetworkWatchersGetNetworkConfigurationDiagnosticPollerResponse{}, err
 	}
@@ -551,7 +549,7 @@ func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx 
 // The API returns whether traffic was allowed or denied, the rules evaluated for
 // the specified flow and the evaluation results.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) getNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters, options *NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions) (*http.Response, error) {
+func (client *WatchersClient) getNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConfigurationDiagnosticParameters, options *NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions) (*http.Response, error) {
 	req, err := client.getNetworkConfigurationDiagnosticCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -567,7 +565,7 @@ func (client *NetworkWatchersClient) getNetworkConfigurationDiagnostic(ctx conte
 }
 
 // getNetworkConfigurationDiagnosticCreateRequest creates the GetNetworkConfigurationDiagnostic request.
-func (client *NetworkWatchersClient) getNetworkConfigurationDiagnosticCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters, options *NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions) (*policy.Request, error) {
+func (client *WatchersClient) getNetworkConfigurationDiagnosticCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConfigurationDiagnosticParameters, options *NetworkWatchersBeginGetNetworkConfigurationDiagnosticOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/networkConfigurationDiagnostic"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -593,7 +591,7 @@ func (client *NetworkWatchersClient) getNetworkConfigurationDiagnosticCreateRequ
 }
 
 // getNetworkConfigurationDiagnosticHandleError handles the GetNetworkConfigurationDiagnostic error response.
-func (client *NetworkWatchersClient) getNetworkConfigurationDiagnosticHandleError(resp *http.Response) error {
+func (client *WatchersClient) getNetworkConfigurationDiagnosticHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -610,9 +608,9 @@ func (client *NetworkWatchersClient) getNetworkConfigurationDiagnosticHandleErro
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
 // parameters - Parameters that define the source and destination endpoint.
-// options - NetworkWatchersBeginGetNextHopOptions contains the optional parameters for the NetworkWatchersClient.BeginGetNextHop
+// options - NetworkWatchersBeginGetNextHopOptions contains the optional parameters for the WatchersClient.BeginGetNextHop
 // method.
-func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersBeginGetNextHopOptions) (NetworkWatchersGetNextHopPollerResponse, error) {
+func (client *WatchersClient) BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersBeginGetNextHopOptions) (NetworkWatchersGetNextHopPollerResponse, error) {
 	resp, err := client.getNextHop(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersGetNextHopPollerResponse{}, err
@@ -620,7 +618,7 @@ func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resour
 	result := NetworkWatchersGetNextHopPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.GetNextHop", "location", resp, client.pl, client.getNextHopHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.GetNextHop", "location", resp, client.pl, client.getNextHopHandleError)
 	if err != nil {
 		return NetworkWatchersGetNextHopPollerResponse{}, err
 	}
@@ -632,7 +630,7 @@ func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resour
 
 // GetNextHop - Gets the next hop from the specified VM.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) getNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersBeginGetNextHopOptions) (*http.Response, error) {
+func (client *WatchersClient) getNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersBeginGetNextHopOptions) (*http.Response, error) {
 	req, err := client.getNextHopCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -648,7 +646,7 @@ func (client *NetworkWatchersClient) getNextHop(ctx context.Context, resourceGro
 }
 
 // getNextHopCreateRequest creates the GetNextHop request.
-func (client *NetworkWatchersClient) getNextHopCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersBeginGetNextHopOptions) (*policy.Request, error) {
+func (client *WatchersClient) getNextHopCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersBeginGetNextHopOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/nextHop"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -674,7 +672,7 @@ func (client *NetworkWatchersClient) getNextHopCreateRequest(ctx context.Context
 }
 
 // getNextHopHandleError handles the GetNextHop error response.
-func (client *NetworkWatchersClient) getNextHopHandleError(resp *http.Response) error {
+func (client *WatchersClient) getNextHopHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -691,9 +689,8 @@ func (client *NetworkWatchersClient) getNextHopHandleError(resp *http.Response) 
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
 // parameters - Parameters that define the representation of topology.
-// options - NetworkWatchersGetTopologyOptions contains the optional parameters for the NetworkWatchersClient.GetTopology
-// method.
-func (client *NetworkWatchersClient) GetTopology(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters, options *NetworkWatchersGetTopologyOptions) (NetworkWatchersGetTopologyResponse, error) {
+// options - NetworkWatchersGetTopologyOptions contains the optional parameters for the WatchersClient.GetTopology method.
+func (client *WatchersClient) GetTopology(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters, options *NetworkWatchersGetTopologyOptions) (NetworkWatchersGetTopologyResponse, error) {
 	req, err := client.getTopologyCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersGetTopologyResponse{}, err
@@ -709,7 +706,7 @@ func (client *NetworkWatchersClient) GetTopology(ctx context.Context, resourceGr
 }
 
 // getTopologyCreateRequest creates the GetTopology request.
-func (client *NetworkWatchersClient) getTopologyCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters, options *NetworkWatchersGetTopologyOptions) (*policy.Request, error) {
+func (client *WatchersClient) getTopologyCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters, options *NetworkWatchersGetTopologyOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/topology"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -735,7 +732,7 @@ func (client *NetworkWatchersClient) getTopologyCreateRequest(ctx context.Contex
 }
 
 // getTopologyHandleResponse handles the GetTopology response.
-func (client *NetworkWatchersClient) getTopologyHandleResponse(resp *http.Response) (NetworkWatchersGetTopologyResponse, error) {
+func (client *WatchersClient) getTopologyHandleResponse(resp *http.Response) (NetworkWatchersGetTopologyResponse, error) {
 	result := NetworkWatchersGetTopologyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Topology); err != nil {
 		return NetworkWatchersGetTopologyResponse{}, runtime.NewResponseError(err, resp)
@@ -744,7 +741,7 @@ func (client *NetworkWatchersClient) getTopologyHandleResponse(resp *http.Respon
 }
 
 // getTopologyHandleError handles the GetTopology error response.
-func (client *NetworkWatchersClient) getTopologyHandleError(resp *http.Response) error {
+func (client *WatchersClient) getTopologyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -761,9 +758,9 @@ func (client *NetworkWatchersClient) getTopologyHandleError(resp *http.Response)
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher resource.
 // parameters - Parameters that define the resource to troubleshoot.
-// options - NetworkWatchersBeginGetTroubleshootingOptions contains the optional parameters for the NetworkWatchersClient.BeginGetTroubleshooting
+// options - NetworkWatchersBeginGetTroubleshootingOptions contains the optional parameters for the WatchersClient.BeginGetTroubleshooting
 // method.
-func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingOptions) (NetworkWatchersGetTroubleshootingPollerResponse, error) {
+func (client *WatchersClient) BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingOptions) (NetworkWatchersGetTroubleshootingPollerResponse, error) {
 	resp, err := client.getTroubleshooting(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersGetTroubleshootingPollerResponse{}, err
@@ -771,7 +768,7 @@ func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context
 	result := NetworkWatchersGetTroubleshootingPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.GetTroubleshooting", "location", resp, client.pl, client.getTroubleshootingHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.GetTroubleshooting", "location", resp, client.pl, client.getTroubleshootingHandleError)
 	if err != nil {
 		return NetworkWatchersGetTroubleshootingPollerResponse{}, err
 	}
@@ -783,7 +780,7 @@ func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context
 
 // GetTroubleshooting - Initiate troubleshooting on a specified resource.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) getTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingOptions) (*http.Response, error) {
+func (client *WatchersClient) getTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingOptions) (*http.Response, error) {
 	req, err := client.getTroubleshootingCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -799,7 +796,7 @@ func (client *NetworkWatchersClient) getTroubleshooting(ctx context.Context, res
 }
 
 // getTroubleshootingCreateRequest creates the GetTroubleshooting request.
-func (client *NetworkWatchersClient) getTroubleshootingCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingOptions) (*policy.Request, error) {
+func (client *WatchersClient) getTroubleshootingCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/troubleshoot"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -825,7 +822,7 @@ func (client *NetworkWatchersClient) getTroubleshootingCreateRequest(ctx context
 }
 
 // getTroubleshootingHandleError handles the GetTroubleshooting error response.
-func (client *NetworkWatchersClient) getTroubleshootingHandleError(resp *http.Response) error {
+func (client *WatchersClient) getTroubleshootingHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -842,9 +839,9 @@ func (client *NetworkWatchersClient) getTroubleshootingHandleError(resp *http.Re
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher resource.
 // parameters - Parameters that define the resource to query the troubleshooting result.
-// options - NetworkWatchersBeginGetTroubleshootingResultOptions contains the optional parameters for the NetworkWatchersClient.BeginGetTroubleshootingResult
+// options - NetworkWatchersBeginGetTroubleshootingResultOptions contains the optional parameters for the WatchersClient.BeginGetTroubleshootingResult
 // method.
-func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingResultOptions) (NetworkWatchersGetTroubleshootingResultPollerResponse, error) {
+func (client *WatchersClient) BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingResultOptions) (NetworkWatchersGetTroubleshootingResultPollerResponse, error) {
 	resp, err := client.getTroubleshootingResult(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersGetTroubleshootingResultPollerResponse{}, err
@@ -852,7 +849,7 @@ func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.C
 	result := NetworkWatchersGetTroubleshootingResultPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.GetTroubleshootingResult", "location", resp, client.pl, client.getTroubleshootingResultHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.GetTroubleshootingResult", "location", resp, client.pl, client.getTroubleshootingResultHandleError)
 	if err != nil {
 		return NetworkWatchersGetTroubleshootingResultPollerResponse{}, err
 	}
@@ -864,7 +861,7 @@ func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.C
 
 // GetTroubleshootingResult - Get the last completed troubleshooting result on a specified resource.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) getTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingResultOptions) (*http.Response, error) {
+func (client *WatchersClient) getTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingResultOptions) (*http.Response, error) {
 	req, err := client.getTroubleshootingResultCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -880,7 +877,7 @@ func (client *NetworkWatchersClient) getTroubleshootingResult(ctx context.Contex
 }
 
 // getTroubleshootingResultCreateRequest creates the GetTroubleshootingResult request.
-func (client *NetworkWatchersClient) getTroubleshootingResultCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingResultOptions) (*policy.Request, error) {
+func (client *WatchersClient) getTroubleshootingResultCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersBeginGetTroubleshootingResultOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryTroubleshootResult"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -906,7 +903,7 @@ func (client *NetworkWatchersClient) getTroubleshootingResultCreateRequest(ctx c
 }
 
 // getTroubleshootingResultHandleError handles the GetTroubleshootingResult error response.
-func (client *NetworkWatchersClient) getTroubleshootingResultHandleError(resp *http.Response) error {
+func (client *WatchersClient) getTroubleshootingResultHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -923,9 +920,9 @@ func (client *NetworkWatchersClient) getTroubleshootingResultHandleError(resp *h
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
 // parameters - Parameters that define the VM to check security groups for.
-// options - NetworkWatchersBeginGetVMSecurityRulesOptions contains the optional parameters for the NetworkWatchersClient.BeginGetVMSecurityRules
+// options - NetworkWatchersBeginGetVMSecurityRulesOptions contains the optional parameters for the WatchersClient.BeginGetVMSecurityRules
 // method.
-func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersBeginGetVMSecurityRulesOptions) (NetworkWatchersGetVMSecurityRulesPollerResponse, error) {
+func (client *WatchersClient) BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersBeginGetVMSecurityRulesOptions) (NetworkWatchersGetVMSecurityRulesPollerResponse, error) {
 	resp, err := client.getVMSecurityRules(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersGetVMSecurityRulesPollerResponse{}, err
@@ -933,7 +930,7 @@ func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context
 	result := NetworkWatchersGetVMSecurityRulesPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.GetVMSecurityRules", "location", resp, client.pl, client.getVMSecurityRulesHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.GetVMSecurityRules", "location", resp, client.pl, client.getVMSecurityRulesHandleError)
 	if err != nil {
 		return NetworkWatchersGetVMSecurityRulesPollerResponse{}, err
 	}
@@ -945,7 +942,7 @@ func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context
 
 // GetVMSecurityRules - Gets the configured and effective security group rules on the specified VM.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) getVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersBeginGetVMSecurityRulesOptions) (*http.Response, error) {
+func (client *WatchersClient) getVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersBeginGetVMSecurityRulesOptions) (*http.Response, error) {
 	req, err := client.getVMSecurityRulesCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -961,7 +958,7 @@ func (client *NetworkWatchersClient) getVMSecurityRules(ctx context.Context, res
 }
 
 // getVMSecurityRulesCreateRequest creates the GetVMSecurityRules request.
-func (client *NetworkWatchersClient) getVMSecurityRulesCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersBeginGetVMSecurityRulesOptions) (*policy.Request, error) {
+func (client *WatchersClient) getVMSecurityRulesCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersBeginGetVMSecurityRulesOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/securityGroupView"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -987,7 +984,7 @@ func (client *NetworkWatchersClient) getVMSecurityRulesCreateRequest(ctx context
 }
 
 // getVMSecurityRulesHandleError handles the GetVMSecurityRules error response.
-func (client *NetworkWatchersClient) getVMSecurityRulesHandleError(resp *http.Response) error {
+func (client *WatchersClient) getVMSecurityRulesHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1002,8 +999,8 @@ func (client *NetworkWatchersClient) getVMSecurityRulesHandleError(resp *http.Re
 // List - Gets all network watchers by resource group.
 // If the operation fails it returns the *ErrorResponse error type.
 // resourceGroupName - The name of the resource group.
-// options - NetworkWatchersListOptions contains the optional parameters for the NetworkWatchersClient.List method.
-func (client *NetworkWatchersClient) List(ctx context.Context, resourceGroupName string, options *NetworkWatchersListOptions) (NetworkWatchersListResponse, error) {
+// options - NetworkWatchersListOptions contains the optional parameters for the WatchersClient.List method.
+func (client *WatchersClient) List(ctx context.Context, resourceGroupName string, options *NetworkWatchersListOptions) (NetworkWatchersListResponse, error) {
 	req, err := client.listCreateRequest(ctx, resourceGroupName, options)
 	if err != nil {
 		return NetworkWatchersListResponse{}, err
@@ -1019,7 +1016,7 @@ func (client *NetworkWatchersClient) List(ctx context.Context, resourceGroupName
 }
 
 // listCreateRequest creates the List request.
-func (client *NetworkWatchersClient) listCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkWatchersListOptions) (*policy.Request, error) {
+func (client *WatchersClient) listCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkWatchersListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -1041,16 +1038,16 @@ func (client *NetworkWatchersClient) listCreateRequest(ctx context.Context, reso
 }
 
 // listHandleResponse handles the List response.
-func (client *NetworkWatchersClient) listHandleResponse(resp *http.Response) (NetworkWatchersListResponse, error) {
+func (client *WatchersClient) listHandleResponse(resp *http.Response) (NetworkWatchersListResponse, error) {
 	result := NetworkWatchersListResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcherListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.WatcherListResult); err != nil {
 		return NetworkWatchersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listHandleError handles the List error response.
-func (client *NetworkWatchersClient) listHandleError(resp *http.Response) error {
+func (client *WatchersClient) listHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1064,8 +1061,8 @@ func (client *NetworkWatchersClient) listHandleError(resp *http.Response) error 
 
 // ListAll - Gets all network watchers by subscription.
 // If the operation fails it returns the *ErrorResponse error type.
-// options - NetworkWatchersListAllOptions contains the optional parameters for the NetworkWatchersClient.ListAll method.
-func (client *NetworkWatchersClient) ListAll(ctx context.Context, options *NetworkWatchersListAllOptions) (NetworkWatchersListAllResponse, error) {
+// options - NetworkWatchersListAllOptions contains the optional parameters for the WatchersClient.ListAll method.
+func (client *WatchersClient) ListAll(ctx context.Context, options *NetworkWatchersListAllOptions) (NetworkWatchersListAllResponse, error) {
 	req, err := client.listAllCreateRequest(ctx, options)
 	if err != nil {
 		return NetworkWatchersListAllResponse{}, err
@@ -1081,7 +1078,7 @@ func (client *NetworkWatchersClient) ListAll(ctx context.Context, options *Netwo
 }
 
 // listAllCreateRequest creates the ListAll request.
-func (client *NetworkWatchersClient) listAllCreateRequest(ctx context.Context, options *NetworkWatchersListAllOptions) (*policy.Request, error) {
+func (client *WatchersClient) listAllCreateRequest(ctx context.Context, options *NetworkWatchersListAllOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkWatchers"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -1099,16 +1096,16 @@ func (client *NetworkWatchersClient) listAllCreateRequest(ctx context.Context, o
 }
 
 // listAllHandleResponse handles the ListAll response.
-func (client *NetworkWatchersClient) listAllHandleResponse(resp *http.Response) (NetworkWatchersListAllResponse, error) {
+func (client *WatchersClient) listAllHandleResponse(resp *http.Response) (NetworkWatchersListAllResponse, error) {
 	result := NetworkWatchersListAllResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcherListResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.WatcherListResult); err != nil {
 		return NetworkWatchersListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // listAllHandleError handles the ListAll error response.
-func (client *NetworkWatchersClient) listAllHandleError(resp *http.Response) error {
+func (client *WatchersClient) listAllHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1126,9 +1123,9 @@ func (client *NetworkWatchersClient) listAllHandleError(resp *http.Response) err
 // resourceGroupName - The name of the network watcher resource group.
 // networkWatcherName - The name of the network watcher resource.
 // parameters - Parameters that scope the list of available providers.
-// options - NetworkWatchersBeginListAvailableProvidersOptions contains the optional parameters for the NetworkWatchersClient.BeginListAvailableProviders
+// options - NetworkWatchersBeginListAvailableProvidersOptions contains the optional parameters for the WatchersClient.BeginListAvailableProviders
 // method.
-func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersBeginListAvailableProvidersOptions) (NetworkWatchersListAvailableProvidersPollerResponse, error) {
+func (client *WatchersClient) BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersBeginListAvailableProvidersOptions) (NetworkWatchersListAvailableProvidersPollerResponse, error) {
 	resp, err := client.listAvailableProviders(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersListAvailableProvidersPollerResponse{}, err
@@ -1136,7 +1133,7 @@ func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Con
 	result := NetworkWatchersListAvailableProvidersPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.ListAvailableProviders", "location", resp, client.pl, client.listAvailableProvidersHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.ListAvailableProviders", "location", resp, client.pl, client.listAvailableProvidersHandleError)
 	if err != nil {
 		return NetworkWatchersListAvailableProvidersPollerResponse{}, err
 	}
@@ -1149,7 +1146,7 @@ func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Con
 // ListAvailableProviders - NOTE: This feature is currently in preview and still being tested for stability. Lists all available
 // internet service providers for a specified Azure region.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) listAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersBeginListAvailableProvidersOptions) (*http.Response, error) {
+func (client *WatchersClient) listAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersBeginListAvailableProvidersOptions) (*http.Response, error) {
 	req, err := client.listAvailableProvidersCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -1165,7 +1162,7 @@ func (client *NetworkWatchersClient) listAvailableProviders(ctx context.Context,
 }
 
 // listAvailableProvidersCreateRequest creates the ListAvailableProviders request.
-func (client *NetworkWatchersClient) listAvailableProvidersCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersBeginListAvailableProvidersOptions) (*policy.Request, error) {
+func (client *WatchersClient) listAvailableProvidersCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersBeginListAvailableProvidersOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/availableProvidersList"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -1191,7 +1188,7 @@ func (client *NetworkWatchersClient) listAvailableProvidersCreateRequest(ctx con
 }
 
 // listAvailableProvidersHandleError handles the ListAvailableProviders error response.
-func (client *NetworkWatchersClient) listAvailableProvidersHandleError(resp *http.Response) error {
+func (client *WatchersClient) listAvailableProvidersHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1208,9 +1205,9 @@ func (client *NetworkWatchersClient) listAvailableProvidersHandleError(resp *htt
 // resourceGroupName - The name of the network watcher resource group.
 // networkWatcherName - The name of the network watcher resource.
 // parameters - Parameters that define the configuration of flow log.
-// options - NetworkWatchersBeginSetFlowLogConfigurationOptions contains the optional parameters for the NetworkWatchersClient.BeginSetFlowLogConfiguration
+// options - NetworkWatchersBeginSetFlowLogConfigurationOptions contains the optional parameters for the WatchersClient.BeginSetFlowLogConfiguration
 // method.
-func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersBeginSetFlowLogConfigurationOptions) (NetworkWatchersSetFlowLogConfigurationPollerResponse, error) {
+func (client *WatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersBeginSetFlowLogConfigurationOptions) (NetworkWatchersSetFlowLogConfigurationPollerResponse, error) {
 	resp, err := client.setFlowLogConfiguration(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersSetFlowLogConfigurationPollerResponse{}, err
@@ -1218,7 +1215,7 @@ func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Co
 	result := NetworkWatchersSetFlowLogConfigurationPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.SetFlowLogConfiguration", "location", resp, client.pl, client.setFlowLogConfigurationHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.SetFlowLogConfiguration", "location", resp, client.pl, client.setFlowLogConfigurationHandleError)
 	if err != nil {
 		return NetworkWatchersSetFlowLogConfigurationPollerResponse{}, err
 	}
@@ -1230,7 +1227,7 @@ func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Co
 
 // SetFlowLogConfiguration - Configures flow log and traffic analytics (optional) on a specified resource.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) setFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersBeginSetFlowLogConfigurationOptions) (*http.Response, error) {
+func (client *WatchersClient) setFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersBeginSetFlowLogConfigurationOptions) (*http.Response, error) {
 	req, err := client.setFlowLogConfigurationCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -1246,7 +1243,7 @@ func (client *NetworkWatchersClient) setFlowLogConfiguration(ctx context.Context
 }
 
 // setFlowLogConfigurationCreateRequest creates the SetFlowLogConfiguration request.
-func (client *NetworkWatchersClient) setFlowLogConfigurationCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersBeginSetFlowLogConfigurationOptions) (*policy.Request, error) {
+func (client *WatchersClient) setFlowLogConfigurationCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersBeginSetFlowLogConfigurationOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/configureFlowLog"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -1272,7 +1269,7 @@ func (client *NetworkWatchersClient) setFlowLogConfigurationCreateRequest(ctx co
 }
 
 // setFlowLogConfigurationHandleError handles the SetFlowLogConfiguration error response.
-func (client *NetworkWatchersClient) setFlowLogConfigurationHandleError(resp *http.Response) error {
+func (client *WatchersClient) setFlowLogConfigurationHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1289,8 +1286,8 @@ func (client *NetworkWatchersClient) setFlowLogConfigurationHandleError(resp *ht
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
 // parameters - Parameters supplied to update network watcher tags.
-// options - NetworkWatchersUpdateTagsOptions contains the optional parameters for the NetworkWatchersClient.UpdateTags method.
-func (client *NetworkWatchersClient) UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject, options *NetworkWatchersUpdateTagsOptions) (NetworkWatchersUpdateTagsResponse, error) {
+// options - NetworkWatchersUpdateTagsOptions contains the optional parameters for the WatchersClient.UpdateTags method.
+func (client *WatchersClient) UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject, options *NetworkWatchersUpdateTagsOptions) (NetworkWatchersUpdateTagsResponse, error) {
 	req, err := client.updateTagsCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersUpdateTagsResponse{}, err
@@ -1306,7 +1303,7 @@ func (client *NetworkWatchersClient) UpdateTags(ctx context.Context, resourceGro
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkWatchersClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject, options *NetworkWatchersUpdateTagsOptions) (*policy.Request, error) {
+func (client *WatchersClient) updateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject, options *NetworkWatchersUpdateTagsOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -1332,16 +1329,16 @@ func (client *NetworkWatchersClient) updateTagsCreateRequest(ctx context.Context
 }
 
 // updateTagsHandleResponse handles the UpdateTags response.
-func (client *NetworkWatchersClient) updateTagsHandleResponse(resp *http.Response) (NetworkWatchersUpdateTagsResponse, error) {
+func (client *WatchersClient) updateTagsHandleResponse(resp *http.Response) (NetworkWatchersUpdateTagsResponse, error) {
 	result := NetworkWatchersUpdateTagsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcher); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Watcher); err != nil {
 		return NetworkWatchersUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.
-func (client *NetworkWatchersClient) updateTagsHandleError(resp *http.Response) error {
+func (client *WatchersClient) updateTagsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1358,9 +1355,9 @@ func (client *NetworkWatchersClient) updateTagsHandleError(resp *http.Response) 
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
 // parameters - Parameters that define the IP flow to be verified.
-// options - NetworkWatchersBeginVerifyIPFlowOptions contains the optional parameters for the NetworkWatchersClient.BeginVerifyIPFlow
+// options - NetworkWatchersBeginVerifyIPFlowOptions contains the optional parameters for the WatchersClient.BeginVerifyIPFlow
 // method.
-func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersBeginVerifyIPFlowOptions) (NetworkWatchersVerifyIPFlowPollerResponse, error) {
+func (client *WatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersBeginVerifyIPFlowOptions) (NetworkWatchersVerifyIPFlowPollerResponse, error) {
 	resp, err := client.verifyIPFlow(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return NetworkWatchersVerifyIPFlowPollerResponse{}, err
@@ -1368,7 +1365,7 @@ func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, reso
 	result := NetworkWatchersVerifyIPFlowPollerResponse{
 		RawResponse: resp,
 	}
-	pt, err := armruntime.NewPoller("NetworkWatchersClient.VerifyIPFlow", "location", resp, client.pl, client.verifyIPFlowHandleError)
+	pt, err := armruntime.NewPoller("WatchersClient.VerifyIPFlow", "location", resp, client.pl, client.verifyIPFlowHandleError)
 	if err != nil {
 		return NetworkWatchersVerifyIPFlowPollerResponse{}, err
 	}
@@ -1380,7 +1377,7 @@ func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, reso
 
 // VerifyIPFlow - Verify IP flow from the specified VM to a location given the currently configured NSG rules.
 // If the operation fails it returns the *ErrorResponse error type.
-func (client *NetworkWatchersClient) verifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersBeginVerifyIPFlowOptions) (*http.Response, error) {
+func (client *WatchersClient) verifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersBeginVerifyIPFlowOptions) (*http.Response, error) {
 	req, err := client.verifyIPFlowCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
@@ -1396,7 +1393,7 @@ func (client *NetworkWatchersClient) verifyIPFlow(ctx context.Context, resourceG
 }
 
 // verifyIPFlowCreateRequest creates the VerifyIPFlow request.
-func (client *NetworkWatchersClient) verifyIPFlowCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersBeginVerifyIPFlowOptions) (*policy.Request, error) {
+func (client *WatchersClient) verifyIPFlowCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersBeginVerifyIPFlowOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/ipFlowVerify"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -1422,7 +1419,7 @@ func (client *NetworkWatchersClient) verifyIPFlowCreateRequest(ctx context.Conte
 }
 
 // verifyIPFlowHandleError handles the VerifyIPFlow error response.
-func (client *NetworkWatchersClient) verifyIPFlowHandleError(resp *http.Response) error {
+func (client *WatchersClient) verifyIPFlowHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/storage/2020-06-12/azblob/zz_generated_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_client.go
@@ -20,20 +20,20 @@ import (
 	"time"
 )
 
-type blobClient struct {
+type client struct {
 	endpoint       string
 	version        Enum2
 	pathRenameMode *PathRenameMode
 	pl             runtime.Pipeline
 }
 
-// newBlobClient creates a new instance of blobClient with the specified values.
+// newClient creates a new instance of client with the specified values.
 // endpoint - The URL of the service account, container, or blob that is the targe of the desired operation.
 // version - Specifies the version of the operation to use for this request.
 // pathRenameMode - Determines the behavior of the rename operation
 // pl - the pipeline used for sending requests and handling responses.
-func newBlobClient(endpoint string, version Enum2, pathRenameMode *PathRenameMode, pl runtime.Pipeline) *blobClient {
-	client := &blobClient{
+func newClient(endpoint string, version Enum2, pathRenameMode *PathRenameMode, pl runtime.Pipeline) *client {
+	client := &client{
 		endpoint:       endpoint,
 		version:        version,
 		pathRenameMode: pathRenameMode,
@@ -46,10 +46,10 @@ func newBlobClient(endpoint string, version Enum2, pathRenameMode *PathRenameMod
 // blob with zero length and full metadata.
 // If the operation fails it returns the *StorageError error type.
 // copyID - The copy identifier provided in the x-ms-copy-id header of the original Copy Blob operation.
-// BlobAbortCopyFromURLOptions - BlobAbortCopyFromURLOptions contains the optional parameters for the blobClient.AbortCopyFromURL
+// BlobAbortCopyFromURLOptions - BlobAbortCopyFromURLOptions contains the optional parameters for the client.AbortCopyFromURL
 // method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
-func (client *blobClient) AbortCopyFromURL(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, blobAbortCopyFromURLOptions *BlobAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (BlobAbortCopyFromURLResponse, error) {
+func (client *client) AbortCopyFromURL(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, blobAbortCopyFromURLOptions *BlobAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (BlobAbortCopyFromURLResponse, error) {
 	req, err := client.abortCopyFromURLCreateRequest(ctx, comp, copyActionAbortConstant, copyID, blobAbortCopyFromURLOptions, leaseAccessConditions)
 	if err != nil {
 		return BlobAbortCopyFromURLResponse{}, err
@@ -65,7 +65,7 @@ func (client *blobClient) AbortCopyFromURL(ctx context.Context, comp Enum30, cop
 }
 
 // abortCopyFromURLCreateRequest creates the AbortCopyFromURL request.
-func (client *blobClient) abortCopyFromURLCreateRequest(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, blobAbortCopyFromURLOptions *BlobAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) abortCopyFromURLCreateRequest(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, blobAbortCopyFromURLOptions *BlobAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func (client *blobClient) abortCopyFromURLCreateRequest(ctx context.Context, com
 }
 
 // abortCopyFromURLHandleResponse handles the AbortCopyFromURL response.
-func (client *blobClient) abortCopyFromURLHandleResponse(resp *http.Response) (BlobAbortCopyFromURLResponse, error) {
+func (client *client) abortCopyFromURLHandleResponse(resp *http.Response) (BlobAbortCopyFromURLResponse, error) {
 	result := BlobAbortCopyFromURLResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -112,7 +112,7 @@ func (client *blobClient) abortCopyFromURLHandleResponse(resp *http.Response) (B
 }
 
 // abortCopyFromURLHandleError handles the AbortCopyFromURL error response.
-func (client *blobClient) abortCopyFromURLHandleError(resp *http.Response) error {
+func (client *client) abortCopyFromURLHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -126,9 +126,9 @@ func (client *blobClient) abortCopyFromURLHandleError(resp *http.Response) error
 
 // AcquireLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 // If the operation fails it returns the *StorageError error type.
-// BlobAcquireLeaseOptions - BlobAcquireLeaseOptions contains the optional parameters for the blobClient.AcquireLease method.
+// BlobAcquireLeaseOptions - BlobAcquireLeaseOptions contains the optional parameters for the client.AcquireLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) AcquireLease(ctx context.Context, comp Enum16, blobAcquireLeaseOptions *BlobAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobAcquireLeaseResponse, error) {
+func (client *client) AcquireLease(ctx context.Context, comp Enum16, blobAcquireLeaseOptions *BlobAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobAcquireLeaseResponse, error) {
 	req, err := client.acquireLeaseCreateRequest(ctx, comp, blobAcquireLeaseOptions, modifiedAccessConditions)
 	if err != nil {
 		return BlobAcquireLeaseResponse{}, err
@@ -144,7 +144,7 @@ func (client *blobClient) AcquireLease(ctx context.Context, comp Enum16, blobAcq
 }
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
-func (client *blobClient) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, blobAcquireLeaseOptions *BlobAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, blobAcquireLeaseOptions *BlobAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func (client *blobClient) acquireLeaseCreateRequest(ctx context.Context, comp En
 }
 
 // acquireLeaseHandleResponse handles the AcquireLease response.
-func (client *blobClient) acquireLeaseHandleResponse(resp *http.Response) (BlobAcquireLeaseResponse, error) {
+func (client *client) acquireLeaseHandleResponse(resp *http.Response) (BlobAcquireLeaseResponse, error) {
 	result := BlobAcquireLeaseResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -221,7 +221,7 @@ func (client *blobClient) acquireLeaseHandleResponse(resp *http.Response) (BlobA
 }
 
 // acquireLeaseHandleError handles the AcquireLease error response.
-func (client *blobClient) acquireLeaseHandleError(resp *http.Response) error {
+func (client *client) acquireLeaseHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -235,9 +235,9 @@ func (client *blobClient) acquireLeaseHandleError(resp *http.Response) error {
 
 // BreakLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 // If the operation fails it returns the *StorageError error type.
-// BlobBreakLeaseOptions - BlobBreakLeaseOptions contains the optional parameters for the blobClient.BreakLease method.
+// BlobBreakLeaseOptions - BlobBreakLeaseOptions contains the optional parameters for the client.BreakLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) BreakLease(ctx context.Context, comp Enum16, blobBreakLeaseOptions *BlobBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobBreakLeaseResponse, error) {
+func (client *client) BreakLease(ctx context.Context, comp Enum16, blobBreakLeaseOptions *BlobBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobBreakLeaseResponse, error) {
 	req, err := client.breakLeaseCreateRequest(ctx, comp, blobBreakLeaseOptions, modifiedAccessConditions)
 	if err != nil {
 		return BlobBreakLeaseResponse{}, err
@@ -253,7 +253,7 @@ func (client *blobClient) BreakLease(ctx context.Context, comp Enum16, blobBreak
 }
 
 // breakLeaseCreateRequest creates the BreakLease request.
-func (client *blobClient) breakLeaseCreateRequest(ctx context.Context, comp Enum16, blobBreakLeaseOptions *BlobBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) breakLeaseCreateRequest(ctx context.Context, comp Enum16, blobBreakLeaseOptions *BlobBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -292,7 +292,7 @@ func (client *blobClient) breakLeaseCreateRequest(ctx context.Context, comp Enum
 }
 
 // breakLeaseHandleResponse handles the BreakLease response.
-func (client *blobClient) breakLeaseHandleResponse(resp *http.Response) (BlobBreakLeaseResponse, error) {
+func (client *client) breakLeaseHandleResponse(resp *http.Response) (BlobBreakLeaseResponse, error) {
 	result := BlobBreakLeaseResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -332,7 +332,7 @@ func (client *blobClient) breakLeaseHandleResponse(resp *http.Response) (BlobBre
 }
 
 // breakLeaseHandleError handles the BreakLease error response.
-func (client *blobClient) breakLeaseHandleError(resp *http.Response) error {
+func (client *client) breakLeaseHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -350,9 +350,9 @@ func (client *blobClient) breakLeaseHandleError(resp *http.Response) error {
 // proposedLeaseID - Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed
 // lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID
 // string formats.
-// BlobChangeLeaseOptions - BlobChangeLeaseOptions contains the optional parameters for the blobClient.ChangeLease method.
+// BlobChangeLeaseOptions - BlobChangeLeaseOptions contains the optional parameters for the client.ChangeLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) ChangeLease(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, blobChangeLeaseOptions *BlobChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobChangeLeaseResponse, error) {
+func (client *client) ChangeLease(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, blobChangeLeaseOptions *BlobChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobChangeLeaseResponse, error) {
 	req, err := client.changeLeaseCreateRequest(ctx, comp, leaseID, proposedLeaseID, blobChangeLeaseOptions, modifiedAccessConditions)
 	if err != nil {
 		return BlobChangeLeaseResponse{}, err
@@ -368,7 +368,7 @@ func (client *blobClient) ChangeLease(ctx context.Context, comp Enum16, leaseID 
 }
 
 // changeLeaseCreateRequest creates the ChangeLease request.
-func (client *blobClient) changeLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, blobChangeLeaseOptions *BlobChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) changeLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, blobChangeLeaseOptions *BlobChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -406,7 +406,7 @@ func (client *blobClient) changeLeaseCreateRequest(ctx context.Context, comp Enu
 }
 
 // changeLeaseHandleResponse handles the ChangeLease response.
-func (client *blobClient) changeLeaseHandleResponse(resp *http.Response) (BlobChangeLeaseResponse, error) {
+func (client *client) changeLeaseHandleResponse(resp *http.Response) (BlobChangeLeaseResponse, error) {
 	result := BlobChangeLeaseResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -441,7 +441,7 @@ func (client *blobClient) changeLeaseHandleResponse(resp *http.Response) (BlobCh
 }
 
 // changeLeaseHandleError handles the ChangeLease error response.
-func (client *blobClient) changeLeaseHandleError(resp *http.Response) error {
+func (client *client) changeLeaseHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -459,12 +459,12 @@ func (client *blobClient) changeLeaseHandleError(resp *http.Response) error {
 // copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 // a page blob snapshot. The value should be URL-encoded as it would appear in a request
 // URI. The source blob must either be public or must be authenticated via a shared access signature.
-// BlobCopyFromURLOptions - BlobCopyFromURLOptions contains the optional parameters for the blobClient.CopyFromURL method.
+// BlobCopyFromURLOptions - BlobCopyFromURLOptions contains the optional parameters for the client.CopyFromURL method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Directory.Rename
 // method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
-func (client *blobClient) CopyFromURL(ctx context.Context, xmsRequiresSync Enum29, copySource string, blobCopyFromURLOptions *BlobCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobCopyFromURLResponse, error) {
+func (client *client) CopyFromURL(ctx context.Context, xmsRequiresSync Enum29, copySource string, blobCopyFromURLOptions *BlobCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobCopyFromURLResponse, error) {
 	req, err := client.copyFromURLCreateRequest(ctx, xmsRequiresSync, copySource, blobCopyFromURLOptions, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return BlobCopyFromURLResponse{}, err
@@ -480,7 +480,7 @@ func (client *blobClient) CopyFromURL(ctx context.Context, xmsRequiresSync Enum2
 }
 
 // copyFromURLCreateRequest creates the CopyFromURL request.
-func (client *blobClient) copyFromURLCreateRequest(ctx context.Context, xmsRequiresSync Enum29, copySource string, blobCopyFromURLOptions *BlobCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) copyFromURLCreateRequest(ctx context.Context, xmsRequiresSync Enum29, copySource string, blobCopyFromURLOptions *BlobCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -554,7 +554,7 @@ func (client *blobClient) copyFromURLCreateRequest(ctx context.Context, xmsRequi
 }
 
 // copyFromURLHandleResponse handles the CopyFromURL response.
-func (client *blobClient) copyFromURLHandleResponse(resp *http.Response) (BlobCopyFromURLResponse, error) {
+func (client *client) copyFromURLHandleResponse(resp *http.Response) (BlobCopyFromURLResponse, error) {
 	result := BlobCopyFromURLResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -609,7 +609,7 @@ func (client *blobClient) copyFromURLHandleResponse(resp *http.Response) (BlobCo
 }
 
 // copyFromURLHandleError handles the CopyFromURL error response.
-func (client *blobClient) copyFromURLHandleError(resp *http.Response) error {
+func (client *client) copyFromURLHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -623,13 +623,12 @@ func (client *blobClient) copyFromURLHandleError(resp *http.Response) error {
 
 // CreateSnapshot - The Create Snapshot operation creates a read-only snapshot of a blob
 // If the operation fails it returns the *StorageError error type.
-// BlobCreateSnapshotOptions - BlobCreateSnapshotOptions contains the optional parameters for the blobClient.CreateSnapshot
-// method.
+// BlobCreateSnapshotOptions - BlobCreateSnapshotOptions contains the optional parameters for the client.CreateSnapshot method.
 // CpkInfo - CpkInfo contains a group of parameters for the Blob.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Blob.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
-func (client *blobClient) CreateSnapshot(ctx context.Context, comp Enum28, blobCreateSnapshotOptions *BlobCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobCreateSnapshotResponse, error) {
+func (client *client) CreateSnapshot(ctx context.Context, comp Enum28, blobCreateSnapshotOptions *BlobCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobCreateSnapshotResponse, error) {
 	req, err := client.createSnapshotCreateRequest(ctx, comp, blobCreateSnapshotOptions, cpkInfo, cpkScopeInfo, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return BlobCreateSnapshotResponse{}, err
@@ -645,7 +644,7 @@ func (client *blobClient) CreateSnapshot(ctx context.Context, comp Enum28, blobC
 }
 
 // createSnapshotCreateRequest creates the CreateSnapshot request.
-func (client *blobClient) createSnapshotCreateRequest(ctx context.Context, comp Enum28, blobCreateSnapshotOptions *BlobCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) createSnapshotCreateRequest(ctx context.Context, comp Enum28, blobCreateSnapshotOptions *BlobCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -700,7 +699,7 @@ func (client *blobClient) createSnapshotCreateRequest(ctx context.Context, comp 
 }
 
 // createSnapshotHandleResponse handles the CreateSnapshot response.
-func (client *blobClient) createSnapshotHandleResponse(resp *http.Response) (BlobCreateSnapshotResponse, error) {
+func (client *client) createSnapshotHandleResponse(resp *http.Response) (BlobCreateSnapshotResponse, error) {
 	result := BlobCreateSnapshotResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-snapshot"); val != "" {
 		result.Snapshot = &val
@@ -745,7 +744,7 @@ func (client *blobClient) createSnapshotHandleResponse(resp *http.Response) (Blo
 }
 
 // createSnapshotHandleError handles the CreateSnapshot error response.
-func (client *blobClient) createSnapshotHandleError(resp *http.Response) error {
+func (client *client) createSnapshotHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -769,10 +768,10 @@ func (client *blobClient) createSnapshotHandleError(resp *http.Response) error {
 // All other operations on a soft-deleted blob or snapshot causes the service to
 // return an HTTP status code of 404 (ResourceNotFound).
 // If the operation fails it returns the *StorageError error type.
-// BlobDeleteOptions - BlobDeleteOptions contains the optional parameters for the blobClient.Delete method.
+// BlobDeleteOptions - BlobDeleteOptions contains the optional parameters for the client.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) Delete(ctx context.Context, blobDeleteOptions *BlobDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobDeleteResponse, error) {
+func (client *client) Delete(ctx context.Context, blobDeleteOptions *BlobDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobDeleteResponse, error) {
 	req, err := client.deleteCreateRequest(ctx, blobDeleteOptions, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return BlobDeleteResponse{}, err
@@ -788,7 +787,7 @@ func (client *blobClient) Delete(ctx context.Context, blobDeleteOptions *BlobDel
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *blobClient) deleteCreateRequest(ctx context.Context, blobDeleteOptions *BlobDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) deleteCreateRequest(ctx context.Context, blobDeleteOptions *BlobDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -837,7 +836,7 @@ func (client *blobClient) deleteCreateRequest(ctx context.Context, blobDeleteOpt
 }
 
 // deleteHandleResponse handles the Delete response.
-func (client *blobClient) deleteHandleResponse(resp *http.Response) (BlobDeleteResponse, error) {
+func (client *client) deleteHandleResponse(resp *http.Response) (BlobDeleteResponse, error) {
 	result := BlobDeleteResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -859,7 +858,7 @@ func (client *blobClient) deleteHandleResponse(resp *http.Response) (BlobDeleteR
 }
 
 // deleteHandleError handles the Delete error response.
-func (client *blobClient) deleteHandleError(resp *http.Response) error {
+func (client *client) deleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -873,9 +872,9 @@ func (client *blobClient) deleteHandleError(resp *http.Response) error {
 
 // DeleteImmutabilityPolicy - The Delete Immutability Policy operation deletes the immutability policy on the blob
 // If the operation fails it returns the *StorageError error type.
-// options - BlobDeleteImmutabilityPolicyOptions contains the optional parameters for the blobClient.DeleteImmutabilityPolicy
+// options - BlobDeleteImmutabilityPolicyOptions contains the optional parameters for the client.DeleteImmutabilityPolicy
 // method.
-func (client *blobClient) DeleteImmutabilityPolicy(ctx context.Context, comp Enum26, options *BlobDeleteImmutabilityPolicyOptions) (BlobDeleteImmutabilityPolicyResponse, error) {
+func (client *client) DeleteImmutabilityPolicy(ctx context.Context, comp Enum26, options *BlobDeleteImmutabilityPolicyOptions) (BlobDeleteImmutabilityPolicyResponse, error) {
 	req, err := client.deleteImmutabilityPolicyCreateRequest(ctx, comp, options)
 	if err != nil {
 		return BlobDeleteImmutabilityPolicyResponse{}, err
@@ -891,7 +890,7 @@ func (client *blobClient) DeleteImmutabilityPolicy(ctx context.Context, comp Enu
 }
 
 // deleteImmutabilityPolicyCreateRequest creates the DeleteImmutabilityPolicy request.
-func (client *blobClient) deleteImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, options *BlobDeleteImmutabilityPolicyOptions) (*policy.Request, error) {
+func (client *client) deleteImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, options *BlobDeleteImmutabilityPolicyOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -911,7 +910,7 @@ func (client *blobClient) deleteImmutabilityPolicyCreateRequest(ctx context.Cont
 }
 
 // deleteImmutabilityPolicyHandleResponse handles the DeleteImmutabilityPolicy response.
-func (client *blobClient) deleteImmutabilityPolicyHandleResponse(resp *http.Response) (BlobDeleteImmutabilityPolicyResponse, error) {
+func (client *client) deleteImmutabilityPolicyHandleResponse(resp *http.Response) (BlobDeleteImmutabilityPolicyResponse, error) {
 	result := BlobDeleteImmutabilityPolicyResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -933,7 +932,7 @@ func (client *blobClient) deleteImmutabilityPolicyHandleResponse(resp *http.Resp
 }
 
 // deleteImmutabilityPolicyHandleError handles the DeleteImmutabilityPolicy error response.
-func (client *blobClient) deleteImmutabilityPolicyHandleError(resp *http.Response) error {
+func (client *client) deleteImmutabilityPolicyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -948,11 +947,11 @@ func (client *blobClient) deleteImmutabilityPolicyHandleError(resp *http.Respons
 // Download - The Download operation reads or downloads a blob from the system, including its metadata and properties. You
 // can also call Download to read a snapshot.
 // If the operation fails it returns the *StorageError error type.
-// BlobDownloadOptions - BlobDownloadOptions contains the optional parameters for the blobClient.Download method.
+// BlobDownloadOptions - BlobDownloadOptions contains the optional parameters for the client.Download method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the Blob.Download method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) Download(ctx context.Context, blobDownloadOptions *BlobDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobDownloadResponse, error) {
+func (client *client) Download(ctx context.Context, blobDownloadOptions *BlobDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobDownloadResponse, error) {
 	req, err := client.downloadCreateRequest(ctx, blobDownloadOptions, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return BlobDownloadResponse{}, err
@@ -968,7 +967,7 @@ func (client *blobClient) Download(ctx context.Context, blobDownloadOptions *Blo
 }
 
 // downloadCreateRequest creates the Download request.
-func (client *blobClient) downloadCreateRequest(ctx context.Context, blobDownloadOptions *BlobDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) downloadCreateRequest(ctx context.Context, blobDownloadOptions *BlobDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1030,7 +1029,7 @@ func (client *blobClient) downloadCreateRequest(ctx context.Context, blobDownloa
 }
 
 // downloadHandleResponse handles the Download response.
-func (client *blobClient) downloadHandleResponse(resp *http.Response) (BlobDownloadResponse, error) {
+func (client *client) downloadHandleResponse(resp *http.Response) (BlobDownloadResponse, error) {
 	result := BlobDownloadResponse{RawResponse: resp}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -1240,7 +1239,7 @@ func (client *blobClient) downloadHandleResponse(resp *http.Response) (BlobDownl
 }
 
 // downloadHandleError handles the Download error response.
-func (client *blobClient) downloadHandleError(resp *http.Response) error {
+func (client *client) downloadHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1254,11 +1253,11 @@ func (client *blobClient) downloadHandleError(resp *http.Response) error {
 
 // GetAccessControl - Get the owner, group, permissions, or access control list for a blob.
 // If the operation fails it returns the *DataLakeStorageError error type.
-// BlobGetAccessControlOptions - BlobGetAccessControlOptions contains the optional parameters for the blobClient.GetAccessControl
+// BlobGetAccessControlOptions - BlobGetAccessControlOptions contains the optional parameters for the client.GetAccessControl
 // method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) GetAccessControl(ctx context.Context, action Enum22, blobGetAccessControlOptions *BlobGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobGetAccessControlResponse, error) {
+func (client *client) GetAccessControl(ctx context.Context, action Enum22, blobGetAccessControlOptions *BlobGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobGetAccessControlResponse, error) {
 	req, err := client.getAccessControlCreateRequest(ctx, action, blobGetAccessControlOptions, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return BlobGetAccessControlResponse{}, err
@@ -1274,7 +1273,7 @@ func (client *blobClient) GetAccessControl(ctx context.Context, action Enum22, b
 }
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
-func (client *blobClient) getAccessControlCreateRequest(ctx context.Context, action Enum22, blobGetAccessControlOptions *BlobGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) getAccessControlCreateRequest(ctx context.Context, action Enum22, blobGetAccessControlOptions *BlobGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodHead, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1312,7 +1311,7 @@ func (client *blobClient) getAccessControlCreateRequest(ctx context.Context, act
 }
 
 // getAccessControlHandleResponse handles the GetAccessControl response.
-func (client *blobClient) getAccessControlHandleResponse(resp *http.Response) (BlobGetAccessControlResponse, error) {
+func (client *client) getAccessControlHandleResponse(resp *http.Response) (BlobGetAccessControlResponse, error) {
 	result := BlobGetAccessControlResponse{RawResponse: resp}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -1353,7 +1352,7 @@ func (client *blobClient) getAccessControlHandleResponse(resp *http.Response) (B
 }
 
 // getAccessControlHandleError handles the GetAccessControl error response.
-func (client *blobClient) getAccessControlHandleError(resp *http.Response) error {
+func (client *client) getAccessControlHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1367,8 +1366,8 @@ func (client *blobClient) getAccessControlHandleError(resp *http.Response) error
 
 // GetAccountInfo - Returns the sku name and account kind
 // If the operation fails it returns the *StorageError error type.
-// options - BlobGetAccountInfoOptions contains the optional parameters for the blobClient.GetAccountInfo method.
-func (client *blobClient) GetAccountInfo(ctx context.Context, restype Enum8, comp Enum1, options *BlobGetAccountInfoOptions) (BlobGetAccountInfoResponse, error) {
+// options - BlobGetAccountInfoOptions contains the optional parameters for the client.GetAccountInfo method.
+func (client *client) GetAccountInfo(ctx context.Context, restype Enum8, comp Enum1, options *BlobGetAccountInfoOptions) (BlobGetAccountInfoResponse, error) {
 	req, err := client.getAccountInfoCreateRequest(ctx, restype, comp, options)
 	if err != nil {
 		return BlobGetAccountInfoResponse{}, err
@@ -1384,7 +1383,7 @@ func (client *blobClient) GetAccountInfo(ctx context.Context, restype Enum8, com
 }
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
-func (client *blobClient) getAccountInfoCreateRequest(ctx context.Context, restype Enum8, comp Enum1, options *BlobGetAccountInfoOptions) (*policy.Request, error) {
+func (client *client) getAccountInfoCreateRequest(ctx context.Context, restype Enum8, comp Enum1, options *BlobGetAccountInfoOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1399,7 +1398,7 @@ func (client *blobClient) getAccountInfoCreateRequest(ctx context.Context, resty
 }
 
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
-func (client *blobClient) getAccountInfoHandleResponse(resp *http.Response) (BlobGetAccountInfoResponse, error) {
+func (client *client) getAccountInfoHandleResponse(resp *http.Response) (BlobGetAccountInfoResponse, error) {
 	result := BlobGetAccountInfoResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -1427,7 +1426,7 @@ func (client *blobClient) getAccountInfoHandleResponse(resp *http.Response) (Blo
 }
 
 // getAccountInfoHandleError handles the GetAccountInfo error response.
-func (client *blobClient) getAccountInfoHandleError(resp *http.Response) error {
+func (client *client) getAccountInfoHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1442,11 +1441,11 @@ func (client *blobClient) getAccountInfoHandleError(resp *http.Response) error {
 // GetProperties - The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties
 // for the blob. It does not return the content of the blob.
 // If the operation fails it returns the *StorageError error type.
-// BlobGetPropertiesOptions - BlobGetPropertiesOptions contains the optional parameters for the blobClient.GetProperties method.
+// BlobGetPropertiesOptions - BlobGetPropertiesOptions contains the optional parameters for the client.GetProperties method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the Blob.Download method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) GetProperties(ctx context.Context, blobGetPropertiesOptions *BlobGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobGetPropertiesResponse, error) {
+func (client *client) GetProperties(ctx context.Context, blobGetPropertiesOptions *BlobGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobGetPropertiesResponse, error) {
 	req, err := client.getPropertiesCreateRequest(ctx, blobGetPropertiesOptions, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return BlobGetPropertiesResponse{}, err
@@ -1462,7 +1461,7 @@ func (client *blobClient) GetProperties(ctx context.Context, blobGetPropertiesOp
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
-func (client *blobClient) getPropertiesCreateRequest(ctx context.Context, blobGetPropertiesOptions *BlobGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) getPropertiesCreateRequest(ctx context.Context, blobGetPropertiesOptions *BlobGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodHead, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1514,7 +1513,7 @@ func (client *blobClient) getPropertiesCreateRequest(ctx context.Context, blobGe
 }
 
 // getPropertiesHandleResponse handles the GetProperties response.
-func (client *blobClient) getPropertiesHandleResponse(resp *http.Response) (BlobGetPropertiesResponse, error) {
+func (client *client) getPropertiesHandleResponse(resp *http.Response) (BlobGetPropertiesResponse, error) {
 	result := BlobGetPropertiesResponse{RawResponse: resp}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -1754,7 +1753,7 @@ func (client *blobClient) getPropertiesHandleResponse(resp *http.Response) (Blob
 }
 
 // getPropertiesHandleError handles the GetProperties error response.
-func (client *blobClient) getPropertiesHandleError(resp *http.Response) error {
+func (client *client) getPropertiesHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1768,10 +1767,10 @@ func (client *blobClient) getPropertiesHandleError(resp *http.Response) error {
 
 // GetTags - The Get Tags operation enables users to get the tags associated with a blob.
 // If the operation fails it returns the *StorageError error type.
-// BlobGetTagsOptions - BlobGetTagsOptions contains the optional parameters for the blobClient.GetTags method.
+// BlobGetTagsOptions - BlobGetTagsOptions contains the optional parameters for the client.GetTags method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
-func (client *blobClient) GetTags(ctx context.Context, comp Enum42, blobGetTagsOptions *BlobGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobGetTagsResponse, error) {
+func (client *client) GetTags(ctx context.Context, comp Enum42, blobGetTagsOptions *BlobGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobGetTagsResponse, error) {
 	req, err := client.getTagsCreateRequest(ctx, comp, blobGetTagsOptions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return BlobGetTagsResponse{}, err
@@ -1787,7 +1786,7 @@ func (client *blobClient) GetTags(ctx context.Context, comp Enum42, blobGetTagsO
 }
 
 // getTagsCreateRequest creates the GetTags request.
-func (client *blobClient) getTagsCreateRequest(ctx context.Context, comp Enum42, blobGetTagsOptions *BlobGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) getTagsCreateRequest(ctx context.Context, comp Enum42, blobGetTagsOptions *BlobGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1819,7 +1818,7 @@ func (client *blobClient) getTagsCreateRequest(ctx context.Context, comp Enum42,
 }
 
 // getTagsHandleResponse handles the GetTags response.
-func (client *blobClient) getTagsHandleResponse(resp *http.Response) (BlobGetTagsResponse, error) {
+func (client *client) getTagsHandleResponse(resp *http.Response) (BlobGetTagsResponse, error) {
 	result := BlobGetTagsResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -1837,14 +1836,14 @@ func (client *blobClient) getTagsHandleResponse(resp *http.Response) (BlobGetTag
 		}
 		result.Date = &date
 	}
-	if err := runtime.UnmarshalAsXML(resp, &result.BlobTags); err != nil {
+	if err := runtime.UnmarshalAsXML(resp, &result.Tags); err != nil {
 		return BlobGetTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getTagsHandleError handles the GetTags error response.
-func (client *blobClient) getTagsHandleError(resp *http.Response) error {
+func (client *client) getTagsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -1858,11 +1857,11 @@ func (client *blobClient) getTagsHandleError(resp *http.Response) error {
 
 // Query - The Query operation enables users to select/project on blob data by providing simple query expressions.
 // If the operation fails it returns the *StorageError error type.
-// BlobQueryOptions - BlobQueryOptions contains the optional parameters for the blobClient.Query method.
+// BlobQueryOptions - BlobQueryOptions contains the optional parameters for the client.Query method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the Blob.Download method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) Query(ctx context.Context, comp Enum40, blobQueryOptions *BlobQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobQueryResponse, error) {
+func (client *client) Query(ctx context.Context, comp Enum40, blobQueryOptions *BlobQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobQueryResponse, error) {
 	req, err := client.queryCreateRequest(ctx, comp, blobQueryOptions, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return BlobQueryResponse{}, err
@@ -1878,7 +1877,7 @@ func (client *blobClient) Query(ctx context.Context, comp Enum40, blobQueryOptio
 }
 
 // queryCreateRequest creates the Query request.
-func (client *blobClient) queryCreateRequest(ctx context.Context, comp Enum40, blobQueryOptions *BlobQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) queryCreateRequest(ctx context.Context, comp Enum40, blobQueryOptions *BlobQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPost, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1932,7 +1931,7 @@ func (client *blobClient) queryCreateRequest(ctx context.Context, comp Enum40, b
 }
 
 // queryHandleResponse handles the Query response.
-func (client *blobClient) queryHandleResponse(resp *http.Response) (BlobQueryResponse, error) {
+func (client *client) queryHandleResponse(resp *http.Response) (BlobQueryResponse, error) {
 	result := BlobQueryResponse{RawResponse: resp}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -2083,7 +2082,7 @@ func (client *blobClient) queryHandleResponse(resp *http.Response) (BlobQueryRes
 }
 
 // queryHandleError handles the Query error response.
-func (client *blobClient) queryHandleError(resp *http.Response) error {
+func (client *client) queryHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2098,9 +2097,9 @@ func (client *blobClient) queryHandleError(resp *http.Response) error {
 // ReleaseLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 // If the operation fails it returns the *StorageError error type.
 // leaseID - Specifies the current lease ID on the resource.
-// BlobReleaseLeaseOptions - BlobReleaseLeaseOptions contains the optional parameters for the blobClient.ReleaseLease method.
+// BlobReleaseLeaseOptions - BlobReleaseLeaseOptions contains the optional parameters for the client.ReleaseLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) ReleaseLease(ctx context.Context, comp Enum16, leaseID string, blobReleaseLeaseOptions *BlobReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobReleaseLeaseResponse, error) {
+func (client *client) ReleaseLease(ctx context.Context, comp Enum16, leaseID string, blobReleaseLeaseOptions *BlobReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobReleaseLeaseResponse, error) {
 	req, err := client.releaseLeaseCreateRequest(ctx, comp, leaseID, blobReleaseLeaseOptions, modifiedAccessConditions)
 	if err != nil {
 		return BlobReleaseLeaseResponse{}, err
@@ -2116,7 +2115,7 @@ func (client *blobClient) ReleaseLease(ctx context.Context, comp Enum16, leaseID
 }
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
-func (client *blobClient) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, blobReleaseLeaseOptions *BlobReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, blobReleaseLeaseOptions *BlobReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2153,7 +2152,7 @@ func (client *blobClient) releaseLeaseCreateRequest(ctx context.Context, comp En
 }
 
 // releaseLeaseHandleResponse handles the ReleaseLease response.
-func (client *blobClient) releaseLeaseHandleResponse(resp *http.Response) (BlobReleaseLeaseResponse, error) {
+func (client *client) releaseLeaseHandleResponse(resp *http.Response) (BlobReleaseLeaseResponse, error) {
 	result := BlobReleaseLeaseResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2185,7 +2184,7 @@ func (client *blobClient) releaseLeaseHandleResponse(resp *http.Response) (BlobR
 }
 
 // releaseLeaseHandleError handles the ReleaseLease error response.
-func (client *blobClient) releaseLeaseHandleError(resp *http.Response) error {
+func (client *client) releaseLeaseHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2206,13 +2205,13 @@ func (client *blobClient) releaseLeaseHandleError(resp *http.Response) error {
 // renameSource - The file or directory to be renamed. The value must have the following format: "/{filesysystem}/{path}".
 // If "x-ms-properties" is specified, the properties will overwrite the existing properties;
 // otherwise, the existing properties will be preserved.
-// BlobRenameOptions - BlobRenameOptions contains the optional parameters for the blobClient.Rename method.
+// BlobRenameOptions - BlobRenameOptions contains the optional parameters for the client.Rename method.
 // DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the Directory.Create method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Directory.Rename
 // method.
-func (client *blobClient) Rename(ctx context.Context, renameSource string, blobRenameOptions *BlobRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (BlobRenameResponse, error) {
+func (client *client) Rename(ctx context.Context, renameSource string, blobRenameOptions *BlobRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (BlobRenameResponse, error) {
 	req, err := client.renameCreateRequest(ctx, renameSource, blobRenameOptions, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return BlobRenameResponse{}, err
@@ -2228,7 +2227,7 @@ func (client *blobClient) Rename(ctx context.Context, renameSource string, blobR
 }
 
 // renameCreateRequest creates the Rename request.
-func (client *blobClient) renameCreateRequest(ctx context.Context, renameSource string, blobRenameOptions *BlobRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) renameCreateRequest(ctx context.Context, renameSource string, blobRenameOptions *BlobRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2305,7 +2304,7 @@ func (client *blobClient) renameCreateRequest(ctx context.Context, renameSource 
 }
 
 // renameHandleResponse handles the Rename response.
-func (client *blobClient) renameHandleResponse(resp *http.Response) (BlobRenameResponse, error) {
+func (client *client) renameHandleResponse(resp *http.Response) (BlobRenameResponse, error) {
 	result := BlobRenameResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2344,7 +2343,7 @@ func (client *blobClient) renameHandleResponse(resp *http.Response) (BlobRenameR
 }
 
 // renameHandleError handles the Rename error response.
-func (client *blobClient) renameHandleError(resp *http.Response) error {
+func (client *client) renameHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2359,9 +2358,9 @@ func (client *blobClient) renameHandleError(resp *http.Response) error {
 // RenewLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 // If the operation fails it returns the *StorageError error type.
 // leaseID - Specifies the current lease ID on the resource.
-// BlobRenewLeaseOptions - BlobRenewLeaseOptions contains the optional parameters for the blobClient.RenewLease method.
+// BlobRenewLeaseOptions - BlobRenewLeaseOptions contains the optional parameters for the client.RenewLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) RenewLease(ctx context.Context, comp Enum16, leaseID string, blobRenewLeaseOptions *BlobRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobRenewLeaseResponse, error) {
+func (client *client) RenewLease(ctx context.Context, comp Enum16, leaseID string, blobRenewLeaseOptions *BlobRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobRenewLeaseResponse, error) {
 	req, err := client.renewLeaseCreateRequest(ctx, comp, leaseID, blobRenewLeaseOptions, modifiedAccessConditions)
 	if err != nil {
 		return BlobRenewLeaseResponse{}, err
@@ -2377,7 +2376,7 @@ func (client *blobClient) RenewLease(ctx context.Context, comp Enum16, leaseID s
 }
 
 // renewLeaseCreateRequest creates the RenewLease request.
-func (client *blobClient) renewLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, blobRenewLeaseOptions *BlobRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) renewLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, blobRenewLeaseOptions *BlobRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2414,7 +2413,7 @@ func (client *blobClient) renewLeaseCreateRequest(ctx context.Context, comp Enum
 }
 
 // renewLeaseHandleResponse handles the RenewLease response.
-func (client *blobClient) renewLeaseHandleResponse(resp *http.Response) (BlobRenewLeaseResponse, error) {
+func (client *client) renewLeaseHandleResponse(resp *http.Response) (BlobRenewLeaseResponse, error) {
 	result := BlobRenewLeaseResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2449,7 +2448,7 @@ func (client *blobClient) renewLeaseHandleResponse(resp *http.Response) (BlobRen
 }
 
 // renewLeaseHandleError handles the RenewLease error response.
-func (client *blobClient) renewLeaseHandleError(resp *http.Response) error {
+func (client *client) renewLeaseHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2463,11 +2462,11 @@ func (client *blobClient) renewLeaseHandleError(resp *http.Response) error {
 
 // SetAccessControl - Set the owner, group, permissions, or access control list for a blob.
 // If the operation fails it returns the *DataLakeStorageError error type.
-// BlobSetAccessControlOptions - BlobSetAccessControlOptions contains the optional parameters for the blobClient.SetAccessControl
+// BlobSetAccessControlOptions - BlobSetAccessControlOptions contains the optional parameters for the client.SetAccessControl
 // method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) SetAccessControl(ctx context.Context, action Enum21, blobSetAccessControlOptions *BlobSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetAccessControlResponse, error) {
+func (client *client) SetAccessControl(ctx context.Context, action Enum21, blobSetAccessControlOptions *BlobSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetAccessControlResponse, error) {
 	req, err := client.setAccessControlCreateRequest(ctx, action, blobSetAccessControlOptions, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return BlobSetAccessControlResponse{}, err
@@ -2483,7 +2482,7 @@ func (client *blobClient) SetAccessControl(ctx context.Context, action Enum21, b
 }
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
-func (client *blobClient) setAccessControlCreateRequest(ctx context.Context, action Enum21, blobSetAccessControlOptions *BlobSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setAccessControlCreateRequest(ctx context.Context, action Enum21, blobSetAccessControlOptions *BlobSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2530,7 +2529,7 @@ func (client *blobClient) setAccessControlCreateRequest(ctx context.Context, act
 }
 
 // setAccessControlHandleResponse handles the SetAccessControl response.
-func (client *blobClient) setAccessControlHandleResponse(resp *http.Response) (BlobSetAccessControlResponse, error) {
+func (client *client) setAccessControlHandleResponse(resp *http.Response) (BlobSetAccessControlResponse, error) {
 	result := BlobSetAccessControlResponse{RawResponse: resp}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -2559,7 +2558,7 @@ func (client *blobClient) setAccessControlHandleResponse(resp *http.Response) (B
 }
 
 // setAccessControlHandleError handles the SetAccessControl error response.
-func (client *blobClient) setAccessControlHandleError(resp *http.Response) error {
+func (client *client) setAccessControlHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2574,8 +2573,8 @@ func (client *blobClient) setAccessControlHandleError(resp *http.Response) error
 // SetExpiry - Sets the time a blob will expire and be deleted.
 // If the operation fails it returns the *StorageError error type.
 // expiryOptions - Required. Indicates mode of the expiry time
-// options - BlobSetExpiryOptions contains the optional parameters for the blobClient.SetExpiry method.
-func (client *blobClient) SetExpiry(ctx context.Context, comp Enum24, expiryOptions BlobExpiryOptions, options *BlobSetExpiryOptions) (BlobSetExpiryResponse, error) {
+// options - BlobSetExpiryOptions contains the optional parameters for the client.SetExpiry method.
+func (client *client) SetExpiry(ctx context.Context, comp Enum24, expiryOptions BlobExpiryOptions, options *BlobSetExpiryOptions) (BlobSetExpiryResponse, error) {
 	req, err := client.setExpiryCreateRequest(ctx, comp, expiryOptions, options)
 	if err != nil {
 		return BlobSetExpiryResponse{}, err
@@ -2591,7 +2590,7 @@ func (client *blobClient) SetExpiry(ctx context.Context, comp Enum24, expiryOpti
 }
 
 // setExpiryCreateRequest creates the SetExpiry request.
-func (client *blobClient) setExpiryCreateRequest(ctx context.Context, comp Enum24, expiryOptions BlobExpiryOptions, options *BlobSetExpiryOptions) (*policy.Request, error) {
+func (client *client) setExpiryCreateRequest(ctx context.Context, comp Enum24, expiryOptions BlobExpiryOptions, options *BlobSetExpiryOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2615,7 +2614,7 @@ func (client *blobClient) setExpiryCreateRequest(ctx context.Context, comp Enum2
 }
 
 // setExpiryHandleResponse handles the SetExpiry response.
-func (client *blobClient) setExpiryHandleResponse(resp *http.Response) (BlobSetExpiryResponse, error) {
+func (client *client) setExpiryHandleResponse(resp *http.Response) (BlobSetExpiryResponse, error) {
 	result := BlobSetExpiryResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2647,7 +2646,7 @@ func (client *blobClient) setExpiryHandleResponse(resp *http.Response) (BlobSetE
 }
 
 // setExpiryHandleError handles the SetExpiry error response.
-func (client *blobClient) setExpiryHandleError(resp *http.Response) error {
+func (client *client) setExpiryHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2661,12 +2660,11 @@ func (client *blobClient) setExpiryHandleError(resp *http.Response) error {
 
 // SetHTTPHeaders - The Set HTTP Headers operation sets system properties on the blob
 // If the operation fails it returns the *StorageError error type.
-// BlobSetHTTPHeadersOptions - BlobSetHTTPHeadersOptions contains the optional parameters for the blobClient.SetHTTPHeaders
-// method.
+// BlobSetHTTPHeadersOptions - BlobSetHTTPHeadersOptions contains the optional parameters for the client.SetHTTPHeaders method.
 // BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Blob.SetHTTPHeaders method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) SetHTTPHeaders(ctx context.Context, comp Enum1, blobSetHTTPHeadersOptions *BlobSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetHTTPHeadersResponse, error) {
+func (client *client) SetHTTPHeaders(ctx context.Context, comp Enum1, blobSetHTTPHeadersOptions *BlobSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetHTTPHeadersResponse, error) {
 	req, err := client.setHTTPHeadersCreateRequest(ctx, comp, blobSetHTTPHeadersOptions, blobHTTPHeaders, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return BlobSetHTTPHeadersResponse{}, err
@@ -2682,7 +2680,7 @@ func (client *blobClient) SetHTTPHeaders(ctx context.Context, comp Enum1, blobSe
 }
 
 // setHTTPHeadersCreateRequest creates the SetHTTPHeaders request.
-func (client *blobClient) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum1, blobSetHTTPHeadersOptions *BlobSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum1, blobSetHTTPHeadersOptions *BlobSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2738,7 +2736,7 @@ func (client *blobClient) setHTTPHeadersCreateRequest(ctx context.Context, comp 
 }
 
 // setHTTPHeadersHandleResponse handles the SetHTTPHeaders response.
-func (client *blobClient) setHTTPHeadersHandleResponse(resp *http.Response) (BlobSetHTTPHeadersResponse, error) {
+func (client *client) setHTTPHeadersHandleResponse(resp *http.Response) (BlobSetHTTPHeadersResponse, error) {
 	result := BlobSetHTTPHeadersResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2777,7 +2775,7 @@ func (client *blobClient) setHTTPHeadersHandleResponse(resp *http.Response) (Blo
 }
 
 // setHTTPHeadersHandleError handles the SetHTTPHeaders error response.
-func (client *blobClient) setHTTPHeadersHandleError(resp *http.Response) error {
+func (client *client) setHTTPHeadersHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2791,10 +2789,10 @@ func (client *blobClient) setHTTPHeadersHandleError(resp *http.Response) error {
 
 // SetImmutabilityPolicy - The Set Immutability Policy operation sets the immutability policy on the blob
 // If the operation fails it returns the *StorageError error type.
-// BlobSetImmutabilityPolicyOptions - BlobSetImmutabilityPolicyOptions contains the optional parameters for the blobClient.SetImmutabilityPolicy
+// BlobSetImmutabilityPolicyOptions - BlobSetImmutabilityPolicyOptions contains the optional parameters for the client.SetImmutabilityPolicy
 // method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) SetImmutabilityPolicy(ctx context.Context, comp Enum26, blobSetImmutabilityPolicyOptions *BlobSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetImmutabilityPolicyResponse, error) {
+func (client *client) SetImmutabilityPolicy(ctx context.Context, comp Enum26, blobSetImmutabilityPolicyOptions *BlobSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetImmutabilityPolicyResponse, error) {
 	req, err := client.setImmutabilityPolicyCreateRequest(ctx, comp, blobSetImmutabilityPolicyOptions, modifiedAccessConditions)
 	if err != nil {
 		return BlobSetImmutabilityPolicyResponse{}, err
@@ -2810,7 +2808,7 @@ func (client *blobClient) SetImmutabilityPolicy(ctx context.Context, comp Enum26
 }
 
 // setImmutabilityPolicyCreateRequest creates the SetImmutabilityPolicy request.
-func (client *blobClient) setImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, blobSetImmutabilityPolicyOptions *BlobSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, blobSetImmutabilityPolicyOptions *BlobSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2839,7 +2837,7 @@ func (client *blobClient) setImmutabilityPolicyCreateRequest(ctx context.Context
 }
 
 // setImmutabilityPolicyHandleResponse handles the SetImmutabilityPolicy response.
-func (client *blobClient) setImmutabilityPolicyHandleResponse(resp *http.Response) (BlobSetImmutabilityPolicyResponse, error) {
+func (client *client) setImmutabilityPolicyHandleResponse(resp *http.Response) (BlobSetImmutabilityPolicyResponse, error) {
 	result := BlobSetImmutabilityPolicyResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -2871,7 +2869,7 @@ func (client *blobClient) setImmutabilityPolicyHandleResponse(resp *http.Respons
 }
 
 // setImmutabilityPolicyHandleError handles the SetImmutabilityPolicy error response.
-func (client *blobClient) setImmutabilityPolicyHandleError(resp *http.Response) error {
+func (client *client) setImmutabilityPolicyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2886,8 +2884,8 @@ func (client *blobClient) setImmutabilityPolicyHandleError(resp *http.Response) 
 // SetLegalHold - The Set Legal Hold operation sets a legal hold on the blob.
 // If the operation fails it returns the *StorageError error type.
 // legalHold - Specified if a legal hold should be set on the blob.
-// options - BlobSetLegalHoldOptions contains the optional parameters for the blobClient.SetLegalHold method.
-func (client *blobClient) SetLegalHold(ctx context.Context, comp Enum27, legalHold bool, options *BlobSetLegalHoldOptions) (BlobSetLegalHoldResponse, error) {
+// options - BlobSetLegalHoldOptions contains the optional parameters for the client.SetLegalHold method.
+func (client *client) SetLegalHold(ctx context.Context, comp Enum27, legalHold bool, options *BlobSetLegalHoldOptions) (BlobSetLegalHoldResponse, error) {
 	req, err := client.setLegalHoldCreateRequest(ctx, comp, legalHold, options)
 	if err != nil {
 		return BlobSetLegalHoldResponse{}, err
@@ -2903,7 +2901,7 @@ func (client *blobClient) SetLegalHold(ctx context.Context, comp Enum27, legalHo
 }
 
 // setLegalHoldCreateRequest creates the SetLegalHold request.
-func (client *blobClient) setLegalHoldCreateRequest(ctx context.Context, comp Enum27, legalHold bool, options *BlobSetLegalHoldOptions) (*policy.Request, error) {
+func (client *client) setLegalHoldCreateRequest(ctx context.Context, comp Enum27, legalHold bool, options *BlobSetLegalHoldOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2924,7 +2922,7 @@ func (client *blobClient) setLegalHoldCreateRequest(ctx context.Context, comp En
 }
 
 // setLegalHoldHandleResponse handles the SetLegalHold response.
-func (client *blobClient) setLegalHoldHandleResponse(resp *http.Response) (BlobSetLegalHoldResponse, error) {
+func (client *client) setLegalHoldHandleResponse(resp *http.Response) (BlobSetLegalHoldResponse, error) {
 	result := BlobSetLegalHoldResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -2953,7 +2951,7 @@ func (client *blobClient) setLegalHoldHandleResponse(resp *http.Response) (BlobS
 }
 
 // setLegalHoldHandleError handles the SetLegalHold error response.
-func (client *blobClient) setLegalHoldHandleError(resp *http.Response) error {
+func (client *client) setLegalHoldHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -2968,12 +2966,12 @@ func (client *blobClient) setLegalHoldHandleError(resp *http.Response) error {
 // SetMetadata - The Set Blob Metadata operation sets user-defined metadata for the specified blob as one or more name-value
 // pairs
 // If the operation fails it returns the *StorageError error type.
-// BlobSetMetadataOptions - BlobSetMetadataOptions contains the optional parameters for the blobClient.SetMetadata method.
+// BlobSetMetadataOptions - BlobSetMetadataOptions contains the optional parameters for the client.SetMetadata method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the Blob.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Blob.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) SetMetadata(ctx context.Context, comp Enum12, blobSetMetadataOptions *BlobSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetMetadataResponse, error) {
+func (client *client) SetMetadata(ctx context.Context, comp Enum12, blobSetMetadataOptions *BlobSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetMetadataResponse, error) {
 	req, err := client.setMetadataCreateRequest(ctx, comp, blobSetMetadataOptions, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return BlobSetMetadataResponse{}, err
@@ -2989,7 +2987,7 @@ func (client *blobClient) SetMetadata(ctx context.Context, comp Enum12, blobSetM
 }
 
 // setMetadataCreateRequest creates the SetMetadata request.
-func (client *blobClient) setMetadataCreateRequest(ctx context.Context, comp Enum12, blobSetMetadataOptions *BlobSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setMetadataCreateRequest(ctx context.Context, comp Enum12, blobSetMetadataOptions *BlobSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -3044,7 +3042,7 @@ func (client *blobClient) setMetadataCreateRequest(ctx context.Context, comp Enu
 }
 
 // setMetadataHandleResponse handles the SetMetadata response.
-func (client *blobClient) setMetadataHandleResponse(resp *http.Response) (BlobSetMetadataResponse, error) {
+func (client *client) setMetadataHandleResponse(resp *http.Response) (BlobSetMetadataResponse, error) {
 	result := BlobSetMetadataResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -3092,7 +3090,7 @@ func (client *blobClient) setMetadataHandleResponse(resp *http.Response) (BlobSe
 }
 
 // setMetadataHandleError handles the SetMetadata error response.
-func (client *blobClient) setMetadataHandleError(resp *http.Response) error {
+func (client *client) setMetadataHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -3106,10 +3104,10 @@ func (client *blobClient) setMetadataHandleError(resp *http.Response) error {
 
 // SetTags - The Set Tags operation enables users to set tags on a blob.
 // If the operation fails it returns the *StorageError error type.
-// BlobSetTagsOptions - BlobSetTagsOptions contains the optional parameters for the blobClient.SetTags method.
+// BlobSetTagsOptions - BlobSetTagsOptions contains the optional parameters for the client.SetTags method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
-func (client *blobClient) SetTags(ctx context.Context, comp Enum42, blobSetTagsOptions *BlobSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobSetTagsResponse, error) {
+func (client *client) SetTags(ctx context.Context, comp Enum42, blobSetTagsOptions *BlobSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobSetTagsResponse, error) {
 	req, err := client.setTagsCreateRequest(ctx, comp, blobSetTagsOptions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return BlobSetTagsResponse{}, err
@@ -3125,7 +3123,7 @@ func (client *blobClient) SetTags(ctx context.Context, comp Enum42, blobSetTagsO
 }
 
 // setTagsCreateRequest creates the SetTags request.
-func (client *blobClient) setTagsCreateRequest(ctx context.Context, comp Enum42, blobSetTagsOptions *BlobSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) setTagsCreateRequest(ctx context.Context, comp Enum42, blobSetTagsOptions *BlobSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -3163,7 +3161,7 @@ func (client *blobClient) setTagsCreateRequest(ctx context.Context, comp Enum42,
 }
 
 // setTagsHandleResponse handles the SetTags response.
-func (client *blobClient) setTagsHandleResponse(resp *http.Response) (BlobSetTagsResponse, error) {
+func (client *client) setTagsHandleResponse(resp *http.Response) (BlobSetTagsResponse, error) {
 	result := BlobSetTagsResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -3185,7 +3183,7 @@ func (client *blobClient) setTagsHandleResponse(resp *http.Response) (BlobSetTag
 }
 
 // setTagsHandleError handles the SetTags error response.
-func (client *blobClient) setTagsHandleError(resp *http.Response) error {
+func (client *client) setTagsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -3203,10 +3201,10 @@ func (client *blobClient) setTagsHandleError(resp *http.Response) error {
 // storage type. This operation does not update the blob's ETag.
 // If the operation fails it returns the *StorageError error type.
 // tier - Indicates the tier to be set on the blob.
-// BlobSetTierOptions - BlobSetTierOptions contains the optional parameters for the blobClient.SetTier method.
+// BlobSetTierOptions - BlobSetTierOptions contains the optional parameters for the client.SetTier method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
-func (client *blobClient) SetTier(ctx context.Context, comp Enum32, tier AccessTier, blobSetTierOptions *BlobSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetTierResponse, error) {
+func (client *client) SetTier(ctx context.Context, comp Enum32, tier AccessTier, blobSetTierOptions *BlobSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobSetTierResponse, error) {
 	req, err := client.setTierCreateRequest(ctx, comp, tier, blobSetTierOptions, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return BlobSetTierResponse{}, err
@@ -3222,7 +3220,7 @@ func (client *blobClient) SetTier(ctx context.Context, comp Enum32, tier AccessT
 }
 
 // setTierCreateRequest creates the SetTier request.
-func (client *blobClient) setTierCreateRequest(ctx context.Context, comp Enum32, tier AccessTier, blobSetTierOptions *BlobSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setTierCreateRequest(ctx context.Context, comp Enum32, tier AccessTier, blobSetTierOptions *BlobSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -3258,7 +3256,7 @@ func (client *blobClient) setTierCreateRequest(ctx context.Context, comp Enum32,
 }
 
 // setTierHandleResponse handles the SetTier response.
-func (client *blobClient) setTierHandleResponse(resp *http.Response) (BlobSetTierResponse, error) {
+func (client *client) setTierHandleResponse(resp *http.Response) (BlobSetTierResponse, error) {
 	result := BlobSetTierResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -3273,7 +3271,7 @@ func (client *blobClient) setTierHandleResponse(resp *http.Response) (BlobSetTie
 }
 
 // setTierHandleError handles the SetTier error response.
-func (client *blobClient) setTierHandleError(resp *http.Response) error {
+func (client *client) setTierHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -3290,13 +3288,13 @@ func (client *blobClient) setTierHandleError(resp *http.Response) error {
 // copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 // a page blob snapshot. The value should be URL-encoded as it would appear in a request
 // URI. The source blob must either be public or must be authenticated via a shared access signature.
-// BlobStartCopyFromURLOptions - BlobStartCopyFromURLOptions contains the optional parameters for the blobClient.StartCopyFromURL
+// BlobStartCopyFromURLOptions - BlobStartCopyFromURLOptions contains the optional parameters for the client.StartCopyFromURL
 // method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Directory.Rename
 // method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the Container.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the Container.GetProperties method.
-func (client *blobClient) StartCopyFromURL(ctx context.Context, copySource string, blobStartCopyFromURLOptions *BlobStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobStartCopyFromURLResponse, error) {
+func (client *client) StartCopyFromURL(ctx context.Context, copySource string, blobStartCopyFromURLOptions *BlobStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobStartCopyFromURLResponse, error) {
 	req, err := client.startCopyFromURLCreateRequest(ctx, copySource, blobStartCopyFromURLOptions, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return BlobStartCopyFromURLResponse{}, err
@@ -3312,7 +3310,7 @@ func (client *blobClient) StartCopyFromURL(ctx context.Context, copySource strin
 }
 
 // startCopyFromURLCreateRequest creates the StartCopyFromURL request.
-func (client *blobClient) startCopyFromURLCreateRequest(ctx context.Context, copySource string, blobStartCopyFromURLOptions *BlobStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) startCopyFromURLCreateRequest(ctx context.Context, copySource string, blobStartCopyFromURLOptions *BlobStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -3391,7 +3389,7 @@ func (client *blobClient) startCopyFromURLCreateRequest(ctx context.Context, cop
 }
 
 // startCopyFromURLHandleResponse handles the StartCopyFromURL response.
-func (client *blobClient) startCopyFromURLHandleResponse(resp *http.Response) (BlobStartCopyFromURLResponse, error) {
+func (client *client) startCopyFromURLHandleResponse(resp *http.Response) (BlobStartCopyFromURLResponse, error) {
 	result := BlobStartCopyFromURLResponse{RawResponse: resp}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -3432,7 +3430,7 @@ func (client *blobClient) startCopyFromURLHandleResponse(resp *http.Response) (B
 }
 
 // startCopyFromURLHandleError handles the StartCopyFromURL error response.
-func (client *blobClient) startCopyFromURLHandleError(resp *http.Response) error {
+func (client *client) startCopyFromURLHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -3446,8 +3444,8 @@ func (client *blobClient) startCopyFromURLHandleError(resp *http.Response) error
 
 // Undelete - Undelete a blob that was previously soft deleted
 // If the operation fails it returns the *StorageError error type.
-// options - BlobUndeleteOptions contains the optional parameters for the blobClient.Undelete method.
-func (client *blobClient) Undelete(ctx context.Context, comp Enum14, options *BlobUndeleteOptions) (BlobUndeleteResponse, error) {
+// options - BlobUndeleteOptions contains the optional parameters for the client.Undelete method.
+func (client *client) Undelete(ctx context.Context, comp Enum14, options *BlobUndeleteOptions) (BlobUndeleteResponse, error) {
 	req, err := client.undeleteCreateRequest(ctx, comp, options)
 	if err != nil {
 		return BlobUndeleteResponse{}, err
@@ -3463,7 +3461,7 @@ func (client *blobClient) Undelete(ctx context.Context, comp Enum14, options *Bl
 }
 
 // undeleteCreateRequest creates the Undelete request.
-func (client *blobClient) undeleteCreateRequest(ctx context.Context, comp Enum14, options *BlobUndeleteOptions) (*policy.Request, error) {
+func (client *client) undeleteCreateRequest(ctx context.Context, comp Enum14, options *BlobUndeleteOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -3483,7 +3481,7 @@ func (client *blobClient) undeleteCreateRequest(ctx context.Context, comp Enum14
 }
 
 // undeleteHandleResponse handles the Undelete response.
-func (client *blobClient) undeleteHandleResponse(resp *http.Response) (BlobUndeleteResponse, error) {
+func (client *client) undeleteHandleResponse(resp *http.Response) (BlobUndeleteResponse, error) {
 	result := BlobUndeleteResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -3505,7 +3503,7 @@ func (client *blobClient) undeleteHandleResponse(resp *http.Response) (BlobUndel
 }
 
 // undeleteHandleError handles the Undelete error response.
-func (client *blobClient) undeleteHandleError(resp *http.Response) error {
+func (client *client) undeleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/storage/2020-06-12/azblob/zz_generated_models.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_models.go
@@ -168,7 +168,7 @@ type ArrowField struct {
 	Scale     *int32  `xml:"Scale"`
 }
 
-// BlobAbortCopyFromURLOptions contains the optional parameters for the blobClient.AbortCopyFromURL method.
+// BlobAbortCopyFromURLOptions contains the optional parameters for the client.AbortCopyFromURL method.
 type BlobAbortCopyFromURLOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -178,7 +178,7 @@ type BlobAbortCopyFromURLOptions struct {
 	Timeout *int32
 }
 
-// BlobAcquireLeaseOptions contains the optional parameters for the blobClient.AcquireLease method.
+// BlobAcquireLeaseOptions contains the optional parameters for the client.AcquireLease method.
 type BlobAcquireLeaseOptions struct {
 	// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease
 	// can be between 15 and 60 seconds. A lease duration cannot be changed using
@@ -196,7 +196,7 @@ type BlobAcquireLeaseOptions struct {
 	Timeout *int32
 }
 
-// BlobBreakLeaseOptions contains the optional parameters for the blobClient.BreakLease method.
+// BlobBreakLeaseOptions contains the optional parameters for the client.BreakLease method.
 type BlobBreakLeaseOptions struct {
 	// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This
 	// break period is only used if it is shorter than the time remaining on the
@@ -213,7 +213,7 @@ type BlobBreakLeaseOptions struct {
 	Timeout *int32
 }
 
-// BlobChangeLeaseOptions contains the optional parameters for the blobClient.ChangeLease method.
+// BlobChangeLeaseOptions contains the optional parameters for the client.ChangeLease method.
 type BlobChangeLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -223,7 +223,7 @@ type BlobChangeLeaseOptions struct {
 	Timeout *int32
 }
 
-// BlobCopyFromURLOptions contains the optional parameters for the blobClient.CopyFromURL method.
+// BlobCopyFromURLOptions contains the optional parameters for the client.CopyFromURL method.
 type BlobCopyFromURLOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
@@ -252,7 +252,7 @@ type BlobCopyFromURLOptions struct {
 	Timeout *int32
 }
 
-// BlobCreateSnapshotOptions contains the optional parameters for the blobClient.CreateSnapshot method.
+// BlobCreateSnapshotOptions contains the optional parameters for the client.CreateSnapshot method.
 type BlobCreateSnapshotOptions struct {
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
@@ -269,7 +269,7 @@ type BlobCreateSnapshotOptions struct {
 	Timeout *int32
 }
 
-// BlobDeleteImmutabilityPolicyOptions contains the optional parameters for the blobClient.DeleteImmutabilityPolicy method.
+// BlobDeleteImmutabilityPolicyOptions contains the optional parameters for the client.DeleteImmutabilityPolicy method.
 type BlobDeleteImmutabilityPolicyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -279,7 +279,7 @@ type BlobDeleteImmutabilityPolicyOptions struct {
 	Timeout *int32
 }
 
-// BlobDeleteOptions contains the optional parameters for the blobClient.Delete method.
+// BlobDeleteOptions contains the optional parameters for the client.Delete method.
 type BlobDeleteOptions struct {
 	// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled..
 	// Specifying any value will set the value to Permanent.
@@ -303,7 +303,7 @@ type BlobDeleteOptions struct {
 	VersionID *string
 }
 
-// BlobDownloadOptions contains the optional parameters for the blobClient.Download method.
+// BlobDownloadOptions contains the optional parameters for the client.Download method.
 type BlobDownloadOptions struct {
 	// Return only the bytes of the blob in the specified range.
 	Range *string
@@ -328,27 +328,7 @@ type BlobDownloadOptions struct {
 	VersionID *string
 }
 
-type BlobFlatListSegment struct {
-	// REQUIRED
-	BlobItems []*BlobItemInternal `xml:"Blob"`
-}
-
-// MarshalXML implements the xml.Marshaller interface for type BlobFlatListSegment.
-func (b BlobFlatListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	type alias BlobFlatListSegment
-	aux := &struct {
-		*alias
-		BlobItems *[]*BlobItemInternal `xml:"Blob"`
-	}{
-		alias: (*alias)(&b),
-	}
-	if b.BlobItems != nil {
-		aux.BlobItems = &b.BlobItems
-	}
-	return e.EncodeElement(aux, start)
-}
-
-// BlobGetAccessControlOptions contains the optional parameters for the blobClient.GetAccessControl method.
+// BlobGetAccessControlOptions contains the optional parameters for the client.GetAccessControl method.
 type BlobGetAccessControlOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -363,12 +343,12 @@ type BlobGetAccessControlOptions struct {
 	Upn *bool
 }
 
-// BlobGetAccountInfoOptions contains the optional parameters for the blobClient.GetAccountInfo method.
+// BlobGetAccountInfoOptions contains the optional parameters for the client.GetAccountInfo method.
 type BlobGetAccountInfoOptions struct {
 	// placeholder for future optional parameters
 }
 
-// BlobGetPropertiesOptions contains the optional parameters for the blobClient.GetProperties method.
+// BlobGetPropertiesOptions contains the optional parameters for the client.GetProperties method.
 type BlobGetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -385,7 +365,7 @@ type BlobGetPropertiesOptions struct {
 	VersionID *string
 }
 
-// BlobGetTagsOptions contains the optional parameters for the blobClient.GetTags method.
+// BlobGetTagsOptions contains the optional parameters for the client.GetTags method.
 type BlobGetTagsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -421,199 +401,7 @@ type BlobHTTPHeaders struct {
 	BlobContentType *string
 }
 
-type BlobHierarchyListSegment struct {
-	// REQUIRED
-	BlobItems    []*BlobItemInternal `xml:"Blob"`
-	BlobPrefixes []*BlobPrefix       `xml:"BlobPrefix"`
-}
-
-// MarshalXML implements the xml.Marshaller interface for type BlobHierarchyListSegment.
-func (b BlobHierarchyListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	type alias BlobHierarchyListSegment
-	aux := &struct {
-		*alias
-		BlobItems    *[]*BlobItemInternal `xml:"Blob"`
-		BlobPrefixes *[]*BlobPrefix       `xml:"BlobPrefix"`
-	}{
-		alias: (*alias)(&b),
-	}
-	if b.BlobItems != nil {
-		aux.BlobItems = &b.BlobItems
-	}
-	if b.BlobPrefixes != nil {
-		aux.BlobPrefixes = &b.BlobPrefixes
-	}
-	return e.EncodeElement(aux, start)
-}
-
-// BlobItemInternal - An Azure Storage blob
-type BlobItemInternal struct {
-	// REQUIRED
-	Deleted *bool `xml:"Deleted"`
-
-	// REQUIRED
-	Name *string `xml:"Name"`
-
-	// REQUIRED; Properties of a blob
-	Properties *BlobPropertiesInternal `xml:"Properties"`
-
-	// REQUIRED
-	Snapshot *string `xml:"Snapshot"`
-
-	// Blob tags
-	BlobTags         *BlobTags     `xml:"Tags"`
-	IsCurrentVersion *bool         `xml:"IsCurrentVersion"`
-	Metadata         *BlobMetadata `xml:"Metadata"`
-
-	// Dictionary of
-	ObjectReplicationMetadata map[string]*string `xml:"OrMetadata"`
-	VersionID                 *string            `xml:"VersionId"`
-}
-
-// UnmarshalXML implements the xml.Unmarshaller interface for type BlobItemInternal.
-func (b *BlobItemInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	type alias BlobItemInternal
-	aux := &struct {
-		*alias
-		ObjectReplicationMetadata additionalProperties `xml:"OrMetadata"`
-	}{
-		alias: (*alias)(b),
-	}
-	if err := d.DecodeElement(aux, &start); err != nil {
-		return err
-	}
-	b.ObjectReplicationMetadata = (map[string]*string)(aux.ObjectReplicationMetadata)
-	return nil
-}
-
-type BlobMetadata struct {
-	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties map[string]*string
-	Encrypted            *string `xml:"Encrypted,attr"`
-}
-
-type BlobPrefix struct {
-	// REQUIRED
-	Name *string `xml:"Name"`
-}
-
-// BlobPropertiesInternal - Properties of a blob
-type BlobPropertiesInternal struct {
-	// REQUIRED
-	Etag *string `xml:"Etag"`
-
-	// REQUIRED
-	LastModified         *time.Time     `xml:"Last-Modified"`
-	AccessTier           *AccessTier    `xml:"AccessTier"`
-	AccessTierChangeTime *time.Time     `xml:"AccessTierChangeTime"`
-	AccessTierInferred   *bool          `xml:"AccessTierInferred"`
-	ArchiveStatus        *ArchiveStatus `xml:"ArchiveStatus"`
-	BlobSequenceNumber   *int64         `xml:"x-ms-blob-sequence-number"`
-	BlobType             *BlobType      `xml:"BlobType"`
-	CacheControl         *string        `xml:"Cache-Control"`
-	ContentDisposition   *string        `xml:"Content-Disposition"`
-	ContentEncoding      *string        `xml:"Content-Encoding"`
-	ContentLanguage      *string        `xml:"Content-Language"`
-
-	// Size in bytes
-	ContentLength             *int64          `xml:"Content-Length"`
-	ContentMD5                []byte          `xml:"Content-MD5"`
-	ContentType               *string         `xml:"Content-Type"`
-	CopyCompletionTime        *time.Time      `xml:"CopyCompletionTime"`
-	CopyID                    *string         `xml:"CopyId"`
-	CopyProgress              *string         `xml:"CopyProgress"`
-	CopySource                *string         `xml:"CopySource"`
-	CopyStatus                *CopyStatusType `xml:"CopyStatus"`
-	CopyStatusDescription     *string         `xml:"CopyStatusDescription"`
-	CreationTime              *time.Time      `xml:"Creation-Time"`
-	CustomerProvidedKeySHA256 *string         `xml:"CustomerProvidedKeySha256"`
-	DeletedTime               *time.Time      `xml:"DeletedTime"`
-	DestinationSnapshot       *string         `xml:"DestinationSnapshot"`
-
-	// The name of the encryption scope under which the blob is encrypted.
-	EncryptionScope             *string                     `xml:"EncryptionScope"`
-	ExpiresOn                   *time.Time                  `xml:"Expiry-Time"`
-	ImmutabilityPolicyExpiresOn *time.Time                  `xml:"ImmutabilityPolicyUntilDate"`
-	ImmutabilityPolicyMode      *BlobImmutabilityPolicyMode `xml:"ImmutabilityPolicyMode"`
-	IncrementalCopy             *bool                       `xml:"IncrementalCopy"`
-	IsSealed                    *bool                       `xml:"Sealed"`
-	LastAccessedOn              *time.Time                  `xml:"LastAccessTime"`
-	LeaseDuration               *LeaseDurationType          `xml:"LeaseDuration"`
-	LeaseState                  *LeaseStateType             `xml:"LeaseState"`
-	LeaseStatus                 *LeaseStatusType            `xml:"LeaseStatus"`
-	LegalHold                   *bool                       `xml:"LegalHold"`
-
-	// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
-	// and Standard.
-	RehydratePriority      *RehydratePriority `xml:"RehydratePriority"`
-	RemainingRetentionDays *int32             `xml:"RemainingRetentionDays"`
-	ServerEncrypted        *bool              `xml:"ServerEncrypted"`
-	TagCount               *int32             `xml:"TagCount"`
-}
-
-// MarshalXML implements the xml.Marshaller interface for type BlobPropertiesInternal.
-func (b BlobPropertiesInternal) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	type alias BlobPropertiesInternal
-	aux := &struct {
-		*alias
-		AccessTierChangeTime        *timeRFC1123 `xml:"AccessTierChangeTime"`
-		ContentMD5                  *[]byte      `xml:"Content-MD5"`
-		CopyCompletionTime          *timeRFC1123 `xml:"CopyCompletionTime"`
-		CreationTime                *timeRFC1123 `xml:"Creation-Time"`
-		DeletedTime                 *timeRFC1123 `xml:"DeletedTime"`
-		ExpiresOn                   *timeRFC1123 `xml:"Expiry-Time"`
-		ImmutabilityPolicyExpiresOn *timeRFC1123 `xml:"ImmutabilityPolicyUntilDate"`
-		LastAccessedOn              *timeRFC1123 `xml:"LastAccessTime"`
-		LastModified                *timeRFC1123 `xml:"Last-Modified"`
-	}{
-		alias:                       (*alias)(&b),
-		AccessTierChangeTime:        (*timeRFC1123)(b.AccessTierChangeTime),
-		CopyCompletionTime:          (*timeRFC1123)(b.CopyCompletionTime),
-		CreationTime:                (*timeRFC1123)(b.CreationTime),
-		DeletedTime:                 (*timeRFC1123)(b.DeletedTime),
-		ExpiresOn:                   (*timeRFC1123)(b.ExpiresOn),
-		ImmutabilityPolicyExpiresOn: (*timeRFC1123)(b.ImmutabilityPolicyExpiresOn),
-		LastAccessedOn:              (*timeRFC1123)(b.LastAccessedOn),
-		LastModified:                (*timeRFC1123)(b.LastModified),
-	}
-	if b.ContentMD5 != nil {
-		aux.ContentMD5 = &b.ContentMD5
-	}
-	return e.EncodeElement(aux, start)
-}
-
-// UnmarshalXML implements the xml.Unmarshaller interface for type BlobPropertiesInternal.
-func (b *BlobPropertiesInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	type alias BlobPropertiesInternal
-	aux := &struct {
-		*alias
-		AccessTierChangeTime        *timeRFC1123 `xml:"AccessTierChangeTime"`
-		ContentMD5                  *[]byte      `xml:"Content-MD5"`
-		CopyCompletionTime          *timeRFC1123 `xml:"CopyCompletionTime"`
-		CreationTime                *timeRFC1123 `xml:"Creation-Time"`
-		DeletedTime                 *timeRFC1123 `xml:"DeletedTime"`
-		ExpiresOn                   *timeRFC1123 `xml:"Expiry-Time"`
-		ImmutabilityPolicyExpiresOn *timeRFC1123 `xml:"ImmutabilityPolicyUntilDate"`
-		LastAccessedOn              *timeRFC1123 `xml:"LastAccessTime"`
-		LastModified                *timeRFC1123 `xml:"Last-Modified"`
-	}{
-		alias: (*alias)(b),
-	}
-	if err := d.DecodeElement(aux, &start); err != nil {
-		return err
-	}
-	b.AccessTierChangeTime = (*time.Time)(aux.AccessTierChangeTime)
-	b.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
-	b.CreationTime = (*time.Time)(aux.CreationTime)
-	b.DeletedTime = (*time.Time)(aux.DeletedTime)
-	b.ExpiresOn = (*time.Time)(aux.ExpiresOn)
-	b.ImmutabilityPolicyExpiresOn = (*time.Time)(aux.ImmutabilityPolicyExpiresOn)
-	b.LastAccessedOn = (*time.Time)(aux.LastAccessedOn)
-	b.LastModified = (*time.Time)(aux.LastModified)
-	return nil
-}
-
-// BlobQueryOptions contains the optional parameters for the blobClient.Query method.
+// BlobQueryOptions contains the optional parameters for the client.Query method.
 type BlobQueryOptions struct {
 	// the query request
 	QueryRequest *QueryRequest
@@ -629,7 +417,7 @@ type BlobQueryOptions struct {
 	Timeout *int32
 }
 
-// BlobReleaseLeaseOptions contains the optional parameters for the blobClient.ReleaseLease method.
+// BlobReleaseLeaseOptions contains the optional parameters for the client.ReleaseLease method.
 type BlobReleaseLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -639,7 +427,7 @@ type BlobReleaseLeaseOptions struct {
 	Timeout *int32
 }
 
-// BlobRenameOptions contains the optional parameters for the blobClient.Rename method.
+// BlobRenameOptions contains the optional parameters for the client.Rename method.
 type BlobRenameOptions struct {
 	// Optional. User-defined properties to be stored with the file or directory, in the format of a comma-separated list of name
 	// and value pairs "n1=v1, n2=v2, …", where each value is base64 encoded.
@@ -665,7 +453,7 @@ type BlobRenameOptions struct {
 	Timeout *int32
 }
 
-// BlobRenewLeaseOptions contains the optional parameters for the blobClient.RenewLease method.
+// BlobRenewLeaseOptions contains the optional parameters for the client.RenewLease method.
 type BlobRenewLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -675,7 +463,7 @@ type BlobRenewLeaseOptions struct {
 	Timeout *int32
 }
 
-// BlobSetAccessControlOptions contains the optional parameters for the blobClient.SetAccessControl method.
+// BlobSetAccessControlOptions contains the optional parameters for the client.SetAccessControl method.
 type BlobSetAccessControlOptions struct {
 	// Optional. The owning group of the blob or directory.
 	Group *string
@@ -698,7 +486,7 @@ type BlobSetAccessControlOptions struct {
 	Timeout *int32
 }
 
-// BlobSetExpiryOptions contains the optional parameters for the blobClient.SetExpiry method.
+// BlobSetExpiryOptions contains the optional parameters for the client.SetExpiry method.
 type BlobSetExpiryOptions struct {
 	// The time to set the blob to expiry
 	ExpiresOn *string
@@ -710,7 +498,7 @@ type BlobSetExpiryOptions struct {
 	Timeout *int32
 }
 
-// BlobSetHTTPHeadersOptions contains the optional parameters for the blobClient.SetHTTPHeaders method.
+// BlobSetHTTPHeadersOptions contains the optional parameters for the client.SetHTTPHeaders method.
 type BlobSetHTTPHeadersOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -720,7 +508,7 @@ type BlobSetHTTPHeadersOptions struct {
 	Timeout *int32
 }
 
-// BlobSetImmutabilityPolicyOptions contains the optional parameters for the blobClient.SetImmutabilityPolicy method.
+// BlobSetImmutabilityPolicyOptions contains the optional parameters for the client.SetImmutabilityPolicy method.
 type BlobSetImmutabilityPolicyOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
@@ -734,7 +522,7 @@ type BlobSetImmutabilityPolicyOptions struct {
 	Timeout *int32
 }
 
-// BlobSetLegalHoldOptions contains the optional parameters for the blobClient.SetLegalHold method.
+// BlobSetLegalHoldOptions contains the optional parameters for the client.SetLegalHold method.
 type BlobSetLegalHoldOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -744,7 +532,7 @@ type BlobSetLegalHoldOptions struct {
 	Timeout *int32
 }
 
-// BlobSetMetadataOptions contains the optional parameters for the blobClient.SetMetadata method.
+// BlobSetMetadataOptions contains the optional parameters for the client.SetMetadata method.
 type BlobSetMetadataOptions struct {
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
@@ -761,13 +549,13 @@ type BlobSetMetadataOptions struct {
 	Timeout *int32
 }
 
-// BlobSetTagsOptions contains the optional parameters for the blobClient.SetTags method.
+// BlobSetTagsOptions contains the optional parameters for the client.SetTags method.
 type BlobSetTagsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
 	// Blob tags
-	Tags *BlobTags
+	Tags *Tags
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -780,7 +568,7 @@ type BlobSetTagsOptions struct {
 	VersionID *string
 }
 
-// BlobSetTierOptions contains the optional parameters for the blobClient.SetTier method.
+// BlobSetTierOptions contains the optional parameters for the client.SetTier method.
 type BlobSetTierOptions struct {
 	// Optional: Indicates the priority with which to rehydrate an archived blob.
 	RehydratePriority *RehydratePriority
@@ -799,7 +587,7 @@ type BlobSetTierOptions struct {
 	VersionID *string
 }
 
-// BlobStartCopyFromURLOptions contains the optional parameters for the blobClient.StartCopyFromURL method.
+// BlobStartCopyFromURLOptions contains the optional parameters for the client.StartCopyFromURL method.
 type BlobStartCopyFromURLOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
@@ -830,37 +618,7 @@ type BlobStartCopyFromURLOptions struct {
 	Timeout *int32
 }
 
-type BlobTag struct {
-	// REQUIRED
-	Key *string `xml:"Key"`
-
-	// REQUIRED
-	Value *string `xml:"Value"`
-}
-
-// BlobTags - Blob tags
-type BlobTags struct {
-	// REQUIRED
-	BlobTagSet []*BlobTag `xml:"TagSet>Tag"`
-}
-
-// MarshalXML implements the xml.Marshaller interface for type BlobTags.
-func (b BlobTags) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	start.Name.Local = "Tags"
-	type alias BlobTags
-	aux := &struct {
-		*alias
-		BlobTagSet *[]*BlobTag `xml:"TagSet>Tag"`
-	}{
-		alias: (*alias)(&b),
-	}
-	if b.BlobTagSet != nil {
-		aux.BlobTagSet = &b.BlobTagSet
-	}
-	return e.EncodeElement(aux, start)
-}
-
-// BlobUndeleteOptions contains the optional parameters for the blobClient.Undelete method.
+// BlobUndeleteOptions contains the optional parameters for the client.Undelete method.
 type BlobUndeleteOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1623,7 +1381,7 @@ type FilterBlobItem struct {
 	Name *string `xml:"Name"`
 
 	// Blob tags
-	Tags *BlobTags `xml:"Tags"`
+	Tags *Tags `xml:"Tags"`
 }
 
 // FilterBlobSegment - The result of a Filter Blobs API call
@@ -1650,6 +1408,26 @@ func (f FilterBlobSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 	}
 	if f.Blobs != nil {
 		aux.Blobs = &f.Blobs
+	}
+	return e.EncodeElement(aux, start)
+}
+
+type FlatListSegment struct {
+	// REQUIRED
+	BlobItems []*ItemInternal `xml:"Blob"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type FlatListSegment.
+func (f FlatListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias FlatListSegment
+	aux := &struct {
+		*alias
+		BlobItems *[]*ItemInternal `xml:"Blob"`
+	}{
+		alias: (*alias)(&f),
+	}
+	if f.BlobItems != nil {
+		aux.BlobItems = &f.BlobItems
 	}
 	return e.EncodeElement(aux, start)
 }
@@ -1694,6 +1472,71 @@ func (g *GeoReplication) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	return nil
 }
 
+type HierarchyListSegment struct {
+	// REQUIRED
+	BlobItems    []*ItemInternal `xml:"Blob"`
+	BlobPrefixes []*Prefix       `xml:"Prefix"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type HierarchyListSegment.
+func (h HierarchyListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias HierarchyListSegment
+	aux := &struct {
+		*alias
+		BlobItems    *[]*ItemInternal `xml:"Blob"`
+		BlobPrefixes *[]*Prefix       `xml:"Prefix"`
+	}{
+		alias: (*alias)(&h),
+	}
+	if h.BlobItems != nil {
+		aux.BlobItems = &h.BlobItems
+	}
+	if h.BlobPrefixes != nil {
+		aux.BlobPrefixes = &h.BlobPrefixes
+	}
+	return e.EncodeElement(aux, start)
+}
+
+// ItemInternal - An Azure Storage blob
+type ItemInternal struct {
+	// REQUIRED
+	Deleted *bool `xml:"Deleted"`
+
+	// REQUIRED
+	Name *string `xml:"Name"`
+
+	// REQUIRED; Properties of a blob
+	Properties *PropertiesInternal `xml:"Properties"`
+
+	// REQUIRED
+	Snapshot *string `xml:"Snapshot"`
+
+	// Blob tags
+	BlobTags         *Tags     `xml:"Tags"`
+	IsCurrentVersion *bool     `xml:"IsCurrentVersion"`
+	Metadata         *Metadata `xml:"Metadata"`
+
+	// Dictionary of
+	ObjectReplicationMetadata map[string]*string `xml:"OrMetadata"`
+	VersionID                 *string            `xml:"VersionId"`
+}
+
+// UnmarshalXML implements the xml.Unmarshaller interface for type ItemInternal.
+func (i *ItemInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type alias ItemInternal
+	aux := &struct {
+		*alias
+		ObjectReplicationMetadata additionalProperties `xml:"OrMetadata"`
+	}{
+		alias: (*alias)(i),
+	}
+	if err := d.DecodeElement(aux, &start); err != nil {
+		return err
+	}
+	i.ObjectReplicationMetadata = (map[string]*string)(aux.ObjectReplicationMetadata)
+	return nil
+}
+
 // JSONTextConfiguration - json text configuration
 type JSONTextConfiguration struct {
 	// REQUIRED; record separator
@@ -1721,7 +1564,7 @@ type ListBlobsFlatSegmentResponse struct {
 	ContainerName *string `xml:"ContainerName,attr"`
 
 	// REQUIRED
-	Segment *BlobFlatListSegment `xml:"Blobs"`
+	Segment *FlatListSegment `xml:"Blobs"`
 
 	// REQUIRED
 	ServiceEndpoint *string `xml:"ServiceEndpoint,attr"`
@@ -1737,7 +1580,7 @@ type ListBlobsHierarchySegmentResponse struct {
 	ContainerName *string `xml:"ContainerName,attr"`
 
 	// REQUIRED
-	Segment *BlobHierarchyListSegment `xml:"Blobs"`
+	Segment *HierarchyListSegment `xml:"Blobs"`
 
 	// REQUIRED
 	ServiceEndpoint *string `xml:"ServiceEndpoint,attr"`
@@ -1792,6 +1635,12 @@ type Logging struct {
 
 	// REQUIRED; Indicates whether all write requests should be logged.
 	Write *bool `xml:"Write"`
+}
+
+type Metadata struct {
+	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
+	AdditionalProperties map[string]*string
+	Encrypted            *string `xml:"Encrypted,attr"`
 }
 
 // Metrics - a summary of request statistics grouped by API in hour or minute aggregates for blobs
@@ -2001,6 +1850,127 @@ type PageRange struct {
 
 	// REQUIRED
 	Start *int64 `xml:"Start"`
+}
+
+type Prefix struct {
+	// REQUIRED
+	Name *string `xml:"Name"`
+}
+
+// PropertiesInternal - Properties of a blob
+type PropertiesInternal struct {
+	// REQUIRED
+	Etag *string `xml:"Etag"`
+
+	// REQUIRED
+	LastModified         *time.Time     `xml:"Last-Modified"`
+	AccessTier           *AccessTier    `xml:"AccessTier"`
+	AccessTierChangeTime *time.Time     `xml:"AccessTierChangeTime"`
+	AccessTierInferred   *bool          `xml:"AccessTierInferred"`
+	ArchiveStatus        *ArchiveStatus `xml:"ArchiveStatus"`
+	BlobSequenceNumber   *int64         `xml:"x-ms-blob-sequence-number"`
+	BlobType             *BlobType      `xml:"BlobType"`
+	CacheControl         *string        `xml:"Cache-Control"`
+	ContentDisposition   *string        `xml:"Content-Disposition"`
+	ContentEncoding      *string        `xml:"Content-Encoding"`
+	ContentLanguage      *string        `xml:"Content-Language"`
+
+	// Size in bytes
+	ContentLength             *int64          `xml:"Content-Length"`
+	ContentMD5                []byte          `xml:"Content-MD5"`
+	ContentType               *string         `xml:"Content-Type"`
+	CopyCompletionTime        *time.Time      `xml:"CopyCompletionTime"`
+	CopyID                    *string         `xml:"CopyId"`
+	CopyProgress              *string         `xml:"CopyProgress"`
+	CopySource                *string         `xml:"CopySource"`
+	CopyStatus                *CopyStatusType `xml:"CopyStatus"`
+	CopyStatusDescription     *string         `xml:"CopyStatusDescription"`
+	CreationTime              *time.Time      `xml:"Creation-Time"`
+	CustomerProvidedKeySHA256 *string         `xml:"CustomerProvidedKeySha256"`
+	DeletedTime               *time.Time      `xml:"DeletedTime"`
+	DestinationSnapshot       *string         `xml:"DestinationSnapshot"`
+
+	// The name of the encryption scope under which the blob is encrypted.
+	EncryptionScope             *string                     `xml:"EncryptionScope"`
+	ExpiresOn                   *time.Time                  `xml:"Expiry-Time"`
+	ImmutabilityPolicyExpiresOn *time.Time                  `xml:"ImmutabilityPolicyUntilDate"`
+	ImmutabilityPolicyMode      *BlobImmutabilityPolicyMode `xml:"ImmutabilityPolicyMode"`
+	IncrementalCopy             *bool                       `xml:"IncrementalCopy"`
+	IsSealed                    *bool                       `xml:"Sealed"`
+	LastAccessedOn              *time.Time                  `xml:"LastAccessTime"`
+	LeaseDuration               *LeaseDurationType          `xml:"LeaseDuration"`
+	LeaseState                  *LeaseStateType             `xml:"LeaseState"`
+	LeaseStatus                 *LeaseStatusType            `xml:"LeaseStatus"`
+	LegalHold                   *bool                       `xml:"LegalHold"`
+
+	// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
+	// and Standard.
+	RehydratePriority      *RehydratePriority `xml:"RehydratePriority"`
+	RemainingRetentionDays *int32             `xml:"RemainingRetentionDays"`
+	ServerEncrypted        *bool              `xml:"ServerEncrypted"`
+	TagCount               *int32             `xml:"TagCount"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type PropertiesInternal.
+func (p PropertiesInternal) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias PropertiesInternal
+	aux := &struct {
+		*alias
+		AccessTierChangeTime        *timeRFC1123 `xml:"AccessTierChangeTime"`
+		ContentMD5                  *[]byte      `xml:"Content-MD5"`
+		CopyCompletionTime          *timeRFC1123 `xml:"CopyCompletionTime"`
+		CreationTime                *timeRFC1123 `xml:"Creation-Time"`
+		DeletedTime                 *timeRFC1123 `xml:"DeletedTime"`
+		ExpiresOn                   *timeRFC1123 `xml:"Expiry-Time"`
+		ImmutabilityPolicyExpiresOn *timeRFC1123 `xml:"ImmutabilityPolicyUntilDate"`
+		LastAccessedOn              *timeRFC1123 `xml:"LastAccessTime"`
+		LastModified                *timeRFC1123 `xml:"Last-Modified"`
+	}{
+		alias:                       (*alias)(&p),
+		AccessTierChangeTime:        (*timeRFC1123)(p.AccessTierChangeTime),
+		CopyCompletionTime:          (*timeRFC1123)(p.CopyCompletionTime),
+		CreationTime:                (*timeRFC1123)(p.CreationTime),
+		DeletedTime:                 (*timeRFC1123)(p.DeletedTime),
+		ExpiresOn:                   (*timeRFC1123)(p.ExpiresOn),
+		ImmutabilityPolicyExpiresOn: (*timeRFC1123)(p.ImmutabilityPolicyExpiresOn),
+		LastAccessedOn:              (*timeRFC1123)(p.LastAccessedOn),
+		LastModified:                (*timeRFC1123)(p.LastModified),
+	}
+	if p.ContentMD5 != nil {
+		aux.ContentMD5 = &p.ContentMD5
+	}
+	return e.EncodeElement(aux, start)
+}
+
+// UnmarshalXML implements the xml.Unmarshaller interface for type PropertiesInternal.
+func (p *PropertiesInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type alias PropertiesInternal
+	aux := &struct {
+		*alias
+		AccessTierChangeTime        *timeRFC1123 `xml:"AccessTierChangeTime"`
+		ContentMD5                  *[]byte      `xml:"Content-MD5"`
+		CopyCompletionTime          *timeRFC1123 `xml:"CopyCompletionTime"`
+		CreationTime                *timeRFC1123 `xml:"Creation-Time"`
+		DeletedTime                 *timeRFC1123 `xml:"DeletedTime"`
+		ExpiresOn                   *timeRFC1123 `xml:"Expiry-Time"`
+		ImmutabilityPolicyExpiresOn *timeRFC1123 `xml:"ImmutabilityPolicyUntilDate"`
+		LastAccessedOn              *timeRFC1123 `xml:"LastAccessTime"`
+		LastModified                *timeRFC1123 `xml:"Last-Modified"`
+	}{
+		alias: (*alias)(p),
+	}
+	if err := d.DecodeElement(aux, &start); err != nil {
+		return err
+	}
+	p.AccessTierChangeTime = (*time.Time)(aux.AccessTierChangeTime)
+	p.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
+	p.CreationTime = (*time.Time)(aux.CreationTime)
+	p.DeletedTime = (*time.Time)(aux.DeletedTime)
+	p.ExpiresOn = (*time.Time)(aux.ExpiresOn)
+	p.ImmutabilityPolicyExpiresOn = (*time.Time)(aux.ImmutabilityPolicyExpiresOn)
+	p.LastAccessedOn = (*time.Time)(aux.LastAccessedOn)
+	p.LastModified = (*time.Time)(aux.LastModified)
+	return nil
 }
 
 type QueryFormat struct {
@@ -2267,6 +2237,36 @@ func (s StorageServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElem
 type StorageServiceStats struct {
 	// Geo-Replication information for the Secondary Storage Service
 	GeoReplication *GeoReplication `xml:"GeoReplication"`
+}
+
+type Tag struct {
+	// REQUIRED
+	Key *string `xml:"Key"`
+
+	// REQUIRED
+	Value *string `xml:"Value"`
+}
+
+// Tags - Blob tags
+type Tags struct {
+	// REQUIRED
+	BlobTagSet []*Tag `xml:"TagSet>Tag"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type Tags.
+func (t Tags) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "Tags"
+	type alias Tags
+	aux := &struct {
+		*alias
+		BlobTagSet *[]*Tag `xml:"TagSet>Tag"`
+	}{
+		alias: (*alias)(&t),
+	}
+	if t.BlobTagSet != nil {
+		aux.BlobTagSet = &t.BlobTagSet
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // UserDelegationKey - A user delegation key

--- a/test/storage/2020-06-12/azblob/zz_generated_response_types.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_response_types.go
@@ -791,7 +791,7 @@ type BlobGetTagsResponse struct {
 
 // BlobGetTagsResult contains the result from method Blob.GetTags.
 type BlobGetTagsResult struct {
-	BlobTags
+	Tags
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 

--- a/test/synapse/2019-06-01/azspark/zz_generated_batch_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_batch_client.go
@@ -19,17 +19,17 @@ import (
 	"strings"
 )
 
-type sparkBatchClient struct {
+type batchClient struct {
 	endpoint string
 	pl       runtime.Pipeline
 }
 
-// newSparkBatchClient creates a new instance of sparkBatchClient with the specified values.
+// newBatchClient creates a new instance of batchClient with the specified values.
 // endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
 // livyAPIVersion - Valid api-version for the request.
 // sparkPoolName - Name of the spark pool.
 // pl - the pipeline used for sending requests and handling responses.
-func newSparkBatchClient(endpoint string, livyAPIVersion *string, sparkPoolName string, pl runtime.Pipeline) *sparkBatchClient {
+func newBatchClient(endpoint string, livyAPIVersion *string, sparkPoolName string, pl runtime.Pipeline) *batchClient {
 	hostURL := "{endpoint}/livyApi/versions/{livyApiVersion}/sparkPools/{sparkPoolName}"
 	hostURL = strings.ReplaceAll(hostURL, "{endpoint}", endpoint)
 	if livyAPIVersion == nil {
@@ -38,7 +38,7 @@ func newSparkBatchClient(endpoint string, livyAPIVersion *string, sparkPoolName 
 	}
 	hostURL = strings.ReplaceAll(hostURL, "{livyApiVersion}", *livyAPIVersion)
 	hostURL = strings.ReplaceAll(hostURL, "{sparkPoolName}", sparkPoolName)
-	client := &sparkBatchClient{
+	client := &batchClient{
 		endpoint: hostURL,
 		pl:       pl,
 	}
@@ -48,9 +48,9 @@ func newSparkBatchClient(endpoint string, livyAPIVersion *string, sparkPoolName 
 // CancelSparkBatchJob - Cancels a running spark batch job.
 // If the operation fails it returns a generic error.
 // batchID - Identifier for the batch job.
-// options - SparkBatchCancelSparkBatchJobOptions contains the optional parameters for the sparkBatchClient.CancelSparkBatchJob
+// options - SparkBatchCancelSparkBatchJobOptions contains the optional parameters for the batchClient.CancelSparkBatchJob
 // method.
-func (client *sparkBatchClient) CancelSparkBatchJob(ctx context.Context, batchID int32, options *SparkBatchCancelSparkBatchJobOptions) (SparkBatchCancelSparkBatchJobResponse, error) {
+func (client *batchClient) CancelSparkBatchJob(ctx context.Context, batchID int32, options *SparkBatchCancelSparkBatchJobOptions) (SparkBatchCancelSparkBatchJobResponse, error) {
 	req, err := client.cancelSparkBatchJobCreateRequest(ctx, batchID, options)
 	if err != nil {
 		return SparkBatchCancelSparkBatchJobResponse{}, err
@@ -66,7 +66,7 @@ func (client *sparkBatchClient) CancelSparkBatchJob(ctx context.Context, batchID
 }
 
 // cancelSparkBatchJobCreateRequest creates the CancelSparkBatchJob request.
-func (client *sparkBatchClient) cancelSparkBatchJobCreateRequest(ctx context.Context, batchID int32, options *SparkBatchCancelSparkBatchJobOptions) (*policy.Request, error) {
+func (client *batchClient) cancelSparkBatchJobCreateRequest(ctx context.Context, batchID int32, options *SparkBatchCancelSparkBatchJobOptions) (*policy.Request, error) {
 	urlPath := "/batches/{batchId}"
 	urlPath = strings.ReplaceAll(urlPath, "{batchId}", url.PathEscape(strconv.FormatInt(int64(batchID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.endpoint, urlPath))
@@ -77,7 +77,7 @@ func (client *sparkBatchClient) cancelSparkBatchJobCreateRequest(ctx context.Con
 }
 
 // cancelSparkBatchJobHandleError handles the CancelSparkBatchJob error response.
-func (client *sparkBatchClient) cancelSparkBatchJobHandleError(resp *http.Response) error {
+func (client *batchClient) cancelSparkBatchJobHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -91,9 +91,9 @@ func (client *sparkBatchClient) cancelSparkBatchJobHandleError(resp *http.Respon
 // CreateSparkBatchJob - Create new spark batch job.
 // If the operation fails it returns a generic error.
 // sparkBatchJobOptions - Livy compatible batch job request payload.
-// options - SparkBatchCreateSparkBatchJobOptions contains the optional parameters for the sparkBatchClient.CreateSparkBatchJob
+// options - SparkBatchCreateSparkBatchJobOptions contains the optional parameters for the batchClient.CreateSparkBatchJob
 // method.
-func (client *sparkBatchClient) CreateSparkBatchJob(ctx context.Context, sparkBatchJobOptions SparkBatchJobOptions, options *SparkBatchCreateSparkBatchJobOptions) (SparkBatchCreateSparkBatchJobResponse, error) {
+func (client *batchClient) CreateSparkBatchJob(ctx context.Context, sparkBatchJobOptions BatchJobOptions, options *SparkBatchCreateSparkBatchJobOptions) (SparkBatchCreateSparkBatchJobResponse, error) {
 	req, err := client.createSparkBatchJobCreateRequest(ctx, sparkBatchJobOptions, options)
 	if err != nil {
 		return SparkBatchCreateSparkBatchJobResponse{}, err
@@ -109,7 +109,7 @@ func (client *sparkBatchClient) CreateSparkBatchJob(ctx context.Context, sparkBa
 }
 
 // createSparkBatchJobCreateRequest creates the CreateSparkBatchJob request.
-func (client *sparkBatchClient) createSparkBatchJobCreateRequest(ctx context.Context, sparkBatchJobOptions SparkBatchJobOptions, options *SparkBatchCreateSparkBatchJobOptions) (*policy.Request, error) {
+func (client *batchClient) createSparkBatchJobCreateRequest(ctx context.Context, sparkBatchJobOptions BatchJobOptions, options *SparkBatchCreateSparkBatchJobOptions) (*policy.Request, error) {
 	urlPath := "/batches"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -125,16 +125,16 @@ func (client *sparkBatchClient) createSparkBatchJobCreateRequest(ctx context.Con
 }
 
 // createSparkBatchJobHandleResponse handles the CreateSparkBatchJob response.
-func (client *sparkBatchClient) createSparkBatchJobHandleResponse(resp *http.Response) (SparkBatchCreateSparkBatchJobResponse, error) {
+func (client *batchClient) createSparkBatchJobHandleResponse(resp *http.Response) (SparkBatchCreateSparkBatchJobResponse, error) {
 	result := SparkBatchCreateSparkBatchJobResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkBatchJob); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJob); err != nil {
 		return SparkBatchCreateSparkBatchJobResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // createSparkBatchJobHandleError handles the CreateSparkBatchJob error response.
-func (client *sparkBatchClient) createSparkBatchJobHandleError(resp *http.Response) error {
+func (client *batchClient) createSparkBatchJobHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -148,9 +148,8 @@ func (client *sparkBatchClient) createSparkBatchJobHandleError(resp *http.Respon
 // GetSparkBatchJob - Gets a single spark batch job.
 // If the operation fails it returns a generic error.
 // batchID - Identifier for the batch job.
-// options - SparkBatchGetSparkBatchJobOptions contains the optional parameters for the sparkBatchClient.GetSparkBatchJob
-// method.
-func (client *sparkBatchClient) GetSparkBatchJob(ctx context.Context, batchID int32, options *SparkBatchGetSparkBatchJobOptions) (SparkBatchGetSparkBatchJobResponse, error) {
+// options - SparkBatchGetSparkBatchJobOptions contains the optional parameters for the batchClient.GetSparkBatchJob method.
+func (client *batchClient) GetSparkBatchJob(ctx context.Context, batchID int32, options *SparkBatchGetSparkBatchJobOptions) (SparkBatchGetSparkBatchJobResponse, error) {
 	req, err := client.getSparkBatchJobCreateRequest(ctx, batchID, options)
 	if err != nil {
 		return SparkBatchGetSparkBatchJobResponse{}, err
@@ -166,7 +165,7 @@ func (client *sparkBatchClient) GetSparkBatchJob(ctx context.Context, batchID in
 }
 
 // getSparkBatchJobCreateRequest creates the GetSparkBatchJob request.
-func (client *sparkBatchClient) getSparkBatchJobCreateRequest(ctx context.Context, batchID int32, options *SparkBatchGetSparkBatchJobOptions) (*policy.Request, error) {
+func (client *batchClient) getSparkBatchJobCreateRequest(ctx context.Context, batchID int32, options *SparkBatchGetSparkBatchJobOptions) (*policy.Request, error) {
 	urlPath := "/batches/{batchId}"
 	urlPath = strings.ReplaceAll(urlPath, "{batchId}", url.PathEscape(strconv.FormatInt(int64(batchID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -183,16 +182,16 @@ func (client *sparkBatchClient) getSparkBatchJobCreateRequest(ctx context.Contex
 }
 
 // getSparkBatchJobHandleResponse handles the GetSparkBatchJob response.
-func (client *sparkBatchClient) getSparkBatchJobHandleResponse(resp *http.Response) (SparkBatchGetSparkBatchJobResponse, error) {
+func (client *batchClient) getSparkBatchJobHandleResponse(resp *http.Response) (SparkBatchGetSparkBatchJobResponse, error) {
 	result := SparkBatchGetSparkBatchJobResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkBatchJob); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJob); err != nil {
 		return SparkBatchGetSparkBatchJobResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getSparkBatchJobHandleError handles the GetSparkBatchJob error response.
-func (client *sparkBatchClient) getSparkBatchJobHandleError(resp *http.Response) error {
+func (client *batchClient) getSparkBatchJobHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -205,9 +204,8 @@ func (client *sparkBatchClient) getSparkBatchJobHandleError(resp *http.Response)
 
 // GetSparkBatchJobs - List all spark batch jobs which are running under a particular spark pool.
 // If the operation fails it returns a generic error.
-// options - SparkBatchGetSparkBatchJobsOptions contains the optional parameters for the sparkBatchClient.GetSparkBatchJobs
-// method.
-func (client *sparkBatchClient) GetSparkBatchJobs(ctx context.Context, options *SparkBatchGetSparkBatchJobsOptions) (SparkBatchGetSparkBatchJobsResponse, error) {
+// options - SparkBatchGetSparkBatchJobsOptions contains the optional parameters for the batchClient.GetSparkBatchJobs method.
+func (client *batchClient) GetSparkBatchJobs(ctx context.Context, options *SparkBatchGetSparkBatchJobsOptions) (SparkBatchGetSparkBatchJobsResponse, error) {
 	req, err := client.getSparkBatchJobsCreateRequest(ctx, options)
 	if err != nil {
 		return SparkBatchGetSparkBatchJobsResponse{}, err
@@ -223,7 +221,7 @@ func (client *sparkBatchClient) GetSparkBatchJobs(ctx context.Context, options *
 }
 
 // getSparkBatchJobsCreateRequest creates the GetSparkBatchJobs request.
-func (client *sparkBatchClient) getSparkBatchJobsCreateRequest(ctx context.Context, options *SparkBatchGetSparkBatchJobsOptions) (*policy.Request, error) {
+func (client *batchClient) getSparkBatchJobsCreateRequest(ctx context.Context, options *SparkBatchGetSparkBatchJobsOptions) (*policy.Request, error) {
 	urlPath := "/batches"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -245,16 +243,16 @@ func (client *sparkBatchClient) getSparkBatchJobsCreateRequest(ctx context.Conte
 }
 
 // getSparkBatchJobsHandleResponse handles the GetSparkBatchJobs response.
-func (client *sparkBatchClient) getSparkBatchJobsHandleResponse(resp *http.Response) (SparkBatchGetSparkBatchJobsResponse, error) {
+func (client *batchClient) getSparkBatchJobsHandleResponse(resp *http.Response) (SparkBatchGetSparkBatchJobsResponse, error) {
 	result := SparkBatchGetSparkBatchJobsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkBatchJobCollection); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJobCollection); err != nil {
 		return SparkBatchGetSparkBatchJobsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getSparkBatchJobsHandleError handles the GetSparkBatchJobs error response.
-func (client *sparkBatchClient) getSparkBatchJobsHandleError(resp *http.Response) error {
+func (client *batchClient) getSparkBatchJobsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/synapse/2019-06-01/azspark/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_models.go
@@ -15,34 +15,7 @@ import (
 	"time"
 )
 
-// SparkBatchCancelSparkBatchJobOptions contains the optional parameters for the sparkBatchClient.CancelSparkBatchJob method.
-type SparkBatchCancelSparkBatchJobOptions struct {
-	// placeholder for future optional parameters
-}
-
-// SparkBatchCreateSparkBatchJobOptions contains the optional parameters for the sparkBatchClient.CreateSparkBatchJob method.
-type SparkBatchCreateSparkBatchJobOptions struct {
-	// Optional query param specifying whether detailed response is returned beyond plain livy.
-	Detailed *bool
-}
-
-// SparkBatchGetSparkBatchJobOptions contains the optional parameters for the sparkBatchClient.GetSparkBatchJob method.
-type SparkBatchGetSparkBatchJobOptions struct {
-	// Optional query param specifying whether detailed response is returned beyond plain livy.
-	Detailed *bool
-}
-
-// SparkBatchGetSparkBatchJobsOptions contains the optional parameters for the sparkBatchClient.GetSparkBatchJobs method.
-type SparkBatchGetSparkBatchJobsOptions struct {
-	// Optional query param specifying whether detailed response is returned beyond plain livy.
-	Detailed *bool
-	// Optional param specifying which index the list should begin from.
-	From *int32
-	// Optional param specifying the size of the returned list. By default it is 20 and that is the maximum.
-	Size *int32
-}
-
-type SparkBatchJob struct {
+type BatchJob struct {
 	// REQUIRED; The session Id.
 	ID *int32 `json:"id,omitempty"`
 
@@ -56,11 +29,11 @@ type SparkBatchJob struct {
 	ArtifactID *string `json:"artifactId,omitempty"`
 
 	// The error information.
-	Errors []*SparkServiceError `json:"errorInfo,omitempty"`
+	Errors []*ServiceError `json:"errorInfo,omitempty"`
 
 	// The job type.
-	JobType  *SparkJobType       `json:"jobType,omitempty"`
-	LivyInfo *SparkBatchJobState `json:"livyInfo,omitempty"`
+	JobType  *SparkJobType  `json:"jobType,omitempty"`
+	LivyInfo *BatchJobState `json:"livyInfo,omitempty"`
 
 	// The log lines.
 	LogLines []*string `json:"log,omitempty"`
@@ -69,13 +42,13 @@ type SparkBatchJob struct {
 	Name *string `json:"name,omitempty"`
 
 	// The plugin information.
-	Plugin *SparkServicePlugin `json:"pluginInfo,omitempty"`
+	Plugin *ServicePlugin `json:"pluginInfo,omitempty"`
 
 	// The Spark batch job result.
 	Result *SparkBatchJobResultType `json:"result,omitempty"`
 
 	// The scheduler information.
-	Scheduler *SparkScheduler `json:"schedulerInfo,omitempty"`
+	Scheduler *Scheduler `json:"schedulerInfo,omitempty"`
 
 	// The Spark pool name.
 	SparkPoolName *string `json:"sparkPoolName,omitempty"`
@@ -96,32 +69,32 @@ type SparkBatchJob struct {
 	WorkspaceName *string `json:"workspaceName,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkBatchJob.
-func (s SparkBatchJob) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type BatchJob.
+func (b BatchJob) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "appId", s.AppID)
-	populate(objectMap, "appInfo", s.AppInfo)
-	populate(objectMap, "artifactId", s.ArtifactID)
-	populate(objectMap, "errorInfo", s.Errors)
-	populate(objectMap, "id", s.ID)
-	populate(objectMap, "jobType", s.JobType)
-	populate(objectMap, "livyInfo", s.LivyInfo)
-	populate(objectMap, "log", s.LogLines)
-	populate(objectMap, "name", s.Name)
-	populate(objectMap, "pluginInfo", s.Plugin)
-	populate(objectMap, "result", s.Result)
-	populate(objectMap, "schedulerInfo", s.Scheduler)
-	populate(objectMap, "sparkPoolName", s.SparkPoolName)
-	populate(objectMap, "state", s.State)
-	populate(objectMap, "submitterId", s.SubmitterID)
-	populate(objectMap, "submitterName", s.SubmitterName)
-	populate(objectMap, "tags", s.Tags)
-	populate(objectMap, "workspaceName", s.WorkspaceName)
+	populate(objectMap, "appId", b.AppID)
+	populate(objectMap, "appInfo", b.AppInfo)
+	populate(objectMap, "artifactId", b.ArtifactID)
+	populate(objectMap, "errorInfo", b.Errors)
+	populate(objectMap, "id", b.ID)
+	populate(objectMap, "jobType", b.JobType)
+	populate(objectMap, "livyInfo", b.LivyInfo)
+	populate(objectMap, "log", b.LogLines)
+	populate(objectMap, "name", b.Name)
+	populate(objectMap, "pluginInfo", b.Plugin)
+	populate(objectMap, "result", b.Result)
+	populate(objectMap, "schedulerInfo", b.Scheduler)
+	populate(objectMap, "sparkPoolName", b.SparkPoolName)
+	populate(objectMap, "state", b.State)
+	populate(objectMap, "submitterId", b.SubmitterID)
+	populate(objectMap, "submitterName", b.SubmitterName)
+	populate(objectMap, "tags", b.Tags)
+	populate(objectMap, "workspaceName", b.WorkspaceName)
 	return json.Marshal(objectMap)
 }
 
-// SparkBatchJobCollection - Response for batch list operation.
-type SparkBatchJobCollection struct {
+// BatchJobCollection - Response for batch list operation.
+type BatchJobCollection struct {
 	// REQUIRED; The start index of fetched sessions.
 	From *int32 `json:"from,omitempty"`
 
@@ -129,19 +102,19 @@ type SparkBatchJobCollection struct {
 	Total *int32 `json:"total,omitempty"`
 
 	// Batch list
-	Sessions []*SparkBatchJob `json:"sessions,omitempty"`
+	Sessions []*BatchJob `json:"sessions,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkBatchJobCollection.
-func (s SparkBatchJobCollection) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type BatchJobCollection.
+func (b BatchJobCollection) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "from", s.From)
-	populate(objectMap, "sessions", s.Sessions)
-	populate(objectMap, "total", s.Total)
+	populate(objectMap, "from", b.From)
+	populate(objectMap, "sessions", b.Sessions)
+	populate(objectMap, "total", b.Total)
 	return json.Marshal(objectMap)
 }
 
-type SparkBatchJobOptions struct {
+type BatchJobOptions struct {
 	// REQUIRED
 	File *string `json:"file,omitempty"`
 
@@ -167,35 +140,35 @@ type SparkBatchJobOptions struct {
 	Tags map[string]*string `json:"tags,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkBatchJobOptions.
-func (s SparkBatchJobOptions) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type BatchJobOptions.
+func (b BatchJobOptions) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "archives", s.Archives)
-	populate(objectMap, "args", s.Arguments)
-	populate(objectMap, "artifactId", s.ArtifactID)
-	populate(objectMap, "className", s.ClassName)
-	populate(objectMap, "conf", s.Configuration)
-	populate(objectMap, "driverCores", s.DriverCores)
-	populate(objectMap, "driverMemory", s.DriverMemory)
-	populate(objectMap, "executorCores", s.ExecutorCores)
-	populate(objectMap, "numExecutors", s.ExecutorCount)
-	populate(objectMap, "executorMemory", s.ExecutorMemory)
-	populate(objectMap, "file", s.File)
-	populate(objectMap, "files", s.Files)
-	populate(objectMap, "jars", s.Jars)
-	populate(objectMap, "name", s.Name)
-	populate(objectMap, "pyFiles", s.PythonFiles)
-	populate(objectMap, "tags", s.Tags)
+	populate(objectMap, "archives", b.Archives)
+	populate(objectMap, "args", b.Arguments)
+	populate(objectMap, "artifactId", b.ArtifactID)
+	populate(objectMap, "className", b.ClassName)
+	populate(objectMap, "conf", b.Configuration)
+	populate(objectMap, "driverCores", b.DriverCores)
+	populate(objectMap, "driverMemory", b.DriverMemory)
+	populate(objectMap, "executorCores", b.ExecutorCores)
+	populate(objectMap, "numExecutors", b.ExecutorCount)
+	populate(objectMap, "executorMemory", b.ExecutorMemory)
+	populate(objectMap, "file", b.File)
+	populate(objectMap, "files", b.Files)
+	populate(objectMap, "jars", b.Jars)
+	populate(objectMap, "name", b.Name)
+	populate(objectMap, "pyFiles", b.PythonFiles)
+	populate(objectMap, "tags", b.Tags)
 	return json.Marshal(objectMap)
 }
 
-type SparkBatchJobState struct {
+type BatchJobState struct {
 	// the Spark job state.
 	CurrentState *string `json:"currentState,omitempty"`
 
 	// time that at which "dead" livy state was first seen.
-	DeadAt             *time.Time    `json:"deadAt,omitempty"`
-	JobCreationRequest *SparkRequest `json:"jobCreationRequest,omitempty"`
+	DeadAt             *time.Time `json:"deadAt,omitempty"`
+	JobCreationRequest *Request   `json:"jobCreationRequest,omitempty"`
 
 	// the time that at which "not_started" livy state was first seen.
 	NotStartedAt *time.Time `json:"notStartedAt,omitempty"`
@@ -216,23 +189,23 @@ type SparkBatchJobState struct {
 	TerminatedAt *time.Time `json:"killedAt,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkBatchJobState.
-func (s SparkBatchJobState) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type BatchJobState.
+func (b BatchJobState) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "currentState", s.CurrentState)
-	populateTimeRFC3339(objectMap, "deadAt", s.DeadAt)
-	populate(objectMap, "jobCreationRequest", s.JobCreationRequest)
-	populateTimeRFC3339(objectMap, "notStartedAt", s.NotStartedAt)
-	populateTimeRFC3339(objectMap, "recoveringAt", s.RecoveringAt)
-	populateTimeRFC3339(objectMap, "runningAt", s.RunningAt)
-	populateTimeRFC3339(objectMap, "startingAt", s.StartingAt)
-	populateTimeRFC3339(objectMap, "successAt", s.SuccessAt)
-	populateTimeRFC3339(objectMap, "killedAt", s.TerminatedAt)
+	populate(objectMap, "currentState", b.CurrentState)
+	populateTimeRFC3339(objectMap, "deadAt", b.DeadAt)
+	populate(objectMap, "jobCreationRequest", b.JobCreationRequest)
+	populateTimeRFC3339(objectMap, "notStartedAt", b.NotStartedAt)
+	populateTimeRFC3339(objectMap, "recoveringAt", b.RecoveringAt)
+	populateTimeRFC3339(objectMap, "runningAt", b.RunningAt)
+	populateTimeRFC3339(objectMap, "startingAt", b.StartingAt)
+	populateTimeRFC3339(objectMap, "successAt", b.SuccessAt)
+	populateTimeRFC3339(objectMap, "killedAt", b.TerminatedAt)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type SparkBatchJobState.
-func (s *SparkBatchJobState) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type BatchJobState.
+func (b *BatchJobState) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
@@ -241,31 +214,31 @@ func (s *SparkBatchJobState) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "currentState":
-			err = unpopulate(val, &s.CurrentState)
+			err = unpopulate(val, &b.CurrentState)
 			delete(rawMsg, key)
 		case "deadAt":
-			err = unpopulateTimeRFC3339(val, &s.DeadAt)
+			err = unpopulateTimeRFC3339(val, &b.DeadAt)
 			delete(rawMsg, key)
 		case "jobCreationRequest":
-			err = unpopulate(val, &s.JobCreationRequest)
+			err = unpopulate(val, &b.JobCreationRequest)
 			delete(rawMsg, key)
 		case "notStartedAt":
-			err = unpopulateTimeRFC3339(val, &s.NotStartedAt)
+			err = unpopulateTimeRFC3339(val, &b.NotStartedAt)
 			delete(rawMsg, key)
 		case "recoveringAt":
-			err = unpopulateTimeRFC3339(val, &s.RecoveringAt)
+			err = unpopulateTimeRFC3339(val, &b.RecoveringAt)
 			delete(rawMsg, key)
 		case "runningAt":
-			err = unpopulateTimeRFC3339(val, &s.RunningAt)
+			err = unpopulateTimeRFC3339(val, &b.RunningAt)
 			delete(rawMsg, key)
 		case "startingAt":
-			err = unpopulateTimeRFC3339(val, &s.StartingAt)
+			err = unpopulateTimeRFC3339(val, &b.StartingAt)
 			delete(rawMsg, key)
 		case "successAt":
-			err = unpopulateTimeRFC3339(val, &s.SuccessAt)
+			err = unpopulateTimeRFC3339(val, &b.SuccessAt)
 			delete(rawMsg, key)
 		case "killedAt":
-			err = unpopulateTimeRFC3339(val, &s.TerminatedAt)
+			err = unpopulateTimeRFC3339(val, &b.TerminatedAt)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -275,7 +248,7 @@ func (s *SparkBatchJobState) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type SparkRequest struct {
+type Request struct {
 	Archives  []*string `json:"archives,omitempty"`
 	Arguments []*string `json:"args,omitempty"`
 	ClassName *string   `json:"className,omitempty"`
@@ -294,27 +267,27 @@ type SparkRequest struct {
 	PythonFiles    []*string          `json:"pyFiles,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkRequest.
-func (s SparkRequest) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type Request.
+func (r Request) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "archives", s.Archives)
-	populate(objectMap, "args", s.Arguments)
-	populate(objectMap, "className", s.ClassName)
-	populate(objectMap, "conf", s.Configuration)
-	populate(objectMap, "driverCores", s.DriverCores)
-	populate(objectMap, "driverMemory", s.DriverMemory)
-	populate(objectMap, "executorCores", s.ExecutorCores)
-	populate(objectMap, "numExecutors", s.ExecutorCount)
-	populate(objectMap, "executorMemory", s.ExecutorMemory)
-	populate(objectMap, "file", s.File)
-	populate(objectMap, "files", s.Files)
-	populate(objectMap, "jars", s.Jars)
-	populate(objectMap, "name", s.Name)
-	populate(objectMap, "pyFiles", s.PythonFiles)
+	populate(objectMap, "archives", r.Archives)
+	populate(objectMap, "args", r.Arguments)
+	populate(objectMap, "className", r.ClassName)
+	populate(objectMap, "conf", r.Configuration)
+	populate(objectMap, "driverCores", r.DriverCores)
+	populate(objectMap, "driverMemory", r.DriverMemory)
+	populate(objectMap, "executorCores", r.ExecutorCores)
+	populate(objectMap, "numExecutors", r.ExecutorCount)
+	populate(objectMap, "executorMemory", r.ExecutorMemory)
+	populate(objectMap, "file", r.File)
+	populate(objectMap, "files", r.Files)
+	populate(objectMap, "jars", r.Jars)
+	populate(objectMap, "name", r.Name)
+	populate(objectMap, "pyFiles", r.PythonFiles)
 	return json.Marshal(objectMap)
 }
 
-type SparkScheduler struct {
+type Scheduler struct {
 	CancellationRequestedAt *time.Time             `json:"cancellationRequestedAt,omitempty"`
 	CurrentState            *SchedulerCurrentState `json:"currentState,omitempty"`
 	EndedAt                 *time.Time             `json:"endedAt,omitempty"`
@@ -322,8 +295,8 @@ type SparkScheduler struct {
 	SubmittedAt             *time.Time             `json:"submittedAt,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkScheduler.
-func (s SparkScheduler) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type Scheduler.
+func (s Scheduler) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populateTimeRFC3339(objectMap, "cancellationRequestedAt", s.CancellationRequestedAt)
 	populate(objectMap, "currentState", s.CurrentState)
@@ -333,8 +306,8 @@ func (s SparkScheduler) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type SparkScheduler.
-func (s *SparkScheduler) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type Scheduler.
+func (s *Scheduler) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
@@ -365,13 +338,13 @@ func (s *SparkScheduler) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type SparkServiceError struct {
+type ServiceError struct {
 	ErrorCode *string           `json:"errorCode,omitempty"`
 	Message   *string           `json:"message,omitempty"`
 	Source    *SparkErrorSource `json:"source,omitempty"`
 }
 
-type SparkServicePlugin struct {
+type ServicePlugin struct {
 	CleanupStartedAt             *time.Time          `json:"cleanupStartedAt,omitempty"`
 	CurrentState                 *PluginCurrentState `json:"currentState,omitempty"`
 	MonitoringStartedAt          *time.Time          `json:"monitoringStartedAt,omitempty"`
@@ -380,8 +353,8 @@ type SparkServicePlugin struct {
 	SubmissionStartedAt          *time.Time          `json:"submissionStartedAt,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkServicePlugin.
-func (s SparkServicePlugin) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type ServicePlugin.
+func (s ServicePlugin) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populateTimeRFC3339(objectMap, "cleanupStartedAt", s.CleanupStartedAt)
 	populate(objectMap, "currentState", s.CurrentState)
@@ -392,8 +365,8 @@ func (s SparkServicePlugin) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type SparkServicePlugin.
-func (s *SparkServicePlugin) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type ServicePlugin.
+func (s *ServicePlugin) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
@@ -427,24 +400,24 @@ func (s *SparkServicePlugin) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type SparkSession struct {
+type Session struct {
 	// REQUIRED
 	ID    *int32  `json:"id,omitempty"`
 	AppID *string `json:"appId,omitempty"`
 
 	// Dictionary of
-	AppInfo    map[string]*string   `json:"appInfo,omitempty"`
-	ArtifactID *string              `json:"artifactId,omitempty"`
-	Errors     []*SparkServiceError `json:"errorInfo,omitempty"`
+	AppInfo    map[string]*string `json:"appInfo,omitempty"`
+	ArtifactID *string            `json:"artifactId,omitempty"`
+	Errors     []*ServiceError    `json:"errorInfo,omitempty"`
 
 	// The job type.
 	JobType       *SparkJobType           `json:"jobType,omitempty"`
-	LivyInfo      *SparkSessionState      `json:"livyInfo,omitempty"`
+	LivyInfo      *SessionState           `json:"livyInfo,omitempty"`
 	LogLines      []*string               `json:"log,omitempty"`
 	Name          *string                 `json:"name,omitempty"`
-	Plugin        *SparkServicePlugin     `json:"pluginInfo,omitempty"`
+	Plugin        *ServicePlugin          `json:"pluginInfo,omitempty"`
 	Result        *SparkSessionResultType `json:"result,omitempty"`
-	Scheduler     *SparkScheduler         `json:"schedulerInfo,omitempty"`
+	Scheduler     *Scheduler              `json:"schedulerInfo,omitempty"`
 	SparkPoolName *string                 `json:"sparkPoolName,omitempty"`
 	State         *string                 `json:"state,omitempty"`
 	SubmitterID   *string                 `json:"submitterId,omitempty"`
@@ -455,8 +428,8 @@ type SparkSession struct {
 	WorkspaceName *string            `json:"workspaceName,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkSession.
-func (s SparkSession) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type Session.
+func (s Session) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "appId", s.AppID)
 	populate(objectMap, "appInfo", s.AppInfo)
@@ -479,28 +452,17 @@ func (s SparkSession) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// SparkSessionCancelSparkSessionOptions contains the optional parameters for the sparkSessionClient.CancelSparkSession method.
-type SparkSessionCancelSparkSessionOptions struct {
-	// placeholder for future optional parameters
-}
-
-// SparkSessionCancelSparkStatementOptions contains the optional parameters for the sparkSessionClient.CancelSparkStatement
-// method.
-type SparkSessionCancelSparkStatementOptions struct {
-	// placeholder for future optional parameters
-}
-
-type SparkSessionCollection struct {
+type SessionCollection struct {
 	// REQUIRED
 	From *int32 `json:"from,omitempty"`
 
 	// REQUIRED
-	Total    *int32          `json:"total,omitempty"`
-	Sessions []*SparkSession `json:"sessions,omitempty"`
+	Total    *int32     `json:"total,omitempty"`
+	Sessions []*Session `json:"sessions,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkSessionCollection.
-func (s SparkSessionCollection) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type SessionCollection.
+func (s SessionCollection) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "from", s.From)
 	populate(objectMap, "sessions", s.Sessions)
@@ -508,45 +470,7 @@ func (s SparkSessionCollection) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// SparkSessionCreateSparkSessionOptions contains the optional parameters for the sparkSessionClient.CreateSparkSession method.
-type SparkSessionCreateSparkSessionOptions struct {
-	// Optional query param specifying whether detailed response is returned beyond plain livy.
-	Detailed *bool
-}
-
-// SparkSessionCreateSparkStatementOptions contains the optional parameters for the sparkSessionClient.CreateSparkStatement
-// method.
-type SparkSessionCreateSparkStatementOptions struct {
-	// placeholder for future optional parameters
-}
-
-// SparkSessionGetSparkSessionOptions contains the optional parameters for the sparkSessionClient.GetSparkSession method.
-type SparkSessionGetSparkSessionOptions struct {
-	// Optional query param specifying whether detailed response is returned beyond plain livy.
-	Detailed *bool
-}
-
-// SparkSessionGetSparkSessionsOptions contains the optional parameters for the sparkSessionClient.GetSparkSessions method.
-type SparkSessionGetSparkSessionsOptions struct {
-	// Optional query param specifying whether detailed response is returned beyond plain livy.
-	Detailed *bool
-	// Optional param specifying which index the list should begin from.
-	From *int32
-	// Optional param specifying the size of the returned list. By default it is 20 and that is the maximum.
-	Size *int32
-}
-
-// SparkSessionGetSparkStatementOptions contains the optional parameters for the sparkSessionClient.GetSparkStatement method.
-type SparkSessionGetSparkStatementOptions struct {
-	// placeholder for future optional parameters
-}
-
-// SparkSessionGetSparkStatementsOptions contains the optional parameters for the sparkSessionClient.GetSparkStatements method.
-type SparkSessionGetSparkStatementsOptions struct {
-	// placeholder for future optional parameters
-}
-
-type SparkSessionOptions struct {
+type SessionOptions struct {
 	// REQUIRED
 	Name       *string   `json:"name,omitempty"`
 	Archives   []*string `json:"archives,omitempty"`
@@ -570,8 +494,8 @@ type SparkSessionOptions struct {
 	Tags map[string]*string `json:"tags,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkSessionOptions.
-func (s SparkSessionOptions) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type SessionOptions.
+func (s SessionOptions) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "archives", s.Archives)
 	populate(objectMap, "args", s.Arguments)
@@ -592,28 +516,22 @@ func (s SparkSessionOptions) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// SparkSessionResetSparkSessionTimeoutOptions contains the optional parameters for the sparkSessionClient.ResetSparkSessionTimeout
-// method.
-type SparkSessionResetSparkSessionTimeoutOptions struct {
-	// placeholder for future optional parameters
+type SessionState struct {
+	BusyAt             *time.Time `json:"busyAt,omitempty"`
+	CurrentState       *string    `json:"currentState,omitempty"`
+	DeadAt             *time.Time `json:"deadAt,omitempty"`
+	ErrorAt            *time.Time `json:"errorAt,omitempty"`
+	IdleAt             *time.Time `json:"idleAt,omitempty"`
+	JobCreationRequest *Request   `json:"jobCreationRequest,omitempty"`
+	NotStartedAt       *time.Time `json:"notStartedAt,omitempty"`
+	RecoveringAt       *time.Time `json:"recoveringAt,omitempty"`
+	ShuttingDownAt     *time.Time `json:"shuttingDownAt,omitempty"`
+	StartingAt         *time.Time `json:"startingAt,omitempty"`
+	TerminatedAt       *time.Time `json:"killedAt,omitempty"`
 }
 
-type SparkSessionState struct {
-	BusyAt             *time.Time    `json:"busyAt,omitempty"`
-	CurrentState       *string       `json:"currentState,omitempty"`
-	DeadAt             *time.Time    `json:"deadAt,omitempty"`
-	ErrorAt            *time.Time    `json:"errorAt,omitempty"`
-	IdleAt             *time.Time    `json:"idleAt,omitempty"`
-	JobCreationRequest *SparkRequest `json:"jobCreationRequest,omitempty"`
-	NotStartedAt       *time.Time    `json:"notStartedAt,omitempty"`
-	RecoveringAt       *time.Time    `json:"recoveringAt,omitempty"`
-	ShuttingDownAt     *time.Time    `json:"shuttingDownAt,omitempty"`
-	StartingAt         *time.Time    `json:"startingAt,omitempty"`
-	TerminatedAt       *time.Time    `json:"killedAt,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type SparkSessionState.
-func (s SparkSessionState) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type SessionState.
+func (s SessionState) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populateTimeRFC3339(objectMap, "busyAt", s.BusyAt)
 	populate(objectMap, "currentState", s.CurrentState)
@@ -629,8 +547,8 @@ func (s SparkSessionState) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type SparkSessionState.
-func (s *SparkSessionState) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type SessionState.
+func (s *SessionState) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
@@ -679,39 +597,119 @@ func (s *SparkSessionState) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type SparkStatement struct {
-	// REQUIRED
-	ID     *int32                `json:"id,omitempty"`
-	Code   *string               `json:"code,omitempty"`
-	Output *SparkStatementOutput `json:"output,omitempty"`
-	State  *string               `json:"state,omitempty"`
+// SparkBatchCancelSparkBatchJobOptions contains the optional parameters for the batchClient.CancelSparkBatchJob method.
+type SparkBatchCancelSparkBatchJobOptions struct {
+	// placeholder for future optional parameters
 }
 
-type SparkStatementCancellationResult struct {
+// SparkBatchCreateSparkBatchJobOptions contains the optional parameters for the batchClient.CreateSparkBatchJob method.
+type SparkBatchCreateSparkBatchJobOptions struct {
+	// Optional query param specifying whether detailed response is returned beyond plain livy.
+	Detailed *bool
+}
+
+// SparkBatchGetSparkBatchJobOptions contains the optional parameters for the batchClient.GetSparkBatchJob method.
+type SparkBatchGetSparkBatchJobOptions struct {
+	// Optional query param specifying whether detailed response is returned beyond plain livy.
+	Detailed *bool
+}
+
+// SparkBatchGetSparkBatchJobsOptions contains the optional parameters for the batchClient.GetSparkBatchJobs method.
+type SparkBatchGetSparkBatchJobsOptions struct {
+	// Optional query param specifying whether detailed response is returned beyond plain livy.
+	Detailed *bool
+	// Optional param specifying which index the list should begin from.
+	From *int32
+	// Optional param specifying the size of the returned list. By default it is 20 and that is the maximum.
+	Size *int32
+}
+
+// SparkSessionCancelSparkSessionOptions contains the optional parameters for the sessionClient.CancelSparkSession method.
+type SparkSessionCancelSparkSessionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkSessionCancelSparkStatementOptions contains the optional parameters for the sessionClient.CancelSparkStatement method.
+type SparkSessionCancelSparkStatementOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkSessionCreateSparkSessionOptions contains the optional parameters for the sessionClient.CreateSparkSession method.
+type SparkSessionCreateSparkSessionOptions struct {
+	// Optional query param specifying whether detailed response is returned beyond plain livy.
+	Detailed *bool
+}
+
+// SparkSessionCreateSparkStatementOptions contains the optional parameters for the sessionClient.CreateSparkStatement method.
+type SparkSessionCreateSparkStatementOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkSessionGetSparkSessionOptions contains the optional parameters for the sessionClient.GetSparkSession method.
+type SparkSessionGetSparkSessionOptions struct {
+	// Optional query param specifying whether detailed response is returned beyond plain livy.
+	Detailed *bool
+}
+
+// SparkSessionGetSparkSessionsOptions contains the optional parameters for the sessionClient.GetSparkSessions method.
+type SparkSessionGetSparkSessionsOptions struct {
+	// Optional query param specifying whether detailed response is returned beyond plain livy.
+	Detailed *bool
+	// Optional param specifying which index the list should begin from.
+	From *int32
+	// Optional param specifying the size of the returned list. By default it is 20 and that is the maximum.
+	Size *int32
+}
+
+// SparkSessionGetSparkStatementOptions contains the optional parameters for the sessionClient.GetSparkStatement method.
+type SparkSessionGetSparkStatementOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkSessionGetSparkStatementsOptions contains the optional parameters for the sessionClient.GetSparkStatements method.
+type SparkSessionGetSparkStatementsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkSessionResetSparkSessionTimeoutOptions contains the optional parameters for the sessionClient.ResetSparkSessionTimeout
+// method.
+type SparkSessionResetSparkSessionTimeoutOptions struct {
+	// placeholder for future optional parameters
+}
+
+type Statement struct {
+	// REQUIRED
+	ID     *int32           `json:"id,omitempty"`
+	Code   *string          `json:"code,omitempty"`
+	Output *StatementOutput `json:"output,omitempty"`
+	State  *string          `json:"state,omitempty"`
+}
+
+type StatementCancellationResult struct {
 	// The msg property from the Livy API. The value is always "canceled".
 	Message *string `json:"msg,omitempty"`
 }
 
-type SparkStatementCollection struct {
+type StatementCollection struct {
 	// REQUIRED
-	Total      *int32            `json:"total_statements,omitempty"`
-	Statements []*SparkStatement `json:"statements,omitempty"`
+	Total      *int32       `json:"total_statements,omitempty"`
+	Statements []*Statement `json:"statements,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkStatementCollection.
-func (s SparkStatementCollection) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type StatementCollection.
+func (s StatementCollection) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "statements", s.Statements)
 	populate(objectMap, "total_statements", s.Total)
 	return json.Marshal(objectMap)
 }
 
-type SparkStatementOptions struct {
+type StatementOptions struct {
 	Code *string                     `json:"code,omitempty"`
 	Kind *SparkStatementLanguageType `json:"kind,omitempty"`
 }
 
-type SparkStatementOutput struct {
+type StatementOutput struct {
 	// REQUIRED
 	ExecutionCount *int32 `json:"execution_count,omitempty"`
 
@@ -723,8 +721,8 @@ type SparkStatementOutput struct {
 	Traceback  []*string              `json:"traceback,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type SparkStatementOutput.
-func (s SparkStatementOutput) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type StatementOutput.
+func (s StatementOutput) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "data", s.Data)
 	populate(objectMap, "ename", s.ErrorName)

--- a/test/synapse/2019-06-01/azspark/zz_generated_response_types.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_response_types.go
@@ -25,7 +25,7 @@ type SparkBatchCreateSparkBatchJobResponse struct {
 
 // SparkBatchCreateSparkBatchJobResult contains the result from method SparkBatch.CreateSparkBatchJob.
 type SparkBatchCreateSparkBatchJobResult struct {
-	SparkBatchJob
+	BatchJob
 }
 
 // SparkBatchGetSparkBatchJobResponse contains the response from method SparkBatch.GetSparkBatchJob.
@@ -37,7 +37,7 @@ type SparkBatchGetSparkBatchJobResponse struct {
 
 // SparkBatchGetSparkBatchJobResult contains the result from method SparkBatch.GetSparkBatchJob.
 type SparkBatchGetSparkBatchJobResult struct {
-	SparkBatchJob
+	BatchJob
 }
 
 // SparkBatchGetSparkBatchJobsResponse contains the response from method SparkBatch.GetSparkBatchJobs.
@@ -49,7 +49,7 @@ type SparkBatchGetSparkBatchJobsResponse struct {
 
 // SparkBatchGetSparkBatchJobsResult contains the result from method SparkBatch.GetSparkBatchJobs.
 type SparkBatchGetSparkBatchJobsResult struct {
-	SparkBatchJobCollection
+	BatchJobCollection
 }
 
 // SparkSessionCancelSparkSessionResponse contains the response from method SparkSession.CancelSparkSession.
@@ -67,7 +67,7 @@ type SparkSessionCancelSparkStatementResponse struct {
 
 // SparkSessionCancelSparkStatementResult contains the result from method SparkSession.CancelSparkStatement.
 type SparkSessionCancelSparkStatementResult struct {
-	SparkStatementCancellationResult
+	StatementCancellationResult
 }
 
 // SparkSessionCreateSparkSessionResponse contains the response from method SparkSession.CreateSparkSession.
@@ -79,7 +79,7 @@ type SparkSessionCreateSparkSessionResponse struct {
 
 // SparkSessionCreateSparkSessionResult contains the result from method SparkSession.CreateSparkSession.
 type SparkSessionCreateSparkSessionResult struct {
-	SparkSession
+	Session
 }
 
 // SparkSessionCreateSparkStatementResponse contains the response from method SparkSession.CreateSparkStatement.
@@ -91,7 +91,7 @@ type SparkSessionCreateSparkStatementResponse struct {
 
 // SparkSessionCreateSparkStatementResult contains the result from method SparkSession.CreateSparkStatement.
 type SparkSessionCreateSparkStatementResult struct {
-	SparkStatement
+	Statement
 }
 
 // SparkSessionGetSparkSessionResponse contains the response from method SparkSession.GetSparkSession.
@@ -103,7 +103,7 @@ type SparkSessionGetSparkSessionResponse struct {
 
 // SparkSessionGetSparkSessionResult contains the result from method SparkSession.GetSparkSession.
 type SparkSessionGetSparkSessionResult struct {
-	SparkSession
+	Session
 }
 
 // SparkSessionGetSparkSessionsResponse contains the response from method SparkSession.GetSparkSessions.
@@ -115,7 +115,7 @@ type SparkSessionGetSparkSessionsResponse struct {
 
 // SparkSessionGetSparkSessionsResult contains the result from method SparkSession.GetSparkSessions.
 type SparkSessionGetSparkSessionsResult struct {
-	SparkSessionCollection
+	SessionCollection
 }
 
 // SparkSessionGetSparkStatementResponse contains the response from method SparkSession.GetSparkStatement.
@@ -127,7 +127,7 @@ type SparkSessionGetSparkStatementResponse struct {
 
 // SparkSessionGetSparkStatementResult contains the result from method SparkSession.GetSparkStatement.
 type SparkSessionGetSparkStatementResult struct {
-	SparkStatement
+	Statement
 }
 
 // SparkSessionGetSparkStatementsResponse contains the response from method SparkSession.GetSparkStatements.
@@ -139,7 +139,7 @@ type SparkSessionGetSparkStatementsResponse struct {
 
 // SparkSessionGetSparkStatementsResult contains the result from method SparkSession.GetSparkStatements.
 type SparkSessionGetSparkStatementsResult struct {
-	SparkStatementCollection
+	StatementCollection
 }
 
 // SparkSessionResetSparkSessionTimeoutResponse contains the response from method SparkSession.ResetSparkSessionTimeout.

--- a/test/synapse/2019-06-01/azspark/zz_generated_session_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_session_client.go
@@ -19,17 +19,17 @@ import (
 	"strings"
 )
 
-type sparkSessionClient struct {
+type sessionClient struct {
 	endpoint string
 	pl       runtime.Pipeline
 }
 
-// newSparkSessionClient creates a new instance of sparkSessionClient with the specified values.
+// newSessionClient creates a new instance of sessionClient with the specified values.
 // endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
 // livyAPIVersion - Valid api-version for the request.
 // sparkPoolName - Name of the spark pool.
 // pl - the pipeline used for sending requests and handling responses.
-func newSparkSessionClient(endpoint string, livyAPIVersion *string, sparkPoolName string, pl runtime.Pipeline) *sparkSessionClient {
+func newSessionClient(endpoint string, livyAPIVersion *string, sparkPoolName string, pl runtime.Pipeline) *sessionClient {
 	hostURL := "{endpoint}/livyApi/versions/{livyApiVersion}/sparkPools/{sparkPoolName}"
 	hostURL = strings.ReplaceAll(hostURL, "{endpoint}", endpoint)
 	if livyAPIVersion == nil {
@@ -38,7 +38,7 @@ func newSparkSessionClient(endpoint string, livyAPIVersion *string, sparkPoolNam
 	}
 	hostURL = strings.ReplaceAll(hostURL, "{livyApiVersion}", *livyAPIVersion)
 	hostURL = strings.ReplaceAll(hostURL, "{sparkPoolName}", sparkPoolName)
-	client := &sparkSessionClient{
+	client := &sessionClient{
 		endpoint: hostURL,
 		pl:       pl,
 	}
@@ -48,9 +48,9 @@ func newSparkSessionClient(endpoint string, livyAPIVersion *string, sparkPoolNam
 // CancelSparkSession - Cancels a running spark session.
 // If the operation fails it returns a generic error.
 // sessionID - Identifier for the session.
-// options - SparkSessionCancelSparkSessionOptions contains the optional parameters for the sparkSessionClient.CancelSparkSession
+// options - SparkSessionCancelSparkSessionOptions contains the optional parameters for the sessionClient.CancelSparkSession
 // method.
-func (client *sparkSessionClient) CancelSparkSession(ctx context.Context, sessionID int32, options *SparkSessionCancelSparkSessionOptions) (SparkSessionCancelSparkSessionResponse, error) {
+func (client *sessionClient) CancelSparkSession(ctx context.Context, sessionID int32, options *SparkSessionCancelSparkSessionOptions) (SparkSessionCancelSparkSessionResponse, error) {
 	req, err := client.cancelSparkSessionCreateRequest(ctx, sessionID, options)
 	if err != nil {
 		return SparkSessionCancelSparkSessionResponse{}, err
@@ -66,7 +66,7 @@ func (client *sparkSessionClient) CancelSparkSession(ctx context.Context, sessio
 }
 
 // cancelSparkSessionCreateRequest creates the CancelSparkSession request.
-func (client *sparkSessionClient) cancelSparkSessionCreateRequest(ctx context.Context, sessionID int32, options *SparkSessionCancelSparkSessionOptions) (*policy.Request, error) {
+func (client *sessionClient) cancelSparkSessionCreateRequest(ctx context.Context, sessionID int32, options *SparkSessionCancelSparkSessionOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.endpoint, urlPath))
@@ -77,7 +77,7 @@ func (client *sparkSessionClient) cancelSparkSessionCreateRequest(ctx context.Co
 }
 
 // cancelSparkSessionHandleError handles the CancelSparkSession error response.
-func (client *sparkSessionClient) cancelSparkSessionHandleError(resp *http.Response) error {
+func (client *sessionClient) cancelSparkSessionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -92,9 +92,9 @@ func (client *sparkSessionClient) cancelSparkSessionHandleError(resp *http.Respo
 // If the operation fails it returns a generic error.
 // sessionID - Identifier for the session.
 // statementID - Identifier for the statement.
-// options - SparkSessionCancelSparkStatementOptions contains the optional parameters for the sparkSessionClient.CancelSparkStatement
+// options - SparkSessionCancelSparkStatementOptions contains the optional parameters for the sessionClient.CancelSparkStatement
 // method.
-func (client *sparkSessionClient) CancelSparkStatement(ctx context.Context, sessionID int32, statementID int32, options *SparkSessionCancelSparkStatementOptions) (SparkSessionCancelSparkStatementResponse, error) {
+func (client *sessionClient) CancelSparkStatement(ctx context.Context, sessionID int32, statementID int32, options *SparkSessionCancelSparkStatementOptions) (SparkSessionCancelSparkStatementResponse, error) {
 	req, err := client.cancelSparkStatementCreateRequest(ctx, sessionID, statementID, options)
 	if err != nil {
 		return SparkSessionCancelSparkStatementResponse{}, err
@@ -110,7 +110,7 @@ func (client *sparkSessionClient) CancelSparkStatement(ctx context.Context, sess
 }
 
 // cancelSparkStatementCreateRequest creates the CancelSparkStatement request.
-func (client *sparkSessionClient) cancelSparkStatementCreateRequest(ctx context.Context, sessionID int32, statementID int32, options *SparkSessionCancelSparkStatementOptions) (*policy.Request, error) {
+func (client *sessionClient) cancelSparkStatementCreateRequest(ctx context.Context, sessionID int32, statementID int32, options *SparkSessionCancelSparkStatementOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements/{statementId}/cancel"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	urlPath = strings.ReplaceAll(urlPath, "{statementId}", url.PathEscape(strconv.FormatInt(int64(statementID), 10)))
@@ -123,16 +123,16 @@ func (client *sparkSessionClient) cancelSparkStatementCreateRequest(ctx context.
 }
 
 // cancelSparkStatementHandleResponse handles the CancelSparkStatement response.
-func (client *sparkSessionClient) cancelSparkStatementHandleResponse(resp *http.Response) (SparkSessionCancelSparkStatementResponse, error) {
+func (client *sessionClient) cancelSparkStatementHandleResponse(resp *http.Response) (SparkSessionCancelSparkStatementResponse, error) {
 	result := SparkSessionCancelSparkStatementResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkStatementCancellationResult); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.StatementCancellationResult); err != nil {
 		return SparkSessionCancelSparkStatementResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // cancelSparkStatementHandleError handles the CancelSparkStatement error response.
-func (client *sparkSessionClient) cancelSparkStatementHandleError(resp *http.Response) error {
+func (client *sessionClient) cancelSparkStatementHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -146,9 +146,9 @@ func (client *sparkSessionClient) cancelSparkStatementHandleError(resp *http.Res
 // CreateSparkSession - Create new spark session.
 // If the operation fails it returns a generic error.
 // sparkSessionOptions - Livy compatible batch job request payload.
-// options - SparkSessionCreateSparkSessionOptions contains the optional parameters for the sparkSessionClient.CreateSparkSession
+// options - SparkSessionCreateSparkSessionOptions contains the optional parameters for the sessionClient.CreateSparkSession
 // method.
-func (client *sparkSessionClient) CreateSparkSession(ctx context.Context, sparkSessionOptions SparkSessionOptions, options *SparkSessionCreateSparkSessionOptions) (SparkSessionCreateSparkSessionResponse, error) {
+func (client *sessionClient) CreateSparkSession(ctx context.Context, sparkSessionOptions SessionOptions, options *SparkSessionCreateSparkSessionOptions) (SparkSessionCreateSparkSessionResponse, error) {
 	req, err := client.createSparkSessionCreateRequest(ctx, sparkSessionOptions, options)
 	if err != nil {
 		return SparkSessionCreateSparkSessionResponse{}, err
@@ -164,7 +164,7 @@ func (client *sparkSessionClient) CreateSparkSession(ctx context.Context, sparkS
 }
 
 // createSparkSessionCreateRequest creates the CreateSparkSession request.
-func (client *sparkSessionClient) createSparkSessionCreateRequest(ctx context.Context, sparkSessionOptions SparkSessionOptions, options *SparkSessionCreateSparkSessionOptions) (*policy.Request, error) {
+func (client *sessionClient) createSparkSessionCreateRequest(ctx context.Context, sparkSessionOptions SessionOptions, options *SparkSessionCreateSparkSessionOptions) (*policy.Request, error) {
 	urlPath := "/sessions"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -180,16 +180,16 @@ func (client *sparkSessionClient) createSparkSessionCreateRequest(ctx context.Co
 }
 
 // createSparkSessionHandleResponse handles the CreateSparkSession response.
-func (client *sparkSessionClient) createSparkSessionHandleResponse(resp *http.Response) (SparkSessionCreateSparkSessionResponse, error) {
+func (client *sessionClient) createSparkSessionHandleResponse(resp *http.Response) (SparkSessionCreateSparkSessionResponse, error) {
 	result := SparkSessionCreateSparkSessionResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkSession); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Session); err != nil {
 		return SparkSessionCreateSparkSessionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // createSparkSessionHandleError handles the CreateSparkSession error response.
-func (client *sparkSessionClient) createSparkSessionHandleError(resp *http.Response) error {
+func (client *sessionClient) createSparkSessionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -204,9 +204,9 @@ func (client *sparkSessionClient) createSparkSessionHandleError(resp *http.Respo
 // If the operation fails it returns a generic error.
 // sessionID - Identifier for the session.
 // sparkStatementOptions - Livy compatible batch job request payload.
-// options - SparkSessionCreateSparkStatementOptions contains the optional parameters for the sparkSessionClient.CreateSparkStatement
+// options - SparkSessionCreateSparkStatementOptions contains the optional parameters for the sessionClient.CreateSparkStatement
 // method.
-func (client *sparkSessionClient) CreateSparkStatement(ctx context.Context, sessionID int32, sparkStatementOptions SparkStatementOptions, options *SparkSessionCreateSparkStatementOptions) (SparkSessionCreateSparkStatementResponse, error) {
+func (client *sessionClient) CreateSparkStatement(ctx context.Context, sessionID int32, sparkStatementOptions StatementOptions, options *SparkSessionCreateSparkStatementOptions) (SparkSessionCreateSparkStatementResponse, error) {
 	req, err := client.createSparkStatementCreateRequest(ctx, sessionID, sparkStatementOptions, options)
 	if err != nil {
 		return SparkSessionCreateSparkStatementResponse{}, err
@@ -222,7 +222,7 @@ func (client *sparkSessionClient) CreateSparkStatement(ctx context.Context, sess
 }
 
 // createSparkStatementCreateRequest creates the CreateSparkStatement request.
-func (client *sparkSessionClient) createSparkStatementCreateRequest(ctx context.Context, sessionID int32, sparkStatementOptions SparkStatementOptions, options *SparkSessionCreateSparkStatementOptions) (*policy.Request, error) {
+func (client *sessionClient) createSparkStatementCreateRequest(ctx context.Context, sessionID int32, sparkStatementOptions StatementOptions, options *SparkSessionCreateSparkStatementOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
@@ -234,16 +234,16 @@ func (client *sparkSessionClient) createSparkStatementCreateRequest(ctx context.
 }
 
 // createSparkStatementHandleResponse handles the CreateSparkStatement response.
-func (client *sparkSessionClient) createSparkStatementHandleResponse(resp *http.Response) (SparkSessionCreateSparkStatementResponse, error) {
+func (client *sessionClient) createSparkStatementHandleResponse(resp *http.Response) (SparkSessionCreateSparkStatementResponse, error) {
 	result := SparkSessionCreateSparkStatementResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkStatement); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Statement); err != nil {
 		return SparkSessionCreateSparkStatementResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // createSparkStatementHandleError handles the CreateSparkStatement error response.
-func (client *sparkSessionClient) createSparkStatementHandleError(resp *http.Response) error {
+func (client *sessionClient) createSparkStatementHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -257,9 +257,8 @@ func (client *sparkSessionClient) createSparkStatementHandleError(resp *http.Res
 // GetSparkSession - Gets a single spark session.
 // If the operation fails it returns a generic error.
 // sessionID - Identifier for the session.
-// options - SparkSessionGetSparkSessionOptions contains the optional parameters for the sparkSessionClient.GetSparkSession
-// method.
-func (client *sparkSessionClient) GetSparkSession(ctx context.Context, sessionID int32, options *SparkSessionGetSparkSessionOptions) (SparkSessionGetSparkSessionResponse, error) {
+// options - SparkSessionGetSparkSessionOptions contains the optional parameters for the sessionClient.GetSparkSession method.
+func (client *sessionClient) GetSparkSession(ctx context.Context, sessionID int32, options *SparkSessionGetSparkSessionOptions) (SparkSessionGetSparkSessionResponse, error) {
 	req, err := client.getSparkSessionCreateRequest(ctx, sessionID, options)
 	if err != nil {
 		return SparkSessionGetSparkSessionResponse{}, err
@@ -275,7 +274,7 @@ func (client *sparkSessionClient) GetSparkSession(ctx context.Context, sessionID
 }
 
 // getSparkSessionCreateRequest creates the GetSparkSession request.
-func (client *sparkSessionClient) getSparkSessionCreateRequest(ctx context.Context, sessionID int32, options *SparkSessionGetSparkSessionOptions) (*policy.Request, error) {
+func (client *sessionClient) getSparkSessionCreateRequest(ctx context.Context, sessionID int32, options *SparkSessionGetSparkSessionOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -292,16 +291,16 @@ func (client *sparkSessionClient) getSparkSessionCreateRequest(ctx context.Conte
 }
 
 // getSparkSessionHandleResponse handles the GetSparkSession response.
-func (client *sparkSessionClient) getSparkSessionHandleResponse(resp *http.Response) (SparkSessionGetSparkSessionResponse, error) {
+func (client *sessionClient) getSparkSessionHandleResponse(resp *http.Response) (SparkSessionGetSparkSessionResponse, error) {
 	result := SparkSessionGetSparkSessionResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkSession); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Session); err != nil {
 		return SparkSessionGetSparkSessionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getSparkSessionHandleError handles the GetSparkSession error response.
-func (client *sparkSessionClient) getSparkSessionHandleError(resp *http.Response) error {
+func (client *sessionClient) getSparkSessionHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -314,9 +313,8 @@ func (client *sparkSessionClient) getSparkSessionHandleError(resp *http.Response
 
 // GetSparkSessions - List all spark sessions which are running under a particular spark pool.
 // If the operation fails it returns a generic error.
-// options - SparkSessionGetSparkSessionsOptions contains the optional parameters for the sparkSessionClient.GetSparkSessions
-// method.
-func (client *sparkSessionClient) GetSparkSessions(ctx context.Context, options *SparkSessionGetSparkSessionsOptions) (SparkSessionGetSparkSessionsResponse, error) {
+// options - SparkSessionGetSparkSessionsOptions contains the optional parameters for the sessionClient.GetSparkSessions method.
+func (client *sessionClient) GetSparkSessions(ctx context.Context, options *SparkSessionGetSparkSessionsOptions) (SparkSessionGetSparkSessionsResponse, error) {
 	req, err := client.getSparkSessionsCreateRequest(ctx, options)
 	if err != nil {
 		return SparkSessionGetSparkSessionsResponse{}, err
@@ -332,7 +330,7 @@ func (client *sparkSessionClient) GetSparkSessions(ctx context.Context, options 
 }
 
 // getSparkSessionsCreateRequest creates the GetSparkSessions request.
-func (client *sparkSessionClient) getSparkSessionsCreateRequest(ctx context.Context, options *SparkSessionGetSparkSessionsOptions) (*policy.Request, error) {
+func (client *sessionClient) getSparkSessionsCreateRequest(ctx context.Context, options *SparkSessionGetSparkSessionsOptions) (*policy.Request, error) {
 	urlPath := "/sessions"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -354,16 +352,16 @@ func (client *sparkSessionClient) getSparkSessionsCreateRequest(ctx context.Cont
 }
 
 // getSparkSessionsHandleResponse handles the GetSparkSessions response.
-func (client *sparkSessionClient) getSparkSessionsHandleResponse(resp *http.Response) (SparkSessionGetSparkSessionsResponse, error) {
+func (client *sessionClient) getSparkSessionsHandleResponse(resp *http.Response) (SparkSessionGetSparkSessionsResponse, error) {
 	result := SparkSessionGetSparkSessionsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkSessionCollection); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.SessionCollection); err != nil {
 		return SparkSessionGetSparkSessionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getSparkSessionsHandleError handles the GetSparkSessions error response.
-func (client *sparkSessionClient) getSparkSessionsHandleError(resp *http.Response) error {
+func (client *sessionClient) getSparkSessionsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -378,9 +376,9 @@ func (client *sparkSessionClient) getSparkSessionsHandleError(resp *http.Respons
 // If the operation fails it returns a generic error.
 // sessionID - Identifier for the session.
 // statementID - Identifier for the statement.
-// options - SparkSessionGetSparkStatementOptions contains the optional parameters for the sparkSessionClient.GetSparkStatement
+// options - SparkSessionGetSparkStatementOptions contains the optional parameters for the sessionClient.GetSparkStatement
 // method.
-func (client *sparkSessionClient) GetSparkStatement(ctx context.Context, sessionID int32, statementID int32, options *SparkSessionGetSparkStatementOptions) (SparkSessionGetSparkStatementResponse, error) {
+func (client *sessionClient) GetSparkStatement(ctx context.Context, sessionID int32, statementID int32, options *SparkSessionGetSparkStatementOptions) (SparkSessionGetSparkStatementResponse, error) {
 	req, err := client.getSparkStatementCreateRequest(ctx, sessionID, statementID, options)
 	if err != nil {
 		return SparkSessionGetSparkStatementResponse{}, err
@@ -396,7 +394,7 @@ func (client *sparkSessionClient) GetSparkStatement(ctx context.Context, session
 }
 
 // getSparkStatementCreateRequest creates the GetSparkStatement request.
-func (client *sparkSessionClient) getSparkStatementCreateRequest(ctx context.Context, sessionID int32, statementID int32, options *SparkSessionGetSparkStatementOptions) (*policy.Request, error) {
+func (client *sessionClient) getSparkStatementCreateRequest(ctx context.Context, sessionID int32, statementID int32, options *SparkSessionGetSparkStatementOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements/{statementId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	urlPath = strings.ReplaceAll(urlPath, "{statementId}", url.PathEscape(strconv.FormatInt(int64(statementID), 10)))
@@ -409,16 +407,16 @@ func (client *sparkSessionClient) getSparkStatementCreateRequest(ctx context.Con
 }
 
 // getSparkStatementHandleResponse handles the GetSparkStatement response.
-func (client *sparkSessionClient) getSparkStatementHandleResponse(resp *http.Response) (SparkSessionGetSparkStatementResponse, error) {
+func (client *sessionClient) getSparkStatementHandleResponse(resp *http.Response) (SparkSessionGetSparkStatementResponse, error) {
 	result := SparkSessionGetSparkStatementResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkStatement); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Statement); err != nil {
 		return SparkSessionGetSparkStatementResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getSparkStatementHandleError handles the GetSparkStatement error response.
-func (client *sparkSessionClient) getSparkStatementHandleError(resp *http.Response) error {
+func (client *sessionClient) getSparkStatementHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -432,9 +430,9 @@ func (client *sparkSessionClient) getSparkStatementHandleError(resp *http.Respon
 // GetSparkStatements - Gets a list of statements within a spark session.
 // If the operation fails it returns a generic error.
 // sessionID - Identifier for the session.
-// options - SparkSessionGetSparkStatementsOptions contains the optional parameters for the sparkSessionClient.GetSparkStatements
+// options - SparkSessionGetSparkStatementsOptions contains the optional parameters for the sessionClient.GetSparkStatements
 // method.
-func (client *sparkSessionClient) GetSparkStatements(ctx context.Context, sessionID int32, options *SparkSessionGetSparkStatementsOptions) (SparkSessionGetSparkStatementsResponse, error) {
+func (client *sessionClient) GetSparkStatements(ctx context.Context, sessionID int32, options *SparkSessionGetSparkStatementsOptions) (SparkSessionGetSparkStatementsResponse, error) {
 	req, err := client.getSparkStatementsCreateRequest(ctx, sessionID, options)
 	if err != nil {
 		return SparkSessionGetSparkStatementsResponse{}, err
@@ -450,7 +448,7 @@ func (client *sparkSessionClient) GetSparkStatements(ctx context.Context, sessio
 }
 
 // getSparkStatementsCreateRequest creates the GetSparkStatements request.
-func (client *sparkSessionClient) getSparkStatementsCreateRequest(ctx context.Context, sessionID int32, options *SparkSessionGetSparkStatementsOptions) (*policy.Request, error) {
+func (client *sessionClient) getSparkStatementsCreateRequest(ctx context.Context, sessionID int32, options *SparkSessionGetSparkStatementsOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -462,16 +460,16 @@ func (client *sparkSessionClient) getSparkStatementsCreateRequest(ctx context.Co
 }
 
 // getSparkStatementsHandleResponse handles the GetSparkStatements response.
-func (client *sparkSessionClient) getSparkStatementsHandleResponse(resp *http.Response) (SparkSessionGetSparkStatementsResponse, error) {
+func (client *sessionClient) getSparkStatementsHandleResponse(resp *http.Response) (SparkSessionGetSparkStatementsResponse, error) {
 	result := SparkSessionGetSparkStatementsResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.SparkStatementCollection); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.StatementCollection); err != nil {
 		return SparkSessionGetSparkStatementsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // getSparkStatementsHandleError handles the GetSparkStatements error response.
-func (client *sparkSessionClient) getSparkStatementsHandleError(resp *http.Response) error {
+func (client *sessionClient) getSparkStatementsHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -485,9 +483,9 @@ func (client *sparkSessionClient) getSparkStatementsHandleError(resp *http.Respo
 // ResetSparkSessionTimeout - Sends a keep alive call to the current session to reset the session timeout.
 // If the operation fails it returns a generic error.
 // sessionID - Identifier for the session.
-// options - SparkSessionResetSparkSessionTimeoutOptions contains the optional parameters for the sparkSessionClient.ResetSparkSessionTimeout
+// options - SparkSessionResetSparkSessionTimeoutOptions contains the optional parameters for the sessionClient.ResetSparkSessionTimeout
 // method.
-func (client *sparkSessionClient) ResetSparkSessionTimeout(ctx context.Context, sessionID int32, options *SparkSessionResetSparkSessionTimeoutOptions) (SparkSessionResetSparkSessionTimeoutResponse, error) {
+func (client *sessionClient) ResetSparkSessionTimeout(ctx context.Context, sessionID int32, options *SparkSessionResetSparkSessionTimeoutOptions) (SparkSessionResetSparkSessionTimeoutResponse, error) {
 	req, err := client.resetSparkSessionTimeoutCreateRequest(ctx, sessionID, options)
 	if err != nil {
 		return SparkSessionResetSparkSessionTimeoutResponse{}, err
@@ -503,7 +501,7 @@ func (client *sparkSessionClient) ResetSparkSessionTimeout(ctx context.Context, 
 }
 
 // resetSparkSessionTimeoutCreateRequest creates the ResetSparkSessionTimeout request.
-func (client *sparkSessionClient) resetSparkSessionTimeoutCreateRequest(ctx context.Context, sessionID int32, options *SparkSessionResetSparkSessionTimeoutOptions) (*policy.Request, error) {
+func (client *sessionClient) resetSparkSessionTimeoutCreateRequest(ctx context.Context, sessionID int32, options *SparkSessionResetSparkSessionTimeoutOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/reset-timeout"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
@@ -514,7 +512,7 @@ func (client *sparkSessionClient) resetSparkSessionTimeoutCreateRequest(ctx cont
 }
 
 // resetSparkSessionTimeoutHandleError handles the ResetSparkSessionTimeout error response.
-func (client *sparkSessionClient) resetSparkSessionTimeoutHandleError(resp *http.Response) error {
+func (client *sessionClient) resetSparkSessionTimeoutHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/tables/2019-02-02/aztables/zz_generated_client.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_client.go
@@ -22,20 +22,20 @@ import (
 	"time"
 )
 
-// TableClient contains the methods for the Table group.
-// Don't use this type directly, use NewTableClient() instead.
-type TableClient struct {
+// Client contains the methods for the Table group.
+// Don't use this type directly, use NewClient() instead.
+type Client struct {
 	endpoint string
 	version  Enum0
 	pl       runtime.Pipeline
 }
 
-// NewTableClient creates a new instance of TableClient with the specified values.
+// NewClient creates a new instance of Client with the specified values.
 // endpoint - The URL of the service account or table that is the target of the desired operation.
 // version - Specifies the version of the operation to use for this request.
 // pl - the pipeline used for sending requests and handling responses.
-func NewTableClient(endpoint string, version Enum0, pl runtime.Pipeline) *TableClient {
-	client := &TableClient{
+func NewClient(endpoint string, version Enum0, pl runtime.Pipeline) *Client {
+	client := &Client{
 		endpoint: endpoint,
 		version:  version,
 		pl:       pl,
@@ -44,11 +44,11 @@ func NewTableClient(endpoint string, version Enum0, pl runtime.Pipeline) *TableC
 }
 
 // Create - Creates a new table under the given account.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // dataServiceVersion - Specifies the data service version.
 // tableProperties - The Table properties.
-// options - TableCreateOptions contains the optional parameters for the TableClient.Create method.
-func (client *TableClient) Create(ctx context.Context, dataServiceVersion Enum1, tableProperties TableProperties, options *TableCreateOptions) (TableCreateResponse, error) {
+// options - TableCreateOptions contains the optional parameters for the Client.Create method.
+func (client *Client) Create(ctx context.Context, dataServiceVersion Enum1, tableProperties Properties, options *TableCreateOptions) (TableCreateResponse, error) {
 	req, err := client.createCreateRequest(ctx, dataServiceVersion, tableProperties, options)
 	if err != nil {
 		return TableCreateResponse{}, err
@@ -64,7 +64,7 @@ func (client *TableClient) Create(ctx context.Context, dataServiceVersion Enum1,
 }
 
 // createCreateRequest creates the Create request.
-func (client *TableClient) createCreateRequest(ctx context.Context, dataServiceVersion Enum1, tableProperties TableProperties, options *TableCreateOptions) (*policy.Request, error) {
+func (client *Client) createCreateRequest(ctx context.Context, dataServiceVersion Enum1, tableProperties Properties, options *TableCreateOptions) (*policy.Request, error) {
 	urlPath := "/Tables"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -88,7 +88,7 @@ func (client *TableClient) createCreateRequest(ctx context.Context, dataServiceV
 }
 
 // createHandleResponse handles the Create response.
-func (client *TableClient) createHandleResponse(resp *http.Response) (TableCreateResponse, error) {
+func (client *Client) createHandleResponse(resp *http.Response) (TableCreateResponse, error) {
 	result := TableCreateResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -109,19 +109,19 @@ func (client *TableClient) createHandleResponse(resp *http.Response) (TableCreat
 	if val := resp.Header.Get("Preference-Applied"); val != "" {
 		result.PreferenceApplied = &val
 	}
-	if err := runtime.UnmarshalAsJSON(resp, &result.TableResponse); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Response); err != nil {
 		return TableCreateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // createHandleError handles the Create error response.
-func (client *TableClient) createHandleError(resp *http.Response) error {
+func (client *Client) createHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -129,10 +129,10 @@ func (client *TableClient) createHandleError(resp *http.Response) error {
 }
 
 // Delete - Operation permanently deletes the specified table.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // table - The name of the table.
-// options - TableDeleteOptions contains the optional parameters for the TableClient.Delete method.
-func (client *TableClient) Delete(ctx context.Context, table string, options *TableDeleteOptions) (TableDeleteResponse, error) {
+// options - TableDeleteOptions contains the optional parameters for the Client.Delete method.
+func (client *Client) Delete(ctx context.Context, table string, options *TableDeleteOptions) (TableDeleteResponse, error) {
 	req, err := client.deleteCreateRequest(ctx, table, options)
 	if err != nil {
 		return TableDeleteResponse{}, err
@@ -148,7 +148,7 @@ func (client *TableClient) Delete(ctx context.Context, table string, options *Ta
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *TableClient) deleteCreateRequest(ctx context.Context, table string, options *TableDeleteOptions) (*policy.Request, error) {
+func (client *Client) deleteCreateRequest(ctx context.Context, table string, options *TableDeleteOptions) (*policy.Request, error) {
 	urlPath := "/Tables('{table}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -167,7 +167,7 @@ func (client *TableClient) deleteCreateRequest(ctx context.Context, table string
 }
 
 // deleteHandleResponse handles the Delete response.
-func (client *TableClient) deleteHandleResponse(resp *http.Response) (TableDeleteResponse, error) {
+func (client *Client) deleteHandleResponse(resp *http.Response) (TableDeleteResponse, error) {
 	result := TableDeleteResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -189,12 +189,12 @@ func (client *TableClient) deleteHandleResponse(resp *http.Response) (TableDelet
 }
 
 // deleteHandleError handles the Delete error response.
-func (client *TableClient) deleteHandleError(resp *http.Response) error {
+func (client *Client) deleteHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -202,15 +202,15 @@ func (client *TableClient) deleteHandleError(resp *http.Response) error {
 }
 
 // DeleteEntity - Deletes the specified entity in a table.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // dataServiceVersion - Specifies the data service version.
 // table - The name of the table.
 // partitionKey - The partition key of the entity.
 // rowKey - The row key of the entity.
 // ifMatch - Match condition for an entity to be deleted. If specified and a matching entity is not found, an error will be
 // raised. To force an unconditional delete, set to the wildcard character (*).
-// options - TableDeleteEntityOptions contains the optional parameters for the TableClient.DeleteEntity method.
-func (client *TableClient) DeleteEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, ifMatch string, options *TableDeleteEntityOptions) (TableDeleteEntityResponse, error) {
+// options - TableDeleteEntityOptions contains the optional parameters for the Client.DeleteEntity method.
+func (client *Client) DeleteEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, ifMatch string, options *TableDeleteEntityOptions) (TableDeleteEntityResponse, error) {
 	req, err := client.deleteEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, ifMatch, options)
 	if err != nil {
 		return TableDeleteEntityResponse{}, err
@@ -226,7 +226,7 @@ func (client *TableClient) DeleteEntity(ctx context.Context, dataServiceVersion 
 }
 
 // deleteEntityCreateRequest creates the DeleteEntity request.
-func (client *TableClient) deleteEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, ifMatch string, options *TableDeleteEntityOptions) (*policy.Request, error) {
+func (client *Client) deleteEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, ifMatch string, options *TableDeleteEntityOptions) (*policy.Request, error) {
 	urlPath := "/{table}(PartitionKey='{partitionKey}',RowKey='{rowKey}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -263,7 +263,7 @@ func (client *TableClient) deleteEntityCreateRequest(ctx context.Context, dataSe
 }
 
 // deleteEntityHandleResponse handles the DeleteEntity response.
-func (client *TableClient) deleteEntityHandleResponse(resp *http.Response) (TableDeleteEntityResponse, error) {
+func (client *Client) deleteEntityHandleResponse(resp *http.Response) (TableDeleteEntityResponse, error) {
 	result := TableDeleteEntityResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -285,12 +285,12 @@ func (client *TableClient) deleteEntityHandleResponse(resp *http.Response) (Tabl
 }
 
 // deleteEntityHandleError handles the DeleteEntity error response.
-func (client *TableClient) deleteEntityHandleError(resp *http.Response) error {
+func (client *Client) deleteEntityHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -299,11 +299,11 @@ func (client *TableClient) deleteEntityHandleError(resp *http.Response) error {
 
 // GetAccessPolicy - Retrieves details about any stored access policies specified on the table that may be used with Shared
 // Access Signatures.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // table - The name of the table.
 // comp - Required query string to handle stored access policies for the table that may be used with Shared Access Signatures.
-// options - TableGetAccessPolicyOptions contains the optional parameters for the TableClient.GetAccessPolicy method.
-func (client *TableClient) GetAccessPolicy(ctx context.Context, table string, comp Enum4, options *TableGetAccessPolicyOptions) (TableGetAccessPolicyResponse, error) {
+// options - TableGetAccessPolicyOptions contains the optional parameters for the Client.GetAccessPolicy method.
+func (client *Client) GetAccessPolicy(ctx context.Context, table string, comp Enum4, options *TableGetAccessPolicyOptions) (TableGetAccessPolicyResponse, error) {
 	req, err := client.getAccessPolicyCreateRequest(ctx, table, comp, options)
 	if err != nil {
 		return TableGetAccessPolicyResponse{}, err
@@ -319,7 +319,7 @@ func (client *TableClient) GetAccessPolicy(ctx context.Context, table string, co
 }
 
 // getAccessPolicyCreateRequest creates the GetAccessPolicy request.
-func (client *TableClient) getAccessPolicyCreateRequest(ctx context.Context, table string, comp Enum4, options *TableGetAccessPolicyOptions) (*policy.Request, error) {
+func (client *Client) getAccessPolicyCreateRequest(ctx context.Context, table string, comp Enum4, options *TableGetAccessPolicyOptions) (*policy.Request, error) {
 	urlPath := "/{table}"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -344,7 +344,7 @@ func (client *TableClient) getAccessPolicyCreateRequest(ctx context.Context, tab
 }
 
 // getAccessPolicyHandleResponse handles the GetAccessPolicy response.
-func (client *TableClient) getAccessPolicyHandleResponse(resp *http.Response) (TableGetAccessPolicyResponse, error) {
+func (client *Client) getAccessPolicyHandleResponse(resp *http.Response) (TableGetAccessPolicyResponse, error) {
 	result := TableGetAccessPolicyResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -369,12 +369,12 @@ func (client *TableClient) getAccessPolicyHandleResponse(resp *http.Response) (T
 }
 
 // getAccessPolicyHandleError handles the GetAccessPolicy error response.
-func (client *TableClient) getAccessPolicyHandleError(resp *http.Response) error {
+func (client *Client) getAccessPolicyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -382,11 +382,11 @@ func (client *TableClient) getAccessPolicyHandleError(resp *http.Response) error
 }
 
 // InsertEntity - Insert entity in a table.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // dataServiceVersion - Specifies the data service version.
 // table - The name of the table.
-// options - TableInsertEntityOptions contains the optional parameters for the TableClient.InsertEntity method.
-func (client *TableClient) InsertEntity(ctx context.Context, dataServiceVersion Enum1, table string, options *TableInsertEntityOptions) (TableInsertEntityResponse, error) {
+// options - TableInsertEntityOptions contains the optional parameters for the Client.InsertEntity method.
+func (client *Client) InsertEntity(ctx context.Context, dataServiceVersion Enum1, table string, options *TableInsertEntityOptions) (TableInsertEntityResponse, error) {
 	req, err := client.insertEntityCreateRequest(ctx, dataServiceVersion, table, options)
 	if err != nil {
 		return TableInsertEntityResponse{}, err
@@ -402,7 +402,7 @@ func (client *TableClient) InsertEntity(ctx context.Context, dataServiceVersion 
 }
 
 // insertEntityCreateRequest creates the InsertEntity request.
-func (client *TableClient) insertEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, options *TableInsertEntityOptions) (*policy.Request, error) {
+func (client *Client) insertEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, options *TableInsertEntityOptions) (*policy.Request, error) {
 	urlPath := "/{table}"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -436,7 +436,7 @@ func (client *TableClient) insertEntityCreateRequest(ctx context.Context, dataSe
 }
 
 // insertEntityHandleResponse handles the InsertEntity response.
-func (client *TableClient) insertEntityHandleResponse(resp *http.Response) (TableInsertEntityResponse, error) {
+func (client *Client) insertEntityHandleResponse(resp *http.Response) (TableInsertEntityResponse, error) {
 	result := TableInsertEntityResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -470,12 +470,12 @@ func (client *TableClient) insertEntityHandleResponse(resp *http.Response) (Tabl
 }
 
 // insertEntityHandleError handles the InsertEntity error response.
-func (client *TableClient) insertEntityHandleError(resp *http.Response) error {
+func (client *Client) insertEntityHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -483,13 +483,13 @@ func (client *TableClient) insertEntityHandleError(resp *http.Response) error {
 }
 
 // MergeEntity - Merge entity in a table.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // dataServiceVersion - Specifies the data service version.
 // table - The name of the table.
 // partitionKey - The partition key of the entity.
 // rowKey - The row key of the entity.
-// options - TableMergeEntityOptions contains the optional parameters for the TableClient.MergeEntity method.
-func (client *TableClient) MergeEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableMergeEntityOptions) (TableMergeEntityResponse, error) {
+// options - TableMergeEntityOptions contains the optional parameters for the Client.MergeEntity method.
+func (client *Client) MergeEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableMergeEntityOptions) (TableMergeEntityResponse, error) {
 	req, err := client.mergeEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, options)
 	if err != nil {
 		return TableMergeEntityResponse{}, err
@@ -505,7 +505,7 @@ func (client *TableClient) MergeEntity(ctx context.Context, dataServiceVersion E
 }
 
 // mergeEntityCreateRequest creates the MergeEntity request.
-func (client *TableClient) mergeEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableMergeEntityOptions) (*policy.Request, error) {
+func (client *Client) mergeEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableMergeEntityOptions) (*policy.Request, error) {
 	urlPath := "/{table}(PartitionKey='{partitionKey}',RowKey='{rowKey}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -547,7 +547,7 @@ func (client *TableClient) mergeEntityCreateRequest(ctx context.Context, dataSer
 }
 
 // mergeEntityHandleResponse handles the MergeEntity response.
-func (client *TableClient) mergeEntityHandleResponse(resp *http.Response) (TableMergeEntityResponse, error) {
+func (client *Client) mergeEntityHandleResponse(resp *http.Response) (TableMergeEntityResponse, error) {
 	result := TableMergeEntityResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -572,12 +572,12 @@ func (client *TableClient) mergeEntityHandleResponse(resp *http.Response) (Table
 }
 
 // mergeEntityHandleError handles the MergeEntity error response.
-func (client *TableClient) mergeEntityHandleError(resp *http.Response) error {
+func (client *Client) mergeEntityHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -587,24 +587,24 @@ func (client *TableClient) mergeEntityHandleError(resp *http.Response) error {
 // Query - Queries tables under the given account.
 // If the operation fails it returns a generic error.
 // dataServiceVersion - Specifies the data service version.
-// options - TableQueryOptions contains the optional parameters for the TableClient.Query method.
-func (client *TableClient) Query(ctx context.Context, dataServiceVersion Enum1, options *TableQueryOptions) (TableQueryResponseEnvelope, error) {
+// options - TableQueryOptions contains the optional parameters for the Client.Query method.
+func (client *Client) Query(ctx context.Context, dataServiceVersion Enum1, options *TableQueryOptions) (TableQueryResponse, error) {
 	req, err := client.queryCreateRequest(ctx, dataServiceVersion, options)
 	if err != nil {
-		return TableQueryResponseEnvelope{}, err
+		return TableQueryResponse{}, err
 	}
 	resp, err := client.pl.Do(req)
 	if err != nil {
-		return TableQueryResponseEnvelope{}, err
+		return TableQueryResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return TableQueryResponseEnvelope{}, client.queryHandleError(resp)
+		return TableQueryResponse{}, client.queryHandleError(resp)
 	}
 	return client.queryHandleResponse(resp)
 }
 
 // queryCreateRequest creates the Query request.
-func (client *TableClient) queryCreateRequest(ctx context.Context, dataServiceVersion Enum1, options *TableQueryOptions) (*policy.Request, error) {
+func (client *Client) queryCreateRequest(ctx context.Context, dataServiceVersion Enum1, options *TableQueryOptions) (*policy.Request, error) {
 	urlPath := "/Tables"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -637,8 +637,8 @@ func (client *TableClient) queryCreateRequest(ctx context.Context, dataServiceVe
 }
 
 // queryHandleResponse handles the Query response.
-func (client *TableClient) queryHandleResponse(resp *http.Response) (TableQueryResponseEnvelope, error) {
-	result := TableQueryResponseEnvelope{RawResponse: resp}
+func (client *Client) queryHandleResponse(resp *http.Response) (TableQueryResponse, error) {
+	result := TableQueryResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -651,21 +651,21 @@ func (client *TableClient) queryHandleResponse(resp *http.Response) (TableQueryR
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return TableQueryResponseEnvelope{}, err
+			return TableQueryResponse{}, err
 		}
 		result.Date = &date
 	}
 	if val := resp.Header.Get("x-ms-continuation-NextTableName"); val != "" {
 		result.XMSContinuationNextTableName = &val
 	}
-	if err := runtime.UnmarshalAsJSON(resp, &result.TableQueryResponse); err != nil {
-		return TableQueryResponseEnvelope{}, runtime.NewResponseError(err, resp)
+	if err := runtime.UnmarshalAsJSON(resp, &result.QueryResponse); err != nil {
+		return TableQueryResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // queryHandleError handles the Query error response.
-func (client *TableClient) queryHandleError(resp *http.Response) error {
+func (client *Client) queryHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -677,11 +677,11 @@ func (client *TableClient) queryHandleError(resp *http.Response) error {
 }
 
 // QueryEntities - Queries entities in a table.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // dataServiceVersion - Specifies the data service version.
 // table - The name of the table.
-// options - TableQueryEntitiesOptions contains the optional parameters for the TableClient.QueryEntities method.
-func (client *TableClient) QueryEntities(ctx context.Context, dataServiceVersion Enum1, table string, options *TableQueryEntitiesOptions) (TableQueryEntitiesResponse, error) {
+// options - TableQueryEntitiesOptions contains the optional parameters for the Client.QueryEntities method.
+func (client *Client) QueryEntities(ctx context.Context, dataServiceVersion Enum1, table string, options *TableQueryEntitiesOptions) (TableQueryEntitiesResponse, error) {
 	req, err := client.queryEntitiesCreateRequest(ctx, dataServiceVersion, table, options)
 	if err != nil {
 		return TableQueryEntitiesResponse{}, err
@@ -697,7 +697,7 @@ func (client *TableClient) QueryEntities(ctx context.Context, dataServiceVersion
 }
 
 // queryEntitiesCreateRequest creates the QueryEntities request.
-func (client *TableClient) queryEntitiesCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, options *TableQueryEntitiesOptions) (*policy.Request, error) {
+func (client *Client) queryEntitiesCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, options *TableQueryEntitiesOptions) (*policy.Request, error) {
 	urlPath := "/{table}()"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -740,7 +740,7 @@ func (client *TableClient) queryEntitiesCreateRequest(ctx context.Context, dataS
 }
 
 // queryEntitiesHandleResponse handles the QueryEntities response.
-func (client *TableClient) queryEntitiesHandleResponse(resp *http.Response) (TableQueryEntitiesResponse, error) {
+func (client *Client) queryEntitiesHandleResponse(resp *http.Response) (TableQueryEntitiesResponse, error) {
 	result := TableQueryEntitiesResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -764,19 +764,19 @@ func (client *TableClient) queryEntitiesHandleResponse(resp *http.Response) (Tab
 	if val := resp.Header.Get("x-ms-continuation-NextRowKey"); val != "" {
 		result.XMSContinuationNextRowKey = &val
 	}
-	if err := runtime.UnmarshalAsJSON(resp, &result.TableEntityQueryResponse); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.EntityQueryResponse); err != nil {
 		return TableQueryEntitiesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
 // queryEntitiesHandleError handles the QueryEntities error response.
-func (client *TableClient) queryEntitiesHandleError(resp *http.Response) error {
+func (client *Client) queryEntitiesHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -784,14 +784,14 @@ func (client *TableClient) queryEntitiesHandleError(resp *http.Response) error {
 }
 
 // QueryEntityWithPartitionAndRowKey - Queries a single entity in a table.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // dataServiceVersion - Specifies the data service version.
 // table - The name of the table.
 // partitionKey - The partition key of the entity.
 // rowKey - The row key of the entity.
-// options - TableQueryEntityWithPartitionAndRowKeyOptions contains the optional parameters for the TableClient.QueryEntityWithPartitionAndRowKey
+// options - TableQueryEntityWithPartitionAndRowKeyOptions contains the optional parameters for the Client.QueryEntityWithPartitionAndRowKey
 // method.
-func (client *TableClient) QueryEntityWithPartitionAndRowKey(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableQueryEntityWithPartitionAndRowKeyOptions) (TableQueryEntityWithPartitionAndRowKeyResponse, error) {
+func (client *Client) QueryEntityWithPartitionAndRowKey(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableQueryEntityWithPartitionAndRowKeyOptions) (TableQueryEntityWithPartitionAndRowKeyResponse, error) {
 	req, err := client.queryEntityWithPartitionAndRowKeyCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, options)
 	if err != nil {
 		return TableQueryEntityWithPartitionAndRowKeyResponse{}, err
@@ -807,7 +807,7 @@ func (client *TableClient) QueryEntityWithPartitionAndRowKey(ctx context.Context
 }
 
 // queryEntityWithPartitionAndRowKeyCreateRequest creates the QueryEntityWithPartitionAndRowKey request.
-func (client *TableClient) queryEntityWithPartitionAndRowKeyCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableQueryEntityWithPartitionAndRowKeyOptions) (*policy.Request, error) {
+func (client *Client) queryEntityWithPartitionAndRowKeyCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableQueryEntityWithPartitionAndRowKeyOptions) (*policy.Request, error) {
 	urlPath := "/{table}(PartitionKey='{partitionKey}',RowKey='{rowKey}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -849,7 +849,7 @@ func (client *TableClient) queryEntityWithPartitionAndRowKeyCreateRequest(ctx co
 }
 
 // queryEntityWithPartitionAndRowKeyHandleResponse handles the QueryEntityWithPartitionAndRowKey response.
-func (client *TableClient) queryEntityWithPartitionAndRowKeyHandleResponse(resp *http.Response) (TableQueryEntityWithPartitionAndRowKeyResponse, error) {
+func (client *Client) queryEntityWithPartitionAndRowKeyHandleResponse(resp *http.Response) (TableQueryEntityWithPartitionAndRowKeyResponse, error) {
 	result := TableQueryEntityWithPartitionAndRowKeyResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -883,12 +883,12 @@ func (client *TableClient) queryEntityWithPartitionAndRowKeyHandleResponse(resp 
 }
 
 // queryEntityWithPartitionAndRowKeyHandleError handles the QueryEntityWithPartitionAndRowKey error response.
-func (client *TableClient) queryEntityWithPartitionAndRowKeyHandleError(resp *http.Response) error {
+func (client *Client) queryEntityWithPartitionAndRowKeyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -896,11 +896,11 @@ func (client *TableClient) queryEntityWithPartitionAndRowKeyHandleError(resp *ht
 }
 
 // SetAccessPolicy - Sets stored access policies for the table that may be used with Shared Access Signatures.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // table - The name of the table.
 // comp - Required query string to handle stored access policies for the table that may be used with Shared Access Signatures.
-// options - TableSetAccessPolicyOptions contains the optional parameters for the TableClient.SetAccessPolicy method.
-func (client *TableClient) SetAccessPolicy(ctx context.Context, table string, comp Enum4, options *TableSetAccessPolicyOptions) (TableSetAccessPolicyResponse, error) {
+// options - TableSetAccessPolicyOptions contains the optional parameters for the Client.SetAccessPolicy method.
+func (client *Client) SetAccessPolicy(ctx context.Context, table string, comp Enum4, options *TableSetAccessPolicyOptions) (TableSetAccessPolicyResponse, error) {
 	req, err := client.setAccessPolicyCreateRequest(ctx, table, comp, options)
 	if err != nil {
 		return TableSetAccessPolicyResponse{}, err
@@ -916,7 +916,7 @@ func (client *TableClient) SetAccessPolicy(ctx context.Context, table string, co
 }
 
 // setAccessPolicyCreateRequest creates the SetAccessPolicy request.
-func (client *TableClient) setAccessPolicyCreateRequest(ctx context.Context, table string, comp Enum4, options *TableSetAccessPolicyOptions) (*policy.Request, error) {
+func (client *Client) setAccessPolicyCreateRequest(ctx context.Context, table string, comp Enum4, options *TableSetAccessPolicyOptions) (*policy.Request, error) {
 	urlPath := "/{table}"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -948,7 +948,7 @@ func (client *TableClient) setAccessPolicyCreateRequest(ctx context.Context, tab
 }
 
 // setAccessPolicyHandleResponse handles the SetAccessPolicy response.
-func (client *TableClient) setAccessPolicyHandleResponse(resp *http.Response) (TableSetAccessPolicyResponse, error) {
+func (client *Client) setAccessPolicyHandleResponse(resp *http.Response) (TableSetAccessPolicyResponse, error) {
 	result := TableSetAccessPolicyResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -970,12 +970,12 @@ func (client *TableClient) setAccessPolicyHandleResponse(resp *http.Response) (T
 }
 
 // setAccessPolicyHandleError handles the SetAccessPolicy error response.
-func (client *TableClient) setAccessPolicyHandleError(resp *http.Response) error {
+func (client *Client) setAccessPolicyHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -983,13 +983,13 @@ func (client *TableClient) setAccessPolicyHandleError(resp *http.Response) error
 }
 
 // UpdateEntity - Update entity in a table.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // dataServiceVersion - Specifies the data service version.
 // table - The name of the table.
 // partitionKey - The partition key of the entity.
 // rowKey - The row key of the entity.
-// options - TableUpdateEntityOptions contains the optional parameters for the TableClient.UpdateEntity method.
-func (client *TableClient) UpdateEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableUpdateEntityOptions) (TableUpdateEntityResponse, error) {
+// options - TableUpdateEntityOptions contains the optional parameters for the Client.UpdateEntity method.
+func (client *Client) UpdateEntity(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableUpdateEntityOptions) (TableUpdateEntityResponse, error) {
 	req, err := client.updateEntityCreateRequest(ctx, dataServiceVersion, table, partitionKey, rowKey, options)
 	if err != nil {
 		return TableUpdateEntityResponse{}, err
@@ -1005,7 +1005,7 @@ func (client *TableClient) UpdateEntity(ctx context.Context, dataServiceVersion 
 }
 
 // updateEntityCreateRequest creates the UpdateEntity request.
-func (client *TableClient) updateEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableUpdateEntityOptions) (*policy.Request, error) {
+func (client *Client) updateEntityCreateRequest(ctx context.Context, dataServiceVersion Enum1, table string, partitionKey string, rowKey string, options *TableUpdateEntityOptions) (*policy.Request, error) {
 	urlPath := "/{table}(PartitionKey='{partitionKey}',RowKey='{rowKey}')"
 	if table == "" {
 		return nil, errors.New("parameter table cannot be empty")
@@ -1047,7 +1047,7 @@ func (client *TableClient) updateEntityCreateRequest(ctx context.Context, dataSe
 }
 
 // updateEntityHandleResponse handles the UpdateEntity response.
-func (client *TableClient) updateEntityHandleResponse(resp *http.Response) (TableUpdateEntityResponse, error) {
+func (client *Client) updateEntityHandleResponse(resp *http.Response) (TableUpdateEntityResponse, error) {
 	result := TableUpdateEntityResponse{RawResponse: resp}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -1072,12 +1072,12 @@ func (client *TableClient) updateEntityHandleResponse(resp *http.Response) (Tabl
 }
 
 // updateEntityHandleError handles the UpdateEntity error response.
-func (client *TableClient) updateEntityHandleError(resp *http.Response) error {
+func (client *Client) updateEntityHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}

--- a/test/tables/2019-02-02/aztables/zz_generated_response_types.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_response_types.go
@@ -22,7 +22,7 @@ type ServiceGetPropertiesResponse struct {
 
 // ServiceGetPropertiesResult contains the result from method Service.GetProperties.
 type ServiceGetPropertiesResult struct {
-	TableServiceProperties
+	ServiceProperties
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
@@ -42,7 +42,7 @@ type ServiceGetStatisticsResponse struct {
 
 // ServiceGetStatisticsResult contains the result from method Service.GetStatistics.
 type ServiceGetStatisticsResult struct {
-	TableServiceStats
+	ServiceStats
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
@@ -84,7 +84,7 @@ type TableCreateResponse struct {
 
 // TableCreateResult contains the result from method Table.Create.
 type TableCreateResult struct {
-	TableResponse
+	Response
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -238,7 +238,7 @@ type TableQueryEntitiesResponse struct {
 
 // TableQueryEntitiesResult contains the result from method Table.QueryEntities.
 type TableQueryEntitiesResult struct {
-	TableEntityQueryResponse
+	EntityQueryResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -292,8 +292,8 @@ type TableQueryEntityWithPartitionAndRowKeyResult struct {
 	XMSContinuationNextRowKey *string
 }
 
-// TableQueryResponseEnvelope contains the response from method Table.Query.
-type TableQueryResponseEnvelope struct {
+// TableQueryResponse contains the response from method Table.Query.
+type TableQueryResponse struct {
 	TableQueryResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -301,7 +301,7 @@ type TableQueryResponseEnvelope struct {
 
 // TableQueryResult contains the result from method Table.Query.
 type TableQueryResult struct {
-	TableQueryResponse
+	QueryResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 

--- a/test/tables/2019-02-02/aztables/zz_generated_service_client.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_service_client.go
@@ -41,7 +41,7 @@ func NewServiceClient(endpoint string, version Enum0, pl runtime.Pipeline) *Serv
 
 // GetProperties - Gets the properties of an account's Table service, including properties for Analytics and CORS (Cross-Origin
 // Resource Sharing) rules.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // restype - Required query string to set the service properties.
 // comp - Required query string to set the service properties.
 // options - ServiceGetPropertiesOptions contains the optional parameters for the ServiceClient.GetProperties method.
@@ -93,7 +93,7 @@ func (client *ServiceClient) getPropertiesHandleResponse(resp *http.Response) (S
 	if val := resp.Header.Get("x-ms-version"); val != "" {
 		result.Version = &val
 	}
-	if err := runtime.UnmarshalAsXML(resp, &result.TableServiceProperties); err != nil {
+	if err := runtime.UnmarshalAsXML(resp, &result.ServiceProperties); err != nil {
 		return ServiceGetPropertiesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
@@ -105,7 +105,7 @@ func (client *ServiceClient) getPropertiesHandleError(resp *http.Response) error
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -114,7 +114,7 @@ func (client *ServiceClient) getPropertiesHandleError(resp *http.Response) error
 
 // GetStatistics - Retrieves statistics related to replication for the Table service. It is only available on the secondary
 // location endpoint when read-access geo-redundant replication is enabled for the account.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // restype - Required query string to get service stats.
 // comp - Required query string to get service stats.
 // options - ServiceGetStatisticsOptions contains the optional parameters for the ServiceClient.GetStatistics method.
@@ -173,7 +173,7 @@ func (client *ServiceClient) getStatisticsHandleResponse(resp *http.Response) (S
 		}
 		result.Date = &date
 	}
-	if err := runtime.UnmarshalAsXML(resp, &result.TableServiceStats); err != nil {
+	if err := runtime.UnmarshalAsXML(resp, &result.ServiceStats); err != nil {
 		return ServiceGetStatisticsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
@@ -185,7 +185,7 @@ func (client *ServiceClient) getStatisticsHandleError(resp *http.Response) error
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}
@@ -194,12 +194,12 @@ func (client *ServiceClient) getStatisticsHandleError(resp *http.Response) error
 
 // SetProperties - Sets properties for an account's Table service endpoint, including properties for Analytics and CORS (Cross-Origin
 // Resource Sharing) rules.
-// If the operation fails it returns the *TableServiceError error type.
+// If the operation fails it returns the *ServiceError error type.
 // restype - Required query string to set the service properties.
 // comp - Required query string to set the service properties.
 // tableServiceProperties - The Table Service properties.
 // options - ServiceSetPropertiesOptions contains the optional parameters for the ServiceClient.SetProperties method.
-func (client *ServiceClient) SetProperties(ctx context.Context, restype Enum5, comp Enum6, tableServiceProperties TableServiceProperties, options *ServiceSetPropertiesOptions) (ServiceSetPropertiesResponse, error) {
+func (client *ServiceClient) SetProperties(ctx context.Context, restype Enum5, comp Enum6, tableServiceProperties ServiceProperties, options *ServiceSetPropertiesOptions) (ServiceSetPropertiesResponse, error) {
 	req, err := client.setPropertiesCreateRequest(ctx, restype, comp, tableServiceProperties, options)
 	if err != nil {
 		return ServiceSetPropertiesResponse{}, err
@@ -215,7 +215,7 @@ func (client *ServiceClient) SetProperties(ctx context.Context, restype Enum5, c
 }
 
 // setPropertiesCreateRequest creates the SetProperties request.
-func (client *ServiceClient) setPropertiesCreateRequest(ctx context.Context, restype Enum5, comp Enum6, tableServiceProperties TableServiceProperties, options *ServiceSetPropertiesOptions) (*policy.Request, error) {
+func (client *ServiceClient) setPropertiesCreateRequest(ctx context.Context, restype Enum5, comp Enum6, tableServiceProperties ServiceProperties, options *ServiceSetPropertiesOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -256,7 +256,7 @@ func (client *ServiceClient) setPropertiesHandleError(resp *http.Response) error
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
 	}
-	errType := TableServiceError{raw: string(body)}
+	errType := ServiceError{raw: string(body)}
 	if err := runtime.UnmarshalAsJSON(resp, &errType); err != nil {
 		return runtime.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp)
 	}


### PR DESCRIPTION
Remove the package name, minus any well-known prefixes, from types.
Added a --stutter switch allowing a custom prefix to be removed instead.