### PR TITLE
Simplify pager API

### DIFF
--- a/src/generator/pagers.ts
+++ b/src/generator/pagers.ts
@@ -20,6 +20,7 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
   // add standard imports
   const imports = new ImportManager();
   imports.add('context');
+  imports.add('errors');
   imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/policy');
   imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
   imports.add('net/http');
@@ -38,7 +39,6 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
     text += `type ${pager.name} struct {\n`;
     text += `\tclient *${pager.op.language.go!.clientName}\n`;
     text += `\tcurrent ${respEnv}\n`;
-    text += '\terr error\n';
     if (isLROOperation(pager.op)) {
       text += '\tsecond bool\n';
     } else {
@@ -47,24 +47,29 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
     }
     text += '}\n\n';
     // pager methods
-    text += '// Err returns the last error encountered while paging.\n';
-    text += `func (p *${pager.name}) Err() error {\n\treturn p.err\n}\n\n`;
-    text += '// NextPage returns true if the pager advanced to the next page.\n'
-    text += '// Returns false if there are no more pages or an error occurred.\n';
-    text += `func (p *${pager.name}) NextPage(ctx context.Context) bool {\n`;
+    const nextLinkField = `${getResultFieldName(pager.op)}.${pager.op.language.go!.paging.nextLinkName}`;
+    text += '// More returns true if there are more pages to retrieve.\n';
+    text += `func (p *${pager.name}) More() bool {\n`;
+    text += '\tif !reflect.ValueOf(p.current).IsZero() {\n';
+    text += `\t\tif p.current.${nextLinkField} == nil || len(*p.current.${nextLinkField}) == 0 {\n`;
+    text += '\t\t\treturn false\n\t\t}\n';
+    text += '\t}\n\treturn true\n';
+    text += '}\n\n';
+
+    text += '// NextPage advances the pager to the next page.\n'
+    text += `func (p *${pager.name}) NextPage(ctx context.Context) (${respEnv}, error) {\n`;
     if (isLROOperation(pager.op)) {
       text += '\tif !p.second {\n';
       text += '\t\tp.second = true\n';
-      text += '\t\treturn true\n';
+      text += '\t\treturn p.current, nil\n';
       text += '\t} else ';
     } else {
       // note the trailing tab for the next line
       text += '\tvar req *policy.Request\n\tvar err error\n\t';
     }
     text += 'if !reflect.ValueOf(p.current).IsZero() {\n';
-    const nextLinkField = `${getResultFieldName(pager.op)}.${pager.op.language.go!.paging.nextLinkName}`;
-    text += `\t\tif p.current.${nextLinkField} == nil || len(*p.current.${nextLinkField}) == 0 {\n`;
-    text += '\t\t\treturn false\n\t\t}\n';
+    text += `\t\tif !p.More() {\n`;
+    text += `\t\t\treturn ${respEnv}{}, errors.New("no more pages")\n\t\t}\n`;
     if (isLROOperation(pager.op)) {
       text += `\t}\n\treq, err := runtime.NewRequest(ctx, http.MethodGet, *p.current.${nextLinkField})\n`;
     } else {
@@ -72,9 +77,9 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
       text += '\t} else {\n';
       text += '\t\treq, err = p.requester(ctx)\n\t}\n';
     }
-    text += '\tif err != nil {\n\t\tp.err = err\n\t\treturn false\n\t}\n';
+    text += `\tif err != nil {\n\n\t\treturn ${respEnv}{}, err\n\t}\n`;
     text += `\tresp, err := p.client.pl.Do(req)\n`;
-    text += '\tif err != nil {\n\t\tp.err = err\n\t\treturn false\n\t}\n';
+    text += `\tif err != nil {\n\n\t\treturn ${respEnv}{}, err\n\t}\n`;
     let statusCodes: string;
     if (isLROOperation(pager.op)) {
       // 204 no content excluded because why would you get a 204 for paged results?
@@ -83,13 +88,11 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
       statusCodes = formatStatusCodes(getStatusCodes(pager.op));
     }
     text += `\tif !runtime.HasStatusCode(resp, ${statusCodes}) {\n`;
-    text += `\t\tp.err = runtime.NewResponseError(resp)\n\t\treturn false\n\t}\n`;
+    text += `\n\t\treturn ${respEnv}{}, runtime.NewResponseError(resp)\n\t}\n`;
     text += `\tresult, err := p.client.${pager.op.language.go!.protocolNaming.responseMethod}(resp)\n`;
-    text += '\tif err != nil {\n\t\tp.err = err\n\t\treturn false\n\t}\n';
-    text += '\tp.current = result\n\treturn true\n';
+    text += `\tif err != nil {\n\n\t\treturn ${respEnv}{}, err\n\t}\n`;
+    text += '\tp.current = result\n\treturn p.current, nil\n';
     text += '}\n\n';
