### PR TITLE
Clean up some linter issues

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -822,7 +822,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
       body = 'aux';
     } else if (isArrayOfTimesForMarshalling(bodyParam!.schema) || isArrayOfDatesForMarshalling(bodyParam!.schema)) {
       const timeType = (<ArraySchema>bodyParam!.schema).elementType.language.go!.internalTimeType;
-      text += `\taux := make([]*${timeType}, len(${body}), len(${body}))\n`;
+      text += `\taux := make([]*${timeType}, len(${body}))\n`;
       text += `\tfor i := 0; i < len(${body}); i++ {\n`;
       text += `\t\taux[i] = (*${timeType})(${body}[i])\n`;
       text += '\t}\n';
@@ -954,7 +954,7 @@ function generateResponseUnmarshaller(op: Operation, response: SchemaResponse, u
     unmarshallerText += `\tif err := runtime.UnmarshalAs${getMediaType(response.protocol)}(resp, &aux); err != nil {\n`;
     unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
     unmarshallerText += '\t}\n';
-    unmarshallerText += '\tcp := make([]*time.Time, len(aux), len(aux))\n';
+    unmarshallerText += '\tcp := make([]*time.Time, len(aux))\n';
     unmarshallerText += '\tfor i := 0; i < len(aux); i++ {\n';
     unmarshallerText += '\t\tcp[i] = (*time.Time)(aux[i])\n';
     unmarshallerText += '\t}\n';

--- a/src/generator/time.ts
+++ b/src/generator/time.ts
@@ -32,7 +32,7 @@ export async function generateTimeHelpers(session: Session<CodeModel>): Promise<
   }
   let needsPopulate = false;
   for (const obj of values(session.model.schemas.objects)) {
-    if (obj.language.go!.marshallingFormat === 'xml') {
+    if (obj.language.go!.marshallingFormat !== 'json') {
       // population helpers are for JSON only
       continue;
     }

--- a/src/generator/time.ts
+++ b/src/generator/time.ts
@@ -6,6 +6,8 @@
 import { Session } from '@autorest/extension-base';
 import { CodeModel } from '@autorest/codemodel';
 import { contentPreamble } from './helpers'
+import { values } from '@azure-tools/linq';
+import { ImportManager } from './imports';
 
 // represents the generated content for an operation group
 export class Content {
@@ -21,33 +23,57 @@ export class Content {
 // Creates the content for required time marshalling helpers.
 // Will be empty if no helpers are required.
 export async function generateTimeHelpers(session: Session<CodeModel>): Promise<Content[]> {
-  const preamble = await contentPreamble(session);
   const content = new Array<Content>();
+  if (!session.model.language.go!.hasTimeRFC1123 &&
+    !session.model.language.go!.hasTimeRFC3339 &&
+    !session.model.language.go!.hasUnixTime &&
+    !session.model.language.go!.hasDate) {
+    return content;
+  }
+  let needsPopulate = false;
+  for (const obj of values(session.model.schemas.objects)) {
+    if (obj.language.go!.marshallingFormat === 'xml') {
+      // population helpers are for JSON only
+      continue;
+    }
+    for (const prop of values(obj.properties)) {
+      if (prop.schema.language.go!.internalTimeType) {
+        needsPopulate = true;
+        break;
+      }
+    }
+    if (needsPopulate) {
+      break;
+    }
+  }
+  const preamble = await contentPreamble(session);
   if (session.model.language.go!.hasTimeRFC1123) {
-    content.push(new Content('time_rfc1123', generateRFC1123Helper(preamble)));
+    content.push(new Content('time_rfc1123', generateRFC1123Helper(preamble, needsPopulate)));
   }
   if (session.model.language.go!.hasTimeRFC3339) {
-    content.push(new Content('time_rfc3339', generateRFC3339Helper(preamble)));
+    content.push(new Content('time_rfc3339', generateRFC3339Helper(preamble, needsPopulate)));
   }
   if (session.model.language.go!.hasUnixTime) {
-    content.push(new Content('time_unix', generateUnixTimeHelper(preamble)));
+    content.push(new Content('time_unix', generateUnixTimeHelper(preamble, needsPopulate)));
   }
   if (session.model.language.go!.hasDate) {
-    content.push(new Content('date_type', generateDateHelper(preamble)));
+    content.push(new Content('date_type', generateDateHelper(preamble, needsPopulate)));
   }
   return content;
 }
 
-function generateRFC1123Helper(preamble: string): string {
-  return `${preamble}
+function generateRFC1123Helper(preamble: string, needsPopulate: boolean): string {
+  const imports = new ImportManager();
+  imports.add('strings');
+  imports.add('time');
+  if (needsPopulate) {
+    imports.add('encoding/json');
+    imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
+    imports.add('reflect');
+  }
+  let text = `${preamble}
 
-import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"strings"
-	"time"
-)
+${imports.text()}
 
 const (
 	rfc1123JSON = \`"\` + time.RFC1123 + \`"\`
@@ -76,6 +102,10 @@ func (t *timeRFC1123) UnmarshalText(data []byte) error {
 	*t = timeRFC1123(p)
 	return err
 }
+`;
+  if (needsPopulate) {
+    text +=
+`
 
 func populateTimeRFC1123(m map[string]interface{}, k string, t *time.Time) {
 	if t == nil {
@@ -101,19 +131,23 @@ func unpopulateTimeRFC1123(data json.RawMessage, t **time.Time) error {
 	return nil
 }
 `;
+  }
+  return text;
 }
 
-function generateRFC3339Helper(preamble: string): string {
-  return `${preamble}
+function generateRFC3339Helper(preamble: string, needsPopulate: boolean): string {
+  const imports = new ImportManager();
+  imports.add('regexp');
+  imports.add('strings');
+  imports.add('time');
+  if (needsPopulate) {
+    imports.add('encoding/json');
+    imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
+    imports.add('reflect');
+  }
+  let text = `${preamble}
 
-import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"regexp"
-	"strings"
-	"time"
-)
+${imports.text()}
 
 const (
 	utcLayoutJSON = \`"2006-01-02T15:04:05.999999999"\`
@@ -157,6 +191,10 @@ func (t *timeRFC3339) Parse(layout, value string) error {
 	*t = timeRFC3339(p)
 	return err
 }
+`;
+  if (needsPopulate) {
+    text +=
+`
 
 func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
 	if t == nil {
@@ -182,19 +220,23 @@ func unpopulateTimeRFC3339(data json.RawMessage, t **time.Time) error {
 	return nil
 }
 `;
+  }
+  return text;
 }
 
-function generateUnixTimeHelper(preamble: string): string {
-  return `${preamble}
+function generateUnixTimeHelper(preamble: string, needsPopulate: boolean): string {
+  const imports = new ImportManager();
+  imports.add('encoding/json');
+  imports.add('fmt');
+  imports.add('time');
+  if (needsPopulate) {
+    imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
+    imports.add('reflect');
+    imports.add('strings');
+  }
+  let text = `${preamble}
 
-import (
-	"encoding/json"
-	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"strings"
-	"time"
-)
+${imports.text()}
 
 type timeUnix time.Time
 
@@ -214,7 +256,10 @@ func (t *timeUnix) UnmarshalJSON(data []byte) error {
 func (t timeUnix) String() string {
 	return fmt.Sprintf("%d", time.Time(t).Unix())
 }
-
+`;
+  if (needsPopulate) {
+    text +=
+`
 func populateTimeUnix(m map[string]interface{}, k string, t *time.Time) {
 	if t == nil {
 		return
@@ -239,19 +284,23 @@ func unpopulateTimeUnix(data json.RawMessage, t **time.Time) error {
 	return nil
 }
 `;
+  }
+  return text;
 }
 
-function generateDateHelper(preamble: string): string {
-  return `${preamble}
+function generateDateHelper(preamble: string, needsPopulate: boolean): string {
+  const imports = new ImportManager();
+  imports.add('fmt');
+  imports.add('time');
+  if (needsPopulate) {
+    imports.add('encoding/json');
+    imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
+    imports.add('reflect');
+    imports.add('strings');
+  }
+  let text = `${preamble}
 
-import (
-	"encoding/json"
-	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"strings"
-	"time"
-)
+${imports.text()}
 
 const (
 	fullDateJSON = \`"2006-01-02"\`
@@ -269,7 +318,10 @@ func (d *dateType) UnmarshalJSON(data []byte) (err error) {
 	*d = (dateType)(t)
 	return err
 }
-
+`;
+  if (needsPopulate) {
+    text +=
+`
 func populateDateType(m map[string]interface{}, k string, t *time.Time) {
 	if t == nil {
 		return
@@ -294,4 +346,6 @@ func unpopulateDateType(data json.RawMessage, t **time.Time) error {
 	return nil
 }
 `;
+  }
+  return text;
 }

--- a/test/autorest/arraygroup/zz_generated_array_client.go
+++ b/test/autorest/arraygroup/zz_generated_array_client.go
@@ -689,7 +689,7 @@ func (client *ArrayClient) getDateInvalidCharsHandleResponse(resp *http.Response
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateInvalidCharsResponse{}, err
 	}
-	cp := make([]*time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux))
 	for i := 0; i < len(aux); i++ {
 		cp[i] = (*time.Time)(aux[i])
 	}
@@ -734,7 +734,7 @@ func (client *ArrayClient) getDateInvalidNullHandleResponse(resp *http.Response)
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateInvalidNullResponse{}, err
 	}
-	cp := make([]*time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux))
 	for i := 0; i < len(aux); i++ {
 		cp[i] = (*time.Time)(aux[i])
 	}
@@ -779,7 +779,7 @@ func (client *ArrayClient) getDateTimeInvalidCharsHandleResponse(resp *http.Resp
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateTimeInvalidCharsResponse{}, err
 	}
-	cp := make([]*time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux))
 	for i := 0; i < len(aux); i++ {
 		cp[i] = (*time.Time)(aux[i])
 	}
@@ -824,7 +824,7 @@ func (client *ArrayClient) getDateTimeInvalidNullHandleResponse(resp *http.Respo
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateTimeInvalidNullResponse{}, err
 	}
-	cp := make([]*time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux))
 	for i := 0; i < len(aux); i++ {
 		cp[i] = (*time.Time)(aux[i])
 	}
@@ -870,7 +870,7 @@ func (client *ArrayClient) getDateTimeRFC1123ValidHandleResponse(resp *http.Resp
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateTimeRFC1123ValidResponse{}, err
 	}
-	cp := make([]*time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux))
 	for i := 0; i < len(aux); i++ {
 		cp[i] = (*time.Time)(aux[i])
 	}
@@ -914,7 +914,7 @@ func (client *ArrayClient) getDateTimeValidHandleResponse(resp *http.Response) (
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateTimeValidResponse{}, err
 	}
-	cp := make([]*time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux))
 	for i := 0; i < len(aux); i++ {
 		cp[i] = (*time.Time)(aux[i])
 	}
@@ -958,7 +958,7 @@ func (client *ArrayClient) getDateValidHandleResponse(resp *http.Response) (Arra
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateValidResponse{}, err
 	}
-	cp := make([]*time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux))
 	for i := 0; i < len(aux); i++ {
 		cp[i] = (*time.Time)(aux[i])
 	}
@@ -2193,7 +2193,7 @@ func (client *ArrayClient) putDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 		return nil, err
 	}
 	req.Raw().Header.Set("Accept", "application/json")
