### PR TITLE
Skip duplicate entry when aggregating allOf

### DIFF
--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -239,6 +239,8 @@ function aggregateProperties(obj: ObjectSchema): Array<Property> {
             const msg = `type ${obj.language.go!.name} contains duplicate property ${exists.language.go!.name} with mismatched types`;
             throw new Error(msg);
           }
+          // don't add the duplicate
+          continue;
         }
         allProps.push(parentProp);
       }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.33",
+  "version": "4.0.0-preview.34",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/test/maps/azalias/zz_generated_models.go
+++ b/test/maps/azalias/zz_generated_models.go
@@ -74,6 +74,7 @@ type GeoJSONFeature struct {
 func (g *GeoJSONFeature) GetGeoJSONObject() *GeoJSONObject {
 	return &GeoJSONObject{
 		Type: g.Type,
+		ID:   g.ID,
 	}
 }
 
@@ -143,6 +144,9 @@ type GeoJSONObject struct {
 	// MultiLineString, Polygon, MultiPolygon, GeometryCollection, Feature and
 	// FeatureCollection.
 	Type *GeoJSONObjectType `json:"type,omitempty"`
+
+	// Identifier for the feature.
+	ID *string `json:"id,omitempty"`
 }
 
 // GetGeoJSONObject implements the GeoJSONObjectClassification interface for type GeoJSONObject.

--- a/test/swagger/alias.json
+++ b/test/swagger/alias.json
@@ -394,6 +394,10 @@
               }
             ]
           }
+        },
+        "id": {
+          "description": "Identifier for the feature.",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
Some cases M4 does this for us.  In this case, we do it.
Added test to ensure coverage.
Bump version for next release.