### PR TITLE
Fix reading of text responses

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -979,6 +979,16 @@ function generateResponseUnmarshaller(op: Operation, response: SchemaResponse, u
     unmarshallerText += `\tif err := runtime.UnmarshalAs${getMediaFormat(response.schema, mediaType, `resp, &${unmarshalTarget}`)}; err != nil {\n`;
     unmarshallerText += `\t\treturn ${zeroValue}, runtime.NewResponseError(err, resp)\n`;
     unmarshallerText += '\t}\n';
+  } else if (mediaType === 'text') {
+    unmarshallerText += `\tbody, err := runtime.Payload(resp)\n`;
+    unmarshallerText += '\tif err != nil {\n';
+    unmarshallerText += `\t\treturn ${zeroValue}, runtime.NewResponseError(err, resp)\n`;
+    unmarshallerText += '\t}\n';
+    unmarshallerText += '\ttxt := string(body)\n';
+    unmarshallerText += `\t${unmarshalTarget} = &txt\n`;
+  } else {
+    // the remaining media types are handled elsewhere
+    throw new Error(`unhandled media type ${mediaType} for operation ${op.language.go!.clientName}.${op.language.go!.name}`);
   }
   return unmarshallerText;
 }

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypes_client.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypes_client.go
@@ -278,6 +278,12 @@ func (client *MediaTypesClient) binaryBodyWithThreeContentTypesCreateRequest(ctx
 // binaryBodyWithThreeContentTypesHandleResponse handles the BinaryBodyWithThreeContentTypes response.
 func (client *MediaTypesClient) binaryBodyWithThreeContentTypesHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithThreeContentTypesResponse, error) {
 	result := MediaTypesClientBinaryBodyWithThreeContentTypesResponse{RawResponse: resp}
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithThreeContentTypesResponse{}, runtime.NewResponseError(err, resp)
+	}
+	txt := string(body)
+	result.Value = &txt
 	return result, nil
 }
 
@@ -330,6 +336,12 @@ func (client *MediaTypesClient) binaryBodyWithThreeContentTypesWithTextCreateReq
 // binaryBodyWithThreeContentTypesWithTextHandleResponse handles the BinaryBodyWithThreeContentTypesWithText response.
 func (client *MediaTypesClient) binaryBodyWithThreeContentTypesWithTextHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse, error) {
 	result := MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{RawResponse: resp}
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{}, runtime.NewResponseError(err, resp)
+	}
+	txt := string(body)
+	result.Value = &txt
 	return result, nil
 }
 
@@ -382,6 +394,12 @@ func (client *MediaTypesClient) binaryBodyWithTwoContentTypesCreateRequest(ctx c
 // binaryBodyWithTwoContentTypesHandleResponse handles the BinaryBodyWithTwoContentTypes response.
 func (client *MediaTypesClient) binaryBodyWithTwoContentTypesHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithTwoContentTypesResponse, error) {
 	result := MediaTypesClientBinaryBodyWithTwoContentTypesResponse{RawResponse: resp}
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithTwoContentTypesResponse{}, runtime.NewResponseError(err, resp)
+	}
+	txt := string(body)
+	result.Value = &txt
 	return result, nil
 }
 
@@ -486,6 +504,12 @@ func (client *MediaTypesClient) putTextAndJSONBodyWithJSONCreateRequest(ctx cont
 // putTextAndJSONBodyWithJSONHandleResponse handles the PutTextAndJSONBodyWithJSON response.
 func (client *MediaTypesClient) putTextAndJSONBodyWithJSONHandleResponse(resp *http.Response) (MediaTypesClientPutTextAndJSONBodyWithJSONResponse, error) {
 	result := MediaTypesClientPutTextAndJSONBodyWithJSONResponse{RawResponse: resp}
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return MediaTypesClientPutTextAndJSONBodyWithJSONResponse{}, runtime.NewResponseError(err, resp)
+	}
+	txt := string(body)
+	result.Value = &txt
 	return result, nil
 }
 