-	aux := make([]*timeRFC1123, len(arrayBody), len(arrayBody))
+	aux := make([]*timeRFC1123, len(arrayBody))
 	for i := 0; i < len(arrayBody); i++ {
 		aux[i] = (*timeRFC1123)(arrayBody[i])
 	}
@@ -2255,7 +2255,7 @@ func (client *ArrayClient) putDateValidCreateRequest(ctx context.Context, arrayB
 		return nil, err
 	}
 	req.Raw().Header.Set("Accept", "application/json")
-	aux := make([]*dateType, len(arrayBody), len(arrayBody))
+	aux := make([]*dateType, len(arrayBody))
 	for i := 0; i < len(arrayBody); i++ {
 		aux[i] = (*dateType)(arrayBody[i])
 	}

--- a/test/autorest/arraygroup/zz_generated_date_type.go
+++ b/test/autorest/arraygroup/zz_generated_date_type.go
@@ -9,11 +9,7 @@
 package arraygroup
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"strings"
 	"time"
 )
 
@@ -32,28 +28,4 @@ func (d *dateType) UnmarshalJSON(data []byte) (err error) {
 	t, err := time.Parse(fullDateJSON, string(data))
 	*d = (dateType)(t)
 	return err
-}
-
-func populateDateType(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*dateType)(t)
-}
-
-func unpopulateDateType(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux dateType
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/arraygroup/zz_generated_time_rfc1123.go
+++ b/test/autorest/arraygroup/zz_generated_time_rfc1123.go
@@ -9,9 +9,6 @@
 package arraygroup
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -42,28 +39,4 @@ func (t *timeRFC1123) UnmarshalText(data []byte) error {
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = timeRFC1123(p)
 	return err
-}
-
-func populateTimeRFC1123(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC1123)(t)
-}
-
-func unpopulateTimeRFC1123(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC1123
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/arraygroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/arraygroup/zz_generated_time_rfc3339.go
@@ -9,9 +9,6 @@
 package arraygroup
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -58,28 +55,4 @@ func (t *timeRFC3339) Parse(layout, value string) error {
 	p, err := time.Parse(layout, strings.ToUpper(value))
 	*t = timeRFC3339(p)
 	return err
-}
-
-func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC3339)(t)
-}
-
-func unpopulateTimeRFC3339(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC3339
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/dategroup/zz_generated_date_type.go
+++ b/test/autorest/dategroup/zz_generated_date_type.go
@@ -9,11 +9,7 @@
 package dategroup
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"strings"
 	"time"
 )
 