-    text += `// PageResponse returns the current ${respEnv} page.\n`;
-    text += `func (p *${pager.name}) PageResponse() ${respEnv} {\n\treturn p.current\n}\n\n`;
   }
   return text;
 }

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -35,118 +35,110 @@ func httpClientWithCookieJar() policy.Transporter {
 // GetMultiplePages - A paging operation that includes a nextLink that has 10 pages
 func TestGetMultiplePages(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePages(nil)
+	pager := client.GetMultiplePages(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 10); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetMultiplePagesFailure - A paging operation that receives a 400 on the second call
 func TestGetMultiplePagesFailure(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesFailure(nil)
+	pager := client.GetMultiplePagesFailure(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			if !reflect.ValueOf(page).IsZero() {
+				t.Fatal("expected empty payload")
+			}
+			break
+		}
+		if len(page.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if page.Err() == nil {
-		t.Fatal("unexpected nil error")
-	}
 	if r := cmp.Diff(count, 1); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetMultiplePagesFailureURI - A paging operation that receives an invalid nextLink
 func TestGetMultiplePagesFailureURI(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesFailureURI(nil)
+	pager := client.GetMultiplePagesFailureURI(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
-			t.Fatal("missing payload")
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			if !reflect.ValueOf(page).IsZero() {
+				t.Fatal("expected empty payload")
+			}
+			break
 		}
 		count++
 	}
-	if page.Err() == nil {
-		t.Fatal("unexpected nil error")
-	}
 	if r := cmp.Diff(count, 1); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetMultiplePagesFragmentNextLink - A paging operation that doesn't return a full URL, just a fragment
 func TestGetMultiplePagesFragmentNextLink(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesFragmentNextLink("1.6", "test_user", nil)
+	pager := client.GetMultiplePagesFragmentNextLink("1.6", "test_user", nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ODataProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ODataProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 10); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetMultiplePagesFragmentWithGroupingNextLink - A paging operation that doesn't return a full URL, just a fragment with parameters grouped
 func TestGetMultiplePagesFragmentWithGroupingNextLink(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesFragmentWithGroupingNextLink(CustomParameterGroup{
+	pager := client.GetMultiplePagesFragmentWithGroupingNextLink(CustomParameterGroup{
 		APIVersion: "1.6",
 		Tenant:     "test_user",
 	})
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ODataProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ODataProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 10); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
@@ -171,15 +163,14 @@ func TestGetMultiplePagesLro(t *testing.T) {
 		t.Fatal(err)
 	}
 	count := 0
-	for pager.NextPage(context.Background()) {
-		resp := pager.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if len(page.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
-	}
-	if err = pager.Err(); err != nil {
-		t.Fatal(err)
 	}
 	const pageCount = 10
 	if r := cmp.Diff(count, pageCount); r != "" {
@@ -190,92 +181,84 @@ func TestGetMultiplePagesLro(t *testing.T) {
 // GetMultiplePagesRetryFirst - A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages
 func TestGetMultiplePagesRetryFirst(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesRetryFirst(nil)
+	pager := client.GetMultiplePagesRetryFirst(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 10); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetMultiplePagesRetrySecond - A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
 func TestGetMultiplePagesRetrySecond(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesRetrySecond(nil)
+	pager := client.GetMultiplePagesRetrySecond(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 10); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetMultiplePagesWithOffset - A paging operation that includes a nextLink that has 10 pages
 func TestGetMultiplePagesWithOffset(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesWithOffset(PagingClientGetMultiplePagesWithOffsetOptions{})
+	pager := client.GetMultiplePagesWithOffset(PagingClientGetMultiplePagesWithOffsetOptions{})
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 10); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetNoItemNamePages - A paging operation that must return result of the default 'value' node.
 func TestGetNoItemNamePages(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetNoItemNamePages(nil)
+	pager := client.GetNoItemNamePages(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResultValue.Value) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResultValue.Value) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 1); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
@@ -294,114 +277,103 @@ func TestGetNullNextLinkNamePages(t *testing.T) {
 // GetOdataMultiplePages - A paging operation that includes a nextLink in odata format that has 10 pages
 func TestGetOdataMultiplePages(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetODataMultiplePages(nil)
+	pager := client.GetODataMultiplePages(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ODataProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ODataProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 10); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetPagingModelWithItemNameWithXMSClientName - A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
 func TestGetPagingModelWithItemNameWithXMSClientName(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetPagingModelWithItemNameWithXMSClientName(nil)
+	pager := client.GetPagingModelWithItemNameWithXMSClientName(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResultValueWithXMSClientName.Indexes) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResultValueWithXMSClientName.Indexes) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 1); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetSinglePages - A paging operation that finishes on the first call without a nextlink
 func TestGetSinglePages(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetSinglePages(nil)
+	pager := client.GetSinglePages(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 1); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }
 
 // GetSinglePagesFailure - A paging operation that receives a 400 on the first call
 func TestGetSinglePagesFailure(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetSinglePagesFailure(nil)
+	pager := client.GetSinglePagesFailure(nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
-			t.Fatal("missing payload")
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			if !reflect.ValueOf(page).IsZero() {
+				t.Fatal("expected empty payload")
+			}
+			break
 		}
 		count++
 	}
-	if page.Err() == nil {
-		t.Fatal("unexpected nil error")
-	}
 	if r := cmp.Diff(count, 0); r != "" {
 		t.Fatal(r)
-	}
-	if !reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("expected empty payload")
 	}
 }
 
 // GetWithQueryParams - A paging operation that includes a next operation. It has a different query parameter from it's next operation nextOperationWithQueryParams. Returns a ProductResult
 func TestGetWithQueryParams(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetWithQueryParams(100, nil)
+	pager := client.GetWithQueryParams(100, nil)
 	count := 0
-	for page.NextPage(context.Background()) {
-		resp := page.PageResponse()
-		if len(resp.ProductResult.Values) == 0 {
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
 	}
-	if err := page.Err(); err != nil {
-		t.Fatal(err)
-	}
 	if r := cmp.Diff(count, 2); r != "" {
 		t.Fatal(r)
-	}
-	if reflect.ValueOf(page.PageResponse()).IsZero() {
-		t.Fatal("unexpected empty payload")
 	}
 }

--- a/test/autorest/paginggroup/zz_generated_pagers.go
+++ b/test/autorest/paginggroup/zz_generated_pagers.go
@@ -10,6 +10,7 @@ package paginggroup
 
 import (
 	"context"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,968 +21,932 @@ import (
 type PagingClientFirstResponseEmptyPager struct {
 	client    *PagingClient
 	current   PagingClientFirstResponseEmptyResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientFirstResponseEmptyResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientFirstResponseEmptyPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientFirstResponseEmptyPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientFirstResponseEmptyPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResultValue.NextLink == nil || len(*p.current.ProductResultValue.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientFirstResponseEmptyPager) NextPage(ctx context.Context) (PagingClientFirstResponseEmptyResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientFirstResponseEmptyResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientFirstResponseEmptyResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientFirstResponseEmptyResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientFirstResponseEmptyResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.firstResponseEmptyHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientFirstResponseEmptyResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientFirstResponseEmptyResponse page.
-func (p *PagingClientFirstResponseEmptyPager) PageResponse() PagingClientFirstResponseEmptyResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesFailurePager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesFailurePager struct {
 	client    *PagingClient
 	current   PagingClientGetMultiplePagesFailureResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetMultiplePagesFailureResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesFailurePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesFailurePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesFailurePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesFailurePager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesFailureResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesFailureResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFailureResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFailureResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetMultiplePagesFailureResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getMultiplePagesFailureHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFailureResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetMultiplePagesFailureResponse page.
-func (p *PagingClientGetMultiplePagesFailurePager) PageResponse() PagingClientGetMultiplePagesFailureResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesFailureURIPager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesFailureURIPager struct {
 	client    *PagingClient
 	current   PagingClientGetMultiplePagesFailureURIResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetMultiplePagesFailureURIResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesFailureURIPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesFailureURIPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesFailureURIPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesFailureURIPager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesFailureURIResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesFailureURIResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFailureURIResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFailureURIResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetMultiplePagesFailureURIResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getMultiplePagesFailureURIHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFailureURIResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetMultiplePagesFailureURIResponse page.
-func (p *PagingClientGetMultiplePagesFailureURIPager) PageResponse() PagingClientGetMultiplePagesFailureURIResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesFragmentNextLinkPager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesFragmentNextLinkPager struct {
 	client    *PagingClient
 	current   PagingClientGetMultiplePagesFragmentNextLinkResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetMultiplePagesFragmentNextLinkResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesFragmentNextLinkPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesFragmentNextLinkPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesFragmentNextLinkPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ODataProductResult.ODataNextLink == nil || len(*p.current.ODataProductResult.ODataNextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesFragmentNextLinkPager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesFragmentNextLinkResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesFragmentNextLinkResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFragmentNextLinkResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFragmentNextLinkResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetMultiplePagesFragmentNextLinkResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getMultiplePagesFragmentNextLinkHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFragmentNextLinkResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetMultiplePagesFragmentNextLinkResponse page.
-func (p *PagingClientGetMultiplePagesFragmentNextLinkPager) PageResponse() PagingClientGetMultiplePagesFragmentNextLinkResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager struct {
 	client    *PagingClient
 	current   PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ODataProductResult.ODataNextLink == nil || len(*p.current.ODataProductResult.ODataNextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getMultiplePagesFragmentWithGroupingNextLinkHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse page.
-func (p *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager) PageResponse() PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesLROPager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesLROPager struct {
 	client  *PagingClient
 	current PagingClientGetMultiplePagesLROResponse
-	err     error
 	second  bool
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesLROPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesLROPager) NextPage(ctx context.Context) bool {
-	if !p.second {
-		p.second = true
-		return true
-	} else if !reflect.ValueOf(p.current).IsZero() {
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesLROPager) More() bool {
+	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
 		}
 	}
-	req, err := runtime.NewRequest(ctx, http.MethodGet, *p.current.ProductResult.NextLink)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	resp, err := p.client.pl.Do(req)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
-		p.err = runtime.NewResponseError(resp)
-		return false
-	}
-	result, err := p.client.getMultiplePagesLROHandleResponse(resp)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	p.current = result
 	return true
 }
 
-// PageResponse returns the current PagingClientGetMultiplePagesLROResponse page.
-func (p *PagingClientGetMultiplePagesLROPager) PageResponse() PagingClientGetMultiplePagesLROResponse {
-	return p.current
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesLROPager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesLROResponse, error) {
+	if !p.second {
+		p.second = true
+		return p.current, nil
+	} else if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesLROResponse{}, errors.New("no more pages")
+		}
+	}
+	req, err := runtime.NewRequest(ctx, http.MethodGet, *p.current.ProductResult.NextLink)
+	if err != nil {
+
+		return PagingClientGetMultiplePagesLROResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+
+		return PagingClientGetMultiplePagesLROResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
+
+		return PagingClientGetMultiplePagesLROResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.getMultiplePagesLROHandleResponse(resp)
+	if err != nil {
+
+		return PagingClientGetMultiplePagesLROResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesPager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesPager struct {
 	client    *PagingClient
 	current   PagingClientGetMultiplePagesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetMultiplePagesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesPager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetMultiplePagesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getMultiplePagesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetMultiplePagesResponse page.
-func (p *PagingClientGetMultiplePagesPager) PageResponse() PagingClientGetMultiplePagesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesRetryFirstPager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesRetryFirstPager struct {
 	client    *PagingClient
 	current   PagingClientGetMultiplePagesRetryFirstResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetMultiplePagesRetryFirstResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesRetryFirstPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesRetryFirstPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesRetryFirstPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesRetryFirstPager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesRetryFirstResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesRetryFirstResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesRetryFirstResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesRetryFirstResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetMultiplePagesRetryFirstResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getMultiplePagesRetryFirstHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesRetryFirstResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetMultiplePagesRetryFirstResponse page.
-func (p *PagingClientGetMultiplePagesRetryFirstPager) PageResponse() PagingClientGetMultiplePagesRetryFirstResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesRetrySecondPager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesRetrySecondPager struct {
 	client    *PagingClient
 	current   PagingClientGetMultiplePagesRetrySecondResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetMultiplePagesRetrySecondResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesRetrySecondPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesRetrySecondPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesRetrySecondPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesRetrySecondPager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesRetrySecondResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesRetrySecondResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesRetrySecondResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesRetrySecondResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetMultiplePagesRetrySecondResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getMultiplePagesRetrySecondHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesRetrySecondResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetMultiplePagesRetrySecondResponse page.
-func (p *PagingClientGetMultiplePagesRetrySecondPager) PageResponse() PagingClientGetMultiplePagesRetrySecondResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetMultiplePagesWithOffsetPager provides operations for iterating over paged responses.
 type PagingClientGetMultiplePagesWithOffsetPager struct {
 	client    *PagingClient
 	current   PagingClientGetMultiplePagesWithOffsetResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetMultiplePagesWithOffsetResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetMultiplePagesWithOffsetPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetMultiplePagesWithOffsetPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetMultiplePagesWithOffsetPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetMultiplePagesWithOffsetPager) NextPage(ctx context.Context) (PagingClientGetMultiplePagesWithOffsetResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetMultiplePagesWithOffsetResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesWithOffsetResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesWithOffsetResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetMultiplePagesWithOffsetResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getMultiplePagesWithOffsetHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetMultiplePagesWithOffsetResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetMultiplePagesWithOffsetResponse page.
-func (p *PagingClientGetMultiplePagesWithOffsetPager) PageResponse() PagingClientGetMultiplePagesWithOffsetResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetNoItemNamePagesPager provides operations for iterating over paged responses.
 type PagingClientGetNoItemNamePagesPager struct {
 	client    *PagingClient
 	current   PagingClientGetNoItemNamePagesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetNoItemNamePagesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetNoItemNamePagesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetNoItemNamePagesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetNoItemNamePagesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResultValue.NextLink == nil || len(*p.current.ProductResultValue.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetNoItemNamePagesPager) NextPage(ctx context.Context) (PagingClientGetNoItemNamePagesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetNoItemNamePagesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetNoItemNamePagesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetNoItemNamePagesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetNoItemNamePagesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getNoItemNamePagesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetNoItemNamePagesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetNoItemNamePagesResponse page.
-func (p *PagingClientGetNoItemNamePagesPager) PageResponse() PagingClientGetNoItemNamePagesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetODataMultiplePagesPager provides operations for iterating over paged responses.
 type PagingClientGetODataMultiplePagesPager struct {
 	client    *PagingClient
 	current   PagingClientGetODataMultiplePagesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetODataMultiplePagesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetODataMultiplePagesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetODataMultiplePagesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetODataMultiplePagesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ODataProductResult.ODataNextLink == nil || len(*p.current.ODataProductResult.ODataNextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetODataMultiplePagesPager) NextPage(ctx context.Context) (PagingClientGetODataMultiplePagesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetODataMultiplePagesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetODataMultiplePagesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetODataMultiplePagesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetODataMultiplePagesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getODataMultiplePagesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetODataMultiplePagesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetODataMultiplePagesResponse page.
-func (p *PagingClientGetODataMultiplePagesPager) PageResponse() PagingClientGetODataMultiplePagesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetPagingModelWithItemNameWithXMSClientNamePager provides operations for iterating over paged responses.
 type PagingClientGetPagingModelWithItemNameWithXMSClientNamePager struct {
 	client    *PagingClient
 	current   PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetPagingModelWithItemNameWithXMSClientNamePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetPagingModelWithItemNameWithXMSClientNamePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetPagingModelWithItemNameWithXMSClientNamePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResultValueWithXMSClientName.NextLink == nil || len(*p.current.ProductResultValueWithXMSClientName.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetPagingModelWithItemNameWithXMSClientNamePager) NextPage(ctx context.Context) (PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getPagingModelWithItemNameWithXMSClientNameHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse page.
-func (p *PagingClientGetPagingModelWithItemNameWithXMSClientNamePager) PageResponse() PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetSinglePagesFailurePager provides operations for iterating over paged responses.
 type PagingClientGetSinglePagesFailurePager struct {
 	client    *PagingClient
 	current   PagingClientGetSinglePagesFailureResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetSinglePagesFailureResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetSinglePagesFailurePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetSinglePagesFailurePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetSinglePagesFailurePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetSinglePagesFailurePager) NextPage(ctx context.Context) (PagingClientGetSinglePagesFailureResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetSinglePagesFailureResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetSinglePagesFailureResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetSinglePagesFailureResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetSinglePagesFailureResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getSinglePagesFailureHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetSinglePagesFailureResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetSinglePagesFailureResponse page.
-func (p *PagingClientGetSinglePagesFailurePager) PageResponse() PagingClientGetSinglePagesFailureResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetSinglePagesPager provides operations for iterating over paged responses.
 type PagingClientGetSinglePagesPager struct {
 	client    *PagingClient
 	current   PagingClientGetSinglePagesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetSinglePagesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetSinglePagesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetSinglePagesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetSinglePagesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetSinglePagesPager) NextPage(ctx context.Context) (PagingClientGetSinglePagesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetSinglePagesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetSinglePagesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetSinglePagesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetSinglePagesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getSinglePagesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetSinglePagesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetSinglePagesResponse page.
-func (p *PagingClientGetSinglePagesPager) PageResponse() PagingClientGetSinglePagesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientGetWithQueryParamsPager provides operations for iterating over paged responses.
 type PagingClientGetWithQueryParamsPager struct {
 	client    *PagingClient
 	current   PagingClientGetWithQueryParamsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientGetWithQueryParamsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientGetWithQueryParamsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientGetWithQueryParamsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetWithQueryParamsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetWithQueryParamsPager) NextPage(ctx context.Context) (PagingClientGetWithQueryParamsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientGetWithQueryParamsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetWithQueryParamsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetWithQueryParamsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientGetWithQueryParamsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getWithQueryParamsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientGetWithQueryParamsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientGetWithQueryParamsResponse page.
-func (p *PagingClientGetWithQueryParamsPager) PageResponse() PagingClientGetWithQueryParamsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientNextFragmentPager provides operations for iterating over paged responses.
 type PagingClientNextFragmentPager struct {
 	client    *PagingClient
 	current   PagingClientNextFragmentResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientNextFragmentResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientNextFragmentPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientNextFragmentPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientNextFragmentPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ODataProductResult.ODataNextLink == nil || len(*p.current.ODataProductResult.ODataNextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientNextFragmentPager) NextPage(ctx context.Context) (PagingClientNextFragmentResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientNextFragmentResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientNextFragmentResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientNextFragmentResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientNextFragmentResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.nextFragmentHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientNextFragmentResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientNextFragmentResponse page.
-func (p *PagingClientNextFragmentPager) PageResponse() PagingClientNextFragmentResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PagingClientNextFragmentWithGroupingPager provides operations for iterating over paged responses.
 type PagingClientNextFragmentWithGroupingPager struct {
 	client    *PagingClient
 	current   PagingClientNextFragmentWithGroupingResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PagingClientNextFragmentWithGroupingResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PagingClientNextFragmentWithGroupingPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PagingClientNextFragmentWithGroupingPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientNextFragmentWithGroupingPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ODataProductResult.ODataNextLink == nil || len(*p.current.ODataProductResult.ODataNextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientNextFragmentWithGroupingPager) NextPage(ctx context.Context) (PagingClientNextFragmentWithGroupingResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PagingClientNextFragmentWithGroupingResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientNextFragmentWithGroupingResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientNextFragmentWithGroupingResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PagingClientNextFragmentWithGroupingResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.nextFragmentWithGroupingHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PagingClientNextFragmentWithGroupingResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PagingClientNextFragmentWithGroupingResponse page.
-func (p *PagingClientNextFragmentWithGroupingPager) PageResponse() PagingClientNextFragmentWithGroupingResponse {
-	return p.current
+	return p.current, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
@@ -10,6 +10,7 @@ package armcompute
 
 import (
 	"context"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,1996 +21,1922 @@ import (
 type AvailabilitySetsClientListBySubscriptionPager struct {
 	client    *AvailabilitySetsClient
 	current   AvailabilitySetsClientListBySubscriptionResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailabilitySetsClientListBySubscriptionResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailabilitySetsClientListBySubscriptionPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailabilitySetsClientListBySubscriptionPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailabilitySetsClientListBySubscriptionPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AvailabilitySetListResult.NextLink == nil || len(*p.current.AvailabilitySetListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailabilitySetsClientListBySubscriptionPager) NextPage(ctx context.Context) (AvailabilitySetsClientListBySubscriptionResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailabilitySetsClientListBySubscriptionResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailabilitySetsClientListBySubscriptionResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailabilitySetsClientListBySubscriptionResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailabilitySetsClientListBySubscriptionResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBySubscriptionHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailabilitySetsClientListBySubscriptionResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailabilitySetsClientListBySubscriptionResponse page.
-func (p *AvailabilitySetsClientListBySubscriptionPager) PageResponse() AvailabilitySetsClientListBySubscriptionResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailabilitySetsClientListPager provides operations for iterating over paged responses.
 type AvailabilitySetsClientListPager struct {
 	client    *AvailabilitySetsClient
 	current   AvailabilitySetsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailabilitySetsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailabilitySetsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailabilitySetsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailabilitySetsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AvailabilitySetListResult.NextLink == nil || len(*p.current.AvailabilitySetListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailabilitySetsClientListPager) NextPage(ctx context.Context) (AvailabilitySetsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailabilitySetsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailabilitySetsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailabilitySetsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailabilitySetsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailabilitySetsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailabilitySetsClientListResponse page.
-func (p *AvailabilitySetsClientListPager) PageResponse() AvailabilitySetsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ContainerServicesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type ContainerServicesClientListByResourceGroupPager struct {
 	client    *ContainerServicesClient
 	current   ContainerServicesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ContainerServicesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ContainerServicesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ContainerServicesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ContainerServicesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ContainerServiceListResult.NextLink == nil || len(*p.current.ContainerServiceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ContainerServicesClientListByResourceGroupPager) NextPage(ctx context.Context) (ContainerServicesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ContainerServicesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainerServicesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainerServicesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ContainerServicesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainerServicesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ContainerServicesClientListByResourceGroupResponse page.
-func (p *ContainerServicesClientListByResourceGroupPager) PageResponse() ContainerServicesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ContainerServicesClientListPager provides operations for iterating over paged responses.
 type ContainerServicesClientListPager struct {
 	client    *ContainerServicesClient
 	current   ContainerServicesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ContainerServicesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ContainerServicesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ContainerServicesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ContainerServicesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ContainerServiceListResult.NextLink == nil || len(*p.current.ContainerServiceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ContainerServicesClientListPager) NextPage(ctx context.Context) (ContainerServicesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ContainerServicesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainerServicesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainerServicesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ContainerServicesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainerServicesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ContainerServicesClientListResponse page.
-func (p *ContainerServicesClientListPager) PageResponse() ContainerServicesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DedicatedHostGroupsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type DedicatedHostGroupsClientListByResourceGroupPager struct {
 	client    *DedicatedHostGroupsClient
 	current   DedicatedHostGroupsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DedicatedHostGroupsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DedicatedHostGroupsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DedicatedHostGroupsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DedicatedHostGroupsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DedicatedHostGroupListResult.NextLink == nil || len(*p.current.DedicatedHostGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DedicatedHostGroupsClientListByResourceGroupPager) NextPage(ctx context.Context) (DedicatedHostGroupsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DedicatedHostGroupsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostGroupsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostGroupsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DedicatedHostGroupsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostGroupsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DedicatedHostGroupsClientListByResourceGroupResponse page.
-func (p *DedicatedHostGroupsClientListByResourceGroupPager) PageResponse() DedicatedHostGroupsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DedicatedHostGroupsClientListBySubscriptionPager provides operations for iterating over paged responses.
 type DedicatedHostGroupsClientListBySubscriptionPager struct {
 	client    *DedicatedHostGroupsClient
 	current   DedicatedHostGroupsClientListBySubscriptionResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DedicatedHostGroupsClientListBySubscriptionResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DedicatedHostGroupsClientListBySubscriptionPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DedicatedHostGroupsClientListBySubscriptionPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DedicatedHostGroupsClientListBySubscriptionPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DedicatedHostGroupListResult.NextLink == nil || len(*p.current.DedicatedHostGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DedicatedHostGroupsClientListBySubscriptionPager) NextPage(ctx context.Context) (DedicatedHostGroupsClientListBySubscriptionResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DedicatedHostGroupsClientListBySubscriptionResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostGroupsClientListBySubscriptionResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostGroupsClientListBySubscriptionResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DedicatedHostGroupsClientListBySubscriptionResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBySubscriptionHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostGroupsClientListBySubscriptionResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DedicatedHostGroupsClientListBySubscriptionResponse page.
-func (p *DedicatedHostGroupsClientListBySubscriptionPager) PageResponse() DedicatedHostGroupsClientListBySubscriptionResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DedicatedHostsClientListByHostGroupPager provides operations for iterating over paged responses.
 type DedicatedHostsClientListByHostGroupPager struct {
 	client    *DedicatedHostsClient
 	current   DedicatedHostsClientListByHostGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DedicatedHostsClientListByHostGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DedicatedHostsClientListByHostGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DedicatedHostsClientListByHostGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DedicatedHostsClientListByHostGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DedicatedHostListResult.NextLink == nil || len(*p.current.DedicatedHostListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DedicatedHostsClientListByHostGroupPager) NextPage(ctx context.Context) (DedicatedHostsClientListByHostGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DedicatedHostsClientListByHostGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostsClientListByHostGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostsClientListByHostGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DedicatedHostsClientListByHostGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByHostGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DedicatedHostsClientListByHostGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DedicatedHostsClientListByHostGroupResponse page.
-func (p *DedicatedHostsClientListByHostGroupPager) PageResponse() DedicatedHostsClientListByHostGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DiskEncryptionSetsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type DiskEncryptionSetsClientListByResourceGroupPager struct {
 	client    *DiskEncryptionSetsClient
 	current   DiskEncryptionSetsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DiskEncryptionSetsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DiskEncryptionSetsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DiskEncryptionSetsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DiskEncryptionSetsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DiskEncryptionSetList.NextLink == nil || len(*p.current.DiskEncryptionSetList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DiskEncryptionSetsClientListByResourceGroupPager) NextPage(ctx context.Context) (DiskEncryptionSetsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DiskEncryptionSetsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DiskEncryptionSetsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DiskEncryptionSetsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DiskEncryptionSetsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DiskEncryptionSetsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DiskEncryptionSetsClientListByResourceGroupResponse page.
-func (p *DiskEncryptionSetsClientListByResourceGroupPager) PageResponse() DiskEncryptionSetsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DiskEncryptionSetsClientListPager provides operations for iterating over paged responses.
 type DiskEncryptionSetsClientListPager struct {
 	client    *DiskEncryptionSetsClient
 	current   DiskEncryptionSetsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DiskEncryptionSetsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DiskEncryptionSetsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DiskEncryptionSetsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DiskEncryptionSetsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DiskEncryptionSetList.NextLink == nil || len(*p.current.DiskEncryptionSetList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DiskEncryptionSetsClientListPager) NextPage(ctx context.Context) (DiskEncryptionSetsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DiskEncryptionSetsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DiskEncryptionSetsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DiskEncryptionSetsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DiskEncryptionSetsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DiskEncryptionSetsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DiskEncryptionSetsClientListResponse page.
-func (p *DiskEncryptionSetsClientListPager) PageResponse() DiskEncryptionSetsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DisksClientListByResourceGroupPager provides operations for iterating over paged responses.
 type DisksClientListByResourceGroupPager struct {
 	client    *DisksClient
 	current   DisksClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DisksClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DisksClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DisksClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DisksClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DiskList.NextLink == nil || len(*p.current.DiskList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DisksClientListByResourceGroupPager) NextPage(ctx context.Context) (DisksClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DisksClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DisksClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DisksClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DisksClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DisksClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DisksClientListByResourceGroupResponse page.
-func (p *DisksClientListByResourceGroupPager) PageResponse() DisksClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DisksClientListPager provides operations for iterating over paged responses.
 type DisksClientListPager struct {
 	client    *DisksClient
 	current   DisksClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DisksClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DisksClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DisksClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DisksClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DiskList.NextLink == nil || len(*p.current.DiskList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DisksClientListPager) NextPage(ctx context.Context) (DisksClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DisksClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DisksClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DisksClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DisksClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DisksClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DisksClientListResponse page.
-func (p *DisksClientListPager) PageResponse() DisksClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // GalleriesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type GalleriesClientListByResourceGroupPager struct {
 	client    *GalleriesClient
 	current   GalleriesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, GalleriesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *GalleriesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *GalleriesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *GalleriesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.GalleryList.NextLink == nil || len(*p.current.GalleryList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *GalleriesClientListByResourceGroupPager) NextPage(ctx context.Context) (GalleriesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return GalleriesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleriesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleriesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return GalleriesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleriesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current GalleriesClientListByResourceGroupResponse page.
-func (p *GalleriesClientListByResourceGroupPager) PageResponse() GalleriesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // GalleriesClientListPager provides operations for iterating over paged responses.
 type GalleriesClientListPager struct {
 	client    *GalleriesClient
 	current   GalleriesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, GalleriesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *GalleriesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *GalleriesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *GalleriesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.GalleryList.NextLink == nil || len(*p.current.GalleryList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *GalleriesClientListPager) NextPage(ctx context.Context) (GalleriesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return GalleriesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleriesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleriesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return GalleriesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleriesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current GalleriesClientListResponse page.
-func (p *GalleriesClientListPager) PageResponse() GalleriesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // GalleryApplicationVersionsClientListByGalleryApplicationPager provides operations for iterating over paged responses.
 type GalleryApplicationVersionsClientListByGalleryApplicationPager struct {
 	client    *GalleryApplicationVersionsClient
 	current   GalleryApplicationVersionsClientListByGalleryApplicationResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, GalleryApplicationVersionsClientListByGalleryApplicationResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *GalleryApplicationVersionsClientListByGalleryApplicationPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *GalleryApplicationVersionsClientListByGalleryApplicationPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *GalleryApplicationVersionsClientListByGalleryApplicationPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.GalleryApplicationVersionList.NextLink == nil || len(*p.current.GalleryApplicationVersionList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *GalleryApplicationVersionsClientListByGalleryApplicationPager) NextPage(ctx context.Context) (GalleryApplicationVersionsClientListByGalleryApplicationResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return GalleryApplicationVersionsClientListByGalleryApplicationResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryApplicationVersionsClientListByGalleryApplicationResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryApplicationVersionsClientListByGalleryApplicationResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return GalleryApplicationVersionsClientListByGalleryApplicationResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByGalleryApplicationHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryApplicationVersionsClientListByGalleryApplicationResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current GalleryApplicationVersionsClientListByGalleryApplicationResponse page.
-func (p *GalleryApplicationVersionsClientListByGalleryApplicationPager) PageResponse() GalleryApplicationVersionsClientListByGalleryApplicationResponse {
-	return p.current
+	return p.current, nil
 }
 
 // GalleryApplicationsClientListByGalleryPager provides operations for iterating over paged responses.
 type GalleryApplicationsClientListByGalleryPager struct {
 	client    *GalleryApplicationsClient
 	current   GalleryApplicationsClientListByGalleryResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, GalleryApplicationsClientListByGalleryResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *GalleryApplicationsClientListByGalleryPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *GalleryApplicationsClientListByGalleryPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *GalleryApplicationsClientListByGalleryPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.GalleryApplicationList.NextLink == nil || len(*p.current.GalleryApplicationList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *GalleryApplicationsClientListByGalleryPager) NextPage(ctx context.Context) (GalleryApplicationsClientListByGalleryResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return GalleryApplicationsClientListByGalleryResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryApplicationsClientListByGalleryResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryApplicationsClientListByGalleryResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return GalleryApplicationsClientListByGalleryResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByGalleryHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryApplicationsClientListByGalleryResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current GalleryApplicationsClientListByGalleryResponse page.
-func (p *GalleryApplicationsClientListByGalleryPager) PageResponse() GalleryApplicationsClientListByGalleryResponse {
-	return p.current
+	return p.current, nil
 }
 
 // GalleryImageVersionsClientListByGalleryImagePager provides operations for iterating over paged responses.
 type GalleryImageVersionsClientListByGalleryImagePager struct {
 	client    *GalleryImageVersionsClient
 	current   GalleryImageVersionsClientListByGalleryImageResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, GalleryImageVersionsClientListByGalleryImageResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *GalleryImageVersionsClientListByGalleryImagePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *GalleryImageVersionsClientListByGalleryImagePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *GalleryImageVersionsClientListByGalleryImagePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.GalleryImageVersionList.NextLink == nil || len(*p.current.GalleryImageVersionList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *GalleryImageVersionsClientListByGalleryImagePager) NextPage(ctx context.Context) (GalleryImageVersionsClientListByGalleryImageResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return GalleryImageVersionsClientListByGalleryImageResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryImageVersionsClientListByGalleryImageResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryImageVersionsClientListByGalleryImageResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return GalleryImageVersionsClientListByGalleryImageResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByGalleryImageHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryImageVersionsClientListByGalleryImageResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current GalleryImageVersionsClientListByGalleryImageResponse page.
-func (p *GalleryImageVersionsClientListByGalleryImagePager) PageResponse() GalleryImageVersionsClientListByGalleryImageResponse {
-	return p.current
+	return p.current, nil
 }
 
 // GalleryImagesClientListByGalleryPager provides operations for iterating over paged responses.
 type GalleryImagesClientListByGalleryPager struct {
 	client    *GalleryImagesClient
 	current   GalleryImagesClientListByGalleryResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, GalleryImagesClientListByGalleryResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *GalleryImagesClientListByGalleryPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *GalleryImagesClientListByGalleryPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *GalleryImagesClientListByGalleryPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.GalleryImageList.NextLink == nil || len(*p.current.GalleryImageList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *GalleryImagesClientListByGalleryPager) NextPage(ctx context.Context) (GalleryImagesClientListByGalleryResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return GalleryImagesClientListByGalleryResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryImagesClientListByGalleryResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryImagesClientListByGalleryResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return GalleryImagesClientListByGalleryResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByGalleryHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return GalleryImagesClientListByGalleryResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current GalleryImagesClientListByGalleryResponse page.
-func (p *GalleryImagesClientListByGalleryPager) PageResponse() GalleryImagesClientListByGalleryResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ImagesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type ImagesClientListByResourceGroupPager struct {
 	client    *ImagesClient
 	current   ImagesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ImagesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ImagesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ImagesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ImagesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ImageListResult.NextLink == nil || len(*p.current.ImageListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ImagesClientListByResourceGroupPager) NextPage(ctx context.Context) (ImagesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ImagesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ImagesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ImagesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ImagesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ImagesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ImagesClientListByResourceGroupResponse page.
-func (p *ImagesClientListByResourceGroupPager) PageResponse() ImagesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ImagesClientListPager provides operations for iterating over paged responses.
 type ImagesClientListPager struct {
 	client    *ImagesClient
 	current   ImagesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ImagesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ImagesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ImagesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ImagesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ImageListResult.NextLink == nil || len(*p.current.ImageListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ImagesClientListPager) NextPage(ctx context.Context) (ImagesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ImagesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ImagesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ImagesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ImagesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ImagesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ImagesClientListResponse page.
-func (p *ImagesClientListPager) PageResponse() ImagesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ProximityPlacementGroupsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type ProximityPlacementGroupsClientListByResourceGroupPager struct {
 	client    *ProximityPlacementGroupsClient
 	current   ProximityPlacementGroupsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ProximityPlacementGroupsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ProximityPlacementGroupsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ProximityPlacementGroupsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ProximityPlacementGroupsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProximityPlacementGroupListResult.NextLink == nil || len(*p.current.ProximityPlacementGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ProximityPlacementGroupsClientListByResourceGroupPager) NextPage(ctx context.Context) (ProximityPlacementGroupsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ProximityPlacementGroupsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProximityPlacementGroupsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProximityPlacementGroupsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ProximityPlacementGroupsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProximityPlacementGroupsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ProximityPlacementGroupsClientListByResourceGroupResponse page.
-func (p *ProximityPlacementGroupsClientListByResourceGroupPager) PageResponse() ProximityPlacementGroupsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ProximityPlacementGroupsClientListBySubscriptionPager provides operations for iterating over paged responses.
 type ProximityPlacementGroupsClientListBySubscriptionPager struct {
 	client    *ProximityPlacementGroupsClient
 	current   ProximityPlacementGroupsClientListBySubscriptionResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ProximityPlacementGroupsClientListBySubscriptionResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ProximityPlacementGroupsClientListBySubscriptionPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ProximityPlacementGroupsClientListBySubscriptionPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ProximityPlacementGroupsClientListBySubscriptionPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProximityPlacementGroupListResult.NextLink == nil || len(*p.current.ProximityPlacementGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ProximityPlacementGroupsClientListBySubscriptionPager) NextPage(ctx context.Context) (ProximityPlacementGroupsClientListBySubscriptionResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ProximityPlacementGroupsClientListBySubscriptionResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProximityPlacementGroupsClientListBySubscriptionResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProximityPlacementGroupsClientListBySubscriptionResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ProximityPlacementGroupsClientListBySubscriptionResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBySubscriptionHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProximityPlacementGroupsClientListBySubscriptionResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ProximityPlacementGroupsClientListBySubscriptionResponse page.
-func (p *ProximityPlacementGroupsClientListBySubscriptionPager) PageResponse() ProximityPlacementGroupsClientListBySubscriptionResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ResourceSKUsClientListPager provides operations for iterating over paged responses.
 type ResourceSKUsClientListPager struct {
 	client    *ResourceSKUsClient
 	current   ResourceSKUsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ResourceSKUsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ResourceSKUsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ResourceSKUsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ResourceSKUsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ResourceSKUsResult.NextLink == nil || len(*p.current.ResourceSKUsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ResourceSKUsClientListPager) NextPage(ctx context.Context) (ResourceSKUsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ResourceSKUsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ResourceSKUsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ResourceSKUsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ResourceSKUsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ResourceSKUsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ResourceSKUsClientListResponse page.
-func (p *ResourceSKUsClientListPager) PageResponse() ResourceSKUsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SSHPublicKeysClientListByResourceGroupPager provides operations for iterating over paged responses.
 type SSHPublicKeysClientListByResourceGroupPager struct {
 	client    *SSHPublicKeysClient
 	current   SSHPublicKeysClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SSHPublicKeysClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SSHPublicKeysClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SSHPublicKeysClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SSHPublicKeysClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SSHPublicKeysGroupListResult.NextLink == nil || len(*p.current.SSHPublicKeysGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SSHPublicKeysClientListByResourceGroupPager) NextPage(ctx context.Context) (SSHPublicKeysClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SSHPublicKeysClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SSHPublicKeysClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SSHPublicKeysClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SSHPublicKeysClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SSHPublicKeysClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SSHPublicKeysClientListByResourceGroupResponse page.
-func (p *SSHPublicKeysClientListByResourceGroupPager) PageResponse() SSHPublicKeysClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SSHPublicKeysClientListBySubscriptionPager provides operations for iterating over paged responses.
 type SSHPublicKeysClientListBySubscriptionPager struct {
 	client    *SSHPublicKeysClient
 	current   SSHPublicKeysClientListBySubscriptionResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SSHPublicKeysClientListBySubscriptionResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SSHPublicKeysClientListBySubscriptionPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SSHPublicKeysClientListBySubscriptionPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SSHPublicKeysClientListBySubscriptionPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SSHPublicKeysGroupListResult.NextLink == nil || len(*p.current.SSHPublicKeysGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SSHPublicKeysClientListBySubscriptionPager) NextPage(ctx context.Context) (SSHPublicKeysClientListBySubscriptionResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SSHPublicKeysClientListBySubscriptionResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SSHPublicKeysClientListBySubscriptionResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SSHPublicKeysClientListBySubscriptionResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SSHPublicKeysClientListBySubscriptionResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBySubscriptionHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SSHPublicKeysClientListBySubscriptionResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SSHPublicKeysClientListBySubscriptionResponse page.
-func (p *SSHPublicKeysClientListBySubscriptionPager) PageResponse() SSHPublicKeysClientListBySubscriptionResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SnapshotsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type SnapshotsClientListByResourceGroupPager struct {
 	client    *SnapshotsClient
 	current   SnapshotsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SnapshotsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SnapshotsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SnapshotsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SnapshotsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SnapshotList.NextLink == nil || len(*p.current.SnapshotList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SnapshotsClientListByResourceGroupPager) NextPage(ctx context.Context) (SnapshotsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SnapshotsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SnapshotsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SnapshotsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SnapshotsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SnapshotsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SnapshotsClientListByResourceGroupResponse page.
-func (p *SnapshotsClientListByResourceGroupPager) PageResponse() SnapshotsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SnapshotsClientListPager provides operations for iterating over paged responses.
 type SnapshotsClientListPager struct {
 	client    *SnapshotsClient
 	current   SnapshotsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SnapshotsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SnapshotsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SnapshotsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SnapshotsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SnapshotList.NextLink == nil || len(*p.current.SnapshotList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SnapshotsClientListPager) NextPage(ctx context.Context) (SnapshotsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SnapshotsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SnapshotsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SnapshotsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SnapshotsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SnapshotsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SnapshotsClientListResponse page.
-func (p *SnapshotsClientListPager) PageResponse() SnapshotsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // UsageClientListPager provides operations for iterating over paged responses.
 type UsageClientListPager struct {
 	client    *UsageClient
 	current   UsageClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, UsageClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *UsageClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *UsageClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *UsageClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListUsagesResult.NextLink == nil || len(*p.current.ListUsagesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *UsageClientListPager) NextPage(ctx context.Context) (UsageClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return UsageClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsageClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsageClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return UsageClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsageClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current UsageClientListResponse page.
-func (p *UsageClientListPager) PageResponse() UsageClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachineRunCommandsClientListPager provides operations for iterating over paged responses.
 type VirtualMachineRunCommandsClientListPager struct {
 	client    *VirtualMachineRunCommandsClient
 	current   VirtualMachineRunCommandsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachineRunCommandsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachineRunCommandsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachineRunCommandsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachineRunCommandsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RunCommandListResult.NextLink == nil || len(*p.current.RunCommandListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachineRunCommandsClientListPager) NextPage(ctx context.Context) (VirtualMachineRunCommandsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachineRunCommandsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineRunCommandsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineRunCommandsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachineRunCommandsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineRunCommandsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachineRunCommandsClientListResponse page.
-func (p *VirtualMachineRunCommandsClientListPager) PageResponse() VirtualMachineRunCommandsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachineScaleSetExtensionsClientListPager provides operations for iterating over paged responses.
 type VirtualMachineScaleSetExtensionsClientListPager struct {
 	client    *VirtualMachineScaleSetExtensionsClient
 	current   VirtualMachineScaleSetExtensionsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachineScaleSetExtensionsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachineScaleSetExtensionsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachineScaleSetExtensionsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachineScaleSetExtensionsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineScaleSetExtensionListResult.NextLink == nil || len(*p.current.VirtualMachineScaleSetExtensionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachineScaleSetExtensionsClientListPager) NextPage(ctx context.Context) (VirtualMachineScaleSetExtensionsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachineScaleSetExtensionsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetExtensionsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetExtensionsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachineScaleSetExtensionsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetExtensionsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachineScaleSetExtensionsClientListResponse page.
-func (p *VirtualMachineScaleSetExtensionsClientListPager) PageResponse() VirtualMachineScaleSetExtensionsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachineScaleSetVMsClientListPager provides operations for iterating over paged responses.
 type VirtualMachineScaleSetVMsClientListPager struct {
 	client    *VirtualMachineScaleSetVMsClient
 	current   VirtualMachineScaleSetVMsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachineScaleSetVMsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachineScaleSetVMsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachineScaleSetVMsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachineScaleSetVMsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineScaleSetVMListResult.NextLink == nil || len(*p.current.VirtualMachineScaleSetVMListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachineScaleSetVMsClientListPager) NextPage(ctx context.Context) (VirtualMachineScaleSetVMsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachineScaleSetVMsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetVMsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetVMsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachineScaleSetVMsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetVMsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachineScaleSetVMsClientListResponse page.
-func (p *VirtualMachineScaleSetVMsClientListPager) PageResponse() VirtualMachineScaleSetVMsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachineScaleSetsClientGetOSUpgradeHistoryPager provides operations for iterating over paged responses.
 type VirtualMachineScaleSetsClientGetOSUpgradeHistoryPager struct {
 	client    *VirtualMachineScaleSetsClient
 	current   VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachineScaleSetsClientGetOSUpgradeHistoryPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachineScaleSetsClientGetOSUpgradeHistoryPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachineScaleSetsClientGetOSUpgradeHistoryPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineScaleSetListOSUpgradeHistory.NextLink == nil || len(*p.current.VirtualMachineScaleSetListOSUpgradeHistory.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachineScaleSetsClientGetOSUpgradeHistoryPager) NextPage(ctx context.Context) (VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getOSUpgradeHistoryHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse page.
-func (p *VirtualMachineScaleSetsClientGetOSUpgradeHistoryPager) PageResponse() VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachineScaleSetsClientListAllPager provides operations for iterating over paged responses.
 type VirtualMachineScaleSetsClientListAllPager struct {
 	client    *VirtualMachineScaleSetsClient
 	current   VirtualMachineScaleSetsClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachineScaleSetsClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachineScaleSetsClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachineScaleSetsClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachineScaleSetsClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineScaleSetListWithLinkResult.NextLink == nil || len(*p.current.VirtualMachineScaleSetListWithLinkResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachineScaleSetsClientListAllPager) NextPage(ctx context.Context) (VirtualMachineScaleSetsClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachineScaleSetsClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachineScaleSetsClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachineScaleSetsClientListAllResponse page.
-func (p *VirtualMachineScaleSetsClientListAllPager) PageResponse() VirtualMachineScaleSetsClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachineScaleSetsClientListPager provides operations for iterating over paged responses.
 type VirtualMachineScaleSetsClientListPager struct {
 	client    *VirtualMachineScaleSetsClient
 	current   VirtualMachineScaleSetsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachineScaleSetsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachineScaleSetsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachineScaleSetsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachineScaleSetsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineScaleSetListResult.NextLink == nil || len(*p.current.VirtualMachineScaleSetListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachineScaleSetsClientListPager) NextPage(ctx context.Context) (VirtualMachineScaleSetsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachineScaleSetsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachineScaleSetsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachineScaleSetsClientListResponse page.
-func (p *VirtualMachineScaleSetsClientListPager) PageResponse() VirtualMachineScaleSetsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachineScaleSetsClientListSKUsPager provides operations for iterating over paged responses.
 type VirtualMachineScaleSetsClientListSKUsPager struct {
 	client    *VirtualMachineScaleSetsClient
 	current   VirtualMachineScaleSetsClientListSKUsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachineScaleSetsClientListSKUsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachineScaleSetsClientListSKUsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachineScaleSetsClientListSKUsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachineScaleSetsClientListSKUsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineScaleSetListSKUsResult.NextLink == nil || len(*p.current.VirtualMachineScaleSetListSKUsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachineScaleSetsClientListSKUsPager) NextPage(ctx context.Context) (VirtualMachineScaleSetsClientListSKUsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachineScaleSetsClientListSKUsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListSKUsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListSKUsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachineScaleSetsClientListSKUsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listSKUsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachineScaleSetsClientListSKUsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachineScaleSetsClientListSKUsResponse page.
-func (p *VirtualMachineScaleSetsClientListSKUsPager) PageResponse() VirtualMachineScaleSetsClientListSKUsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachinesClientListAllPager provides operations for iterating over paged responses.
 type VirtualMachinesClientListAllPager struct {
 	client    *VirtualMachinesClient
 	current   VirtualMachinesClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachinesClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachinesClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachinesClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachinesClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineListResult.NextLink == nil || len(*p.current.VirtualMachineListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachinesClientListAllPager) NextPage(ctx context.Context) (VirtualMachinesClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachinesClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachinesClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachinesClientListAllResponse page.
-func (p *VirtualMachinesClientListAllPager) PageResponse() VirtualMachinesClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachinesClientListByLocationPager provides operations for iterating over paged responses.
 type VirtualMachinesClientListByLocationPager struct {
 	client    *VirtualMachinesClient
 	current   VirtualMachinesClientListByLocationResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachinesClientListByLocationResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachinesClientListByLocationPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachinesClientListByLocationPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachinesClientListByLocationPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineListResult.NextLink == nil || len(*p.current.VirtualMachineListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachinesClientListByLocationPager) NextPage(ctx context.Context) (VirtualMachinesClientListByLocationResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachinesClientListByLocationResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListByLocationResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListByLocationResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachinesClientListByLocationResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByLocationHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListByLocationResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachinesClientListByLocationResponse page.
-func (p *VirtualMachinesClientListByLocationPager) PageResponse() VirtualMachinesClientListByLocationResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualMachinesClientListPager provides operations for iterating over paged responses.
 type VirtualMachinesClientListPager struct {
 	client    *VirtualMachinesClient
 	current   VirtualMachinesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualMachinesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualMachinesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualMachinesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachinesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualMachineListResult.NextLink == nil || len(*p.current.VirtualMachineListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachinesClientListPager) NextPage(ctx context.Context) (VirtualMachinesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualMachinesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualMachinesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualMachinesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualMachinesClientListResponse page.
-func (p *VirtualMachinesClientListPager) PageResponse() VirtualMachinesClientListResponse {
-	return p.current
+	return p.current, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_pagers.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_pagers.go
@@ -10,6 +10,7 @@ package armconsumption
 
 import (
 	"context"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,808 +21,778 @@ import (
 type BudgetsClientListPager struct {
 	client    *BudgetsClient
 	current   BudgetsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, BudgetsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *BudgetsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *BudgetsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *BudgetsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BudgetsListResult.NextLink == nil || len(*p.current.BudgetsListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *BudgetsClientListPager) NextPage(ctx context.Context) (BudgetsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return BudgetsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return BudgetsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BudgetsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return BudgetsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BudgetsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current BudgetsClientListResponse page.
-func (p *BudgetsClientListPager) PageResponse() BudgetsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // EventsClientListPager provides operations for iterating over paged responses.
 type EventsClientListPager struct {
 	client    *EventsClient
 	current   EventsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, EventsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *EventsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *EventsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *EventsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.Events.NextLink == nil || len(*p.current.Events.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *EventsClientListPager) NextPage(ctx context.Context) (EventsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return EventsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return EventsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return EventsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return EventsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return EventsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current EventsClientListResponse page.
-func (p *EventsClientListPager) PageResponse() EventsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LotsClientListPager provides operations for iterating over paged responses.
 type LotsClientListPager struct {
 	client    *LotsClient
 	current   LotsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LotsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LotsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LotsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LotsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.Lots.NextLink == nil || len(*p.current.Lots.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LotsClientListPager) NextPage(ctx context.Context) (LotsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LotsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LotsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LotsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LotsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LotsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LotsClientListResponse page.
-func (p *LotsClientListPager) PageResponse() LotsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // MarketplacesClientListPager provides operations for iterating over paged responses.
 type MarketplacesClientListPager struct {
 	client    *MarketplacesClient
 	current   MarketplacesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, MarketplacesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *MarketplacesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *MarketplacesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *MarketplacesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.MarketplacesListResult.NextLink == nil || len(*p.current.MarketplacesListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *MarketplacesClientListPager) NextPage(ctx context.Context) (MarketplacesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return MarketplacesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return MarketplacesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return MarketplacesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return MarketplacesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return MarketplacesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current MarketplacesClientListResponse page.
-func (p *MarketplacesClientListPager) PageResponse() MarketplacesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // OperationsClientListPager provides operations for iterating over paged responses.
 type OperationsClientListPager struct {
 	client    *OperationsClient
 	current   OperationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, OperationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *OperationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *OperationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *OperationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.OperationListResult.NextLink == nil || len(*p.current.OperationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *OperationsClientListPager) NextPage(ctx context.Context) (OperationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return OperationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return OperationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current OperationsClientListResponse page.
-func (p *OperationsClientListPager) PageResponse() OperationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationRecommendationsClientListPager provides operations for iterating over paged responses.
 type ReservationRecommendationsClientListPager struct {
 	client    *ReservationRecommendationsClient
 	current   ReservationRecommendationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationRecommendationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationRecommendationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationRecommendationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationRecommendationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ReservationRecommendationsListResult.NextLink == nil || len(*p.current.ReservationRecommendationsListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationRecommendationsClientListPager) NextPage(ctx context.Context) (ReservationRecommendationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationRecommendationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationRecommendationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationRecommendationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusNoContent) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationRecommendationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationRecommendationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationRecommendationsClientListResponse page.
-func (p *ReservationRecommendationsClientListPager) PageResponse() ReservationRecommendationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationTransactionsClientListByBillingProfilePager provides operations for iterating over paged responses.
 type ReservationTransactionsClientListByBillingProfilePager struct {
 	client    *ReservationTransactionsClient
 	current   ReservationTransactionsClientListByBillingProfileResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationTransactionsClientListByBillingProfileResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationTransactionsClientListByBillingProfilePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationTransactionsClientListByBillingProfilePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationTransactionsClientListByBillingProfilePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ModernReservationTransactionsListResult.NextLink == nil || len(*p.current.ModernReservationTransactionsListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationTransactionsClientListByBillingProfilePager) NextPage(ctx context.Context) (ReservationTransactionsClientListByBillingProfileResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationTransactionsClientListByBillingProfileResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationTransactionsClientListByBillingProfileResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationTransactionsClientListByBillingProfileResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationTransactionsClientListByBillingProfileResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByBillingProfileHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationTransactionsClientListByBillingProfileResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationTransactionsClientListByBillingProfileResponse page.
-func (p *ReservationTransactionsClientListByBillingProfilePager) PageResponse() ReservationTransactionsClientListByBillingProfileResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationTransactionsClientListPager provides operations for iterating over paged responses.
 type ReservationTransactionsClientListPager struct {
 	client    *ReservationTransactionsClient
 	current   ReservationTransactionsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationTransactionsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationTransactionsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationTransactionsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationTransactionsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ReservationTransactionsListResult.NextLink == nil || len(*p.current.ReservationTransactionsListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationTransactionsClientListPager) NextPage(ctx context.Context) (ReservationTransactionsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationTransactionsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationTransactionsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationTransactionsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationTransactionsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationTransactionsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationTransactionsClientListResponse page.
-func (p *ReservationTransactionsClientListPager) PageResponse() ReservationTransactionsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationsDetailsClientListByReservationOrderAndReservationPager provides operations for iterating over paged responses.
 type ReservationsDetailsClientListByReservationOrderAndReservationPager struct {
 	client    *ReservationsDetailsClient
 	current   ReservationsDetailsClientListByReservationOrderAndReservationResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationsDetailsClientListByReservationOrderAndReservationResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationsDetailsClientListByReservationOrderAndReservationPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationsDetailsClientListByReservationOrderAndReservationPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationsDetailsClientListByReservationOrderAndReservationPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ReservationDetailsListResult.NextLink == nil || len(*p.current.ReservationDetailsListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationsDetailsClientListByReservationOrderAndReservationPager) NextPage(ctx context.Context) (ReservationsDetailsClientListByReservationOrderAndReservationResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationsDetailsClientListByReservationOrderAndReservationResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListByReservationOrderAndReservationResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListByReservationOrderAndReservationResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationsDetailsClientListByReservationOrderAndReservationResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByReservationOrderAndReservationHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListByReservationOrderAndReservationResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationsDetailsClientListByReservationOrderAndReservationResponse page.
-func (p *ReservationsDetailsClientListByReservationOrderAndReservationPager) PageResponse() ReservationsDetailsClientListByReservationOrderAndReservationResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationsDetailsClientListByReservationOrderPager provides operations for iterating over paged responses.
 type ReservationsDetailsClientListByReservationOrderPager struct {
 	client    *ReservationsDetailsClient
 	current   ReservationsDetailsClientListByReservationOrderResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationsDetailsClientListByReservationOrderResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationsDetailsClientListByReservationOrderPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationsDetailsClientListByReservationOrderPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationsDetailsClientListByReservationOrderPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ReservationDetailsListResult.NextLink == nil || len(*p.current.ReservationDetailsListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationsDetailsClientListByReservationOrderPager) NextPage(ctx context.Context) (ReservationsDetailsClientListByReservationOrderResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationsDetailsClientListByReservationOrderResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListByReservationOrderResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListByReservationOrderResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationsDetailsClientListByReservationOrderResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByReservationOrderHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListByReservationOrderResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationsDetailsClientListByReservationOrderResponse page.
-func (p *ReservationsDetailsClientListByReservationOrderPager) PageResponse() ReservationsDetailsClientListByReservationOrderResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationsDetailsClientListPager provides operations for iterating over paged responses.
 type ReservationsDetailsClientListPager struct {
 	client    *ReservationsDetailsClient
 	current   ReservationsDetailsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationsDetailsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationsDetailsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationsDetailsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationsDetailsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ReservationDetailsListResult.NextLink == nil || len(*p.current.ReservationDetailsListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationsDetailsClientListPager) NextPage(ctx context.Context) (ReservationsDetailsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationsDetailsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationsDetailsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsDetailsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationsDetailsClientListResponse page.
-func (p *ReservationsDetailsClientListPager) PageResponse() ReservationsDetailsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationsSummariesClientListByReservationOrderAndReservationPager provides operations for iterating over paged responses.
 type ReservationsSummariesClientListByReservationOrderAndReservationPager struct {
 	client    *ReservationsSummariesClient
 	current   ReservationsSummariesClientListByReservationOrderAndReservationResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationsSummariesClientListByReservationOrderAndReservationResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationsSummariesClientListByReservationOrderAndReservationPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationsSummariesClientListByReservationOrderAndReservationPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationsSummariesClientListByReservationOrderAndReservationPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ReservationSummariesListResult.NextLink == nil || len(*p.current.ReservationSummariesListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationsSummariesClientListByReservationOrderAndReservationPager) NextPage(ctx context.Context) (ReservationsSummariesClientListByReservationOrderAndReservationResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationsSummariesClientListByReservationOrderAndReservationResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListByReservationOrderAndReservationResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListByReservationOrderAndReservationResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationsSummariesClientListByReservationOrderAndReservationResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByReservationOrderAndReservationHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListByReservationOrderAndReservationResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationsSummariesClientListByReservationOrderAndReservationResponse page.
-func (p *ReservationsSummariesClientListByReservationOrderAndReservationPager) PageResponse() ReservationsSummariesClientListByReservationOrderAndReservationResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationsSummariesClientListByReservationOrderPager provides operations for iterating over paged responses.
 type ReservationsSummariesClientListByReservationOrderPager struct {
 	client    *ReservationsSummariesClient
 	current   ReservationsSummariesClientListByReservationOrderResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationsSummariesClientListByReservationOrderResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationsSummariesClientListByReservationOrderPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationsSummariesClientListByReservationOrderPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationsSummariesClientListByReservationOrderPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ReservationSummariesListResult.NextLink == nil || len(*p.current.ReservationSummariesListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationsSummariesClientListByReservationOrderPager) NextPage(ctx context.Context) (ReservationsSummariesClientListByReservationOrderResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationsSummariesClientListByReservationOrderResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListByReservationOrderResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListByReservationOrderResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationsSummariesClientListByReservationOrderResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByReservationOrderHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListByReservationOrderResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationsSummariesClientListByReservationOrderResponse page.
-func (p *ReservationsSummariesClientListByReservationOrderPager) PageResponse() ReservationsSummariesClientListByReservationOrderResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ReservationsSummariesClientListPager provides operations for iterating over paged responses.
 type ReservationsSummariesClientListPager struct {
 	client    *ReservationsSummariesClient
 	current   ReservationsSummariesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ReservationsSummariesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ReservationsSummariesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ReservationsSummariesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ReservationsSummariesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ReservationSummariesListResult.NextLink == nil || len(*p.current.ReservationSummariesListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ReservationsSummariesClientListPager) NextPage(ctx context.Context) (ReservationsSummariesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ReservationsSummariesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ReservationsSummariesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ReservationsSummariesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ReservationsSummariesClientListResponse page.
-func (p *ReservationsSummariesClientListPager) PageResponse() ReservationsSummariesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // UsageDetailsClientListPager provides operations for iterating over paged responses.
 type UsageDetailsClientListPager struct {
 	client    *UsageDetailsClient
 	current   UsageDetailsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, UsageDetailsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *UsageDetailsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *UsageDetailsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *UsageDetailsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.UsageDetailsListResult.NextLink == nil || len(*p.current.UsageDetailsListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *UsageDetailsClientListPager) NextPage(ctx context.Context) (UsageDetailsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return UsageDetailsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsageDetailsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsageDetailsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return UsageDetailsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsageDetailsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current UsageDetailsClientListResponse page.
-func (p *UsageDetailsClientListPager) PageResponse() UsageDetailsClientListResponse {
-	return p.current
+	return p.current, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pagers.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pagers.go
@@ -10,6 +10,7 @@ package armdataboxedge
 
 import (
 	"context"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,916 +21,882 @@ import (
 type AddonsClientListByRolePager struct {
 	client    *AddonsClient
 	current   AddonsClientListByRoleResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AddonsClientListByRoleResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AddonsClientListByRolePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AddonsClientListByRolePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AddonsClientListByRolePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AddonList.NextLink == nil || len(*p.current.AddonList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AddonsClientListByRolePager) NextPage(ctx context.Context) (AddonsClientListByRoleResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AddonsClientListByRoleResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AddonsClientListByRoleResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AddonsClientListByRoleResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AddonsClientListByRoleResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByRoleHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AddonsClientListByRoleResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AddonsClientListByRoleResponse page.
-func (p *AddonsClientListByRolePager) PageResponse() AddonsClientListByRoleResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AlertsClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type AlertsClientListByDataBoxEdgeDevicePager struct {
 	client    *AlertsClient
 	current   AlertsClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AlertsClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AlertsClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AlertsClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AlertsClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AlertList.NextLink == nil || len(*p.current.AlertList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AlertsClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (AlertsClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AlertsClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AlertsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AlertsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AlertsClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AlertsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AlertsClientListByDataBoxEdgeDeviceResponse page.
-func (p *AlertsClientListByDataBoxEdgeDevicePager) PageResponse() AlertsClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailableSKUsClientListPager provides operations for iterating over paged responses.
 type AvailableSKUsClientListPager struct {
 	client    *AvailableSKUsClient
 	current   AvailableSKUsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailableSKUsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailableSKUsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailableSKUsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailableSKUsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SKUList.NextLink == nil || len(*p.current.SKUList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailableSKUsClientListPager) NextPage(ctx context.Context) (AvailableSKUsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailableSKUsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableSKUsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableSKUsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailableSKUsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableSKUsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailableSKUsClientListResponse page.
-func (p *AvailableSKUsClientListPager) PageResponse() AvailableSKUsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // BandwidthSchedulesClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type BandwidthSchedulesClientListByDataBoxEdgeDevicePager struct {
 	client    *BandwidthSchedulesClient
 	current   BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *BandwidthSchedulesClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *BandwidthSchedulesClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *BandwidthSchedulesClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BandwidthSchedulesList.NextLink == nil || len(*p.current.BandwidthSchedulesList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *BandwidthSchedulesClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse page.
-func (p *BandwidthSchedulesClientListByDataBoxEdgeDevicePager) PageResponse() BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ContainersClientListByStorageAccountPager provides operations for iterating over paged responses.
 type ContainersClientListByStorageAccountPager struct {
 	client    *ContainersClient
 	current   ContainersClientListByStorageAccountResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ContainersClientListByStorageAccountResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ContainersClientListByStorageAccountPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ContainersClientListByStorageAccountPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ContainersClientListByStorageAccountPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ContainerList.NextLink == nil || len(*p.current.ContainerList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ContainersClientListByStorageAccountPager) NextPage(ctx context.Context) (ContainersClientListByStorageAccountResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ContainersClientListByStorageAccountResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainersClientListByStorageAccountResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainersClientListByStorageAccountResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ContainersClientListByStorageAccountResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByStorageAccountHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ContainersClientListByStorageAccountResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ContainersClientListByStorageAccountResponse page.
-func (p *ContainersClientListByStorageAccountPager) PageResponse() ContainersClientListByStorageAccountResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DevicesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type DevicesClientListByResourceGroupPager struct {
 	client    *DevicesClient
 	current   DevicesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DevicesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DevicesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DevicesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DevicesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DeviceList.NextLink == nil || len(*p.current.DeviceList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DevicesClientListByResourceGroupPager) NextPage(ctx context.Context) (DevicesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DevicesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DevicesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DevicesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DevicesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DevicesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DevicesClientListByResourceGroupResponse page.
-func (p *DevicesClientListByResourceGroupPager) PageResponse() DevicesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DevicesClientListBySubscriptionPager provides operations for iterating over paged responses.
 type DevicesClientListBySubscriptionPager struct {
 	client    *DevicesClient
 	current   DevicesClientListBySubscriptionResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DevicesClientListBySubscriptionResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DevicesClientListBySubscriptionPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DevicesClientListBySubscriptionPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DevicesClientListBySubscriptionPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DeviceList.NextLink == nil || len(*p.current.DeviceList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DevicesClientListBySubscriptionPager) NextPage(ctx context.Context) (DevicesClientListBySubscriptionResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DevicesClientListBySubscriptionResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DevicesClientListBySubscriptionResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DevicesClientListBySubscriptionResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DevicesClientListBySubscriptionResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBySubscriptionHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DevicesClientListBySubscriptionResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DevicesClientListBySubscriptionResponse page.
-func (p *DevicesClientListBySubscriptionPager) PageResponse() DevicesClientListBySubscriptionResponse {
-	return p.current
+	return p.current, nil
 }
 
 // MonitoringConfigClientListPager provides operations for iterating over paged responses.
 type MonitoringConfigClientListPager struct {
 	client    *MonitoringConfigClient
 	current   MonitoringConfigClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, MonitoringConfigClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *MonitoringConfigClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *MonitoringConfigClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *MonitoringConfigClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.MonitoringMetricConfigurationList.NextLink == nil || len(*p.current.MonitoringMetricConfigurationList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *MonitoringConfigClientListPager) NextPage(ctx context.Context) (MonitoringConfigClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return MonitoringConfigClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return MonitoringConfigClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return MonitoringConfigClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return MonitoringConfigClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return MonitoringConfigClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current MonitoringConfigClientListResponse page.
-func (p *MonitoringConfigClientListPager) PageResponse() MonitoringConfigClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // NodesClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type NodesClientListByDataBoxEdgeDevicePager struct {
 	client    *NodesClient
 	current   NodesClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, NodesClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *NodesClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *NodesClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *NodesClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.NodeList.NextLink == nil || len(*p.current.NodeList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *NodesClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (NodesClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return NodesClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return NodesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return NodesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return NodesClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return NodesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current NodesClientListByDataBoxEdgeDeviceResponse page.
-func (p *NodesClientListByDataBoxEdgeDevicePager) PageResponse() NodesClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // OperationsClientListPager provides operations for iterating over paged responses.
 type OperationsClientListPager struct {
 	client    *OperationsClient
 	current   OperationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, OperationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *OperationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *OperationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *OperationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.OperationsList.NextLink == nil || len(*p.current.OperationsList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *OperationsClientListPager) NextPage(ctx context.Context) (OperationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return OperationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return OperationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current OperationsClientListResponse page.
-func (p *OperationsClientListPager) PageResponse() OperationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // OrdersClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type OrdersClientListByDataBoxEdgeDevicePager struct {
 	client    *OrdersClient
 	current   OrdersClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, OrdersClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *OrdersClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *OrdersClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *OrdersClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.OrderList.NextLink == nil || len(*p.current.OrderList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *OrdersClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (OrdersClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return OrdersClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return OrdersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return OrdersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return OrdersClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return OrdersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current OrdersClientListByDataBoxEdgeDeviceResponse page.
-func (p *OrdersClientListByDataBoxEdgeDevicePager) PageResponse() OrdersClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RolesClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type RolesClientListByDataBoxEdgeDevicePager struct {
 	client    *RolesClient
 	current   RolesClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RolesClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RolesClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RolesClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RolesClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RoleList.NextLink == nil || len(*p.current.RoleList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RolesClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (RolesClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RolesClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RolesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RolesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RolesClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RolesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RolesClientListByDataBoxEdgeDeviceResponse page.
-func (p *RolesClientListByDataBoxEdgeDevicePager) PageResponse() RolesClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SharesClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type SharesClientListByDataBoxEdgeDevicePager struct {
 	client    *SharesClient
 	current   SharesClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SharesClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SharesClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SharesClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SharesClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ShareList.NextLink == nil || len(*p.current.ShareList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SharesClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (SharesClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SharesClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SharesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SharesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SharesClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SharesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SharesClientListByDataBoxEdgeDeviceResponse page.
-func (p *SharesClientListByDataBoxEdgeDevicePager) PageResponse() SharesClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // StorageAccountCredentialsClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type StorageAccountCredentialsClientListByDataBoxEdgeDevicePager struct {
 	client    *StorageAccountCredentialsClient
 	current   StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *StorageAccountCredentialsClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *StorageAccountCredentialsClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *StorageAccountCredentialsClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.StorageAccountCredentialList.NextLink == nil || len(*p.current.StorageAccountCredentialList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *StorageAccountCredentialsClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse page.
-func (p *StorageAccountCredentialsClientListByDataBoxEdgeDevicePager) PageResponse() StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // StorageAccountsClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type StorageAccountsClientListByDataBoxEdgeDevicePager struct {
 	client    *StorageAccountsClient
 	current   StorageAccountsClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, StorageAccountsClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *StorageAccountsClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *StorageAccountsClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *StorageAccountsClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.StorageAccountList.NextLink == nil || len(*p.current.StorageAccountList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *StorageAccountsClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (StorageAccountsClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return StorageAccountsClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return StorageAccountsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return StorageAccountsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return StorageAccountsClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return StorageAccountsClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current StorageAccountsClientListByDataBoxEdgeDeviceResponse page.
-func (p *StorageAccountsClientListByDataBoxEdgeDevicePager) PageResponse() StorageAccountsClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // TriggersClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type TriggersClientListByDataBoxEdgeDevicePager struct {
 	client    *TriggersClient
 	current   TriggersClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, TriggersClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *TriggersClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *TriggersClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *TriggersClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.TriggerList.NextLink == nil || len(*p.current.TriggerList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *TriggersClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (TriggersClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return TriggersClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return TriggersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return TriggersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return TriggersClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return TriggersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current TriggersClientListByDataBoxEdgeDeviceResponse page.
-func (p *TriggersClientListByDataBoxEdgeDevicePager) PageResponse() TriggersClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // UsersClientListByDataBoxEdgeDevicePager provides operations for iterating over paged responses.
 type UsersClientListByDataBoxEdgeDevicePager struct {
 	client    *UsersClient
 	current   UsersClientListByDataBoxEdgeDeviceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, UsersClientListByDataBoxEdgeDeviceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *UsersClientListByDataBoxEdgeDevicePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *UsersClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *UsersClientListByDataBoxEdgeDevicePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.UserList.NextLink == nil || len(*p.current.UserList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *UsersClientListByDataBoxEdgeDevicePager) NextPage(ctx context.Context) (UsersClientListByDataBoxEdgeDeviceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return UsersClientListByDataBoxEdgeDeviceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return UsersClientListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByDataBoxEdgeDeviceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current UsersClientListByDataBoxEdgeDeviceResponse page.
-func (p *UsersClientListByDataBoxEdgeDevicePager) PageResponse() UsersClientListByDataBoxEdgeDeviceResponse {
-	return p.current
+	return p.current, nil
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_pagers.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_pagers.go
@@ -10,6 +10,7 @@ package azkeyvault
 
 import (
 	"context"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,862 +21,830 @@ import (
 type ClientGetCertificateIssuersPager struct {
 	client    *Client
 	current   ClientGetCertificateIssuersResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetCertificateIssuersResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetCertificateIssuersPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetCertificateIssuersPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetCertificateIssuersPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.CertificateIssuerListResult.NextLink == nil || len(*p.current.CertificateIssuerListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetCertificateIssuersPager) NextPage(ctx context.Context) (ClientGetCertificateIssuersResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetCertificateIssuersResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificateIssuersResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificateIssuersResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetCertificateIssuersResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getCertificateIssuersHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificateIssuersResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetCertificateIssuersResponse page.
-func (p *ClientGetCertificateIssuersPager) PageResponse() ClientGetCertificateIssuersResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetCertificateVersionsPager provides operations for iterating over paged responses.
 type ClientGetCertificateVersionsPager struct {
 	client    *Client
 	current   ClientGetCertificateVersionsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetCertificateVersionsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetCertificateVersionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetCertificateVersionsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetCertificateVersionsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.CertificateListResult.NextLink == nil || len(*p.current.CertificateListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetCertificateVersionsPager) NextPage(ctx context.Context) (ClientGetCertificateVersionsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetCertificateVersionsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificateVersionsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificateVersionsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetCertificateVersionsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getCertificateVersionsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificateVersionsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetCertificateVersionsResponse page.
-func (p *ClientGetCertificateVersionsPager) PageResponse() ClientGetCertificateVersionsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetCertificatesPager provides operations for iterating over paged responses.
 type ClientGetCertificatesPager struct {
 	client    *Client
 	current   ClientGetCertificatesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetCertificatesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetCertificatesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetCertificatesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetCertificatesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.CertificateListResult.NextLink == nil || len(*p.current.CertificateListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetCertificatesPager) NextPage(ctx context.Context) (ClientGetCertificatesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetCertificatesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificatesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificatesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetCertificatesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getCertificatesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetCertificatesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetCertificatesResponse page.
-func (p *ClientGetCertificatesPager) PageResponse() ClientGetCertificatesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetDeletedCertificatesPager provides operations for iterating over paged responses.
 type ClientGetDeletedCertificatesPager struct {
 	client    *Client
 	current   ClientGetDeletedCertificatesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetDeletedCertificatesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetDeletedCertificatesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetDeletedCertificatesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetDeletedCertificatesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DeletedCertificateListResult.NextLink == nil || len(*p.current.DeletedCertificateListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetDeletedCertificatesPager) NextPage(ctx context.Context) (ClientGetDeletedCertificatesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetDeletedCertificatesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedCertificatesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedCertificatesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetDeletedCertificatesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getDeletedCertificatesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedCertificatesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetDeletedCertificatesResponse page.
-func (p *ClientGetDeletedCertificatesPager) PageResponse() ClientGetDeletedCertificatesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetDeletedKeysPager provides operations for iterating over paged responses.
 type ClientGetDeletedKeysPager struct {
 	client    *Client
 	current   ClientGetDeletedKeysResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetDeletedKeysResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetDeletedKeysPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetDeletedKeysPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetDeletedKeysPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DeletedKeyListResult.NextLink == nil || len(*p.current.DeletedKeyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetDeletedKeysPager) NextPage(ctx context.Context) (ClientGetDeletedKeysResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetDeletedKeysResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedKeysResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedKeysResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetDeletedKeysResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getDeletedKeysHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedKeysResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetDeletedKeysResponse page.
-func (p *ClientGetDeletedKeysPager) PageResponse() ClientGetDeletedKeysResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetDeletedSasDefinitionsPager provides operations for iterating over paged responses.
 type ClientGetDeletedSasDefinitionsPager struct {
 	client    *Client
 	current   ClientGetDeletedSasDefinitionsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetDeletedSasDefinitionsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetDeletedSasDefinitionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetDeletedSasDefinitionsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetDeletedSasDefinitionsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DeletedSasDefinitionListResult.NextLink == nil || len(*p.current.DeletedSasDefinitionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetDeletedSasDefinitionsPager) NextPage(ctx context.Context) (ClientGetDeletedSasDefinitionsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetDeletedSasDefinitionsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedSasDefinitionsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedSasDefinitionsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetDeletedSasDefinitionsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getDeletedSasDefinitionsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedSasDefinitionsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetDeletedSasDefinitionsResponse page.
-func (p *ClientGetDeletedSasDefinitionsPager) PageResponse() ClientGetDeletedSasDefinitionsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetDeletedSecretsPager provides operations for iterating over paged responses.
 type ClientGetDeletedSecretsPager struct {
 	client    *Client
 	current   ClientGetDeletedSecretsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetDeletedSecretsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetDeletedSecretsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetDeletedSecretsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetDeletedSecretsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DeletedSecretListResult.NextLink == nil || len(*p.current.DeletedSecretListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetDeletedSecretsPager) NextPage(ctx context.Context) (ClientGetDeletedSecretsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetDeletedSecretsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedSecretsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedSecretsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetDeletedSecretsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getDeletedSecretsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedSecretsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetDeletedSecretsResponse page.
-func (p *ClientGetDeletedSecretsPager) PageResponse() ClientGetDeletedSecretsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetDeletedStorageAccountsPager provides operations for iterating over paged responses.
 type ClientGetDeletedStorageAccountsPager struct {
 	client    *Client
 	current   ClientGetDeletedStorageAccountsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetDeletedStorageAccountsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetDeletedStorageAccountsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetDeletedStorageAccountsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetDeletedStorageAccountsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DeletedStorageListResult.NextLink == nil || len(*p.current.DeletedStorageListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetDeletedStorageAccountsPager) NextPage(ctx context.Context) (ClientGetDeletedStorageAccountsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetDeletedStorageAccountsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedStorageAccountsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedStorageAccountsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetDeletedStorageAccountsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getDeletedStorageAccountsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetDeletedStorageAccountsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetDeletedStorageAccountsResponse page.
-func (p *ClientGetDeletedStorageAccountsPager) PageResponse() ClientGetDeletedStorageAccountsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetKeyVersionsPager provides operations for iterating over paged responses.
 type ClientGetKeyVersionsPager struct {
 	client    *Client
 	current   ClientGetKeyVersionsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetKeyVersionsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetKeyVersionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetKeyVersionsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetKeyVersionsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.KeyListResult.NextLink == nil || len(*p.current.KeyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetKeyVersionsPager) NextPage(ctx context.Context) (ClientGetKeyVersionsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetKeyVersionsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetKeyVersionsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetKeyVersionsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetKeyVersionsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getKeyVersionsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetKeyVersionsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetKeyVersionsResponse page.
-func (p *ClientGetKeyVersionsPager) PageResponse() ClientGetKeyVersionsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetKeysPager provides operations for iterating over paged responses.
 type ClientGetKeysPager struct {
 	client    *Client
 	current   ClientGetKeysResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetKeysResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetKeysPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetKeysPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetKeysPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.KeyListResult.NextLink == nil || len(*p.current.KeyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetKeysPager) NextPage(ctx context.Context) (ClientGetKeysResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetKeysResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetKeysResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetKeysResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetKeysResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getKeysHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetKeysResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetKeysResponse page.
-func (p *ClientGetKeysPager) PageResponse() ClientGetKeysResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetSasDefinitionsPager provides operations for iterating over paged responses.
 type ClientGetSasDefinitionsPager struct {
 	client    *Client
 	current   ClientGetSasDefinitionsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetSasDefinitionsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetSasDefinitionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetSasDefinitionsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetSasDefinitionsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SasDefinitionListResult.NextLink == nil || len(*p.current.SasDefinitionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetSasDefinitionsPager) NextPage(ctx context.Context) (ClientGetSasDefinitionsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetSasDefinitionsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSasDefinitionsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSasDefinitionsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetSasDefinitionsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getSasDefinitionsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSasDefinitionsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetSasDefinitionsResponse page.
-func (p *ClientGetSasDefinitionsPager) PageResponse() ClientGetSasDefinitionsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetSecretVersionsPager provides operations for iterating over paged responses.
 type ClientGetSecretVersionsPager struct {
 	client    *Client
 	current   ClientGetSecretVersionsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetSecretVersionsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetSecretVersionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetSecretVersionsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetSecretVersionsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SecretListResult.NextLink == nil || len(*p.current.SecretListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetSecretVersionsPager) NextPage(ctx context.Context) (ClientGetSecretVersionsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetSecretVersionsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSecretVersionsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSecretVersionsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetSecretVersionsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getSecretVersionsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSecretVersionsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetSecretVersionsResponse page.
-func (p *ClientGetSecretVersionsPager) PageResponse() ClientGetSecretVersionsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetSecretsPager provides operations for iterating over paged responses.
 type ClientGetSecretsPager struct {
 	client    *Client
 	current   ClientGetSecretsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetSecretsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetSecretsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetSecretsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetSecretsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SecretListResult.NextLink == nil || len(*p.current.SecretListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetSecretsPager) NextPage(ctx context.Context) (ClientGetSecretsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetSecretsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSecretsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSecretsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetSecretsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getSecretsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetSecretsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetSecretsResponse page.
-func (p *ClientGetSecretsPager) PageResponse() ClientGetSecretsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ClientGetStorageAccountsPager provides operations for iterating over paged responses.
 type ClientGetStorageAccountsPager struct {
 	client    *Client
 	current   ClientGetStorageAccountsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ClientGetStorageAccountsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ClientGetStorageAccountsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ClientGetStorageAccountsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ClientGetStorageAccountsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.StorageListResult.NextLink == nil || len(*p.current.StorageListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ClientGetStorageAccountsPager) NextPage(ctx context.Context) (ClientGetStorageAccountsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ClientGetStorageAccountsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetStorageAccountsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetStorageAccountsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ClientGetStorageAccountsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getStorageAccountsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ClientGetStorageAccountsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ClientGetStorageAccountsResponse page.
-func (p *ClientGetStorageAccountsPager) PageResponse() ClientGetStorageAccountsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RoleAssignmentsClientListForScopePager provides operations for iterating over paged responses.
 type RoleAssignmentsClientListForScopePager struct {
 	client    *RoleAssignmentsClient
 	current   RoleAssignmentsClientListForScopeResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RoleAssignmentsClientListForScopeResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RoleAssignmentsClientListForScopePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RoleAssignmentsClientListForScopePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RoleAssignmentsClientListForScopePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RoleAssignmentListResult.NextLink == nil || len(*p.current.RoleAssignmentListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RoleAssignmentsClientListForScopePager) NextPage(ctx context.Context) (RoleAssignmentsClientListForScopeResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RoleAssignmentsClientListForScopeResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoleAssignmentsClientListForScopeResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoleAssignmentsClientListForScopeResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RoleAssignmentsClientListForScopeResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listForScopeHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoleAssignmentsClientListForScopeResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RoleAssignmentsClientListForScopeResponse page.
-func (p *RoleAssignmentsClientListForScopePager) PageResponse() RoleAssignmentsClientListForScopeResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RoleDefinitionsClientListPager provides operations for iterating over paged responses.
 type RoleDefinitionsClientListPager struct {
 	client    *RoleDefinitionsClient
 	current   RoleDefinitionsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RoleDefinitionsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RoleDefinitionsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RoleDefinitionsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RoleDefinitionsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RoleDefinitionListResult.NextLink == nil || len(*p.current.RoleDefinitionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RoleDefinitionsClientListPager) NextPage(ctx context.Context) (RoleDefinitionsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RoleDefinitionsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoleDefinitionsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoleDefinitionsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RoleDefinitionsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoleDefinitionsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RoleDefinitionsClientListResponse page.
-func (p *RoleDefinitionsClientListPager) PageResponse() RoleDefinitionsClientListResponse {
-	return p.current
+	return p.current, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
@@ -10,6 +10,7 @@ package armnetwork
 
 import (
 	"context"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,7176 +21,6910 @@ import (
 type ApplicationGatewaysClientListAllPager struct {
 	client    *ApplicationGatewaysClient
 	current   ApplicationGatewaysClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ApplicationGatewaysClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ApplicationGatewaysClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ApplicationGatewaysClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ApplicationGatewaysClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ApplicationGatewayListResult.NextLink == nil || len(*p.current.ApplicationGatewayListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ApplicationGatewaysClientListAllPager) NextPage(ctx context.Context) (ApplicationGatewaysClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ApplicationGatewaysClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ApplicationGatewaysClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ApplicationGatewaysClientListAllResponse page.
-func (p *ApplicationGatewaysClientListAllPager) PageResponse() ApplicationGatewaysClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesPager provides operations for iterating over paged responses.
 type ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesPager struct {
 	client    *ApplicationGatewaysClient
 	current   ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ApplicationGatewayAvailableSSLPredefinedPolicies.NextLink == nil || len(*p.current.ApplicationGatewayAvailableSSLPredefinedPolicies.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesPager) NextPage(ctx context.Context) (ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAvailableSSLPredefinedPoliciesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse page.
-func (p *ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesPager) PageResponse() ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ApplicationGatewaysClientListPager provides operations for iterating over paged responses.
 type ApplicationGatewaysClientListPager struct {
 	client    *ApplicationGatewaysClient
 	current   ApplicationGatewaysClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ApplicationGatewaysClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ApplicationGatewaysClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ApplicationGatewaysClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ApplicationGatewaysClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ApplicationGatewayListResult.NextLink == nil || len(*p.current.ApplicationGatewayListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ApplicationGatewaysClientListPager) NextPage(ctx context.Context) (ApplicationGatewaysClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ApplicationGatewaysClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ApplicationGatewaysClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationGatewaysClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ApplicationGatewaysClientListResponse page.
-func (p *ApplicationGatewaysClientListPager) PageResponse() ApplicationGatewaysClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ApplicationSecurityGroupsClientListAllPager provides operations for iterating over paged responses.
 type ApplicationSecurityGroupsClientListAllPager struct {
 	client    *ApplicationSecurityGroupsClient
 	current   ApplicationSecurityGroupsClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ApplicationSecurityGroupsClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ApplicationSecurityGroupsClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ApplicationSecurityGroupsClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ApplicationSecurityGroupsClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ApplicationSecurityGroupListResult.NextLink == nil || len(*p.current.ApplicationSecurityGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ApplicationSecurityGroupsClientListAllPager) NextPage(ctx context.Context) (ApplicationSecurityGroupsClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ApplicationSecurityGroupsClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationSecurityGroupsClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationSecurityGroupsClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ApplicationSecurityGroupsClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationSecurityGroupsClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ApplicationSecurityGroupsClientListAllResponse page.
-func (p *ApplicationSecurityGroupsClientListAllPager) PageResponse() ApplicationSecurityGroupsClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ApplicationSecurityGroupsClientListPager provides operations for iterating over paged responses.
 type ApplicationSecurityGroupsClientListPager struct {
 	client    *ApplicationSecurityGroupsClient
 	current   ApplicationSecurityGroupsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ApplicationSecurityGroupsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ApplicationSecurityGroupsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ApplicationSecurityGroupsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ApplicationSecurityGroupsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ApplicationSecurityGroupListResult.NextLink == nil || len(*p.current.ApplicationSecurityGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ApplicationSecurityGroupsClientListPager) NextPage(ctx context.Context) (ApplicationSecurityGroupsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ApplicationSecurityGroupsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationSecurityGroupsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationSecurityGroupsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ApplicationSecurityGroupsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ApplicationSecurityGroupsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ApplicationSecurityGroupsClientListResponse page.
-func (p *ApplicationSecurityGroupsClientListPager) PageResponse() ApplicationSecurityGroupsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailableDelegationsClientListPager provides operations for iterating over paged responses.
 type AvailableDelegationsClientListPager struct {
 	client    *AvailableDelegationsClient
 	current   AvailableDelegationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailableDelegationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailableDelegationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailableDelegationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailableDelegationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AvailableDelegationsResult.NextLink == nil || len(*p.current.AvailableDelegationsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailableDelegationsClientListPager) NextPage(ctx context.Context) (AvailableDelegationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailableDelegationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableDelegationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableDelegationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailableDelegationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableDelegationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailableDelegationsClientListResponse page.
-func (p *AvailableDelegationsClientListPager) PageResponse() AvailableDelegationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailableEndpointServicesClientListPager provides operations for iterating over paged responses.
 type AvailableEndpointServicesClientListPager struct {
 	client    *AvailableEndpointServicesClient
 	current   AvailableEndpointServicesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailableEndpointServicesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailableEndpointServicesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailableEndpointServicesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailableEndpointServicesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.EndpointServicesListResult.NextLink == nil || len(*p.current.EndpointServicesListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailableEndpointServicesClientListPager) NextPage(ctx context.Context) (AvailableEndpointServicesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailableEndpointServicesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableEndpointServicesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableEndpointServicesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailableEndpointServicesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableEndpointServicesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailableEndpointServicesClientListResponse page.
-func (p *AvailableEndpointServicesClientListPager) PageResponse() AvailableEndpointServicesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailablePrivateEndpointTypesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type AvailablePrivateEndpointTypesClientListByResourceGroupPager struct {
 	client    *AvailablePrivateEndpointTypesClient
 	current   AvailablePrivateEndpointTypesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailablePrivateEndpointTypesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailablePrivateEndpointTypesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailablePrivateEndpointTypesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailablePrivateEndpointTypesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AvailablePrivateEndpointTypesResult.NextLink == nil || len(*p.current.AvailablePrivateEndpointTypesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailablePrivateEndpointTypesClientListByResourceGroupPager) NextPage(ctx context.Context) (AvailablePrivateEndpointTypesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailablePrivateEndpointTypesClientListByResourceGroupResponse page.
-func (p *AvailablePrivateEndpointTypesClientListByResourceGroupPager) PageResponse() AvailablePrivateEndpointTypesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailablePrivateEndpointTypesClientListPager provides operations for iterating over paged responses.
 type AvailablePrivateEndpointTypesClientListPager struct {
 	client    *AvailablePrivateEndpointTypesClient
 	current   AvailablePrivateEndpointTypesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailablePrivateEndpointTypesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailablePrivateEndpointTypesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailablePrivateEndpointTypesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailablePrivateEndpointTypesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AvailablePrivateEndpointTypesResult.NextLink == nil || len(*p.current.AvailablePrivateEndpointTypesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailablePrivateEndpointTypesClientListPager) NextPage(ctx context.Context) (AvailablePrivateEndpointTypesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailablePrivateEndpointTypesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailablePrivateEndpointTypesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailablePrivateEndpointTypesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailablePrivateEndpointTypesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailablePrivateEndpointTypesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailablePrivateEndpointTypesClientListResponse page.
-func (p *AvailablePrivateEndpointTypesClientListPager) PageResponse() AvailablePrivateEndpointTypesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailableResourceGroupDelegationsClientListPager provides operations for iterating over paged responses.
 type AvailableResourceGroupDelegationsClientListPager struct {
 	client    *AvailableResourceGroupDelegationsClient
 	current   AvailableResourceGroupDelegationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailableResourceGroupDelegationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailableResourceGroupDelegationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailableResourceGroupDelegationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailableResourceGroupDelegationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AvailableDelegationsResult.NextLink == nil || len(*p.current.AvailableDelegationsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailableResourceGroupDelegationsClientListPager) NextPage(ctx context.Context) (AvailableResourceGroupDelegationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailableResourceGroupDelegationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableResourceGroupDelegationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableResourceGroupDelegationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailableResourceGroupDelegationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableResourceGroupDelegationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailableResourceGroupDelegationsClientListResponse page.
-func (p *AvailableResourceGroupDelegationsClientListPager) PageResponse() AvailableResourceGroupDelegationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailableServiceAliasesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type AvailableServiceAliasesClientListByResourceGroupPager struct {
 	client    *AvailableServiceAliasesClient
 	current   AvailableServiceAliasesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailableServiceAliasesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailableServiceAliasesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailableServiceAliasesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailableServiceAliasesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AvailableServiceAliasesResult.NextLink == nil || len(*p.current.AvailableServiceAliasesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailableServiceAliasesClientListByResourceGroupPager) NextPage(ctx context.Context) (AvailableServiceAliasesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailableServiceAliasesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableServiceAliasesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableServiceAliasesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailableServiceAliasesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableServiceAliasesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailableServiceAliasesClientListByResourceGroupResponse page.
-func (p *AvailableServiceAliasesClientListByResourceGroupPager) PageResponse() AvailableServiceAliasesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AvailableServiceAliasesClientListPager provides operations for iterating over paged responses.
 type AvailableServiceAliasesClientListPager struct {
 	client    *AvailableServiceAliasesClient
 	current   AvailableServiceAliasesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AvailableServiceAliasesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AvailableServiceAliasesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AvailableServiceAliasesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AvailableServiceAliasesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AvailableServiceAliasesResult.NextLink == nil || len(*p.current.AvailableServiceAliasesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailableServiceAliasesClientListPager) NextPage(ctx context.Context) (AvailableServiceAliasesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AvailableServiceAliasesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableServiceAliasesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableServiceAliasesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AvailableServiceAliasesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AvailableServiceAliasesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AvailableServiceAliasesClientListResponse page.
-func (p *AvailableServiceAliasesClientListPager) PageResponse() AvailableServiceAliasesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AzureFirewallFqdnTagsClientListAllPager provides operations for iterating over paged responses.
 type AzureFirewallFqdnTagsClientListAllPager struct {
 	client    *AzureFirewallFqdnTagsClient
 	current   AzureFirewallFqdnTagsClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AzureFirewallFqdnTagsClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AzureFirewallFqdnTagsClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AzureFirewallFqdnTagsClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AzureFirewallFqdnTagsClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AzureFirewallFqdnTagListResult.NextLink == nil || len(*p.current.AzureFirewallFqdnTagListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AzureFirewallFqdnTagsClientListAllPager) NextPage(ctx context.Context) (AzureFirewallFqdnTagsClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AzureFirewallFqdnTagsClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallFqdnTagsClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallFqdnTagsClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AzureFirewallFqdnTagsClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallFqdnTagsClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AzureFirewallFqdnTagsClientListAllResponse page.
-func (p *AzureFirewallFqdnTagsClientListAllPager) PageResponse() AzureFirewallFqdnTagsClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AzureFirewallsClientListAllPager provides operations for iterating over paged responses.
 type AzureFirewallsClientListAllPager struct {
 	client    *AzureFirewallsClient
 	current   AzureFirewallsClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AzureFirewallsClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AzureFirewallsClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AzureFirewallsClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AzureFirewallsClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AzureFirewallListResult.NextLink == nil || len(*p.current.AzureFirewallListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AzureFirewallsClientListAllPager) NextPage(ctx context.Context) (AzureFirewallsClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AzureFirewallsClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallsClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallsClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AzureFirewallsClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallsClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AzureFirewallsClientListAllResponse page.
-func (p *AzureFirewallsClientListAllPager) PageResponse() AzureFirewallsClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // AzureFirewallsClientListPager provides operations for iterating over paged responses.
 type AzureFirewallsClientListPager struct {
 	client    *AzureFirewallsClient
 	current   AzureFirewallsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, AzureFirewallsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *AzureFirewallsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *AzureFirewallsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *AzureFirewallsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AzureFirewallListResult.NextLink == nil || len(*p.current.AzureFirewallListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *AzureFirewallsClientListPager) NextPage(ctx context.Context) (AzureFirewallsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return AzureFirewallsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return AzureFirewallsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return AzureFirewallsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current AzureFirewallsClientListResponse page.
-func (p *AzureFirewallsClientListPager) PageResponse() AzureFirewallsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // BastionHostsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type BastionHostsClientListByResourceGroupPager struct {
 	client    *BastionHostsClient
 	current   BastionHostsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, BastionHostsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *BastionHostsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *BastionHostsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *BastionHostsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BastionHostListResult.NextLink == nil || len(*p.current.BastionHostListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *BastionHostsClientListByResourceGroupPager) NextPage(ctx context.Context) (BastionHostsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return BastionHostsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return BastionHostsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BastionHostsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return BastionHostsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BastionHostsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current BastionHostsClientListByResourceGroupResponse page.
-func (p *BastionHostsClientListByResourceGroupPager) PageResponse() BastionHostsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // BastionHostsClientListPager provides operations for iterating over paged responses.
 type BastionHostsClientListPager struct {
 	client    *BastionHostsClient
 	current   BastionHostsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, BastionHostsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *BastionHostsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *BastionHostsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *BastionHostsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BastionHostListResult.NextLink == nil || len(*p.current.BastionHostListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *BastionHostsClientListPager) NextPage(ctx context.Context) (BastionHostsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return BastionHostsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return BastionHostsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BastionHostsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return BastionHostsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BastionHostsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current BastionHostsClientListResponse page.
-func (p *BastionHostsClientListPager) PageResponse() BastionHostsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // BgpServiceCommunitiesClientListPager provides operations for iterating over paged responses.
 type BgpServiceCommunitiesClientListPager struct {
 	client    *BgpServiceCommunitiesClient
 	current   BgpServiceCommunitiesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, BgpServiceCommunitiesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *BgpServiceCommunitiesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *BgpServiceCommunitiesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *BgpServiceCommunitiesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BgpServiceCommunityListResult.NextLink == nil || len(*p.current.BgpServiceCommunityListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *BgpServiceCommunitiesClientListPager) NextPage(ctx context.Context) (BgpServiceCommunitiesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return BgpServiceCommunitiesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return BgpServiceCommunitiesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BgpServiceCommunitiesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return BgpServiceCommunitiesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return BgpServiceCommunitiesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current BgpServiceCommunitiesClientListResponse page.
-func (p *BgpServiceCommunitiesClientListPager) PageResponse() BgpServiceCommunitiesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DdosProtectionPlansClientListByResourceGroupPager provides operations for iterating over paged responses.
 type DdosProtectionPlansClientListByResourceGroupPager struct {
 	client    *DdosProtectionPlansClient
 	current   DdosProtectionPlansClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DdosProtectionPlansClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DdosProtectionPlansClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DdosProtectionPlansClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DdosProtectionPlansClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DdosProtectionPlanListResult.NextLink == nil || len(*p.current.DdosProtectionPlanListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DdosProtectionPlansClientListByResourceGroupPager) NextPage(ctx context.Context) (DdosProtectionPlansClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DdosProtectionPlansClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DdosProtectionPlansClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DdosProtectionPlansClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DdosProtectionPlansClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DdosProtectionPlansClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DdosProtectionPlansClientListByResourceGroupResponse page.
-func (p *DdosProtectionPlansClientListByResourceGroupPager) PageResponse() DdosProtectionPlansClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DdosProtectionPlansClientListPager provides operations for iterating over paged responses.
 type DdosProtectionPlansClientListPager struct {
 	client    *DdosProtectionPlansClient
 	current   DdosProtectionPlansClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DdosProtectionPlansClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DdosProtectionPlansClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DdosProtectionPlansClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DdosProtectionPlansClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DdosProtectionPlanListResult.NextLink == nil || len(*p.current.DdosProtectionPlanListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DdosProtectionPlansClientListPager) NextPage(ctx context.Context) (DdosProtectionPlansClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DdosProtectionPlansClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DdosProtectionPlansClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DdosProtectionPlansClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DdosProtectionPlansClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DdosProtectionPlansClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DdosProtectionPlansClientListResponse page.
-func (p *DdosProtectionPlansClientListPager) PageResponse() DdosProtectionPlansClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // DefaultSecurityRulesClientListPager provides operations for iterating over paged responses.
 type DefaultSecurityRulesClientListPager struct {
 	client    *DefaultSecurityRulesClient
 	current   DefaultSecurityRulesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, DefaultSecurityRulesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *DefaultSecurityRulesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *DefaultSecurityRulesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *DefaultSecurityRulesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SecurityRuleListResult.NextLink == nil || len(*p.current.SecurityRuleListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *DefaultSecurityRulesClientListPager) NextPage(ctx context.Context) (DefaultSecurityRulesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return DefaultSecurityRulesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return DefaultSecurityRulesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DefaultSecurityRulesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return DefaultSecurityRulesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return DefaultSecurityRulesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current DefaultSecurityRulesClientListResponse page.
-func (p *DefaultSecurityRulesClientListPager) PageResponse() DefaultSecurityRulesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteCircuitAuthorizationsClientListPager provides operations for iterating over paged responses.
 type ExpressRouteCircuitAuthorizationsClientListPager struct {
 	client    *ExpressRouteCircuitAuthorizationsClient
 	current   ExpressRouteCircuitAuthorizationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteCircuitAuthorizationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteCircuitAuthorizationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteCircuitAuthorizationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteCircuitAuthorizationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AuthorizationListResult.NextLink == nil || len(*p.current.AuthorizationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteCircuitAuthorizationsClientListPager) NextPage(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteCircuitAuthorizationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitAuthorizationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitAuthorizationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteCircuitAuthorizationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitAuthorizationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteCircuitAuthorizationsClientListResponse page.
-func (p *ExpressRouteCircuitAuthorizationsClientListPager) PageResponse() ExpressRouteCircuitAuthorizationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteCircuitConnectionsClientListPager provides operations for iterating over paged responses.
 type ExpressRouteCircuitConnectionsClientListPager struct {
 	client    *ExpressRouteCircuitConnectionsClient
 	current   ExpressRouteCircuitConnectionsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteCircuitConnectionsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteCircuitConnectionsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteCircuitConnectionsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteCircuitConnectionsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteCircuitConnectionListResult.NextLink == nil || len(*p.current.ExpressRouteCircuitConnectionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteCircuitConnectionsClientListPager) NextPage(ctx context.Context) (ExpressRouteCircuitConnectionsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteCircuitConnectionsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitConnectionsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitConnectionsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteCircuitConnectionsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitConnectionsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteCircuitConnectionsClientListResponse page.
-func (p *ExpressRouteCircuitConnectionsClientListPager) PageResponse() ExpressRouteCircuitConnectionsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteCircuitPeeringsClientListPager provides operations for iterating over paged responses.
 type ExpressRouteCircuitPeeringsClientListPager struct {
 	client    *ExpressRouteCircuitPeeringsClient
 	current   ExpressRouteCircuitPeeringsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteCircuitPeeringsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteCircuitPeeringsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteCircuitPeeringsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteCircuitPeeringsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteCircuitPeeringListResult.NextLink == nil || len(*p.current.ExpressRouteCircuitPeeringListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteCircuitPeeringsClientListPager) NextPage(ctx context.Context) (ExpressRouteCircuitPeeringsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteCircuitPeeringsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitPeeringsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitPeeringsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteCircuitPeeringsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitPeeringsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteCircuitPeeringsClientListResponse page.
-func (p *ExpressRouteCircuitPeeringsClientListPager) PageResponse() ExpressRouteCircuitPeeringsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteCircuitsClientListAllPager provides operations for iterating over paged responses.
 type ExpressRouteCircuitsClientListAllPager struct {
 	client    *ExpressRouteCircuitsClient
 	current   ExpressRouteCircuitsClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteCircuitsClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteCircuitsClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteCircuitsClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteCircuitsClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteCircuitListResult.NextLink == nil || len(*p.current.ExpressRouteCircuitListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteCircuitsClientListAllPager) NextPage(ctx context.Context) (ExpressRouteCircuitsClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteCircuitsClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitsClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitsClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteCircuitsClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitsClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteCircuitsClientListAllResponse page.
-func (p *ExpressRouteCircuitsClientListAllPager) PageResponse() ExpressRouteCircuitsClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteCircuitsClientListPager provides operations for iterating over paged responses.
 type ExpressRouteCircuitsClientListPager struct {
 	client    *ExpressRouteCircuitsClient
 	current   ExpressRouteCircuitsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteCircuitsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteCircuitsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteCircuitsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteCircuitsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteCircuitListResult.NextLink == nil || len(*p.current.ExpressRouteCircuitListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteCircuitsClientListPager) NextPage(ctx context.Context) (ExpressRouteCircuitsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteCircuitsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteCircuitsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCircuitsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteCircuitsClientListResponse page.
-func (p *ExpressRouteCircuitsClientListPager) PageResponse() ExpressRouteCircuitsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteCrossConnectionPeeringsClientListPager provides operations for iterating over paged responses.
 type ExpressRouteCrossConnectionPeeringsClientListPager struct {
 	client    *ExpressRouteCrossConnectionPeeringsClient
 	current   ExpressRouteCrossConnectionPeeringsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteCrossConnectionPeeringsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteCrossConnectionPeeringsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteCrossConnectionPeeringsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteCrossConnectionPeeringsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteCrossConnectionPeeringList.NextLink == nil || len(*p.current.ExpressRouteCrossConnectionPeeringList.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteCrossConnectionPeeringsClientListPager) NextPage(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteCrossConnectionPeeringsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionPeeringsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionPeeringsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteCrossConnectionPeeringsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionPeeringsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteCrossConnectionPeeringsClientListResponse page.
-func (p *ExpressRouteCrossConnectionPeeringsClientListPager) PageResponse() ExpressRouteCrossConnectionPeeringsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteCrossConnectionsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type ExpressRouteCrossConnectionsClientListByResourceGroupPager struct {
 	client    *ExpressRouteCrossConnectionsClient
 	current   ExpressRouteCrossConnectionsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteCrossConnectionsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteCrossConnectionsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteCrossConnectionsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteCrossConnectionsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteCrossConnectionListResult.NextLink == nil || len(*p.current.ExpressRouteCrossConnectionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteCrossConnectionsClientListByResourceGroupPager) NextPage(ctx context.Context) (ExpressRouteCrossConnectionsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteCrossConnectionsClientListByResourceGroupResponse page.
-func (p *ExpressRouteCrossConnectionsClientListByResourceGroupPager) PageResponse() ExpressRouteCrossConnectionsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteCrossConnectionsClientListPager provides operations for iterating over paged responses.
 type ExpressRouteCrossConnectionsClientListPager struct {
 	client    *ExpressRouteCrossConnectionsClient
 	current   ExpressRouteCrossConnectionsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteCrossConnectionsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteCrossConnectionsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteCrossConnectionsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteCrossConnectionsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteCrossConnectionListResult.NextLink == nil || len(*p.current.ExpressRouteCrossConnectionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteCrossConnectionsClientListPager) NextPage(ctx context.Context) (ExpressRouteCrossConnectionsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteCrossConnectionsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteCrossConnectionsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteCrossConnectionsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteCrossConnectionsClientListResponse page.
-func (p *ExpressRouteCrossConnectionsClientListPager) PageResponse() ExpressRouteCrossConnectionsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteLinksClientListPager provides operations for iterating over paged responses.
 type ExpressRouteLinksClientListPager struct {
 	client    *ExpressRouteLinksClient
 	current   ExpressRouteLinksClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteLinksClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteLinksClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteLinksClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteLinksClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteLinkListResult.NextLink == nil || len(*p.current.ExpressRouteLinkListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteLinksClientListPager) NextPage(ctx context.Context) (ExpressRouteLinksClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteLinksClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteLinksClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteLinksClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteLinksClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteLinksClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteLinksClientListResponse page.
-func (p *ExpressRouteLinksClientListPager) PageResponse() ExpressRouteLinksClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRoutePortsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type ExpressRoutePortsClientListByResourceGroupPager struct {
 	client    *ExpressRoutePortsClient
 	current   ExpressRoutePortsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRoutePortsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRoutePortsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRoutePortsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRoutePortsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRoutePortListResult.NextLink == nil || len(*p.current.ExpressRoutePortListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRoutePortsClientListByResourceGroupPager) NextPage(ctx context.Context) (ExpressRoutePortsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRoutePortsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRoutePortsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRoutePortsClientListByResourceGroupResponse page.
-func (p *ExpressRoutePortsClientListByResourceGroupPager) PageResponse() ExpressRoutePortsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRoutePortsClientListPager provides operations for iterating over paged responses.
 type ExpressRoutePortsClientListPager struct {
 	client    *ExpressRoutePortsClient
 	current   ExpressRoutePortsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRoutePortsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRoutePortsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRoutePortsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRoutePortsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRoutePortListResult.NextLink == nil || len(*p.current.ExpressRoutePortListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRoutePortsClientListPager) NextPage(ctx context.Context) (ExpressRoutePortsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRoutePortsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRoutePortsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRoutePortsClientListResponse page.
-func (p *ExpressRoutePortsClientListPager) PageResponse() ExpressRoutePortsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRoutePortsLocationsClientListPager provides operations for iterating over paged responses.
 type ExpressRoutePortsLocationsClientListPager struct {
 	client    *ExpressRoutePortsLocationsClient
 	current   ExpressRoutePortsLocationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRoutePortsLocationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRoutePortsLocationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRoutePortsLocationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRoutePortsLocationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRoutePortsLocationListResult.NextLink == nil || len(*p.current.ExpressRoutePortsLocationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRoutePortsLocationsClientListPager) NextPage(ctx context.Context) (ExpressRoutePortsLocationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRoutePortsLocationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsLocationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsLocationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRoutePortsLocationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRoutePortsLocationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRoutePortsLocationsClientListResponse page.
-func (p *ExpressRoutePortsLocationsClientListPager) PageResponse() ExpressRoutePortsLocationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ExpressRouteServiceProvidersClientListPager provides operations for iterating over paged responses.
 type ExpressRouteServiceProvidersClientListPager struct {
 	client    *ExpressRouteServiceProvidersClient
 	current   ExpressRouteServiceProvidersClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ExpressRouteServiceProvidersClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ExpressRouteServiceProvidersClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ExpressRouteServiceProvidersClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ExpressRouteServiceProvidersClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ExpressRouteServiceProviderListResult.NextLink == nil || len(*p.current.ExpressRouteServiceProviderListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ExpressRouteServiceProvidersClientListPager) NextPage(ctx context.Context) (ExpressRouteServiceProvidersClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ExpressRouteServiceProvidersClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteServiceProvidersClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteServiceProvidersClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ExpressRouteServiceProvidersClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ExpressRouteServiceProvidersClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ExpressRouteServiceProvidersClientListResponse page.
-func (p *ExpressRouteServiceProvidersClientListPager) PageResponse() ExpressRouteServiceProvidersClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // FirewallPoliciesClientListAllPager provides operations for iterating over paged responses.
 type FirewallPoliciesClientListAllPager struct {
 	client    *FirewallPoliciesClient
 	current   FirewallPoliciesClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, FirewallPoliciesClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *FirewallPoliciesClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *FirewallPoliciesClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *FirewallPoliciesClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.FirewallPolicyListResult.NextLink == nil || len(*p.current.FirewallPolicyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *FirewallPoliciesClientListAllPager) NextPage(ctx context.Context) (FirewallPoliciesClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return FirewallPoliciesClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPoliciesClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPoliciesClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return FirewallPoliciesClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPoliciesClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current FirewallPoliciesClientListAllResponse page.
-func (p *FirewallPoliciesClientListAllPager) PageResponse() FirewallPoliciesClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // FirewallPoliciesClientListPager provides operations for iterating over paged responses.
 type FirewallPoliciesClientListPager struct {
 	client    *FirewallPoliciesClient
 	current   FirewallPoliciesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, FirewallPoliciesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *FirewallPoliciesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *FirewallPoliciesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *FirewallPoliciesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.FirewallPolicyListResult.NextLink == nil || len(*p.current.FirewallPolicyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *FirewallPoliciesClientListPager) NextPage(ctx context.Context) (FirewallPoliciesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return FirewallPoliciesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPoliciesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPoliciesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return FirewallPoliciesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPoliciesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current FirewallPoliciesClientListResponse page.
-func (p *FirewallPoliciesClientListPager) PageResponse() FirewallPoliciesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // FirewallPolicyRuleGroupsClientListPager provides operations for iterating over paged responses.
 type FirewallPolicyRuleGroupsClientListPager struct {
 	client    *FirewallPolicyRuleGroupsClient
 	current   FirewallPolicyRuleGroupsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, FirewallPolicyRuleGroupsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *FirewallPolicyRuleGroupsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *FirewallPolicyRuleGroupsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *FirewallPolicyRuleGroupsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.FirewallPolicyRuleGroupListResult.NextLink == nil || len(*p.current.FirewallPolicyRuleGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *FirewallPolicyRuleGroupsClientListPager) NextPage(ctx context.Context) (FirewallPolicyRuleGroupsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return FirewallPolicyRuleGroupsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPolicyRuleGroupsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPolicyRuleGroupsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return FirewallPolicyRuleGroupsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return FirewallPolicyRuleGroupsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current FirewallPolicyRuleGroupsClientListResponse page.
-func (p *FirewallPolicyRuleGroupsClientListPager) PageResponse() FirewallPolicyRuleGroupsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // FlowLogsClientListPager provides operations for iterating over paged responses.
 type FlowLogsClientListPager struct {
 	client    *FlowLogsClient
 	current   FlowLogsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, FlowLogsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *FlowLogsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *FlowLogsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *FlowLogsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.FlowLogListResult.NextLink == nil || len(*p.current.FlowLogListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *FlowLogsClientListPager) NextPage(ctx context.Context) (FlowLogsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return FlowLogsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return FlowLogsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return FlowLogsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return FlowLogsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return FlowLogsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current FlowLogsClientListResponse page.
-func (p *FlowLogsClientListPager) PageResponse() FlowLogsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // HubVirtualNetworkConnectionsClientListPager provides operations for iterating over paged responses.
 type HubVirtualNetworkConnectionsClientListPager struct {
 	client    *HubVirtualNetworkConnectionsClient
 	current   HubVirtualNetworkConnectionsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, HubVirtualNetworkConnectionsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *HubVirtualNetworkConnectionsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *HubVirtualNetworkConnectionsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *HubVirtualNetworkConnectionsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListHubVirtualNetworkConnectionsResult.NextLink == nil || len(*p.current.ListHubVirtualNetworkConnectionsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *HubVirtualNetworkConnectionsClientListPager) NextPage(ctx context.Context) (HubVirtualNetworkConnectionsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return HubVirtualNetworkConnectionsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return HubVirtualNetworkConnectionsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return HubVirtualNetworkConnectionsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return HubVirtualNetworkConnectionsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return HubVirtualNetworkConnectionsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current HubVirtualNetworkConnectionsClientListResponse page.
-func (p *HubVirtualNetworkConnectionsClientListPager) PageResponse() HubVirtualNetworkConnectionsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // IPAllocationsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type IPAllocationsClientListByResourceGroupPager struct {
 	client    *IPAllocationsClient
 	current   IPAllocationsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, IPAllocationsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *IPAllocationsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *IPAllocationsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *IPAllocationsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.IPAllocationListResult.NextLink == nil || len(*p.current.IPAllocationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *IPAllocationsClientListByResourceGroupPager) NextPage(ctx context.Context) (IPAllocationsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return IPAllocationsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPAllocationsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPAllocationsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return IPAllocationsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPAllocationsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current IPAllocationsClientListByResourceGroupResponse page.
-func (p *IPAllocationsClientListByResourceGroupPager) PageResponse() IPAllocationsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // IPAllocationsClientListPager provides operations for iterating over paged responses.
 type IPAllocationsClientListPager struct {
 	client    *IPAllocationsClient
 	current   IPAllocationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, IPAllocationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *IPAllocationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *IPAllocationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *IPAllocationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.IPAllocationListResult.NextLink == nil || len(*p.current.IPAllocationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *IPAllocationsClientListPager) NextPage(ctx context.Context) (IPAllocationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return IPAllocationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPAllocationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPAllocationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return IPAllocationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPAllocationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current IPAllocationsClientListResponse page.
-func (p *IPAllocationsClientListPager) PageResponse() IPAllocationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // IPGroupsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type IPGroupsClientListByResourceGroupPager struct {
 	client    *IPGroupsClient
 	current   IPGroupsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, IPGroupsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *IPGroupsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *IPGroupsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *IPGroupsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.IPGroupListResult.NextLink == nil || len(*p.current.IPGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *IPGroupsClientListByResourceGroupPager) NextPage(ctx context.Context) (IPGroupsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return IPGroupsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPGroupsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPGroupsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return IPGroupsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPGroupsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current IPGroupsClientListByResourceGroupResponse page.
-func (p *IPGroupsClientListByResourceGroupPager) PageResponse() IPGroupsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // IPGroupsClientListPager provides operations for iterating over paged responses.
 type IPGroupsClientListPager struct {
 	client    *IPGroupsClient
 	current   IPGroupsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, IPGroupsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *IPGroupsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *IPGroupsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *IPGroupsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.IPGroupListResult.NextLink == nil || len(*p.current.IPGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *IPGroupsClientListPager) NextPage(ctx context.Context) (IPGroupsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return IPGroupsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPGroupsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPGroupsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return IPGroupsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return IPGroupsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current IPGroupsClientListResponse page.
-func (p *IPGroupsClientListPager) PageResponse() IPGroupsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InboundNatRulesClientListPager provides operations for iterating over paged responses.
 type InboundNatRulesClientListPager struct {
 	client    *InboundNatRulesClient
 	current   InboundNatRulesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InboundNatRulesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InboundNatRulesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InboundNatRulesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InboundNatRulesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InboundNatRuleListResult.NextLink == nil || len(*p.current.InboundNatRuleListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InboundNatRulesClientListPager) NextPage(ctx context.Context) (InboundNatRulesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InboundNatRulesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InboundNatRulesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InboundNatRulesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InboundNatRulesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InboundNatRulesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InboundNatRulesClientListResponse page.
-func (p *InboundNatRulesClientListPager) PageResponse() InboundNatRulesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InterfaceIPConfigurationsClientListPager provides operations for iterating over paged responses.
 type InterfaceIPConfigurationsClientListPager struct {
 	client    *InterfaceIPConfigurationsClient
 	current   InterfaceIPConfigurationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InterfaceIPConfigurationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InterfaceIPConfigurationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InterfaceIPConfigurationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InterfaceIPConfigurationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceIPConfigurationListResult.NextLink == nil || len(*p.current.InterfaceIPConfigurationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InterfaceIPConfigurationsClientListPager) NextPage(ctx context.Context) (InterfaceIPConfigurationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InterfaceIPConfigurationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceIPConfigurationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceIPConfigurationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InterfaceIPConfigurationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceIPConfigurationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InterfaceIPConfigurationsClientListResponse page.
-func (p *InterfaceIPConfigurationsClientListPager) PageResponse() InterfaceIPConfigurationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InterfaceLoadBalancersClientListPager provides operations for iterating over paged responses.
 type InterfaceLoadBalancersClientListPager struct {
 	client    *InterfaceLoadBalancersClient
 	current   InterfaceLoadBalancersClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InterfaceLoadBalancersClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InterfaceLoadBalancersClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InterfaceLoadBalancersClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InterfaceLoadBalancersClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceLoadBalancerListResult.NextLink == nil || len(*p.current.InterfaceLoadBalancerListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InterfaceLoadBalancersClientListPager) NextPage(ctx context.Context) (InterfaceLoadBalancersClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InterfaceLoadBalancersClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceLoadBalancersClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceLoadBalancersClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InterfaceLoadBalancersClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceLoadBalancersClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InterfaceLoadBalancersClientListResponse page.
-func (p *InterfaceLoadBalancersClientListPager) PageResponse() InterfaceLoadBalancersClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InterfaceTapConfigurationsClientListPager provides operations for iterating over paged responses.
 type InterfaceTapConfigurationsClientListPager struct {
 	client    *InterfaceTapConfigurationsClient
 	current   InterfaceTapConfigurationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InterfaceTapConfigurationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InterfaceTapConfigurationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InterfaceTapConfigurationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InterfaceTapConfigurationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceTapConfigurationListResult.NextLink == nil || len(*p.current.InterfaceTapConfigurationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InterfaceTapConfigurationsClientListPager) NextPage(ctx context.Context) (InterfaceTapConfigurationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InterfaceTapConfigurationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceTapConfigurationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceTapConfigurationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InterfaceTapConfigurationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfaceTapConfigurationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InterfaceTapConfigurationsClientListResponse page.
-func (p *InterfaceTapConfigurationsClientListPager) PageResponse() InterfaceTapConfigurationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InterfacesClientListAllPager provides operations for iterating over paged responses.
 type InterfacesClientListAllPager struct {
 	client    *InterfacesClient
 	current   InterfacesClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InterfacesClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InterfacesClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InterfacesClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InterfacesClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InterfacesClientListAllPager) NextPage(ctx context.Context) (InterfacesClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InterfacesClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InterfacesClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InterfacesClientListAllResponse page.
-func (p *InterfacesClientListAllPager) PageResponse() InterfacesClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InterfacesClientListPager provides operations for iterating over paged responses.
 type InterfacesClientListPager struct {
 	client    *InterfacesClient
 	current   InterfacesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InterfacesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InterfacesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InterfacesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InterfacesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InterfacesClientListPager) NextPage(ctx context.Context) (InterfacesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InterfacesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InterfacesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InterfacesClientListResponse page.
-func (p *InterfacesClientListPager) PageResponse() InterfacesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InterfacesClientListVirtualMachineScaleSetIPConfigurationsPager provides operations for iterating over paged responses.
 type InterfacesClientListVirtualMachineScaleSetIPConfigurationsPager struct {
 	client    *InterfacesClient
 	current   InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InterfacesClientListVirtualMachineScaleSetIPConfigurationsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InterfacesClientListVirtualMachineScaleSetIPConfigurationsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InterfacesClientListVirtualMachineScaleSetIPConfigurationsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceIPConfigurationListResult.NextLink == nil || len(*p.current.InterfaceIPConfigurationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InterfacesClientListVirtualMachineScaleSetIPConfigurationsPager) NextPage(ctx context.Context) (InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listVirtualMachineScaleSetIPConfigurationsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse page.
-func (p *InterfacesClientListVirtualMachineScaleSetIPConfigurationsPager) PageResponse() InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InterfacesClientListVirtualMachineScaleSetNetworkInterfacesPager provides operations for iterating over paged responses.
 type InterfacesClientListVirtualMachineScaleSetNetworkInterfacesPager struct {
 	client    *InterfacesClient
 	current   InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InterfacesClientListVirtualMachineScaleSetNetworkInterfacesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InterfacesClientListVirtualMachineScaleSetNetworkInterfacesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InterfacesClientListVirtualMachineScaleSetNetworkInterfacesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InterfacesClientListVirtualMachineScaleSetNetworkInterfacesPager) NextPage(ctx context.Context) (InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listVirtualMachineScaleSetNetworkInterfacesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse page.
-func (p *InterfacesClientListVirtualMachineScaleSetNetworkInterfacesPager) PageResponse() InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesPager provides operations for iterating over paged responses.
 type InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesPager struct {
 	client    *InterfacesClient
 	current   InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesPager) NextPage(ctx context.Context) (InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse page.
-func (p *InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesPager) PageResponse() InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LoadBalancerBackendAddressPoolsClientListPager provides operations for iterating over paged responses.
 type LoadBalancerBackendAddressPoolsClientListPager struct {
 	client    *LoadBalancerBackendAddressPoolsClient
 	current   LoadBalancerBackendAddressPoolsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LoadBalancerBackendAddressPoolsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LoadBalancerBackendAddressPoolsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LoadBalancerBackendAddressPoolsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LoadBalancerBackendAddressPoolsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LoadBalancerBackendAddressPoolListResult.NextLink == nil || len(*p.current.LoadBalancerBackendAddressPoolListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LoadBalancerBackendAddressPoolsClientListPager) NextPage(ctx context.Context) (LoadBalancerBackendAddressPoolsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LoadBalancerBackendAddressPoolsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerBackendAddressPoolsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerBackendAddressPoolsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LoadBalancerBackendAddressPoolsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerBackendAddressPoolsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LoadBalancerBackendAddressPoolsClientListResponse page.
-func (p *LoadBalancerBackendAddressPoolsClientListPager) PageResponse() LoadBalancerBackendAddressPoolsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LoadBalancerFrontendIPConfigurationsClientListPager provides operations for iterating over paged responses.
 type LoadBalancerFrontendIPConfigurationsClientListPager struct {
 	client    *LoadBalancerFrontendIPConfigurationsClient
 	current   LoadBalancerFrontendIPConfigurationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LoadBalancerFrontendIPConfigurationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LoadBalancerFrontendIPConfigurationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LoadBalancerFrontendIPConfigurationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LoadBalancerFrontendIPConfigurationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LoadBalancerFrontendIPConfigurationListResult.NextLink == nil || len(*p.current.LoadBalancerFrontendIPConfigurationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LoadBalancerFrontendIPConfigurationsClientListPager) NextPage(ctx context.Context) (LoadBalancerFrontendIPConfigurationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LoadBalancerFrontendIPConfigurationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerFrontendIPConfigurationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerFrontendIPConfigurationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LoadBalancerFrontendIPConfigurationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerFrontendIPConfigurationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LoadBalancerFrontendIPConfigurationsClientListResponse page.
-func (p *LoadBalancerFrontendIPConfigurationsClientListPager) PageResponse() LoadBalancerFrontendIPConfigurationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LoadBalancerLoadBalancingRulesClientListPager provides operations for iterating over paged responses.
 type LoadBalancerLoadBalancingRulesClientListPager struct {
 	client    *LoadBalancerLoadBalancingRulesClient
 	current   LoadBalancerLoadBalancingRulesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LoadBalancerLoadBalancingRulesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LoadBalancerLoadBalancingRulesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LoadBalancerLoadBalancingRulesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LoadBalancerLoadBalancingRulesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LoadBalancerLoadBalancingRuleListResult.NextLink == nil || len(*p.current.LoadBalancerLoadBalancingRuleListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LoadBalancerLoadBalancingRulesClientListPager) NextPage(ctx context.Context) (LoadBalancerLoadBalancingRulesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LoadBalancerLoadBalancingRulesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerLoadBalancingRulesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerLoadBalancingRulesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LoadBalancerLoadBalancingRulesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerLoadBalancingRulesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LoadBalancerLoadBalancingRulesClientListResponse page.
-func (p *LoadBalancerLoadBalancingRulesClientListPager) PageResponse() LoadBalancerLoadBalancingRulesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LoadBalancerNetworkInterfacesClientListPager provides operations for iterating over paged responses.
 type LoadBalancerNetworkInterfacesClientListPager struct {
 	client    *LoadBalancerNetworkInterfacesClient
 	current   LoadBalancerNetworkInterfacesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LoadBalancerNetworkInterfacesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LoadBalancerNetworkInterfacesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LoadBalancerNetworkInterfacesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LoadBalancerNetworkInterfacesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.InterfaceListResult.NextLink == nil || len(*p.current.InterfaceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LoadBalancerNetworkInterfacesClientListPager) NextPage(ctx context.Context) (LoadBalancerNetworkInterfacesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LoadBalancerNetworkInterfacesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerNetworkInterfacesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerNetworkInterfacesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LoadBalancerNetworkInterfacesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerNetworkInterfacesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LoadBalancerNetworkInterfacesClientListResponse page.
-func (p *LoadBalancerNetworkInterfacesClientListPager) PageResponse() LoadBalancerNetworkInterfacesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LoadBalancerOutboundRulesClientListPager provides operations for iterating over paged responses.
 type LoadBalancerOutboundRulesClientListPager struct {
 	client    *LoadBalancerOutboundRulesClient
 	current   LoadBalancerOutboundRulesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LoadBalancerOutboundRulesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LoadBalancerOutboundRulesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LoadBalancerOutboundRulesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LoadBalancerOutboundRulesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LoadBalancerOutboundRuleListResult.NextLink == nil || len(*p.current.LoadBalancerOutboundRuleListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LoadBalancerOutboundRulesClientListPager) NextPage(ctx context.Context) (LoadBalancerOutboundRulesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LoadBalancerOutboundRulesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerOutboundRulesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerOutboundRulesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LoadBalancerOutboundRulesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerOutboundRulesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LoadBalancerOutboundRulesClientListResponse page.
-func (p *LoadBalancerOutboundRulesClientListPager) PageResponse() LoadBalancerOutboundRulesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LoadBalancerProbesClientListPager provides operations for iterating over paged responses.
 type LoadBalancerProbesClientListPager struct {
 	client    *LoadBalancerProbesClient
 	current   LoadBalancerProbesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LoadBalancerProbesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LoadBalancerProbesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LoadBalancerProbesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LoadBalancerProbesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LoadBalancerProbeListResult.NextLink == nil || len(*p.current.LoadBalancerProbeListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LoadBalancerProbesClientListPager) NextPage(ctx context.Context) (LoadBalancerProbesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LoadBalancerProbesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerProbesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerProbesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LoadBalancerProbesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancerProbesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LoadBalancerProbesClientListResponse page.
-func (p *LoadBalancerProbesClientListPager) PageResponse() LoadBalancerProbesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LoadBalancersClientListAllPager provides operations for iterating over paged responses.
 type LoadBalancersClientListAllPager struct {
 	client    *LoadBalancersClient
 	current   LoadBalancersClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LoadBalancersClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LoadBalancersClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LoadBalancersClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LoadBalancersClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LoadBalancerListResult.NextLink == nil || len(*p.current.LoadBalancerListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LoadBalancersClientListAllPager) NextPage(ctx context.Context) (LoadBalancersClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LoadBalancersClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancersClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancersClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LoadBalancersClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancersClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LoadBalancersClientListAllResponse page.
-func (p *LoadBalancersClientListAllPager) PageResponse() LoadBalancersClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LoadBalancersClientListPager provides operations for iterating over paged responses.
 type LoadBalancersClientListPager struct {
 	client    *LoadBalancersClient
 	current   LoadBalancersClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LoadBalancersClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LoadBalancersClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LoadBalancersClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LoadBalancersClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LoadBalancerListResult.NextLink == nil || len(*p.current.LoadBalancerListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LoadBalancersClientListPager) NextPage(ctx context.Context) (LoadBalancersClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LoadBalancersClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancersClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancersClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LoadBalancersClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LoadBalancersClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LoadBalancersClientListResponse page.
-func (p *LoadBalancersClientListPager) PageResponse() LoadBalancersClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // LocalNetworkGatewaysClientListPager provides operations for iterating over paged responses.
 type LocalNetworkGatewaysClientListPager struct {
 	client    *LocalNetworkGatewaysClient
 	current   LocalNetworkGatewaysClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, LocalNetworkGatewaysClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *LocalNetworkGatewaysClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *LocalNetworkGatewaysClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *LocalNetworkGatewaysClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LocalNetworkGatewayListResult.NextLink == nil || len(*p.current.LocalNetworkGatewayListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *LocalNetworkGatewaysClientListPager) NextPage(ctx context.Context) (LocalNetworkGatewaysClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return LocalNetworkGatewaysClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return LocalNetworkGatewaysClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LocalNetworkGatewaysClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return LocalNetworkGatewaysClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return LocalNetworkGatewaysClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current LocalNetworkGatewaysClientListResponse page.
-func (p *LocalNetworkGatewaysClientListPager) PageResponse() LocalNetworkGatewaysClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ManagementClientDisconnectActiveSessionsPager provides operations for iterating over paged responses.
 type ManagementClientDisconnectActiveSessionsPager struct {
 	client    *ManagementClient
 	current   ManagementClientDisconnectActiveSessionsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ManagementClientDisconnectActiveSessionsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ManagementClientDisconnectActiveSessionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ManagementClientDisconnectActiveSessionsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ManagementClientDisconnectActiveSessionsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BastionSessionDeleteResult.NextLink == nil || len(*p.current.BastionSessionDeleteResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ManagementClientDisconnectActiveSessionsPager) NextPage(ctx context.Context) (ManagementClientDisconnectActiveSessionsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ManagementClientDisconnectActiveSessionsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ManagementClientDisconnectActiveSessionsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ManagementClientDisconnectActiveSessionsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ManagementClientDisconnectActiveSessionsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.disconnectActiveSessionsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ManagementClientDisconnectActiveSessionsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ManagementClientDisconnectActiveSessionsResponse page.
-func (p *ManagementClientDisconnectActiveSessionsPager) PageResponse() ManagementClientDisconnectActiveSessionsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ManagementClientGetActiveSessionsPager provides operations for iterating over paged responses.
 type ManagementClientGetActiveSessionsPager struct {
 	client  *ManagementClient
 	current ManagementClientGetActiveSessionsResponse
-	err     error
 	second  bool
 }
 
-// Err returns the last error encountered while paging.
-func (p *ManagementClientGetActiveSessionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ManagementClientGetActiveSessionsPager) NextPage(ctx context.Context) bool {
-	if !p.second {
-		p.second = true
-		return true
-	} else if !reflect.ValueOf(p.current).IsZero() {
+// More returns true if there are more pages to retrieve.
+func (p *ManagementClientGetActiveSessionsPager) More() bool {
+	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BastionActiveSessionListResult.NextLink == nil || len(*p.current.BastionActiveSessionListResult.NextLink) == 0 {
 			return false
 		}
 	}
-	req, err := runtime.NewRequest(ctx, http.MethodGet, *p.current.BastionActiveSessionListResult.NextLink)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	resp, err := p.client.pl.Do(req)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
-		p.err = runtime.NewResponseError(resp)
-		return false
-	}
-	result, err := p.client.getActiveSessionsHandleResponse(resp)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	p.current = result
 	return true
 }
 
-// PageResponse returns the current ManagementClientGetActiveSessionsResponse page.
-func (p *ManagementClientGetActiveSessionsPager) PageResponse() ManagementClientGetActiveSessionsResponse {
-	return p.current
+// NextPage advances the pager to the next page.
+func (p *ManagementClientGetActiveSessionsPager) NextPage(ctx context.Context) (ManagementClientGetActiveSessionsResponse, error) {
+	if !p.second {
+		p.second = true
+		return p.current, nil
+	} else if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ManagementClientGetActiveSessionsResponse{}, errors.New("no more pages")
+		}
+	}
+	req, err := runtime.NewRequest(ctx, http.MethodGet, *p.current.BastionActiveSessionListResult.NextLink)
+	if err != nil {
+
+		return ManagementClientGetActiveSessionsResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+
+		return ManagementClientGetActiveSessionsResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
+
+		return ManagementClientGetActiveSessionsResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.getActiveSessionsHandleResponse(resp)
+	if err != nil {
+
+		return ManagementClientGetActiveSessionsResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
 }
 
 // ManagementClientGetBastionShareableLinkPager provides operations for iterating over paged responses.
 type ManagementClientGetBastionShareableLinkPager struct {
 	client    *ManagementClient
 	current   ManagementClientGetBastionShareableLinkResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ManagementClientGetBastionShareableLinkResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ManagementClientGetBastionShareableLinkPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ManagementClientGetBastionShareableLinkPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ManagementClientGetBastionShareableLinkPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BastionShareableLinkListResult.NextLink == nil || len(*p.current.BastionShareableLinkListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ManagementClientGetBastionShareableLinkPager) NextPage(ctx context.Context) (ManagementClientGetBastionShareableLinkResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ManagementClientGetBastionShareableLinkResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ManagementClientGetBastionShareableLinkResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ManagementClientGetBastionShareableLinkResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ManagementClientGetBastionShareableLinkResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getBastionShareableLinkHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ManagementClientGetBastionShareableLinkResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ManagementClientGetBastionShareableLinkResponse page.
-func (p *ManagementClientGetBastionShareableLinkPager) PageResponse() ManagementClientGetBastionShareableLinkResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ManagementClientPutBastionShareableLinkPager provides operations for iterating over paged responses.
 type ManagementClientPutBastionShareableLinkPager struct {
 	client  *ManagementClient
 	current ManagementClientPutBastionShareableLinkResponse
-	err     error
 	second  bool
 }
 
-// Err returns the last error encountered while paging.
-func (p *ManagementClientPutBastionShareableLinkPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ManagementClientPutBastionShareableLinkPager) NextPage(ctx context.Context) bool {
-	if !p.second {
-		p.second = true
-		return true
-	} else if !reflect.ValueOf(p.current).IsZero() {
+// More returns true if there are more pages to retrieve.
+func (p *ManagementClientPutBastionShareableLinkPager) More() bool {
+	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.BastionShareableLinkListResult.NextLink == nil || len(*p.current.BastionShareableLinkListResult.NextLink) == 0 {
 			return false
 		}
 	}
-	req, err := runtime.NewRequest(ctx, http.MethodGet, *p.current.BastionShareableLinkListResult.NextLink)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	resp, err := p.client.pl.Do(req)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
-		p.err = runtime.NewResponseError(resp)
-		return false
-	}
-	result, err := p.client.putBastionShareableLinkHandleResponse(resp)
-	if err != nil {
-		p.err = err
-		return false
-	}
-	p.current = result
 	return true
 }
 
-// PageResponse returns the current ManagementClientPutBastionShareableLinkResponse page.
-func (p *ManagementClientPutBastionShareableLinkPager) PageResponse() ManagementClientPutBastionShareableLinkResponse {
-	return p.current
+// NextPage advances the pager to the next page.
+func (p *ManagementClientPutBastionShareableLinkPager) NextPage(ctx context.Context) (ManagementClientPutBastionShareableLinkResponse, error) {
+	if !p.second {
+		p.second = true
+		return p.current, nil
+	} else if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ManagementClientPutBastionShareableLinkResponse{}, errors.New("no more pages")
+		}
+	}
+	req, err := runtime.NewRequest(ctx, http.MethodGet, *p.current.BastionShareableLinkListResult.NextLink)
+	if err != nil {
+
+		return ManagementClientPutBastionShareableLinkResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+
+		return ManagementClientPutBastionShareableLinkResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
+
+		return ManagementClientPutBastionShareableLinkResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.putBastionShareableLinkHandleResponse(resp)
+	if err != nil {
+
+		return ManagementClientPutBastionShareableLinkResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
 }
 
 // NatGatewaysClientListAllPager provides operations for iterating over paged responses.
 type NatGatewaysClientListAllPager struct {
 	client    *NatGatewaysClient
 	current   NatGatewaysClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, NatGatewaysClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *NatGatewaysClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *NatGatewaysClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *NatGatewaysClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.NatGatewayListResult.NextLink == nil || len(*p.current.NatGatewayListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *NatGatewaysClientListAllPager) NextPage(ctx context.Context) (NatGatewaysClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return NatGatewaysClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return NatGatewaysClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return NatGatewaysClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return NatGatewaysClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return NatGatewaysClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current NatGatewaysClientListAllResponse page.
-func (p *NatGatewaysClientListAllPager) PageResponse() NatGatewaysClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // NatGatewaysClientListPager provides operations for iterating over paged responses.
 type NatGatewaysClientListPager struct {
 	client    *NatGatewaysClient
 	current   NatGatewaysClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, NatGatewaysClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *NatGatewaysClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *NatGatewaysClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *NatGatewaysClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.NatGatewayListResult.NextLink == nil || len(*p.current.NatGatewayListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *NatGatewaysClientListPager) NextPage(ctx context.Context) (NatGatewaysClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return NatGatewaysClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return NatGatewaysClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return NatGatewaysClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return NatGatewaysClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return NatGatewaysClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current NatGatewaysClientListResponse page.
-func (p *NatGatewaysClientListPager) PageResponse() NatGatewaysClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // OperationsClientListPager provides operations for iterating over paged responses.
 type OperationsClientListPager struct {
 	client    *OperationsClient
 	current   OperationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, OperationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *OperationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *OperationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *OperationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.OperationListResult.NextLink == nil || len(*p.current.OperationListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *OperationsClientListPager) NextPage(ctx context.Context) (OperationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return OperationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return OperationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return OperationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current OperationsClientListResponse page.
-func (p *OperationsClientListPager) PageResponse() OperationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // P2SVPNGatewaysClientListByResourceGroupPager provides operations for iterating over paged responses.
 type P2SVPNGatewaysClientListByResourceGroupPager struct {
 	client    *P2SVPNGatewaysClient
 	current   P2SVPNGatewaysClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, P2SVPNGatewaysClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *P2SVPNGatewaysClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *P2SVPNGatewaysClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *P2SVPNGatewaysClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListP2SVPNGatewaysResult.NextLink == nil || len(*p.current.ListP2SVPNGatewaysResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *P2SVPNGatewaysClientListByResourceGroupPager) NextPage(ctx context.Context) (P2SVPNGatewaysClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return P2SVPNGatewaysClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return P2SVPNGatewaysClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return P2SVPNGatewaysClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return P2SVPNGatewaysClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return P2SVPNGatewaysClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current P2SVPNGatewaysClientListByResourceGroupResponse page.
-func (p *P2SVPNGatewaysClientListByResourceGroupPager) PageResponse() P2SVPNGatewaysClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // P2SVPNGatewaysClientListPager provides operations for iterating over paged responses.
 type P2SVPNGatewaysClientListPager struct {
 	client    *P2SVPNGatewaysClient
 	current   P2SVPNGatewaysClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, P2SVPNGatewaysClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *P2SVPNGatewaysClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *P2SVPNGatewaysClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *P2SVPNGatewaysClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListP2SVPNGatewaysResult.NextLink == nil || len(*p.current.ListP2SVPNGatewaysResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *P2SVPNGatewaysClientListPager) NextPage(ctx context.Context) (P2SVPNGatewaysClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return P2SVPNGatewaysClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return P2SVPNGatewaysClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return P2SVPNGatewaysClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return P2SVPNGatewaysClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return P2SVPNGatewaysClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current P2SVPNGatewaysClientListResponse page.
-func (p *P2SVPNGatewaysClientListPager) PageResponse() P2SVPNGatewaysClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PeerExpressRouteCircuitConnectionsClientListPager provides operations for iterating over paged responses.
 type PeerExpressRouteCircuitConnectionsClientListPager struct {
 	client    *PeerExpressRouteCircuitConnectionsClient
 	current   PeerExpressRouteCircuitConnectionsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PeerExpressRouteCircuitConnectionsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PeerExpressRouteCircuitConnectionsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PeerExpressRouteCircuitConnectionsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PeerExpressRouteCircuitConnectionsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PeerExpressRouteCircuitConnectionListResult.NextLink == nil || len(*p.current.PeerExpressRouteCircuitConnectionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PeerExpressRouteCircuitConnectionsClientListPager) NextPage(ctx context.Context) (PeerExpressRouteCircuitConnectionsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PeerExpressRouteCircuitConnectionsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PeerExpressRouteCircuitConnectionsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PeerExpressRouteCircuitConnectionsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PeerExpressRouteCircuitConnectionsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PeerExpressRouteCircuitConnectionsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PeerExpressRouteCircuitConnectionsClientListResponse page.
-func (p *PeerExpressRouteCircuitConnectionsClientListPager) PageResponse() PeerExpressRouteCircuitConnectionsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PrivateDNSZoneGroupsClientListPager provides operations for iterating over paged responses.
 type PrivateDNSZoneGroupsClientListPager struct {
 	client    *PrivateDNSZoneGroupsClient
 	current   PrivateDNSZoneGroupsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PrivateDNSZoneGroupsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PrivateDNSZoneGroupsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PrivateDNSZoneGroupsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PrivateDNSZoneGroupsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PrivateDNSZoneGroupListResult.NextLink == nil || len(*p.current.PrivateDNSZoneGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PrivateDNSZoneGroupsClientListPager) NextPage(ctx context.Context) (PrivateDNSZoneGroupsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PrivateDNSZoneGroupsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateDNSZoneGroupsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateDNSZoneGroupsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PrivateDNSZoneGroupsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateDNSZoneGroupsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PrivateDNSZoneGroupsClientListResponse page.
-func (p *PrivateDNSZoneGroupsClientListPager) PageResponse() PrivateDNSZoneGroupsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PrivateEndpointsClientListBySubscriptionPager provides operations for iterating over paged responses.
 type PrivateEndpointsClientListBySubscriptionPager struct {
 	client    *PrivateEndpointsClient
 	current   PrivateEndpointsClientListBySubscriptionResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PrivateEndpointsClientListBySubscriptionResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PrivateEndpointsClientListBySubscriptionPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PrivateEndpointsClientListBySubscriptionPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PrivateEndpointsClientListBySubscriptionPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PrivateEndpointListResult.NextLink == nil || len(*p.current.PrivateEndpointListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PrivateEndpointsClientListBySubscriptionPager) NextPage(ctx context.Context) (PrivateEndpointsClientListBySubscriptionResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PrivateEndpointsClientListBySubscriptionResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateEndpointsClientListBySubscriptionResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateEndpointsClientListBySubscriptionResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PrivateEndpointsClientListBySubscriptionResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBySubscriptionHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateEndpointsClientListBySubscriptionResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PrivateEndpointsClientListBySubscriptionResponse page.
-func (p *PrivateEndpointsClientListBySubscriptionPager) PageResponse() PrivateEndpointsClientListBySubscriptionResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PrivateEndpointsClientListPager provides operations for iterating over paged responses.
 type PrivateEndpointsClientListPager struct {
 	client    *PrivateEndpointsClient
 	current   PrivateEndpointsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PrivateEndpointsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PrivateEndpointsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PrivateEndpointsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PrivateEndpointsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PrivateEndpointListResult.NextLink == nil || len(*p.current.PrivateEndpointListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PrivateEndpointsClientListPager) NextPage(ctx context.Context) (PrivateEndpointsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PrivateEndpointsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateEndpointsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateEndpointsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PrivateEndpointsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateEndpointsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PrivateEndpointsClientListResponse page.
-func (p *PrivateEndpointsClientListPager) PageResponse() PrivateEndpointsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupPager provides operations for iterating over paged responses.
 type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupPager struct {
 	client    *PrivateLinkServicesClient
 	current   PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AutoApprovedPrivateLinkServicesResult.NextLink == nil || len(*p.current.AutoApprovedPrivateLinkServicesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupPager) NextPage(ctx context.Context) (PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse page.
-func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupPager) PageResponse() PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesPager provides operations for iterating over paged responses.
 type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesPager struct {
 	client    *PrivateLinkServicesClient
 	current   PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.AutoApprovedPrivateLinkServicesResult.NextLink == nil || len(*p.current.AutoApprovedPrivateLinkServicesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesPager) NextPage(ctx context.Context) (PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAutoApprovedPrivateLinkServicesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse page.
-func (p *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesPager) PageResponse() PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PrivateLinkServicesClientListBySubscriptionPager provides operations for iterating over paged responses.
 type PrivateLinkServicesClientListBySubscriptionPager struct {
 	client    *PrivateLinkServicesClient
 	current   PrivateLinkServicesClientListBySubscriptionResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PrivateLinkServicesClientListBySubscriptionResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PrivateLinkServicesClientListBySubscriptionPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PrivateLinkServicesClientListBySubscriptionPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PrivateLinkServicesClientListBySubscriptionPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PrivateLinkServiceListResult.NextLink == nil || len(*p.current.PrivateLinkServiceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PrivateLinkServicesClientListBySubscriptionPager) NextPage(ctx context.Context) (PrivateLinkServicesClientListBySubscriptionResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PrivateLinkServicesClientListBySubscriptionResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListBySubscriptionResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListBySubscriptionResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PrivateLinkServicesClientListBySubscriptionResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBySubscriptionHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListBySubscriptionResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PrivateLinkServicesClientListBySubscriptionResponse page.
-func (p *PrivateLinkServicesClientListBySubscriptionPager) PageResponse() PrivateLinkServicesClientListBySubscriptionResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PrivateLinkServicesClientListPager provides operations for iterating over paged responses.
 type PrivateLinkServicesClientListPager struct {
 	client    *PrivateLinkServicesClient
 	current   PrivateLinkServicesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PrivateLinkServicesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PrivateLinkServicesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PrivateLinkServicesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PrivateLinkServicesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PrivateLinkServiceListResult.NextLink == nil || len(*p.current.PrivateLinkServiceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PrivateLinkServicesClientListPager) NextPage(ctx context.Context) (PrivateLinkServicesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PrivateLinkServicesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PrivateLinkServicesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PrivateLinkServicesClientListResponse page.
-func (p *PrivateLinkServicesClientListPager) PageResponse() PrivateLinkServicesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PrivateLinkServicesClientListPrivateEndpointConnectionsPager provides operations for iterating over paged responses.
 type PrivateLinkServicesClientListPrivateEndpointConnectionsPager struct {
 	client    *PrivateLinkServicesClient
 	current   PrivateLinkServicesClientListPrivateEndpointConnectionsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PrivateLinkServicesClientListPrivateEndpointConnectionsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PrivateLinkServicesClientListPrivateEndpointConnectionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PrivateLinkServicesClientListPrivateEndpointConnectionsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PrivateLinkServicesClientListPrivateEndpointConnectionsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PrivateEndpointConnectionListResult.NextLink == nil || len(*p.current.PrivateEndpointConnectionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PrivateLinkServicesClientListPrivateEndpointConnectionsPager) NextPage(ctx context.Context) (PrivateLinkServicesClientListPrivateEndpointConnectionsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listPrivateEndpointConnectionsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PrivateLinkServicesClientListPrivateEndpointConnectionsResponse page.
-func (p *PrivateLinkServicesClientListPrivateEndpointConnectionsPager) PageResponse() PrivateLinkServicesClientListPrivateEndpointConnectionsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ProfilesClientListAllPager provides operations for iterating over paged responses.
 type ProfilesClientListAllPager struct {
 	client    *ProfilesClient
 	current   ProfilesClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ProfilesClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ProfilesClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ProfilesClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ProfilesClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProfileListResult.NextLink == nil || len(*p.current.ProfileListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ProfilesClientListAllPager) NextPage(ctx context.Context) (ProfilesClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ProfilesClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProfilesClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProfilesClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ProfilesClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProfilesClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ProfilesClientListAllResponse page.
-func (p *ProfilesClientListAllPager) PageResponse() ProfilesClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ProfilesClientListPager provides operations for iterating over paged responses.
 type ProfilesClientListPager struct {
 	client    *ProfilesClient
 	current   ProfilesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ProfilesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ProfilesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ProfilesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ProfilesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ProfileListResult.NextLink == nil || len(*p.current.ProfileListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ProfilesClientListPager) NextPage(ctx context.Context) (ProfilesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ProfilesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProfilesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProfilesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ProfilesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ProfilesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ProfilesClientListResponse page.
-func (p *ProfilesClientListPager) PageResponse() ProfilesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PublicIPAddressesClientListAllPager provides operations for iterating over paged responses.
 type PublicIPAddressesClientListAllPager struct {
 	client    *PublicIPAddressesClient
 	current   PublicIPAddressesClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PublicIPAddressesClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PublicIPAddressesClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PublicIPAddressesClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PublicIPAddressesClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PublicIPAddressListResult.NextLink == nil || len(*p.current.PublicIPAddressListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PublicIPAddressesClientListAllPager) NextPage(ctx context.Context) (PublicIPAddressesClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PublicIPAddressesClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PublicIPAddressesClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PublicIPAddressesClientListAllResponse page.
-func (p *PublicIPAddressesClientListAllPager) PageResponse() PublicIPAddressesClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PublicIPAddressesClientListPager provides operations for iterating over paged responses.
 type PublicIPAddressesClientListPager struct {
 	client    *PublicIPAddressesClient
 	current   PublicIPAddressesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PublicIPAddressesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PublicIPAddressesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PublicIPAddressesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PublicIPAddressesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PublicIPAddressListResult.NextLink == nil || len(*p.current.PublicIPAddressListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PublicIPAddressesClientListPager) NextPage(ctx context.Context) (PublicIPAddressesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PublicIPAddressesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PublicIPAddressesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PublicIPAddressesClientListResponse page.
-func (p *PublicIPAddressesClientListPager) PageResponse() PublicIPAddressesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesPager provides operations for iterating over paged responses.
 type PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesPager struct {
 	client    *PublicIPAddressesClient
 	current   PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PublicIPAddressListResult.NextLink == nil || len(*p.current.PublicIPAddressListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesPager) NextPage(ctx context.Context) (PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listVirtualMachineScaleSetPublicIPAddressesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse page.
-func (p *PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesPager) PageResponse() PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesPager provides operations for iterating over paged responses.
 type PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesPager struct {
 	client    *PublicIPAddressesClient
 	current   PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PublicIPAddressListResult.NextLink == nil || len(*p.current.PublicIPAddressListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesPager) NextPage(ctx context.Context) (PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listVirtualMachineScaleSetVMPublicIPAddressesHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse page.
-func (p *PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesPager) PageResponse() PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PublicIPPrefixesClientListAllPager provides operations for iterating over paged responses.
 type PublicIPPrefixesClientListAllPager struct {
 	client    *PublicIPPrefixesClient
 	current   PublicIPPrefixesClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PublicIPPrefixesClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PublicIPPrefixesClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PublicIPPrefixesClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PublicIPPrefixesClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PublicIPPrefixListResult.NextLink == nil || len(*p.current.PublicIPPrefixListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PublicIPPrefixesClientListAllPager) NextPage(ctx context.Context) (PublicIPPrefixesClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PublicIPPrefixesClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPPrefixesClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPPrefixesClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PublicIPPrefixesClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPPrefixesClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PublicIPPrefixesClientListAllResponse page.
-func (p *PublicIPPrefixesClientListAllPager) PageResponse() PublicIPPrefixesClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // PublicIPPrefixesClientListPager provides operations for iterating over paged responses.
 type PublicIPPrefixesClientListPager struct {
 	client    *PublicIPPrefixesClient
 	current   PublicIPPrefixesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, PublicIPPrefixesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *PublicIPPrefixesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *PublicIPPrefixesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *PublicIPPrefixesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PublicIPPrefixListResult.NextLink == nil || len(*p.current.PublicIPPrefixListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *PublicIPPrefixesClientListPager) NextPage(ctx context.Context) (PublicIPPrefixesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return PublicIPPrefixesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPPrefixesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPPrefixesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return PublicIPPrefixesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return PublicIPPrefixesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current PublicIPPrefixesClientListResponse page.
-func (p *PublicIPPrefixesClientListPager) PageResponse() PublicIPPrefixesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RouteFilterRulesClientListByRouteFilterPager provides operations for iterating over paged responses.
 type RouteFilterRulesClientListByRouteFilterPager struct {
 	client    *RouteFilterRulesClient
 	current   RouteFilterRulesClientListByRouteFilterResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RouteFilterRulesClientListByRouteFilterResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RouteFilterRulesClientListByRouteFilterPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RouteFilterRulesClientListByRouteFilterPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RouteFilterRulesClientListByRouteFilterPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RouteFilterRuleListResult.NextLink == nil || len(*p.current.RouteFilterRuleListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RouteFilterRulesClientListByRouteFilterPager) NextPage(ctx context.Context) (RouteFilterRulesClientListByRouteFilterResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RouteFilterRulesClientListByRouteFilterResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFilterRulesClientListByRouteFilterResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFilterRulesClientListByRouteFilterResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RouteFilterRulesClientListByRouteFilterResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByRouteFilterHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFilterRulesClientListByRouteFilterResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RouteFilterRulesClientListByRouteFilterResponse page.
-func (p *RouteFilterRulesClientListByRouteFilterPager) PageResponse() RouteFilterRulesClientListByRouteFilterResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RouteFiltersClientListByResourceGroupPager provides operations for iterating over paged responses.
 type RouteFiltersClientListByResourceGroupPager struct {
 	client    *RouteFiltersClient
 	current   RouteFiltersClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RouteFiltersClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RouteFiltersClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RouteFiltersClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RouteFiltersClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RouteFilterListResult.NextLink == nil || len(*p.current.RouteFilterListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RouteFiltersClientListByResourceGroupPager) NextPage(ctx context.Context) (RouteFiltersClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RouteFiltersClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFiltersClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFiltersClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RouteFiltersClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFiltersClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RouteFiltersClientListByResourceGroupResponse page.
-func (p *RouteFiltersClientListByResourceGroupPager) PageResponse() RouteFiltersClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RouteFiltersClientListPager provides operations for iterating over paged responses.
 type RouteFiltersClientListPager struct {
 	client    *RouteFiltersClient
 	current   RouteFiltersClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RouteFiltersClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RouteFiltersClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RouteFiltersClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RouteFiltersClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RouteFilterListResult.NextLink == nil || len(*p.current.RouteFilterListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RouteFiltersClientListPager) NextPage(ctx context.Context) (RouteFiltersClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RouteFiltersClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFiltersClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFiltersClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RouteFiltersClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteFiltersClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RouteFiltersClientListResponse page.
-func (p *RouteFiltersClientListPager) PageResponse() RouteFiltersClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RouteTablesClientListAllPager provides operations for iterating over paged responses.
 type RouteTablesClientListAllPager struct {
 	client    *RouteTablesClient
 	current   RouteTablesClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RouteTablesClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RouteTablesClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RouteTablesClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RouteTablesClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RouteTableListResult.NextLink == nil || len(*p.current.RouteTableListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RouteTablesClientListAllPager) NextPage(ctx context.Context) (RouteTablesClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RouteTablesClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteTablesClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteTablesClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RouteTablesClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteTablesClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RouteTablesClientListAllResponse page.
-func (p *RouteTablesClientListAllPager) PageResponse() RouteTablesClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RouteTablesClientListPager provides operations for iterating over paged responses.
 type RouteTablesClientListPager struct {
 	client    *RouteTablesClient
 	current   RouteTablesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RouteTablesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RouteTablesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RouteTablesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RouteTablesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RouteTableListResult.NextLink == nil || len(*p.current.RouteTableListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RouteTablesClientListPager) NextPage(ctx context.Context) (RouteTablesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RouteTablesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteTablesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteTablesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RouteTablesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RouteTablesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RouteTablesClientListResponse page.
-func (p *RouteTablesClientListPager) PageResponse() RouteTablesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // RoutesClientListPager provides operations for iterating over paged responses.
 type RoutesClientListPager struct {
 	client    *RoutesClient
 	current   RoutesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, RoutesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *RoutesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *RoutesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *RoutesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.RouteListResult.NextLink == nil || len(*p.current.RouteListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *RoutesClientListPager) NextPage(ctx context.Context) (RoutesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return RoutesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoutesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoutesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return RoutesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return RoutesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current RoutesClientListResponse page.
-func (p *RoutesClientListPager) PageResponse() RoutesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SecurityGroupsClientListAllPager provides operations for iterating over paged responses.
 type SecurityGroupsClientListAllPager struct {
 	client    *SecurityGroupsClient
 	current   SecurityGroupsClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SecurityGroupsClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SecurityGroupsClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SecurityGroupsClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SecurityGroupsClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SecurityGroupListResult.NextLink == nil || len(*p.current.SecurityGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SecurityGroupsClientListAllPager) NextPage(ctx context.Context) (SecurityGroupsClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SecurityGroupsClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityGroupsClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityGroupsClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SecurityGroupsClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityGroupsClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SecurityGroupsClientListAllResponse page.
-func (p *SecurityGroupsClientListAllPager) PageResponse() SecurityGroupsClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SecurityGroupsClientListPager provides operations for iterating over paged responses.
 type SecurityGroupsClientListPager struct {
 	client    *SecurityGroupsClient
 	current   SecurityGroupsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SecurityGroupsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SecurityGroupsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SecurityGroupsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SecurityGroupsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SecurityGroupListResult.NextLink == nil || len(*p.current.SecurityGroupListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SecurityGroupsClientListPager) NextPage(ctx context.Context) (SecurityGroupsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SecurityGroupsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityGroupsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityGroupsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SecurityGroupsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityGroupsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SecurityGroupsClientListResponse page.
-func (p *SecurityGroupsClientListPager) PageResponse() SecurityGroupsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SecurityPartnerProvidersClientListByResourceGroupPager provides operations for iterating over paged responses.
 type SecurityPartnerProvidersClientListByResourceGroupPager struct {
 	client    *SecurityPartnerProvidersClient
 	current   SecurityPartnerProvidersClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SecurityPartnerProvidersClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SecurityPartnerProvidersClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SecurityPartnerProvidersClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SecurityPartnerProvidersClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SecurityPartnerProviderListResult.NextLink == nil || len(*p.current.SecurityPartnerProviderListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SecurityPartnerProvidersClientListByResourceGroupPager) NextPage(ctx context.Context) (SecurityPartnerProvidersClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SecurityPartnerProvidersClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityPartnerProvidersClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityPartnerProvidersClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SecurityPartnerProvidersClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityPartnerProvidersClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SecurityPartnerProvidersClientListByResourceGroupResponse page.
-func (p *SecurityPartnerProvidersClientListByResourceGroupPager) PageResponse() SecurityPartnerProvidersClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SecurityPartnerProvidersClientListPager provides operations for iterating over paged responses.
 type SecurityPartnerProvidersClientListPager struct {
 	client    *SecurityPartnerProvidersClient
 	current   SecurityPartnerProvidersClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SecurityPartnerProvidersClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SecurityPartnerProvidersClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SecurityPartnerProvidersClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SecurityPartnerProvidersClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SecurityPartnerProviderListResult.NextLink == nil || len(*p.current.SecurityPartnerProviderListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SecurityPartnerProvidersClientListPager) NextPage(ctx context.Context) (SecurityPartnerProvidersClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SecurityPartnerProvidersClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityPartnerProvidersClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityPartnerProvidersClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SecurityPartnerProvidersClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityPartnerProvidersClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SecurityPartnerProvidersClientListResponse page.
-func (p *SecurityPartnerProvidersClientListPager) PageResponse() SecurityPartnerProvidersClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SecurityRulesClientListPager provides operations for iterating over paged responses.
 type SecurityRulesClientListPager struct {
 	client    *SecurityRulesClient
 	current   SecurityRulesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SecurityRulesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SecurityRulesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SecurityRulesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SecurityRulesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SecurityRuleListResult.NextLink == nil || len(*p.current.SecurityRuleListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SecurityRulesClientListPager) NextPage(ctx context.Context) (SecurityRulesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SecurityRulesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityRulesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityRulesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SecurityRulesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SecurityRulesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SecurityRulesClientListResponse page.
-func (p *SecurityRulesClientListPager) PageResponse() SecurityRulesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ServiceEndpointPoliciesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type ServiceEndpointPoliciesClientListByResourceGroupPager struct {
 	client    *ServiceEndpointPoliciesClient
 	current   ServiceEndpointPoliciesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ServiceEndpointPoliciesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ServiceEndpointPoliciesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ServiceEndpointPoliciesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ServiceEndpointPoliciesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ServiceEndpointPolicyListResult.NextLink == nil || len(*p.current.ServiceEndpointPolicyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ServiceEndpointPoliciesClientListByResourceGroupPager) NextPage(ctx context.Context) (ServiceEndpointPoliciesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ServiceEndpointPoliciesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPoliciesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPoliciesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ServiceEndpointPoliciesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPoliciesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ServiceEndpointPoliciesClientListByResourceGroupResponse page.
-func (p *ServiceEndpointPoliciesClientListByResourceGroupPager) PageResponse() ServiceEndpointPoliciesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ServiceEndpointPoliciesClientListPager provides operations for iterating over paged responses.
 type ServiceEndpointPoliciesClientListPager struct {
 	client    *ServiceEndpointPoliciesClient
 	current   ServiceEndpointPoliciesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ServiceEndpointPoliciesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ServiceEndpointPoliciesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ServiceEndpointPoliciesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ServiceEndpointPoliciesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ServiceEndpointPolicyListResult.NextLink == nil || len(*p.current.ServiceEndpointPolicyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ServiceEndpointPoliciesClientListPager) NextPage(ctx context.Context) (ServiceEndpointPoliciesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ServiceEndpointPoliciesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPoliciesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPoliciesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ServiceEndpointPoliciesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPoliciesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ServiceEndpointPoliciesClientListResponse page.
-func (p *ServiceEndpointPoliciesClientListPager) PageResponse() ServiceEndpointPoliciesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // ServiceEndpointPolicyDefinitionsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type ServiceEndpointPolicyDefinitionsClientListByResourceGroupPager struct {
 	client    *ServiceEndpointPolicyDefinitionsClient
 	current   ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *ServiceEndpointPolicyDefinitionsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *ServiceEndpointPolicyDefinitionsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *ServiceEndpointPolicyDefinitionsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ServiceEndpointPolicyDefinitionListResult.NextLink == nil || len(*p.current.ServiceEndpointPolicyDefinitionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *ServiceEndpointPolicyDefinitionsClientListByResourceGroupPager) NextPage(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse page.
-func (p *ServiceEndpointPolicyDefinitionsClientListByResourceGroupPager) PageResponse() ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // SubnetsClientListPager provides operations for iterating over paged responses.
 type SubnetsClientListPager struct {
 	client    *SubnetsClient
 	current   SubnetsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, SubnetsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *SubnetsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *SubnetsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *SubnetsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SubnetListResult.NextLink == nil || len(*p.current.SubnetListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *SubnetsClientListPager) NextPage(ctx context.Context) (SubnetsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return SubnetsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return SubnetsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SubnetsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return SubnetsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return SubnetsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current SubnetsClientListResponse page.
-func (p *SubnetsClientListPager) PageResponse() SubnetsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // UsagesClientListPager provides operations for iterating over paged responses.
 type UsagesClientListPager struct {
 	client    *UsagesClient
 	current   UsagesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, UsagesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *UsagesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *UsagesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *UsagesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.UsagesListResult.NextLink == nil || len(*p.current.UsagesListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *UsagesClientListPager) NextPage(ctx context.Context) (UsagesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return UsagesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsagesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsagesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return UsagesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return UsagesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current UsagesClientListResponse page.
-func (p *UsagesClientListPager) PageResponse() UsagesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNConnectionsClientListByVPNGatewayPager provides operations for iterating over paged responses.
 type VPNConnectionsClientListByVPNGatewayPager struct {
 	client    *VPNConnectionsClient
 	current   VPNConnectionsClientListByVPNGatewayResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNConnectionsClientListByVPNGatewayResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNConnectionsClientListByVPNGatewayPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNConnectionsClientListByVPNGatewayPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNConnectionsClientListByVPNGatewayPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNConnectionsResult.NextLink == nil || len(*p.current.ListVPNConnectionsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNConnectionsClientListByVPNGatewayPager) NextPage(ctx context.Context) (VPNConnectionsClientListByVPNGatewayResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNConnectionsClientListByVPNGatewayResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNConnectionsClientListByVPNGatewayResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNConnectionsClientListByVPNGatewayResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNConnectionsClientListByVPNGatewayResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByVPNGatewayHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNConnectionsClientListByVPNGatewayResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNConnectionsClientListByVPNGatewayResponse page.
-func (p *VPNConnectionsClientListByVPNGatewayPager) PageResponse() VPNConnectionsClientListByVPNGatewayResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNGatewaysClientListByResourceGroupPager provides operations for iterating over paged responses.
 type VPNGatewaysClientListByResourceGroupPager struct {
 	client    *VPNGatewaysClient
 	current   VPNGatewaysClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNGatewaysClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNGatewaysClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNGatewaysClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNGatewaysClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNGatewaysResult.NextLink == nil || len(*p.current.ListVPNGatewaysResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNGatewaysClientListByResourceGroupPager) NextPage(ctx context.Context) (VPNGatewaysClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNGatewaysClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNGatewaysClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNGatewaysClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNGatewaysClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNGatewaysClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNGatewaysClientListByResourceGroupResponse page.
-func (p *VPNGatewaysClientListByResourceGroupPager) PageResponse() VPNGatewaysClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNGatewaysClientListPager provides operations for iterating over paged responses.
 type VPNGatewaysClientListPager struct {
 	client    *VPNGatewaysClient
 	current   VPNGatewaysClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNGatewaysClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNGatewaysClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNGatewaysClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNGatewaysClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNGatewaysResult.NextLink == nil || len(*p.current.ListVPNGatewaysResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNGatewaysClientListPager) NextPage(ctx context.Context) (VPNGatewaysClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNGatewaysClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNGatewaysClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNGatewaysClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNGatewaysClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNGatewaysClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNGatewaysClientListResponse page.
-func (p *VPNGatewaysClientListPager) PageResponse() VPNGatewaysClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNLinkConnectionsClientListByVPNConnectionPager provides operations for iterating over paged responses.
 type VPNLinkConnectionsClientListByVPNConnectionPager struct {
 	client    *VPNLinkConnectionsClient
 	current   VPNLinkConnectionsClientListByVPNConnectionResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNLinkConnectionsClientListByVPNConnectionResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNLinkConnectionsClientListByVPNConnectionPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNLinkConnectionsClientListByVPNConnectionPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNLinkConnectionsClientListByVPNConnectionPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNSiteLinkConnectionsResult.NextLink == nil || len(*p.current.ListVPNSiteLinkConnectionsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNLinkConnectionsClientListByVPNConnectionPager) NextPage(ctx context.Context) (VPNLinkConnectionsClientListByVPNConnectionResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNLinkConnectionsClientListByVPNConnectionResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNLinkConnectionsClientListByVPNConnectionResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNLinkConnectionsClientListByVPNConnectionResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNLinkConnectionsClientListByVPNConnectionResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByVPNConnectionHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNLinkConnectionsClientListByVPNConnectionResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNLinkConnectionsClientListByVPNConnectionResponse page.
-func (p *VPNLinkConnectionsClientListByVPNConnectionPager) PageResponse() VPNLinkConnectionsClientListByVPNConnectionResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNServerConfigurationsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type VPNServerConfigurationsClientListByResourceGroupPager struct {
 	client    *VPNServerConfigurationsClient
 	current   VPNServerConfigurationsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNServerConfigurationsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNServerConfigurationsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNServerConfigurationsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNServerConfigurationsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNServerConfigurationsResult.NextLink == nil || len(*p.current.ListVPNServerConfigurationsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNServerConfigurationsClientListByResourceGroupPager) NextPage(ctx context.Context) (VPNServerConfigurationsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNServerConfigurationsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNServerConfigurationsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNServerConfigurationsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNServerConfigurationsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNServerConfigurationsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNServerConfigurationsClientListByResourceGroupResponse page.
-func (p *VPNServerConfigurationsClientListByResourceGroupPager) PageResponse() VPNServerConfigurationsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNServerConfigurationsClientListPager provides operations for iterating over paged responses.
 type VPNServerConfigurationsClientListPager struct {
 	client    *VPNServerConfigurationsClient
 	current   VPNServerConfigurationsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNServerConfigurationsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNServerConfigurationsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNServerConfigurationsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNServerConfigurationsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNServerConfigurationsResult.NextLink == nil || len(*p.current.ListVPNServerConfigurationsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNServerConfigurationsClientListPager) NextPage(ctx context.Context) (VPNServerConfigurationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNServerConfigurationsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNServerConfigurationsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNServerConfigurationsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNServerConfigurationsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNServerConfigurationsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNServerConfigurationsClientListResponse page.
-func (p *VPNServerConfigurationsClientListPager) PageResponse() VPNServerConfigurationsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNSiteLinksClientListByVPNSitePager provides operations for iterating over paged responses.
 type VPNSiteLinksClientListByVPNSitePager struct {
 	client    *VPNSiteLinksClient
 	current   VPNSiteLinksClientListByVPNSiteResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNSiteLinksClientListByVPNSiteResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNSiteLinksClientListByVPNSitePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNSiteLinksClientListByVPNSitePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNSiteLinksClientListByVPNSitePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNSiteLinksResult.NextLink == nil || len(*p.current.ListVPNSiteLinksResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNSiteLinksClientListByVPNSitePager) NextPage(ctx context.Context) (VPNSiteLinksClientListByVPNSiteResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNSiteLinksClientListByVPNSiteResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSiteLinksClientListByVPNSiteResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSiteLinksClientListByVPNSiteResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNSiteLinksClientListByVPNSiteResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByVPNSiteHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSiteLinksClientListByVPNSiteResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNSiteLinksClientListByVPNSiteResponse page.
-func (p *VPNSiteLinksClientListByVPNSitePager) PageResponse() VPNSiteLinksClientListByVPNSiteResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNSitesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type VPNSitesClientListByResourceGroupPager struct {
 	client    *VPNSitesClient
 	current   VPNSitesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNSitesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNSitesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNSitesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNSitesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNSitesResult.NextLink == nil || len(*p.current.ListVPNSitesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNSitesClientListByResourceGroupPager) NextPage(ctx context.Context) (VPNSitesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNSitesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSitesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSitesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNSitesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSitesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNSitesClientListByResourceGroupResponse page.
-func (p *VPNSitesClientListByResourceGroupPager) PageResponse() VPNSitesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VPNSitesClientListPager provides operations for iterating over paged responses.
 type VPNSitesClientListPager struct {
 	client    *VPNSitesClient
 	current   VPNSitesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VPNSitesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VPNSitesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VPNSitesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VPNSitesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVPNSitesResult.NextLink == nil || len(*p.current.ListVPNSitesResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VPNSitesClientListPager) NextPage(ctx context.Context) (VPNSitesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VPNSitesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSitesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSitesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VPNSitesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VPNSitesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VPNSitesClientListResponse page.
-func (p *VPNSitesClientListPager) PageResponse() VPNSitesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualAppliancesClientListByResourceGroupPager provides operations for iterating over paged responses.
 type VirtualAppliancesClientListByResourceGroupPager struct {
 	client    *VirtualAppliancesClient
 	current   VirtualAppliancesClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualAppliancesClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualAppliancesClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualAppliancesClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualAppliancesClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualApplianceListResult.NextLink == nil || len(*p.current.VirtualApplianceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualAppliancesClientListByResourceGroupPager) NextPage(ctx context.Context) (VirtualAppliancesClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualAppliancesClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualAppliancesClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualAppliancesClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualAppliancesClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualAppliancesClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualAppliancesClientListByResourceGroupResponse page.
-func (p *VirtualAppliancesClientListByResourceGroupPager) PageResponse() VirtualAppliancesClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualAppliancesClientListPager provides operations for iterating over paged responses.
 type VirtualAppliancesClientListPager struct {
 	client    *VirtualAppliancesClient
 	current   VirtualAppliancesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualAppliancesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualAppliancesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualAppliancesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualAppliancesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualApplianceListResult.NextLink == nil || len(*p.current.VirtualApplianceListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualAppliancesClientListPager) NextPage(ctx context.Context) (VirtualAppliancesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualAppliancesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualAppliancesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualAppliancesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualAppliancesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualAppliancesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualAppliancesClientListResponse page.
-func (p *VirtualAppliancesClientListPager) PageResponse() VirtualAppliancesClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualHubRouteTableV2SClientListPager provides operations for iterating over paged responses.
 type VirtualHubRouteTableV2SClientListPager struct {
 	client    *VirtualHubRouteTableV2SClient
 	current   VirtualHubRouteTableV2SClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualHubRouteTableV2SClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualHubRouteTableV2SClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualHubRouteTableV2SClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualHubRouteTableV2SClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVirtualHubRouteTableV2SResult.NextLink == nil || len(*p.current.ListVirtualHubRouteTableV2SResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualHubRouteTableV2SClientListPager) NextPage(ctx context.Context) (VirtualHubRouteTableV2SClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualHubRouteTableV2SClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubRouteTableV2SClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubRouteTableV2SClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualHubRouteTableV2SClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubRouteTableV2SClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualHubRouteTableV2SClientListResponse page.
-func (p *VirtualHubRouteTableV2SClientListPager) PageResponse() VirtualHubRouteTableV2SClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualHubsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type VirtualHubsClientListByResourceGroupPager struct {
 	client    *VirtualHubsClient
 	current   VirtualHubsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualHubsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualHubsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualHubsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualHubsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVirtualHubsResult.NextLink == nil || len(*p.current.ListVirtualHubsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualHubsClientListByResourceGroupPager) NextPage(ctx context.Context) (VirtualHubsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualHubsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualHubsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualHubsClientListByResourceGroupResponse page.
-func (p *VirtualHubsClientListByResourceGroupPager) PageResponse() VirtualHubsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualHubsClientListPager provides operations for iterating over paged responses.
 type VirtualHubsClientListPager struct {
 	client    *VirtualHubsClient
 	current   VirtualHubsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualHubsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualHubsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualHubsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualHubsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVirtualHubsResult.NextLink == nil || len(*p.current.ListVirtualHubsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualHubsClientListPager) NextPage(ctx context.Context) (VirtualHubsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualHubsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualHubsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualHubsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualHubsClientListResponse page.
-func (p *VirtualHubsClientListPager) PageResponse() VirtualHubsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworkGatewayConnectionsClientListPager provides operations for iterating over paged responses.
 type VirtualNetworkGatewayConnectionsClientListPager struct {
 	client    *VirtualNetworkGatewayConnectionsClient
 	current   VirtualNetworkGatewayConnectionsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworkGatewayConnectionsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworkGatewayConnectionsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworkGatewayConnectionsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworkGatewayConnectionsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkGatewayConnectionListResult.NextLink == nil || len(*p.current.VirtualNetworkGatewayConnectionListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworkGatewayConnectionsClientListPager) NextPage(ctx context.Context) (VirtualNetworkGatewayConnectionsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworkGatewayConnectionsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewayConnectionsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewayConnectionsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworkGatewayConnectionsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewayConnectionsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworkGatewayConnectionsClientListResponse page.
-func (p *VirtualNetworkGatewayConnectionsClientListPager) PageResponse() VirtualNetworkGatewayConnectionsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworkGatewaysClientListConnectionsPager provides operations for iterating over paged responses.
 type VirtualNetworkGatewaysClientListConnectionsPager struct {
 	client    *VirtualNetworkGatewaysClient
 	current   VirtualNetworkGatewaysClientListConnectionsResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworkGatewaysClientListConnectionsResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworkGatewaysClientListConnectionsPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworkGatewaysClientListConnectionsPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworkGatewaysClientListConnectionsPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkGatewayListConnectionsResult.NextLink == nil || len(*p.current.VirtualNetworkGatewayListConnectionsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworkGatewaysClientListConnectionsPager) NextPage(ctx context.Context) (VirtualNetworkGatewaysClientListConnectionsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworkGatewaysClientListConnectionsResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewaysClientListConnectionsResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewaysClientListConnectionsResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworkGatewaysClientListConnectionsResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listConnectionsHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewaysClientListConnectionsResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworkGatewaysClientListConnectionsResponse page.
-func (p *VirtualNetworkGatewaysClientListConnectionsPager) PageResponse() VirtualNetworkGatewaysClientListConnectionsResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworkGatewaysClientListPager provides operations for iterating over paged responses.
 type VirtualNetworkGatewaysClientListPager struct {
 	client    *VirtualNetworkGatewaysClient
 	current   VirtualNetworkGatewaysClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworkGatewaysClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworkGatewaysClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworkGatewaysClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworkGatewaysClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkGatewayListResult.NextLink == nil || len(*p.current.VirtualNetworkGatewayListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworkGatewaysClientListPager) NextPage(ctx context.Context) (VirtualNetworkGatewaysClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworkGatewaysClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewaysClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewaysClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworkGatewaysClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkGatewaysClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworkGatewaysClientListResponse page.
-func (p *VirtualNetworkGatewaysClientListPager) PageResponse() VirtualNetworkGatewaysClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworkPeeringsClientListPager provides operations for iterating over paged responses.
 type VirtualNetworkPeeringsClientListPager struct {
 	client    *VirtualNetworkPeeringsClient
 	current   VirtualNetworkPeeringsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworkPeeringsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworkPeeringsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworkPeeringsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworkPeeringsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkPeeringListResult.NextLink == nil || len(*p.current.VirtualNetworkPeeringListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworkPeeringsClientListPager) NextPage(ctx context.Context) (VirtualNetworkPeeringsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworkPeeringsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkPeeringsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkPeeringsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworkPeeringsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkPeeringsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworkPeeringsClientListResponse page.
-func (p *VirtualNetworkPeeringsClientListPager) PageResponse() VirtualNetworkPeeringsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworkTapsClientListAllPager provides operations for iterating over paged responses.
 type VirtualNetworkTapsClientListAllPager struct {
 	client    *VirtualNetworkTapsClient
 	current   VirtualNetworkTapsClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworkTapsClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworkTapsClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworkTapsClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworkTapsClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkTapListResult.NextLink == nil || len(*p.current.VirtualNetworkTapListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworkTapsClientListAllPager) NextPage(ctx context.Context) (VirtualNetworkTapsClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworkTapsClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkTapsClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkTapsClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworkTapsClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkTapsClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworkTapsClientListAllResponse page.
-func (p *VirtualNetworkTapsClientListAllPager) PageResponse() VirtualNetworkTapsClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworkTapsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type VirtualNetworkTapsClientListByResourceGroupPager struct {
 	client    *VirtualNetworkTapsClient
 	current   VirtualNetworkTapsClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworkTapsClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworkTapsClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworkTapsClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworkTapsClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkTapListResult.NextLink == nil || len(*p.current.VirtualNetworkTapListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworkTapsClientListByResourceGroupPager) NextPage(ctx context.Context) (VirtualNetworkTapsClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworkTapsClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkTapsClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkTapsClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworkTapsClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworkTapsClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworkTapsClientListByResourceGroupResponse page.
-func (p *VirtualNetworkTapsClientListByResourceGroupPager) PageResponse() VirtualNetworkTapsClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworksClientListAllPager provides operations for iterating over paged responses.
 type VirtualNetworksClientListAllPager struct {
 	client    *VirtualNetworksClient
 	current   VirtualNetworksClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworksClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworksClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworksClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworksClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkListResult.NextLink == nil || len(*p.current.VirtualNetworkListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworksClientListAllPager) NextPage(ctx context.Context) (VirtualNetworksClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworksClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworksClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworksClientListAllResponse page.
-func (p *VirtualNetworksClientListAllPager) PageResponse() VirtualNetworksClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworksClientListPager provides operations for iterating over paged responses.
 type VirtualNetworksClientListPager struct {
 	client    *VirtualNetworksClient
 	current   VirtualNetworksClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworksClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworksClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworksClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworksClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkListResult.NextLink == nil || len(*p.current.VirtualNetworkListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworksClientListPager) NextPage(ctx context.Context) (VirtualNetworksClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworksClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworksClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworksClientListResponse page.
-func (p *VirtualNetworksClientListPager) PageResponse() VirtualNetworksClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualNetworksClientListUsagePager provides operations for iterating over paged responses.
 type VirtualNetworksClientListUsagePager struct {
 	client    *VirtualNetworksClient
 	current   VirtualNetworksClientListUsageResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualNetworksClientListUsageResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualNetworksClientListUsagePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualNetworksClientListUsagePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualNetworksClientListUsagePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualNetworkListUsageResult.NextLink == nil || len(*p.current.VirtualNetworkListUsageResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualNetworksClientListUsagePager) NextPage(ctx context.Context) (VirtualNetworksClientListUsageResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualNetworksClientListUsageResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListUsageResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListUsageResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualNetworksClientListUsageResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listUsageHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualNetworksClientListUsageResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualNetworksClientListUsageResponse page.
-func (p *VirtualNetworksClientListUsagePager) PageResponse() VirtualNetworksClientListUsageResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualRouterPeeringsClientListPager provides operations for iterating over paged responses.
 type VirtualRouterPeeringsClientListPager struct {
 	client    *VirtualRouterPeeringsClient
 	current   VirtualRouterPeeringsClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualRouterPeeringsClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualRouterPeeringsClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualRouterPeeringsClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualRouterPeeringsClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualRouterPeeringListResult.NextLink == nil || len(*p.current.VirtualRouterPeeringListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualRouterPeeringsClientListPager) NextPage(ctx context.Context) (VirtualRouterPeeringsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualRouterPeeringsClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRouterPeeringsClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRouterPeeringsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualRouterPeeringsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRouterPeeringsClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualRouterPeeringsClientListResponse page.
-func (p *VirtualRouterPeeringsClientListPager) PageResponse() VirtualRouterPeeringsClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualRoutersClientListByResourceGroupPager provides operations for iterating over paged responses.
 type VirtualRoutersClientListByResourceGroupPager struct {
 	client    *VirtualRoutersClient
 	current   VirtualRoutersClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualRoutersClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualRoutersClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualRoutersClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualRoutersClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualRouterListResult.NextLink == nil || len(*p.current.VirtualRouterListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualRoutersClientListByResourceGroupPager) NextPage(ctx context.Context) (VirtualRoutersClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualRoutersClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRoutersClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRoutersClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualRoutersClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRoutersClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualRoutersClientListByResourceGroupResponse page.
-func (p *VirtualRoutersClientListByResourceGroupPager) PageResponse() VirtualRoutersClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualRoutersClientListPager provides operations for iterating over paged responses.
 type VirtualRoutersClientListPager struct {
 	client    *VirtualRoutersClient
 	current   VirtualRoutersClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualRoutersClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualRoutersClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualRoutersClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualRoutersClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.VirtualRouterListResult.NextLink == nil || len(*p.current.VirtualRouterListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualRoutersClientListPager) NextPage(ctx context.Context) (VirtualRoutersClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualRoutersClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRoutersClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRoutersClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualRoutersClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualRoutersClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualRoutersClientListResponse page.
-func (p *VirtualRoutersClientListPager) PageResponse() VirtualRoutersClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualWansClientListByResourceGroupPager provides operations for iterating over paged responses.
 type VirtualWansClientListByResourceGroupPager struct {
 	client    *VirtualWansClient
 	current   VirtualWansClientListByResourceGroupResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualWansClientListByResourceGroupResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualWansClientListByResourceGroupPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualWansClientListByResourceGroupPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualWansClientListByResourceGroupPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVirtualWANsResult.NextLink == nil || len(*p.current.ListVirtualWANsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualWansClientListByResourceGroupPager) NextPage(ctx context.Context) (VirtualWansClientListByResourceGroupResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualWansClientListByResourceGroupResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualWansClientListByResourceGroupResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualWansClientListByResourceGroupResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualWansClientListByResourceGroupResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listByResourceGroupHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualWansClientListByResourceGroupResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualWansClientListByResourceGroupResponse page.
-func (p *VirtualWansClientListByResourceGroupPager) PageResponse() VirtualWansClientListByResourceGroupResponse {
-	return p.current
+	return p.current, nil
 }
 
 // VirtualWansClientListPager provides operations for iterating over paged responses.
 type VirtualWansClientListPager struct {
 	client    *VirtualWansClient
 	current   VirtualWansClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, VirtualWansClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *VirtualWansClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *VirtualWansClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *VirtualWansClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListVirtualWANsResult.NextLink == nil || len(*p.current.ListVirtualWANsResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualWansClientListPager) NextPage(ctx context.Context) (VirtualWansClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return VirtualWansClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualWansClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualWansClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return VirtualWansClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return VirtualWansClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current VirtualWansClientListResponse page.
-func (p *VirtualWansClientListPager) PageResponse() VirtualWansClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // WebApplicationFirewallPoliciesClientListAllPager provides operations for iterating over paged responses.
 type WebApplicationFirewallPoliciesClientListAllPager struct {
 	client    *WebApplicationFirewallPoliciesClient
 	current   WebApplicationFirewallPoliciesClientListAllResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, WebApplicationFirewallPoliciesClientListAllResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *WebApplicationFirewallPoliciesClientListAllPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *WebApplicationFirewallPoliciesClientListAllPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *WebApplicationFirewallPoliciesClientListAllPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.WebApplicationFirewallPolicyListResult.NextLink == nil || len(*p.current.WebApplicationFirewallPolicyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *WebApplicationFirewallPoliciesClientListAllPager) NextPage(ctx context.Context) (WebApplicationFirewallPoliciesClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return WebApplicationFirewallPoliciesClientListAllResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return WebApplicationFirewallPoliciesClientListAllResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return WebApplicationFirewallPoliciesClientListAllResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return WebApplicationFirewallPoliciesClientListAllResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return WebApplicationFirewallPoliciesClientListAllResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current WebApplicationFirewallPoliciesClientListAllResponse page.
-func (p *WebApplicationFirewallPoliciesClientListAllPager) PageResponse() WebApplicationFirewallPoliciesClientListAllResponse {
-	return p.current
+	return p.current, nil
 }
 
 // WebApplicationFirewallPoliciesClientListPager provides operations for iterating over paged responses.
 type WebApplicationFirewallPoliciesClientListPager struct {
 	client    *WebApplicationFirewallPoliciesClient
 	current   WebApplicationFirewallPoliciesClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, WebApplicationFirewallPoliciesClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *WebApplicationFirewallPoliciesClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *WebApplicationFirewallPoliciesClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *WebApplicationFirewallPoliciesClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.WebApplicationFirewallPolicyListResult.NextLink == nil || len(*p.current.WebApplicationFirewallPolicyListResult.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *WebApplicationFirewallPoliciesClientListPager) NextPage(ctx context.Context) (WebApplicationFirewallPoliciesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return WebApplicationFirewallPoliciesClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return WebApplicationFirewallPoliciesClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return WebApplicationFirewallPoliciesClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return WebApplicationFirewallPoliciesClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return WebApplicationFirewallPoliciesClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current WebApplicationFirewallPoliciesClientListResponse page.
-func (p *WebApplicationFirewallPoliciesClientListPager) PageResponse() WebApplicationFirewallPoliciesClientListResponse {
-	return p.current
+	return p.current, nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_pagers.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_pagers.go
@@ -10,6 +10,7 @@ package azblob
 
 import (
 	"context"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,160 +21,154 @@ import (
 type containerClientListBlobFlatSegmentPager struct {
 	client    *containerClient
 	current   containerClientListBlobFlatSegmentResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, containerClientListBlobFlatSegmentResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *containerClientListBlobFlatSegmentPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *containerClientListBlobFlatSegmentPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *containerClientListBlobFlatSegmentPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListBlobsFlatSegmentResponse.NextMarker == nil || len(*p.current.ListBlobsFlatSegmentResponse.NextMarker) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *containerClientListBlobFlatSegmentPager) NextPage(ctx context.Context) (containerClientListBlobFlatSegmentResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return containerClientListBlobFlatSegmentResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return containerClientListBlobFlatSegmentResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return containerClientListBlobFlatSegmentResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return containerClientListBlobFlatSegmentResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBlobFlatSegmentHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return containerClientListBlobFlatSegmentResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current containerClientListBlobFlatSegmentResponse page.
-func (p *containerClientListBlobFlatSegmentPager) PageResponse() containerClientListBlobFlatSegmentResponse {
-	return p.current
+	return p.current, nil
 }
 
 // containerClientListBlobHierarchySegmentPager provides operations for iterating over paged responses.
 type containerClientListBlobHierarchySegmentPager struct {
 	client    *containerClient
 	current   containerClientListBlobHierarchySegmentResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, containerClientListBlobHierarchySegmentResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *containerClientListBlobHierarchySegmentPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *containerClientListBlobHierarchySegmentPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *containerClientListBlobHierarchySegmentPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListBlobsHierarchySegmentResponse.NextMarker == nil || len(*p.current.ListBlobsHierarchySegmentResponse.NextMarker) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *containerClientListBlobHierarchySegmentPager) NextPage(ctx context.Context) (containerClientListBlobHierarchySegmentResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return containerClientListBlobHierarchySegmentResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return containerClientListBlobHierarchySegmentResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return containerClientListBlobHierarchySegmentResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return containerClientListBlobHierarchySegmentResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listBlobHierarchySegmentHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return containerClientListBlobHierarchySegmentResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current containerClientListBlobHierarchySegmentResponse page.
-func (p *containerClientListBlobHierarchySegmentPager) PageResponse() containerClientListBlobHierarchySegmentResponse {
-	return p.current
+	return p.current, nil
 }
 
 // serviceClientListContainersSegmentPager provides operations for iterating over paged responses.
 type serviceClientListContainersSegmentPager struct {
 	client    *serviceClient
 	current   serviceClientListContainersSegmentResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, serviceClientListContainersSegmentResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *serviceClientListContainersSegmentPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *serviceClientListContainersSegmentPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *serviceClientListContainersSegmentPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.ListContainersSegmentResponse.NextMarker == nil || len(*p.current.ListContainersSegmentResponse.NextMarker) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *serviceClientListContainersSegmentPager) NextPage(ctx context.Context) (serviceClientListContainersSegmentResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return serviceClientListContainersSegmentResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return serviceClientListContainersSegmentResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return serviceClientListContainersSegmentResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return serviceClientListContainersSegmentResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listContainersSegmentHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return serviceClientListContainersSegmentResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current serviceClientListContainersSegmentResponse page.
-func (p *serviceClientListContainersSegmentPager) PageResponse() serviceClientListContainersSegmentResponse {
-	return p.current
+	return p.current, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pagers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pagers.go
@@ -10,6 +10,7 @@ package azartifacts
 
 import (
 	"context"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,592 +21,570 @@ import (
 type dataFlowClientGetDataFlowsByWorkspacePager struct {
 	client    *dataFlowClient
 	current   dataFlowClientGetDataFlowsByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, dataFlowClientGetDataFlowsByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *dataFlowClientGetDataFlowsByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *dataFlowClientGetDataFlowsByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *dataFlowClientGetDataFlowsByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DataFlowListResponse.NextLink == nil || len(*p.current.DataFlowListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *dataFlowClientGetDataFlowsByWorkspacePager) NextPage(ctx context.Context) (dataFlowClientGetDataFlowsByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return dataFlowClientGetDataFlowsByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return dataFlowClientGetDataFlowsByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return dataFlowClientGetDataFlowsByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return dataFlowClientGetDataFlowsByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getDataFlowsByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return dataFlowClientGetDataFlowsByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current dataFlowClientGetDataFlowsByWorkspaceResponse page.
-func (p *dataFlowClientGetDataFlowsByWorkspacePager) PageResponse() dataFlowClientGetDataFlowsByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspacePager provides operations for iterating over paged responses.
 type dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspacePager struct {
 	client    *dataFlowDebugSessionClient
 	current   dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.QueryDataFlowDebugSessionsResponse.NextLink == nil || len(*p.current.QueryDataFlowDebugSessionsResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspacePager) NextPage(ctx context.Context) (dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.queryDataFlowDebugSessionsByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse page.
-func (p *dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspacePager) PageResponse() dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // datasetClientGetDatasetsByWorkspacePager provides operations for iterating over paged responses.
 type datasetClientGetDatasetsByWorkspacePager struct {
 	client    *datasetClient
 	current   datasetClientGetDatasetsByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, datasetClientGetDatasetsByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *datasetClientGetDatasetsByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *datasetClientGetDatasetsByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *datasetClientGetDatasetsByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.DatasetListResponse.NextLink == nil || len(*p.current.DatasetListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *datasetClientGetDatasetsByWorkspacePager) NextPage(ctx context.Context) (datasetClientGetDatasetsByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return datasetClientGetDatasetsByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return datasetClientGetDatasetsByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return datasetClientGetDatasetsByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return datasetClientGetDatasetsByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getDatasetsByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return datasetClientGetDatasetsByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current datasetClientGetDatasetsByWorkspaceResponse page.
-func (p *datasetClientGetDatasetsByWorkspacePager) PageResponse() datasetClientGetDatasetsByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // libraryClientListPager provides operations for iterating over paged responses.
 type libraryClientListPager struct {
 	client    *libraryClient
 	current   libraryClientListResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, libraryClientListResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *libraryClientListPager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *libraryClientListPager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *libraryClientListPager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LibraryListResponse.NextLink == nil || len(*p.current.LibraryListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *libraryClientListPager) NextPage(ctx context.Context) (libraryClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return libraryClientListResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return libraryClientListResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return libraryClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return libraryClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return libraryClientListResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current libraryClientListResponse page.
-func (p *libraryClientListPager) PageResponse() libraryClientListResponse {
-	return p.current
+	return p.current, nil
 }
 
 // linkedServiceClientGetLinkedServicesByWorkspacePager provides operations for iterating over paged responses.
 type linkedServiceClientGetLinkedServicesByWorkspacePager struct {
 	client    *linkedServiceClient
 	current   linkedServiceClientGetLinkedServicesByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, linkedServiceClientGetLinkedServicesByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *linkedServiceClientGetLinkedServicesByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *linkedServiceClientGetLinkedServicesByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *linkedServiceClientGetLinkedServicesByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.LinkedServiceListResponse.NextLink == nil || len(*p.current.LinkedServiceListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *linkedServiceClientGetLinkedServicesByWorkspacePager) NextPage(ctx context.Context) (linkedServiceClientGetLinkedServicesByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return linkedServiceClientGetLinkedServicesByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return linkedServiceClientGetLinkedServicesByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return linkedServiceClientGetLinkedServicesByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return linkedServiceClientGetLinkedServicesByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getLinkedServicesByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return linkedServiceClientGetLinkedServicesByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current linkedServiceClientGetLinkedServicesByWorkspaceResponse page.
-func (p *linkedServiceClientGetLinkedServicesByWorkspacePager) PageResponse() linkedServiceClientGetLinkedServicesByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // notebookClientGetNotebookSummaryByWorkSpacePager provides operations for iterating over paged responses.
 type notebookClientGetNotebookSummaryByWorkSpacePager struct {
 	client    *notebookClient
 	current   notebookClientGetNotebookSummaryByWorkSpaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, notebookClientGetNotebookSummaryByWorkSpaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *notebookClientGetNotebookSummaryByWorkSpacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *notebookClientGetNotebookSummaryByWorkSpacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *notebookClientGetNotebookSummaryByWorkSpacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.NotebookListResponse.NextLink == nil || len(*p.current.NotebookListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *notebookClientGetNotebookSummaryByWorkSpacePager) NextPage(ctx context.Context) (notebookClientGetNotebookSummaryByWorkSpaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return notebookClientGetNotebookSummaryByWorkSpaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return notebookClientGetNotebookSummaryByWorkSpaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return notebookClientGetNotebookSummaryByWorkSpaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return notebookClientGetNotebookSummaryByWorkSpaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getNotebookSummaryByWorkSpaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return notebookClientGetNotebookSummaryByWorkSpaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current notebookClientGetNotebookSummaryByWorkSpaceResponse page.
-func (p *notebookClientGetNotebookSummaryByWorkSpacePager) PageResponse() notebookClientGetNotebookSummaryByWorkSpaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // notebookClientGetNotebooksByWorkspacePager provides operations for iterating over paged responses.
 type notebookClientGetNotebooksByWorkspacePager struct {
 	client    *notebookClient
 	current   notebookClientGetNotebooksByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, notebookClientGetNotebooksByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *notebookClientGetNotebooksByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *notebookClientGetNotebooksByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *notebookClientGetNotebooksByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.NotebookListResponse.NextLink == nil || len(*p.current.NotebookListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *notebookClientGetNotebooksByWorkspacePager) NextPage(ctx context.Context) (notebookClientGetNotebooksByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return notebookClientGetNotebooksByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return notebookClientGetNotebooksByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return notebookClientGetNotebooksByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return notebookClientGetNotebooksByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getNotebooksByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return notebookClientGetNotebooksByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current notebookClientGetNotebooksByWorkspaceResponse page.
-func (p *notebookClientGetNotebooksByWorkspacePager) PageResponse() notebookClientGetNotebooksByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // pipelineClientGetPipelinesByWorkspacePager provides operations for iterating over paged responses.
 type pipelineClientGetPipelinesByWorkspacePager struct {
 	client    *pipelineClient
 	current   pipelineClientGetPipelinesByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, pipelineClientGetPipelinesByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *pipelineClientGetPipelinesByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *pipelineClientGetPipelinesByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *pipelineClientGetPipelinesByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.PipelineListResponse.NextLink == nil || len(*p.current.PipelineListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *pipelineClientGetPipelinesByWorkspacePager) NextPage(ctx context.Context) (pipelineClientGetPipelinesByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return pipelineClientGetPipelinesByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return pipelineClientGetPipelinesByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return pipelineClientGetPipelinesByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return pipelineClientGetPipelinesByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getPipelinesByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return pipelineClientGetPipelinesByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current pipelineClientGetPipelinesByWorkspaceResponse page.
-func (p *pipelineClientGetPipelinesByWorkspacePager) PageResponse() pipelineClientGetPipelinesByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspacePager provides operations for iterating over paged responses.
 type sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspacePager struct {
 	client    *sparkJobDefinitionClient
 	current   sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SparkJobDefinitionsListResponse.NextLink == nil || len(*p.current.SparkJobDefinitionsListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspacePager) NextPage(ctx context.Context) (sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getSparkJobDefinitionsByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse page.
-func (p *sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspacePager) PageResponse() sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // sqlScriptClientGetSQLScriptsByWorkspacePager provides operations for iterating over paged responses.
 type sqlScriptClientGetSQLScriptsByWorkspacePager struct {
 	client    *sqlScriptClient
 	current   sqlScriptClientGetSQLScriptsByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, sqlScriptClientGetSQLScriptsByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *sqlScriptClientGetSQLScriptsByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *sqlScriptClientGetSQLScriptsByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *sqlScriptClientGetSQLScriptsByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.SQLScriptsListResponse.NextLink == nil || len(*p.current.SQLScriptsListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *sqlScriptClientGetSQLScriptsByWorkspacePager) NextPage(ctx context.Context) (sqlScriptClientGetSQLScriptsByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return sqlScriptClientGetSQLScriptsByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return sqlScriptClientGetSQLScriptsByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return sqlScriptClientGetSQLScriptsByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return sqlScriptClientGetSQLScriptsByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getSQLScriptsByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return sqlScriptClientGetSQLScriptsByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current sqlScriptClientGetSQLScriptsByWorkspaceResponse page.
-func (p *sqlScriptClientGetSQLScriptsByWorkspacePager) PageResponse() sqlScriptClientGetSQLScriptsByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }
 
 // triggerClientGetTriggersByWorkspacePager provides operations for iterating over paged responses.
 type triggerClientGetTriggersByWorkspacePager struct {
 	client    *triggerClient
 	current   triggerClientGetTriggersByWorkspaceResponse
-	err       error
 	requester func(context.Context) (*policy.Request, error)
 	advancer  func(context.Context, triggerClientGetTriggersByWorkspaceResponse) (*policy.Request, error)
 }
 
-// Err returns the last error encountered while paging.
-func (p *triggerClientGetTriggersByWorkspacePager) Err() error {
-	return p.err
-}
-
-// NextPage returns true if the pager advanced to the next page.
-// Returns false if there are no more pages or an error occurred.
-func (p *triggerClientGetTriggersByWorkspacePager) NextPage(ctx context.Context) bool {
-	var req *policy.Request
-	var err error
+// More returns true if there are more pages to retrieve.
+func (p *triggerClientGetTriggersByWorkspacePager) More() bool {
 	if !reflect.ValueOf(p.current).IsZero() {
 		if p.current.TriggerListResponse.NextLink == nil || len(*p.current.TriggerListResponse.NextLink) == 0 {
 			return false
+		}
+	}
+	return true
+}
+
+// NextPage advances the pager to the next page.
+func (p *triggerClientGetTriggersByWorkspacePager) NextPage(ctx context.Context) (triggerClientGetTriggersByWorkspaceResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		if !p.More() {
+			return triggerClientGetTriggersByWorkspaceResponse{}, errors.New("no more pages")
 		}
 		req, err = p.advancer(ctx, p.current)
 	} else {
 		req, err = p.requester(ctx)
 	}
 	if err != nil {
-		p.err = err
-		return false
+
+		return triggerClientGetTriggersByWorkspaceResponse{}, err
 	}
 	resp, err := p.client.pl.Do(req)
 	if err != nil {
-		p.err = err
-		return false
+
+		return triggerClientGetTriggersByWorkspaceResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		p.err = runtime.NewResponseError(resp)
-		return false
+
+		return triggerClientGetTriggersByWorkspaceResponse{}, runtime.NewResponseError(resp)
 	}
 	result, err := p.client.getTriggersByWorkspaceHandleResponse(resp)
 	if err != nil {
-		p.err = err
-		return false
+
+		return triggerClientGetTriggersByWorkspaceResponse{}, err
 	}
 	p.current = result
-	return true
-}
-
-// PageResponse returns the current triggerClientGetTriggersByWorkspaceResponse page.
-func (p *triggerClientGetTriggersByWorkspacePager) PageResponse() triggerClientGetTriggersByWorkspaceResponse {
-	return p.current
+	return p.current, nil
 }


### PR DESCRIPTION
NextPage() now returns the page or an error, effectively combining the
old PageResponse() and Err() methods.
Added method More() which returns true if there are more pages to fetch.
Removed Err() and PageResponse() methods.