@@ -536,6 +560,12 @@ func (client *MediaTypesClient) putTextAndJSONBodyWithTextCreateRequest(ctx cont
 // putTextAndJSONBodyWithTextHandleResponse handles the PutTextAndJSONBodyWithText response.
 func (client *MediaTypesClient) putTextAndJSONBodyWithTextHandleResponse(resp *http.Response) (MediaTypesClientPutTextAndJSONBodyWithTextResponse, error) {
 	result := MediaTypesClientPutTextAndJSONBodyWithTextResponse{RawResponse: resp}
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return MediaTypesClientPutTextAndJSONBodyWithTextResponse{}, runtime.NewResponseError(err, resp)
+	}
+	txt := string(body)
+	result.Value = &txt
 	return result, nil
 }
 

--- a/test/maps/azalias/zz_generated_client.go
+++ b/test/maps/azalias/zz_generated_client.go
@@ -122,6 +122,59 @@ func (client *client) createHandleError(resp *http.Response) error {
 	return runtime.NewResponseError(errors.New(string(body)), resp)
 }
 
+// GetScript - Retrieve the configuration script identified by configuration name.
+// If the operation fails it returns a generic error.
+// options - AliasGetScriptOptions contains the optional parameters for the client.GetScript method.
+func (client *client) GetScript(ctx context.Context, options *AliasGetScriptOptions) (AliasGetScriptResponse, error) {
+	req, err := client.getScriptCreateRequest(ctx, options)
+	if err != nil {
+		return AliasGetScriptResponse{}, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return AliasGetScriptResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return AliasGetScriptResponse{}, client.getScriptHandleError(resp)
+	}
+	return client.getScriptHandleResponse(resp)
+}
+
+// getScriptCreateRequest creates the GetScript request.
+func (client *client) getScriptCreateRequest(ctx context.Context, options *AliasGetScriptOptions) (*policy.Request, error) {
+	urlPath := "/scripts"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Accept", "text/powershell")
+	return req, nil
+}
+
+// getScriptHandleResponse handles the GetScript response.
+func (client *client) getScriptHandleResponse(resp *http.Response) (AliasGetScriptResponse, error) {
+	result := AliasGetScriptResponse{RawResponse: resp}
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return AliasGetScriptResponse{}, runtime.NewResponseError(err, resp)
+	}
+	txt := string(body)
+	result.Value = &txt
+	return result, nil
+}
+
+// getScriptHandleError handles the GetScript error response.
+func (client *client) getScriptHandleError(resp *http.Response) error {
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return runtime.NewResponseError(err, resp)
+	}
+	if len(body) == 0 {
+		return runtime.NewResponseError(errors.New(resp.Status), resp)
+	}
+	return runtime.NewResponseError(errors.New(string(body)), resp)
+}
+
 // List - Applies to: see pricing tiers [https://aka.ms/AzureMapsPricingTier].
 // Creator makes it possible to develop applications based on your private indoor map data using Azure Maps API and SDK. This
 // [https://docs.microsoft.com/azure/azure-maps/creator-indoor-maps] article

--- a/test/maps/azalias/zz_generated_models.go
+++ b/test/maps/azalias/zz_generated_models.go
@@ -22,6 +22,11 @@ type AliasCreateOptions struct {
 	GroupBy           []SomethingCount
 }
 
+// AliasGetScriptOptions contains the optional parameters for the client.GetScript method.
+type AliasGetScriptOptions struct {
+	// placeholder for future optional parameters
+}
+
 // AliasListOptions contains the optional parameters for the client.List method.
 type AliasListOptions struct {
 	GroupBy []LogMetricsGroupBy

--- a/test/maps/azalias/zz_generated_response_types.go
+++ b/test/maps/azalias/zz_generated_response_types.go
@@ -24,6 +24,18 @@ type AliasCreateResult struct {
 	AccessControlExposeHeaders *string
 }
 
+// AliasGetScriptResponse contains the response from method Alias.GetScript.
+type AliasGetScriptResponse struct {
+	AliasGetScriptResult
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
+// AliasGetScriptResult contains the result from method Alias.GetScript.
+type AliasGetScriptResult struct {
+	Value *string
+}
+
 // AliasListResponse contains the response from method Alias.List.
 type AliasListResponse struct {
 	AliasListResult

--- a/test/swagger/alias.json
+++ b/test/swagger/alias.json
@@ -213,6 +213,24 @@
           }
         }
       }
+    },
+    "/scripts": {
+      "get": {
+        "operationId": "Alias_GetScript",
+        "description": "Retrieve the configuration script identified by configuration name.",
+        "produces": [
+          "text/powershell"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
For operations that return text media type, read the response and
populate the Value field in the result envelope.