@@ -32,28 +28,4 @@ func (d *dateType) UnmarshalJSON(data []byte) (err error) {
 	t, err := time.Parse(fullDateJSON, string(data))
 	*d = (dateType)(t)
 	return err
-}
-
-func populateDateType(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*dateType)(t)
-}
-
-func unpopulateDateType(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux dateType
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/datetimegroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/datetimegroup/zz_generated_time_rfc3339.go
@@ -9,9 +9,6 @@
 package datetimegroup
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -58,28 +55,4 @@ func (t *timeRFC3339) Parse(layout, value string) error {
 	p, err := time.Parse(layout, strings.ToUpper(value))
 	*t = timeRFC3339(p)
 	return err
-}
-
-func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC3339)(t)
-}
-
-func unpopulateTimeRFC3339(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC3339
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/datetimerfc1123group/zz_generated_time_rfc1123.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_time_rfc1123.go
@@ -9,9 +9,6 @@
 package datetimerfc1123group
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -42,28 +39,4 @@ func (t *timeRFC1123) UnmarshalText(data []byte) error {
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = timeRFC1123(p)
 	return err
-}
-
-func populateTimeRFC1123(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC1123)(t)
-}
-
-func unpopulateTimeRFC1123(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC1123
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/dictionarygroup/zz_generated_date_type.go
+++ b/test/autorest/dictionarygroup/zz_generated_date_type.go
@@ -9,11 +9,7 @@
 package dictionarygroup
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"strings"
 	"time"
 )
 
