### PR TITLE
Fix codegen failure for obscure paging corner-case

### DIFF
--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -30,7 +30,7 @@ async function getModuleVersion(session: Session<CodeModel>): Promise<string> {
 
 // The generator emits Go source code files to disk.
 export async function protocolGen(host: AutorestExtensionHost) {
-  const debug = await host.GetValue('debug') || false;
+  const debug = await host.getValue('debug') || false;
 
   try {
     // get the code model from the core
@@ -58,7 +58,7 @@ export async function protocolGen(host: AutorestExtensionHost) {
       // insert a _ before Client, i.e. Foo_Client
       // if the name isn't simply Client.
       if (fileName !== 'client') {
-        fileName = fileName.substr(0, fileName.length-6) + '_client';
+        fileName = fileName.substring(0, fileName.length-6) + '_client';
       }
       host.writeFile({
         filename: `${filePrefix}${fileName}.go`,

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -249,14 +249,14 @@ export function formatParamValue(param: Parameter, imports: ImportManager): stri
     case SchemaType.Date:
       if (param.required !== true && paramName[0] === '*') {
         // remove the dereference
-        paramName = paramName.substr(1);
+        paramName = paramName.substring(1);
       }
       return `${paramName}.Format("${dateFormat}")`;
     case SchemaType.DateTime:
       imports.add('time');
       if (param.required !== true && paramName[0] === '*') {
         // remove the dereference
-        paramName = paramName.substr(1);
+        paramName = paramName.substring(1);
       }
       let format = datetimeRFC3339Format;
       const dateTime = <DateTimeSchema>param.schema;

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -511,7 +511,8 @@ function generateOperation(op: Operation, imports: ImportManager): string {
     text += `\t\tadvancer: func(ctx context.Context, resp ${getResponseEnvelopeName(op)}) (*policy.Request, error) {\n`;
     const nextLink = op.language.go!.paging.nextLinkName;
     const response = getResultFieldName(op);
-    if (op.language.go!.paging.member) {
+    // nextLinkOperation might be absent in some cases, see https://github.com/Azure/autorest/issues/4393
+    if (op.language.go!.paging.nextLinkOperation) {
       const nextOpParams = getCreateRequestParametersSig(op.language.go!.paging.nextLinkOperation).split(',');
       // keep the parameter names from the name/type tuples and find nextLink param
       for (let i = 0; i < nextOpParams.length; ++i) {

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -99,7 +99,7 @@ export async function namer(session: Session<CodeModel>) {
     structNames.add(obj.language.go!.name);
   }
 
-  // fix stuttering type names, object fields, and other bits
+  // fix stuttering type names
   for (const obj of values(model.schemas.objects)) {
     const details = <Language>obj.language.go;
     const originalName = details.name;
@@ -108,6 +108,11 @@ export async function namer(session: Session<CodeModel>) {
     if (details.name !== originalName && structNames.has(details.name)) {
       throw new Error(`type ${originalName} was renamed to ${details.name} which collides with an existing type name`);
     }
+  }
+
+  // fix property names and other bits
+  for (const obj of values(model.schemas.objects)) {
+    const details = <Language>obj.language.go;
     if (obj.discriminator) {
       // if this is a discriminator add the interface name
       details.discriminatorInterface = createPolymorphicInterfaceName(details.name);

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -45,7 +45,7 @@ export class protocolMethods implements protocolNaming {
 function packageNameFromOutputFolder(folder: string): string {
   for (let i = folder.length - 1; i > -1; --i) {
     if (folder[i] === '/' || folder[i] === '\\') {
-      return folder.substr(i + 1);
+      return folder.substring(i + 1);
     }
   }
   // no path separator
@@ -73,9 +73,9 @@ export async function namer(session: Session<CodeModel>) {
   let stutteringPrefix = <string>model.language.go!.packageName;
   // if there's a well-known prefix, remove it
   if (stutteringPrefix.startsWith('arm')) {
-    stutteringPrefix = stutteringPrefix.substr(3);
+    stutteringPrefix = stutteringPrefix.substring(3);
   } else if (stutteringPrefix.startsWith('az')) {
-    stutteringPrefix = stutteringPrefix.substr(2);
+    stutteringPrefix = stutteringPrefix.substring(2);
   }
   // use the user-specified value if available
   stutteringPrefix = await session.getValue<string>('stutter', stutteringPrefix);
@@ -92,10 +92,22 @@ export async function namer(session: Session<CodeModel>) {
   const groupParameters = await session.getValue('group-parameters', true);
   model.language.go!.groupParameters = groupParameters;
 
-  // pascal-case and capitzalize acronym names of objects and their fields
+  // fix up type names
+  const structNames = new Set<string>();
+  for (const obj of values(model.schemas.objects)) {
+    obj.language.go!.name = ensureNameCase(obj.language.go!.name);
+    structNames.add(obj.language.go!.name);
+  }
+
+  // fix stuttering type names, object fields, and other bits
   for (const obj of values(model.schemas.objects)) {
     const details = <Language>obj.language.go;
-    details.name = trimPackagePrefix(stutteringPrefix, ensureNameCase(details.name));
+    const originalName = details.name;
+    details.name = trimPackagePrefix(stutteringPrefix, originalName);
+    // if the type was renamed to remove stuttering, check if it collides with an existing type name
+    if (details.name !== originalName && structNames.has(details.name)) {
+      throw new Error(`type ${originalName} was renamed to ${details.name} which collides with an existing type name`);
+    }
     if (obj.discriminator) {
       // if this is a discriminator add the interface name
       details.discriminatorInterface = createPolymorphicInterfaceName(details.name);
@@ -117,15 +129,27 @@ export async function namer(session: Session<CodeModel>) {
     }
   }
 
+  // fix up operation group names
+  const groupNames = new Set<string>();
+  for (const group of values(model.operationGroups)) {
+    if (group.language.go!.name.length > 0) {
+      group.language.go!.name = ensureNameCase(group.language.go!.name);
+      groupNames.add(group.language.go!.name);
+    }
+  }
+
+  const fallbackGroupName = ensureNameCase(session.model.info.title);
   const exportClient = session.model.language.go!.openApiType === 'arm' || exportClients;
-  // pascal-case and capitzalize acronym operation groups and their operations
+  // fix up empty operation group names and operations
   for (const group of values(model.operationGroups)) {
     const groupDetails = <Language>group.language.go;
     // use the swagger title as the default name for operation groups that don't specify a group name
     if (groupDetails.name.length === 0) {
-      groupDetails.name = session.model.info.title;
+      if (groupNames.has(fallbackGroupName)) {
+        throw new Error(`the fallback operation group name ${fallbackGroupName} collides with an existing group name`);
+      }
+      groupDetails.name = fallbackGroupName;
     }
-    groupDetails.name = ensureNameCase(groupDetails.name);
     groupDetails.clientName = groupDetails.name;
     // don't generate a name like FooClientClient
     if (!groupDetails.clientName.endsWith('Client')) {
@@ -297,7 +321,7 @@ function trimPackagePrefix(pkg: string, val: string): string {
   }
 
   // pkg is already upper-case
-  if (pkg !== val.substr(0, pkg.length).toUpperCase()) {
+  if (pkg !== val.substring(0, pkg.length).toUpperCase()) {
     return val;
   }
 
@@ -308,5 +332,5 @@ function trimPackagePrefix(pkg: string, val: string): string {
   if (val.charAt(pkg.length) !== val.charAt(pkg.length).toUpperCase()) {
     return val;
   }
-  return val.substr(pkg.length);
+  return val.substring(pkg.length);
 }

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -14,7 +14,7 @@ import { Converter } from 'showdown';
 
 // The transformer adds Go-specific information to the code model.
 export async function transform(host: AutorestExtensionHost) {
-  const debug = await host.GetValue('debug') || false;
+  const debug = await host.getValue('debug') || false;
 
   try {
     const session = await startSession<CodeModel>(host, codeModelSchema);

--- a/test/maps/azalias/zz_generated_models.go
+++ b/test/maps/azalias/zz_generated_models.go
@@ -137,7 +137,7 @@ type GeoJSONFeatureData struct {
 // GeoJSONObjectClassification provides polymorphic access to related types.
 // Call the interface's GetGeoJSONObject() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
-// - *GeoJSONObject, *GeoJsonFeature
+// - *GeoJSONFeature, *GeoJSONObject
 type GeoJSONObjectClassification interface {
 	// GetGeoJSONObject returns the GeoJSONObject content of the underlying type.
 	GetGeoJSONObject() *GeoJSONObject

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -6627,7 +6627,7 @@ func (f *FirewallPolicyRule) GetFirewallPolicyRule() *FirewallPolicyRule { retur
 // FirewallPolicyRuleConditionClassification provides polymorphic access to related types.
 // Call the interface's GetFirewallPolicyRuleCondition() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
-// - *ApplicationRuleCondition, *FirewallPolicyRuleCondition, *NatRuleCondition, *NetworkRuleCondition
+// - *ApplicationRuleCondition, *FirewallPolicyRuleCondition, *NatRuleCondition, *RuleCondition
 type FirewallPolicyRuleConditionClassification interface {
 	// GetFirewallPolicyRuleCondition returns the FirewallPolicyRuleCondition content of the underlying type.
 	GetFirewallPolicyRuleCondition() *FirewallPolicyRuleCondition

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -23,7 +23,7 @@ import (
 // - *DatabricksNotebookActivity, *DatabricksSparkJarActivity, *DatabricksSparkPythonActivity, *DeleteActivity, *ExecuteDataFlowActivity,
 // - *ExecutePipelineActivity, *ExecuteSSISPackageActivity, *ExecutionActivity, *FilterActivity, *ForEachActivity, *GetMetadataActivity,
 // - *HDInsightHiveActivity, *HDInsightMapReduceActivity, *HDInsightPigActivity, *HDInsightSparkActivity, *HDInsightStreamingActivity,
-// - *IfConditionActivity, *LookupActivity, *SetVariableActivity, *SqlPoolStoredProcedureActivity, *SqlServerStoredProcedureActivity,
+// - *IfConditionActivity, *LookupActivity, *SQLPoolStoredProcedureActivity, *SQLServerStoredProcedureActivity, *SetVariableActivity,
 // - *SwitchActivity, *SynapseNotebookActivity, *SynapseSparkJobDefinitionActivity, *UntilActivity, *ValidationActivity, *WaitActivity,
 // - *WebActivity, *WebHookActivity
 type ActivityClassification interface {
@@ -13449,11 +13449,11 @@ func (c *CopyActivityTypeProperties) UnmarshalJSON(data []byte) error {
 // CopySinkClassification provides polymorphic access to related types.
 // Call the interface's GetCopySink() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
-// - *AvroSink, *AzureBlobFSSink, *AzureDataExplorerSink, *AzureDataLakeStoreSink, *AzureMySqlSink, *AzurePostgreSqlSink,
-// - *AzureQueueSink, *AzureSearchIndexSink, *AzureSqlSink, *AzureTableSink, *BinarySink, *BlobSink, *CommonDataServiceForAppsSink,
-// - *CopySink, *CosmosDbMongoDbApiSink, *CosmosDbSqlApiSink, *DelimitedTextSink, *DocumentDbCollectionSink, *DynamicsCrmSink,
-// - *DynamicsSink, *FileSystemSink, *InformixSink, *JsonSink, *MicrosoftAccessSink, *OdbcSink, *OracleSink, *OrcSink, *ParquetSink,
-// - *SalesforceServiceCloudSink, *SalesforceSink, *SapCloudForCustomerSink, *SqlDWSink, *SqlMISink, *SqlServerSink, *SqlSink
+// - *AvroSink, *AzureBlobFSSink, *AzureDataExplorerSink, *AzureDataLakeStoreSink, *AzureMySQLSink, *AzurePostgreSQLSink,
+// - *AzureQueueSink, *AzureSQLSink, *AzureSearchIndexSink, *AzureTableSink, *BinarySink, *BlobSink, *CommonDataServiceForAppsSink,
+// - *CopySink, *CosmosDbMongoDbAPISink, *CosmosDbSQLAPISink, *DelimitedTextSink, *DocumentDbCollectionSink, *DynamicsCrmSink,
+// - *DynamicsSink, *FileSystemSink, *InformixSink, *JSONSink, *MicrosoftAccessSink, *OdbcSink, *OracleSink, *OrcSink, *ParquetSink,
+// - *SQLDWSink, *SQLMISink, *SQLServerSink, *SQLSink, *SalesforceServiceCloudSink, *SalesforceSink, *SapCloudForCustomerSink
 type CopySinkClassification interface {
 	// GetCopySink returns the CopySink content of the underlying type.
 	GetCopySink() *CopySink
@@ -13552,17 +13552,17 @@ func (c *CopySink) UnmarshalJSON(data []byte) error {
 // Call the interface's GetCopySource() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
 // - *AmazonMWSSource, *AmazonRedshiftSource, *AvroSource, *AzureBlobFSSource, *AzureDataExplorerSource, *AzureDataLakeStoreSource,
-// - *AzureMariaDBSource, *AzureMySqlSource, *AzurePostgreSqlSource, *AzureSqlSource, *AzureTableSource, *BinarySource, *BlobSource,
-// - *CassandraSource, *CommonDataServiceForAppsSource, *ConcurSource, *CopySource, *CosmosDbMongoDbApiSource, *CosmosDbSqlApiSource,
+// - *AzureMariaDBSource, *AzureMySQLSource, *AzurePostgreSQLSource, *AzureSQLSource, *AzureTableSource, *BinarySource, *BlobSource,
+// - *CassandraSource, *CommonDataServiceForAppsSource, *ConcurSource, *CopySource, *CosmosDbMongoDbAPISource, *CosmosDbSQLAPISource,
 // - *CouchbaseSource, *Db2Source, *DelimitedTextSource, *DocumentDbCollectionSource, *DrillSource, *DynamicsAXSource, *DynamicsCrmSource,
 // - *DynamicsSource, *EloquaSource, *FileSystemSource, *GoogleAdWordsSource, *GoogleBigQuerySource, *GreenplumSource, *HBaseSource,
-// - *HdfsSource, *HiveSource, *HttpSource, *HubspotSource, *ImpalaSource, *InformixSource, *JiraSource, *JsonSource, *MagentoSource,
-// - *MariaDBSource, *MarketoSource, *MicrosoftAccessSource, *MongoDbSource, *MongoDbV2Source, *MySqlSource, *NetezzaSource,
+// - *HTTPSource, *HdfsSource, *HiveSource, *HubspotSource, *ImpalaSource, *InformixSource, *JSONSource, *JiraSource, *MagentoSource,
+// - *MariaDBSource, *MarketoSource, *MicrosoftAccessSource, *MongoDbSource, *MongoDbV2Source, *MySQLSource, *NetezzaSource,
 // - *ODataSource, *OdbcSource, *Office365Source, *OracleServiceCloudSource, *OracleSource, *OrcSource, *ParquetSource, *PaypalSource,
-// - *PhoenixSource, *PostgreSqlSource, *PrestoSource, *QuickBooksSource, *RelationalSource, *ResponsysSource, *RestSource,
-// - *SalesforceMarketingCloudSource, *SalesforceServiceCloudSource, *SalesforceSource, *SapBwSource, *SapCloudForCustomerSource,
-// - *SapEccSource, *SapHanaSource, *SapOpenHubSource, *SapTableSource, *ServiceNowSource, *ShopifySource, *SparkSource, *SqlDWSource,
-// - *SqlMISource, *SqlServerSource, *SqlSource, *SquareSource, *SybaseSource, *TabularSource, *TeradataSource, *VerticaSource,
+// - *PhoenixSource, *PostgreSQLSource, *PrestoSource, *QuickBooksSource, *RelationalSource, *ResponsysSource, *RestSource,
+// - *SQLDWSource, *SQLMISource, *SQLServerSource, *SQLSource, *SalesforceMarketingCloudSource, *SalesforceServiceCloudSource,
+// - *SalesforceSource, *SapBwSource, *SapCloudForCustomerSource, *SapEccSource, *SapHanaSource, *SapOpenHubSource, *SapTableSource,
+// - *ServiceNowSource, *ShopifySource, *SparkSource, *SquareSource, *SybaseSource, *TabularSource, *TeradataSource, *VerticaSource,
 // - *WebSource, *XeroSource, *ZohoSource
 type CopySourceClassification interface {
 	// GetCopySource returns the CopySource content of the underlying type.
@@ -16794,21 +16794,21 @@ func (d DatabricksSparkPythonActivityTypeProperties) MarshalJSON() ([]byte, erro
 // Call the interface's GetDataset() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
 // - *AmazonMWSObjectDataset, *AmazonRedshiftTableDataset, *AvroDataset, *AzureDataExplorerTableDataset, *AzureMariaDBTableDataset,
-// - *AzureMySqlTableDataset, *AzurePostgreSqlTableDataset, *AzureSearchIndexDataset, *AzureSqlDWTableDataset, *AzureSqlMITableDataset,
-// - *AzureSqlTableDataset, *AzureTableDataset, *BinaryDataset, *CassandraTableDataset, *CommonDataServiceForAppsEntityDataset,
-// - *ConcurObjectDataset, *CosmosDbMongoDbApiCollectionDataset, *CosmosDbSqlApiCollectionDataset, *CouchbaseTableDataset,
+// - *AzureMySQLTableDataset, *AzurePostgreSQLTableDataset, *AzureSQLDWTableDataset, *AzureSQLMITableDataset, *AzureSQLTableDataset,
+// - *AzureSearchIndexDataset, *AzureTableDataset, *BinaryDataset, *CassandraTableDataset, *CommonDataServiceForAppsEntityDataset,
+// - *ConcurObjectDataset, *CosmosDbMongoDbAPICollectionDataset, *CosmosDbSQLAPICollectionDataset, *CouchbaseTableDataset,
 // - *CustomDataset, *Dataset, *Db2TableDataset, *DelimitedTextDataset, *DocumentDbCollectionDataset, *DrillTableDataset,
 // - *DynamicsAXResourceDataset, *DynamicsCrmEntityDataset, *DynamicsEntityDataset, *EloquaObjectDataset, *GoogleAdWordsObjectDataset,
 // - *GoogleBigQueryObjectDataset, *GreenplumTableDataset, *HBaseObjectDataset, *HiveObjectDataset, *HubspotObjectDataset,
-// - *ImpalaObjectDataset, *InformixTableDataset, *JiraObjectDataset, *JsonDataset, *MagentoObjectDataset, *MariaDBTableDataset,
-// - *MarketoObjectDataset, *MicrosoftAccessTableDataset, *MongoDbCollectionDataset, *MongoDbV2CollectionDataset, *MySqlTableDataset,
+// - *ImpalaObjectDataset, *InformixTableDataset, *JSONDataset, *JiraObjectDataset, *MagentoObjectDataset, *MariaDBTableDataset,
+// - *MarketoObjectDataset, *MicrosoftAccessTableDataset, *MongoDbCollectionDataset, *MongoDbV2CollectionDataset, *MySQLTableDataset,
 // - *NetezzaTableDataset, *ODataResourceDataset, *OdbcTableDataset, *Office365Dataset, *OracleServiceCloudObjectDataset,
-// - *OracleTableDataset, *OrcDataset, *ParquetDataset, *PaypalObjectDataset, *PhoenixObjectDataset, *PostgreSqlTableDataset,
+// - *OracleTableDataset, *OrcDataset, *ParquetDataset, *PaypalObjectDataset, *PhoenixObjectDataset, *PostgreSQLTableDataset,
 // - *PrestoObjectDataset, *QuickBooksObjectDataset, *RelationalTableDataset, *ResponsysObjectDataset, *RestResourceDataset,
-// - *SalesforceMarketingCloudObjectDataset, *SalesforceObjectDataset, *SalesforceServiceCloudObjectDataset, *SapBwCubeDataset,
-// - *SapCloudForCustomerResourceDataset, *SapEccResourceDataset, *SapHanaTableDataset, *SapOpenHubTableDataset, *SapTableResourceDataset,
-// - *ServiceNowObjectDataset, *ShopifyObjectDataset, *SparkObjectDataset, *SqlServerTableDataset, *SquareObjectDataset, *SybaseTableDataset,
-// - *TeradataTableDataset, *VerticaTableDataset, *WebTableDataset, *XeroObjectDataset, *ZohoObjectDataset
+// - *SQLServerTableDataset, *SalesforceMarketingCloudObjectDataset, *SalesforceObjectDataset, *SalesforceServiceCloudObjectDataset,
+// - *SapBwCubeDataset, *SapCloudForCustomerResourceDataset, *SapEccResourceDataset, *SapHanaTableDataset, *SapOpenHubTableDataset,
+// - *SapTableResourceDataset, *ServiceNowObjectDataset, *ShopifyObjectDataset, *SparkObjectDataset, *SquareObjectDataset,
+// - *SybaseTableDataset, *TeradataTableDataset, *VerticaTableDataset, *WebTableDataset, *XeroObjectDataset, *ZohoObjectDataset
 type DatasetClassification interface {
 	// GetDataset returns the Dataset content of the underlying type.
 	GetDataset() *Dataset
@@ -17279,7 +17279,7 @@ func (d DatasetListResponse) MarshalJSON() ([]byte, error) {
 // Call the interface's GetDatasetLocation() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
 // - *AmazonS3Location, *AzureBlobFSLocation, *AzureBlobStorageLocation, *AzureDataLakeStoreLocation, *AzureFileStorageLocation,
-// - *DatasetLocation, *FileServerLocation, *FtpServerLocation, *GoogleCloudStorageLocation, *HdfsLocation, *HttpServerLocation,
+// - *DatasetLocation, *FileServerLocation, *FtpServerLocation, *GoogleCloudStorageLocation, *HTTPServerLocation, *HdfsLocation,
 // - *SftpLocation
 type DatasetLocationClassification interface {
 	// GetDatasetLocation returns the DatasetLocation content of the underlying type.
@@ -17497,7 +17497,7 @@ func (d *DatasetSchemaDataElement) UnmarshalJSON(data []byte) error {
 // DatasetStorageFormatClassification provides polymorphic access to related types.
 // Call the interface's GetDatasetStorageFormat() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
-// - *AvroFormat, *DatasetStorageFormat, *JsonFormat, *OrcFormat, *ParquetFormat, *TextFormat
+// - *AvroFormat, *DatasetStorageFormat, *JSONFormat, *OrcFormat, *ParquetFormat, *TextFormat
 type DatasetStorageFormatClassification interface {
 	// GetDatasetStorageFormat returns the DatasetStorageFormat content of the underlying type.
 	GetDatasetStorageFormat() *DatasetStorageFormat
@@ -22036,7 +22036,7 @@ func (e ExecuteSSISPackageActivityTypeProperties) MarshalJSON() ([]byte, error) 
 // - *AzureMLUpdateResourceActivity, *CopyActivity, *CustomActivity, *DataLakeAnalyticsUSQLActivity, *DatabricksNotebookActivity,
 // - *DatabricksSparkJarActivity, *DatabricksSparkPythonActivity, *DeleteActivity, *ExecuteDataFlowActivity, *ExecuteSSISPackageActivity,
 // - *ExecutionActivity, *GetMetadataActivity, *HDInsightHiveActivity, *HDInsightMapReduceActivity, *HDInsightPigActivity,
-// - *HDInsightSparkActivity, *HDInsightStreamingActivity, *LookupActivity, *SqlServerStoredProcedureActivity, *SynapseNotebookActivity,
+// - *HDInsightSparkActivity, *HDInsightStreamingActivity, *LookupActivity, *SQLServerStoredProcedureActivity, *SynapseNotebookActivity,
 // - *SynapseSparkJobDefinitionActivity, *WebActivity
 type ExecutionActivityClassification interface {
 	ActivityClassification
@@ -23138,7 +23138,7 @@ func (f *FormatReadSettings) UnmarshalJSON(data []byte) error {
 // FormatWriteSettingsClassification provides polymorphic access to related types.
 // Call the interface's GetFormatWriteSettings() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
-// - *AvroWriteSettings, *DelimitedTextWriteSettings, *FormatWriteSettings, *JsonWriteSettings
+// - *AvroWriteSettings, *DelimitedTextWriteSettings, *FormatWriteSettings, *JSONWriteSettings
 type FormatWriteSettingsClassification interface {
 	// GetFormatWriteSettings returns the FormatWriteSettings content of the underlying type.
 	GetFormatWriteSettings() *FormatWriteSettings
@@ -32027,21 +32027,21 @@ func (l *LinkedIntegrationRuntimeType) GetLinkedIntegrationRuntimeType() *Linked
 // - *AmazonMWSLinkedService, *AmazonRedshiftLinkedService, *AmazonS3LinkedService, *AzureBatchLinkedService, *AzureBlobFSLinkedService,
 // - *AzureBlobStorageLinkedService, *AzureDataExplorerLinkedService, *AzureDataLakeAnalyticsLinkedService, *AzureDataLakeStoreLinkedService,
 // - *AzureDatabricksLinkedService, *AzureFileStorageLinkedService, *AzureFunctionLinkedService, *AzureKeyVaultLinkedService,
-// - *AzureMLLinkedService, *AzureMLServiceLinkedService, *AzureMariaDBLinkedService, *AzureMySqlLinkedService, *AzurePostgreSqlLinkedService,
-// - *AzureSearchLinkedService, *AzureSqlDWLinkedService, *AzureSqlDatabaseLinkedService, *AzureSqlMILinkedService, *AzureStorageLinkedService,
+// - *AzureMLLinkedService, *AzureMLServiceLinkedService, *AzureMariaDBLinkedService, *AzureMySQLLinkedService, *AzurePostgreSQLLinkedService,
+// - *AzureSQLDWLinkedService, *AzureSQLDatabaseLinkedService, *AzureSQLMILinkedService, *AzureSearchLinkedService, *AzureStorageLinkedService,
 // - *AzureTableStorageLinkedService, *CassandraLinkedService, *CommonDataServiceForAppsLinkedService, *ConcurLinkedService,
-// - *CosmosDbLinkedService, *CosmosDbMongoDbApiLinkedService, *CouchbaseLinkedService, *CustomDataSourceLinkedService, *Db2LinkedService,
+// - *CosmosDbLinkedService, *CosmosDbMongoDbAPILinkedService, *CouchbaseLinkedService, *CustomDataSourceLinkedService, *Db2LinkedService,
 // - *DrillLinkedService, *DynamicsAXLinkedService, *DynamicsCrmLinkedService, *DynamicsLinkedService, *EloquaLinkedService,
 // - *FileServerLinkedService, *FtpServerLinkedService, *GoogleAdWordsLinkedService, *GoogleBigQueryLinkedService, *GoogleCloudStorageLinkedService,
-// - *GreenplumLinkedService, *HBaseLinkedService, *HDInsightLinkedService, *HDInsightOnDemandLinkedService, *HdfsLinkedService,
-// - *HiveLinkedService, *HttpLinkedService, *HubspotLinkedService, *ImpalaLinkedService, *InformixLinkedService, *JiraLinkedService,
+// - *GreenplumLinkedService, *HBaseLinkedService, *HDInsightLinkedService, *HDInsightOnDemandLinkedService, *HTTPLinkedService,
+// - *HdfsLinkedService, *HiveLinkedService, *HubspotLinkedService, *ImpalaLinkedService, *InformixLinkedService, *JiraLinkedService,
 // - *LinkedService, *MagentoLinkedService, *MariaDBLinkedService, *MarketoLinkedService, *MicrosoftAccessLinkedService, *MongoDbLinkedService,
-// - *MongoDbV2LinkedService, *MySqlLinkedService, *NetezzaLinkedService, *ODataLinkedService, *OdbcLinkedService, *Office365LinkedService,
-// - *OracleLinkedService, *OracleServiceCloudLinkedService, *PaypalLinkedService, *PhoenixLinkedService, *PostgreSqlLinkedService,
-// - *PrestoLinkedService, *QuickBooksLinkedService, *ResponsysLinkedService, *RestServiceLinkedService, *SalesforceLinkedService,
-// - *SalesforceMarketingCloudLinkedService, *SalesforceServiceCloudLinkedService, *SapBWLinkedService, *SapCloudForCustomerLinkedService,
-// - *SapEccLinkedService, *SapHanaLinkedService, *SapOpenHubLinkedService, *SapTableLinkedService, *ServiceNowLinkedService,
-// - *SftpServerLinkedService, *ShopifyLinkedService, *SparkLinkedService, *SqlServerLinkedService, *SquareLinkedService,
+// - *MongoDbV2LinkedService, *MySQLLinkedService, *NetezzaLinkedService, *ODataLinkedService, *OdbcLinkedService, *Office365LinkedService,
+// - *OracleLinkedService, *OracleServiceCloudLinkedService, *PaypalLinkedService, *PhoenixLinkedService, *PostgreSQLLinkedService,
+// - *PrestoLinkedService, *QuickBooksLinkedService, *ResponsysLinkedService, *RestServiceLinkedService, *SQLServerLinkedService,
+// - *SalesforceLinkedService, *SalesforceMarketingCloudLinkedService, *SalesforceServiceCloudLinkedService, *SapBWLinkedService,
+// - *SapCloudForCustomerLinkedService, *SapEccLinkedService, *SapHanaLinkedService, *SapOpenHubLinkedService, *SapTableLinkedService,
+// - *ServiceNowLinkedService, *SftpServerLinkedService, *ShopifyLinkedService, *SparkLinkedService, *SquareLinkedService,
 // - *SybaseLinkedService, *TeradataLinkedService, *VerticaLinkedService, *WebLinkedService, *XeroLinkedService, *ZohoLinkedService
 type LinkedServiceClassification interface {
 	// GetLinkedService returns the LinkedService content of the underlying type.
@@ -53968,7 +53968,7 @@ type StartDataFlowDebugSessionResponse struct {
 // Call the interface's GetStoreReadSettings() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
 // - *AmazonS3ReadSettings, *AzureBlobFSReadSettings, *AzureBlobStorageReadSettings, *AzureDataLakeStoreReadSettings, *AzureFileStorageReadSettings,
-// - *FileServerReadSettings, *FtpReadSettings, *GoogleCloudStorageReadSettings, *HdfsReadSettings, *HttpReadSettings, *SftpReadSettings,
+// - *FileServerReadSettings, *FtpReadSettings, *GoogleCloudStorageReadSettings, *HTTPReadSettings, *HdfsReadSettings, *SftpReadSettings,
 // - *StoreReadSettings
 type StoreReadSettingsClassification interface {
 	// GetStoreReadSettings returns the StoreReadSettings content of the underlying type.
@@ -55053,14 +55053,14 @@ type SynapseSparkJobReference struct {
 // TabularSourceClassification provides polymorphic access to related types.
 // Call the interface's GetTabularSource() method to access the common type.
 // Use a type switch to determine the concrete type.  The possible types are:
-// - *AmazonMWSSource, *AmazonRedshiftSource, *AzureMariaDBSource, *AzureMySqlSource, *AzurePostgreSqlSource, *AzureSqlSource,
+// - *AmazonMWSSource, *AmazonRedshiftSource, *AzureMariaDBSource, *AzureMySQLSource, *AzurePostgreSQLSource, *AzureSQLSource,
 // - *AzureTableSource, *CassandraSource, *ConcurSource, *CouchbaseSource, *Db2Source, *DrillSource, *DynamicsAXSource, *EloquaSource,
 // - *GoogleAdWordsSource, *GoogleBigQuerySource, *GreenplumSource, *HBaseSource, *HiveSource, *HubspotSource, *ImpalaSource,
-// - *InformixSource, *JiraSource, *MagentoSource, *MariaDBSource, *MarketoSource, *MySqlSource, *NetezzaSource, *OdbcSource,
-// - *OracleServiceCloudSource, *PaypalSource, *PhoenixSource, *PostgreSqlSource, *PrestoSource, *QuickBooksSource, *ResponsysSource,
-// - *SalesforceMarketingCloudSource, *SalesforceSource, *SapBwSource, *SapCloudForCustomerSource, *SapEccSource, *SapHanaSource,
-// - *SapOpenHubSource, *SapTableSource, *ServiceNowSource, *ShopifySource, *SparkSource, *SqlDWSource, *SqlMISource, *SqlServerSource,
-// - *SqlSource, *SquareSource, *SybaseSource, *TabularSource, *TeradataSource, *VerticaSource, *XeroSource, *ZohoSource
+// - *InformixSource, *JiraSource, *MagentoSource, *MariaDBSource, *MarketoSource, *MySQLSource, *NetezzaSource, *OdbcSource,
+// - *OracleServiceCloudSource, *PaypalSource, *PhoenixSource, *PostgreSQLSource, *PrestoSource, *QuickBooksSource, *ResponsysSource,
+// - *SQLDWSource, *SQLMISource, *SQLServerSource, *SQLSource, *SalesforceMarketingCloudSource, *SalesforceSource, *SapBwSource,
+// - *SapCloudForCustomerSource, *SapEccSource, *SapHanaSource, *SapOpenHubSource, *SapTableSource, *ServiceNowSource, *ShopifySource,
+// - *SparkSource, *SquareSource, *SybaseSource, *TabularSource, *TeradataSource, *VerticaSource, *XeroSource, *ZohoSource
 type TabularSourceClassification interface {
 	CopySourceClassification
 	// GetTabularSource returns the TabularSource content of the underlying type.


### PR DESCRIPTION
Predicate using the next page operation on the existence of
nextLinkOperation instead of member as it might be removed when the
underlying operation has been removed via a transform.
Throw an Error if stuttering type name fix-up causes a collision.
Throw an Error if the fallback operation group name causes a collision.
Replaced some deprecated methods with their corresponding updates.