@@ -32,28 +28,4 @@ func (d *dateType) UnmarshalJSON(data []byte) (err error) {
 	t, err := time.Parse(fullDateJSON, string(data))
 	*d = (dateType)(t)
 	return err
-}
-
-func populateDateType(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*dateType)(t)
-}
-
-func unpopulateDateType(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux dateType
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/dictionarygroup/zz_generated_time_rfc1123.go
+++ b/test/autorest/dictionarygroup/zz_generated_time_rfc1123.go
@@ -9,9 +9,6 @@
 package dictionarygroup
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -42,28 +39,4 @@ func (t *timeRFC1123) UnmarshalText(data []byte) error {
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = timeRFC1123(p)
 	return err
-}
-
-func populateTimeRFC1123(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC1123)(t)
-}
-
-func unpopulateTimeRFC1123(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC1123
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/dictionarygroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/dictionarygroup/zz_generated_time_rfc3339.go
@@ -9,9 +9,6 @@
 package dictionarygroup
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -58,28 +55,4 @@ func (t *timeRFC3339) Parse(layout, value string) error {
 	p, err := time.Parse(layout, strings.ToUpper(value))
 	*t = timeRFC3339(p)
 	return err
-}
-
-func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC3339)(t)
-}
-
-func unpopulateTimeRFC3339(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC3339
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/integergroup/zz_generated_time_unix.go
+++ b/test/autorest/integergroup/zz_generated_time_unix.go
@@ -11,9 +11,6 @@ package integergroup
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"strings"
 	"time"
 )
 
@@ -34,28 +31,4 @@ func (t *timeUnix) UnmarshalJSON(data []byte) error {
 
 func (t timeUnix) String() string {
 	return fmt.Sprintf("%d", time.Time(t).Unix())
-}
-
-func populateTimeUnix(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeUnix)(t)
-}
-
-func unpopulateTimeUnix(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeUnix
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/urlgroup/zz_generated_time_unix.go
+++ b/test/autorest/urlgroup/zz_generated_time_unix.go
@@ -11,9 +11,6 @@ package urlgroup
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
-	"strings"
 	"time"
 )
 
@@ -34,28 +31,4 @@ func (t *timeUnix) UnmarshalJSON(data []byte) error {
 
 func (t timeUnix) String() string {
 	return fmt.Sprintf("%d", time.Time(t).Unix())
-}
-
-func populateTimeUnix(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeUnix)(t)
-}
-
-func unpopulateTimeUnix(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeUnix
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/xmlgroup/zz_generated_time_rfc1123.go
+++ b/test/autorest/xmlgroup/zz_generated_time_rfc1123.go
@@ -9,9 +9,6 @@
 package xmlgroup
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -42,28 +39,4 @@ func (t *timeRFC1123) UnmarshalText(data []byte) error {
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = timeRFC1123(p)
 	return err
-}
-
-func populateTimeRFC1123(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC1123)(t)
-}
-
-func unpopulateTimeRFC1123(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC1123
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/autorest/xmlgroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/xmlgroup/zz_generated_time_rfc3339.go
@@ -9,9 +9,6 @@
 package xmlgroup
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -58,28 +55,4 @@ func (t *timeRFC3339) Parse(layout, value string) error {
 	p, err := time.Parse(layout, strings.ToUpper(value))
 	*t = timeRFC3339(p)
 	return err
-}
-
-func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC3339)(t)
-}
-
-func unpopulateTimeRFC3339(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC3339
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_time_rfc1123.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_time_rfc1123.go
@@ -9,9 +9,6 @@
 package azblob
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -42,28 +39,4 @@ func (t *timeRFC1123) UnmarshalText(data []byte) error {
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = timeRFC1123(p)
 	return err
-}
-
-func populateTimeRFC1123(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC1123)(t)
-}
-
-func unpopulateTimeRFC1123(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC1123
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_time_rfc3339.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_time_rfc3339.go
@@ -9,9 +9,6 @@
 package azblob
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -58,28 +55,4 @@ func (t *timeRFC3339) Parse(layout, value string) error {
 	p, err := time.Parse(layout, strings.ToUpper(value))
 	*t = timeRFC3339(p)
 	return err
-}
-
-func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC3339)(t)
-}
-
-func unpopulateTimeRFC3339(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC3339
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/tables/2019-02-02/aztables/zz_generated_time_rfc1123.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_time_rfc1123.go
@@ -9,9 +9,6 @@
 package aztables
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -42,28 +39,4 @@ func (t *timeRFC1123) UnmarshalText(data []byte) error {
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = timeRFC1123(p)
 	return err
-}
-
-func populateTimeRFC1123(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC1123)(t)
-}
-
-func unpopulateTimeRFC1123(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC1123
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }

--- a/test/tables/2019-02-02/aztables/zz_generated_time_rfc3339.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_time_rfc3339.go
@@ -9,9 +9,6 @@
 package aztables
 
 import (
-	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -58,28 +55,4 @@ func (t *timeRFC3339) Parse(layout, value string) error {
 	p, err := time.Parse(layout, strings.ToUpper(value))
 	*t = timeRFC3339(p)
 	return err
-}
-
-func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
-	if t == nil {
-		return
-	} else if azcore.IsNullValue(t) {
-		m[k] = nil
-		return
-	} else if reflect.ValueOf(t).IsNil() {
-		return
-	}
-	m[k] = (*timeRFC3339)(t)
-}
-
-func unpopulateTimeRFC3339(data json.RawMessage, t **time.Time) error {
-	if data == nil || strings.EqualFold(string(data), "null") {
-		return nil
-	}
-	var aux timeRFC3339
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*t = (*time.Time)(&aux)
-	return nil
 }


### PR DESCRIPTION
Removed redundant capacity parameter when calling make().
Omit time helper funcs when they aren't needed.