### PR TITLE
Generate pager APIs for single-page operations

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -48,7 +48,7 @@ export interface PagerInfo {
 
 // returns true if the operation is pageable
 export function isPageableOperation(op: Operation): boolean {
-  return op.language.go!.paging && op.language.go!.paging.nextLinkName !== null;
+  return op.language.go!.paging;
 }
 
 export interface PollerInfo {

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -505,7 +505,7 @@ function generateOperation(op: Operation, imports: ImportManager): string {
     text += `\t\trequester: func(ctx context.Context) (*policy.Request, error) {\n`;
     text += `\t\t\treturn client.${info.protocolNaming.requestMethod}(${reqParams})\n`;
     text += '\t\t},\n';
-    // this is no advancer for single-page pagers
+    // there is no advancer for single-page pagers
     if (op.language.go!.paging.nextLinkName) {
       text += `\t\tadvancer: func(ctx context.Context, resp ${getResponseEnvelopeName(op)}) (*policy.Request, error) {\n`;
       const nextLink = op.language.go!.paging.nextLinkName;

--- a/src/generator/pagers.ts
+++ b/src/generator/pagers.ts
@@ -74,8 +74,8 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
       // note the trailing tab for the next line
       text += '\tvar req *policy.Request\n\tvar err error\n\t';
     }
-    text += 'if !reflect.ValueOf(p.current).IsZero() {\n';
     if (pager.op.language.go!.paging.nextLinkName) {
+      text += 'if !reflect.ValueOf(p.current).IsZero() {\n';
       text += `\t\tif !p.More() {\n`;
       text += `\t\t\treturn ${respEnv}{}, errors.New("no more pages")\n\t\t}\n`;
       if (isLROOperation(pager.op)) {
@@ -86,6 +86,7 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
         text += '\t\treq, err = p.requester(ctx)\n\t}\n';
       }
     } else {
+      text += 'if !p.More() {\n';
       text += `\t\treturn ${respEnv}{}, errors.New("no more pages")\n\t} else {\n\treq, err = p.requester(ctx)\n\t}\n`;
     }
     text += `\tif err != nil {\n\t\treturn ${respEnv}{}, err\n\t}\n`;

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -265,12 +265,21 @@ func TestGetNoItemNamePages(t *testing.T) {
 // GetNullNextLinkNamePages - A paging operation that must ignore any kind of nextLink, and stop after page 1.
 func TestGetNullNextLinkNamePages(t *testing.T) {
 	client := newPagingClient()
-	resp, err := client.GetNullNextLinkNamePages(context.Background(), nil)
-	if err != nil {
-		t.Fatal(err)
+	pager := client.GetNullNextLinkNamePages(nil)
+	count := 0
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if reflect.ValueOf(page).IsZero() {
+			t.Fatal("unexpected empty payload")
+		} else if len(page.ProductResult.Values) == 0 {
+			t.Fatal("missing payload")
+		}
+		count++
 	}
-	if len(resp.ProductResult.Values) == 0 {
-		t.Fatal("missing payload")
+	if r := cmp.Diff(count, 1); r != "" {
+		t.Fatal(r)
 	}
 }
 

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -52,6 +52,9 @@ func TestGetMultiplePages(t *testing.T) {
 	if r := cmp.Diff(count, 10); r != "" {
 		t.Fatal(r)
 	}
+	if _, err := pager.NextPage(context.Background()); err == nil {
+		t.Fatal("unexpected nil error")
+	}
 }
 
 // GetMultiplePagesFailure - A paging operation that receives a 400 on the second call
@@ -280,6 +283,9 @@ func TestGetNullNextLinkNamePages(t *testing.T) {
 	}
 	if r := cmp.Diff(count, 1); r != "" {
 		t.Fatal(r)
+	}
+	if _, err := pager.NextPage(context.Background()); err == nil {
+		t.Fatal("unexpected nil error")
 	}
 }
 

--- a/test/autorest/paginggroup/zz_generated_pagers.go
+++ b/test/autorest/paginggroup/zz_generated_pagers.go
@@ -554,6 +554,46 @@ func (p *PagingClientGetNoItemNamePagesPager) NextPage(ctx context.Context) (Pag
 	return p.current, nil
 }
 
+// PagingClientGetNullNextLinkNamePagesPager provides operations for iterating over paged responses.
+type PagingClientGetNullNextLinkNamePagesPager struct {
+	client    *PagingClient
+	current   PagingClientGetNullNextLinkNamePagesResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientGetNullNextLinkNamePagesPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientGetNullNextLinkNamePagesPager) NextPage(ctx context.Context) (PagingClientGetNullNextLinkNamePagesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return PagingClientGetNullNextLinkNamePagesResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return PagingClientGetNullNextLinkNamePagesResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return PagingClientGetNullNextLinkNamePagesResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return PagingClientGetNullNextLinkNamePagesResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.getNullNextLinkNamePagesHandleResponse(resp)
+	if err != nil {
+		return PagingClientGetNullNextLinkNamePagesResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
 // PagingClientGetODataMultiplePagesPager provides operations for iterating over paged responses.
 type PagingClientGetODataMultiplePagesPager struct {
 	client    *PagingClient
@@ -892,6 +932,46 @@ func (p *PagingClientNextFragmentWithGroupingPager) NextPage(ctx context.Context
 	result, err := p.client.nextFragmentWithGroupingHandleResponse(resp)
 	if err != nil {
 		return PagingClientNextFragmentWithGroupingResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
+// PagingClientNextOperationWithQueryParamsPager provides operations for iterating over paged responses.
+type PagingClientNextOperationWithQueryParamsPager struct {
+	client    *PagingClient
+	current   PagingClientNextOperationWithQueryParamsResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *PagingClientNextOperationWithQueryParamsPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *PagingClientNextOperationWithQueryParamsPager) NextPage(ctx context.Context) (PagingClientNextOperationWithQueryParamsResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return PagingClientNextOperationWithQueryParamsResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return PagingClientNextOperationWithQueryParamsResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return PagingClientNextOperationWithQueryParamsResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return PagingClientNextOperationWithQueryParamsResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.nextOperationWithQueryParamsHandleResponse(resp)
+	if err != nil {
+		return PagingClientNextOperationWithQueryParamsResponse{}, err
 	}
 	p.current = result
 	return p.current, nil

--- a/test/autorest/paginggroup/zz_generated_pagers.go
+++ b/test/autorest/paginggroup/zz_generated_pagers.go
@@ -570,7 +570,7 @@ func (p *PagingClientGetNullNextLinkNamePagesPager) More() bool {
 func (p *PagingClientGetNullNextLinkNamePagesPager) NextPage(ctx context.Context) (PagingClientGetNullNextLinkNamePagesResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return PagingClientGetNullNextLinkNamePagesResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)
@@ -953,7 +953,7 @@ func (p *PagingClientNextOperationWithQueryParamsPager) More() bool {
 func (p *PagingClientNextOperationWithQueryParamsPager) NextPage(ctx context.Context) (PagingClientNextOperationWithQueryParamsResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return PagingClientNextOperationWithQueryParamsResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)

--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -510,19 +510,13 @@ func (client *PagingClient) getNoItemNamePagesHandleResponse(resp *http.Response
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - PagingClientGetNullNextLinkNamePagesOptions contains the optional parameters for the PagingClient.GetNullNextLinkNamePages
 // method.
-func (client *PagingClient) GetNullNextLinkNamePages(ctx context.Context, options *PagingClientGetNullNextLinkNamePagesOptions) (PagingClientGetNullNextLinkNamePagesResponse, error) {
-	req, err := client.getNullNextLinkNamePagesCreateRequest(ctx, options)
-	if err != nil {
-		return PagingClientGetNullNextLinkNamePagesResponse{}, err
+func (client *PagingClient) GetNullNextLinkNamePages(options *PagingClientGetNullNextLinkNamePagesOptions) *PagingClientGetNullNextLinkNamePagesPager {
+	return &PagingClientGetNullNextLinkNamePagesPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.getNullNextLinkNamePagesCreateRequest(ctx, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return PagingClientGetNullNextLinkNamePagesResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return PagingClientGetNullNextLinkNamePagesResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.getNullNextLinkNamePagesHandleResponse(resp)
 }
 
 // getNullNextLinkNamePagesCreateRequest creates the GetNullNextLinkNamePages request.

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
@@ -261,19 +261,13 @@ func (client *AvailabilitySetsClient) listHandleResponse(resp *http.Response) (A
 // availabilitySetName - The name of the availability set.
 // options - AvailabilitySetsClientListAvailableSizesOptions contains the optional parameters for the AvailabilitySetsClient.ListAvailableSizes
 // method.
-func (client *AvailabilitySetsClient) ListAvailableSizes(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsClientListAvailableSizesOptions) (AvailabilitySetsClientListAvailableSizesResponse, error) {
-	req, err := client.listAvailableSizesCreateRequest(ctx, resourceGroupName, availabilitySetName, options)
-	if err != nil {
-		return AvailabilitySetsClientListAvailableSizesResponse{}, err
+func (client *AvailabilitySetsClient) ListAvailableSizes(resourceGroupName string, availabilitySetName string, options *AvailabilitySetsClientListAvailableSizesOptions) *AvailabilitySetsClientListAvailableSizesPager {
+	return &AvailabilitySetsClientListAvailableSizesPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listAvailableSizesCreateRequest(ctx, resourceGroupName, availabilitySetName, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return AvailabilitySetsClientListAvailableSizesResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return AvailabilitySetsClientListAvailableSizesResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listAvailableSizesHandleResponse(resp)
 }
 
 // listAvailableSizesCreateRequest creates the ListAvailableSizes request.

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
@@ -46,19 +46,13 @@ func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientO
 // List - Gets a list of compute operations.
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - OperationsClientListOptions contains the optional parameters for the OperationsClient.List method.
-func (client *OperationsClient) List(ctx context.Context, options *OperationsClientListOptions) (OperationsClientListResponse, error) {
-	req, err := client.listCreateRequest(ctx, options)
-	if err != nil {
-		return OperationsClientListResponse{}, err
+func (client *OperationsClient) List(options *OperationsClientListOptions) *OperationsClientListPager {
+	return &OperationsClientListPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listCreateRequest(ctx, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return OperationsClientListResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return OperationsClientListResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.

--- a/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
@@ -17,6 +17,46 @@ import (
 	"reflect"
 )
 
+// AvailabilitySetsClientListAvailableSizesPager provides operations for iterating over paged responses.
+type AvailabilitySetsClientListAvailableSizesPager struct {
+	client    *AvailabilitySetsClient
+	current   AvailabilitySetsClientListAvailableSizesResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *AvailabilitySetsClientListAvailableSizesPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *AvailabilitySetsClientListAvailableSizesPager) NextPage(ctx context.Context) (AvailabilitySetsClientListAvailableSizesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return AvailabilitySetsClientListAvailableSizesResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return AvailabilitySetsClientListAvailableSizesResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return AvailabilitySetsClientListAvailableSizesResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return AvailabilitySetsClientListAvailableSizesResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listAvailableSizesHandleResponse(resp)
+	if err != nil {
+		return AvailabilitySetsClientListAvailableSizesResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
 // AvailabilitySetsClientListBySubscriptionPager provides operations for iterating over paged responses.
 type AvailabilitySetsClientListBySubscriptionPager struct {
 	client    *AvailabilitySetsClient
@@ -948,6 +988,46 @@ func (p *ImagesClientListPager) NextPage(ctx context.Context) (ImagesClientListR
 	return p.current, nil
 }
 
+// OperationsClientListPager provides operations for iterating over paged responses.
+type OperationsClientListPager struct {
+	client    *OperationsClient
+	current   OperationsClientListResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *OperationsClientListPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *OperationsClientListPager) NextPage(ctx context.Context) (OperationsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return OperationsClientListResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return OperationsClientListResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return OperationsClientListResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return OperationsClientListResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listHandleResponse(resp)
+	if err != nil {
+		return OperationsClientListResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
 // ProximityPlacementGroupsClientListByResourceGroupPager provides operations for iterating over paged responses.
 type ProximityPlacementGroupsClientListByResourceGroupPager struct {
 	client    *ProximityPlacementGroupsClient
@@ -1683,6 +1763,46 @@ func (p *VirtualMachineScaleSetsClientListSKUsPager) NextPage(ctx context.Contex
 	return p.current, nil
 }
 
+// VirtualMachineSizesClientListPager provides operations for iterating over paged responses.
+type VirtualMachineSizesClientListPager struct {
+	client    *VirtualMachineSizesClient
+	current   VirtualMachineSizesClientListResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachineSizesClientListPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachineSizesClientListPager) NextPage(ctx context.Context) (VirtualMachineSizesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return VirtualMachineSizesClientListResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return VirtualMachineSizesClientListResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return VirtualMachineSizesClientListResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return VirtualMachineSizesClientListResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listHandleResponse(resp)
+	if err != nil {
+		return VirtualMachineSizesClientListResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
 // VirtualMachinesClientListAllPager provides operations for iterating over paged responses.
 type VirtualMachinesClientListAllPager struct {
 	client    *VirtualMachinesClient
@@ -1727,6 +1847,46 @@ func (p *VirtualMachinesClientListAllPager) NextPage(ctx context.Context) (Virtu
 	result, err := p.client.listAllHandleResponse(resp)
 	if err != nil {
 		return VirtualMachinesClientListAllResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
+// VirtualMachinesClientListAvailableSizesPager provides operations for iterating over paged responses.
+type VirtualMachinesClientListAvailableSizesPager struct {
+	client    *VirtualMachinesClient
+	current   VirtualMachinesClientListAvailableSizesResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *VirtualMachinesClientListAvailableSizesPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *VirtualMachinesClientListAvailableSizesPager) NextPage(ctx context.Context) (VirtualMachinesClientListAvailableSizesResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return VirtualMachinesClientListAvailableSizesResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return VirtualMachinesClientListAvailableSizesResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return VirtualMachinesClientListAvailableSizesResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return VirtualMachinesClientListAvailableSizesResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listAvailableSizesHandleResponse(resp)
+	if err != nil {
+		return VirtualMachinesClientListAvailableSizesResponse{}, err
 	}
 	p.current = result
 	return p.current, nil

--- a/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
@@ -33,7 +33,7 @@ func (p *AvailabilitySetsClientListAvailableSizesPager) More() bool {
 func (p *AvailabilitySetsClientListAvailableSizesPager) NextPage(ctx context.Context) (AvailabilitySetsClientListAvailableSizesResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return AvailabilitySetsClientListAvailableSizesResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)
@@ -1004,7 +1004,7 @@ func (p *OperationsClientListPager) More() bool {
 func (p *OperationsClientListPager) NextPage(ctx context.Context) (OperationsClientListResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return OperationsClientListResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)
@@ -1779,7 +1779,7 @@ func (p *VirtualMachineSizesClientListPager) More() bool {
 func (p *VirtualMachineSizesClientListPager) NextPage(ctx context.Context) (VirtualMachineSizesClientListResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return VirtualMachineSizesClientListResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)
@@ -1868,7 +1868,7 @@ func (p *VirtualMachinesClientListAvailableSizesPager) More() bool {
 func (p *VirtualMachinesClientListAvailableSizesPager) NextPage(ctx context.Context) (VirtualMachinesClientListAvailableSizesResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return VirtualMachinesClientListAvailableSizesResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
@@ -663,19 +663,13 @@ func (client *VirtualMachinesClient) listAllHandleResponse(resp *http.Response) 
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientListAvailableSizesOptions contains the optional parameters for the VirtualMachinesClient.ListAvailableSizes
 // method.
-func (client *VirtualMachinesClient) ListAvailableSizes(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientListAvailableSizesOptions) (VirtualMachinesClientListAvailableSizesResponse, error) {
-	req, err := client.listAvailableSizesCreateRequest(ctx, resourceGroupName, vmName, options)
-	if err != nil {
-		return VirtualMachinesClientListAvailableSizesResponse{}, err
+func (client *VirtualMachinesClient) ListAvailableSizes(resourceGroupName string, vmName string, options *VirtualMachinesClientListAvailableSizesOptions) *VirtualMachinesClientListAvailableSizesPager {
+	return &VirtualMachinesClientListAvailableSizesPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listAvailableSizesCreateRequest(ctx, resourceGroupName, vmName, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return VirtualMachinesClientListAvailableSizesResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return VirtualMachinesClientListAvailableSizesResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listAvailableSizesHandleResponse(resp)
 }
 
 // listAvailableSizesCreateRequest creates the ListAvailableSizes request.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
@@ -55,19 +55,13 @@ func NewVirtualMachineSizesClient(subscriptionID string, credential azcore.Token
 // location - The location upon which virtual-machine-sizes is queried.
 // options - VirtualMachineSizesClientListOptions contains the optional parameters for the VirtualMachineSizesClient.List
 // method.
-func (client *VirtualMachineSizesClient) List(ctx context.Context, location string, options *VirtualMachineSizesClientListOptions) (VirtualMachineSizesClientListResponse, error) {
-	req, err := client.listCreateRequest(ctx, location, options)
-	if err != nil {
-		return VirtualMachineSizesClientListResponse{}, err
+func (client *VirtualMachineSizesClient) List(location string, options *VirtualMachineSizesClientListOptions) *VirtualMachineSizesClientListPager {
+	return &VirtualMachineSizesClientListPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listCreateRequest(ctx, location, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return VirtualMachineSizesClientListResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return VirtualMachineSizesClientListResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_forecasts_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_forecasts_client.go
@@ -54,19 +54,13 @@ func NewForecastsClient(subscriptionID string, credential azcore.TokenCredential
 // https://docs.microsoft.com/en-us/rest/api/cost-management/forecast/usage.
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - ForecastsClientListOptions contains the optional parameters for the ForecastsClient.List method.
-func (client *ForecastsClient) List(ctx context.Context, options *ForecastsClientListOptions) (ForecastsClientListResponse, error) {
-	req, err := client.listCreateRequest(ctx, options)
-	if err != nil {
-		return ForecastsClientListResponse{}, err
+func (client *ForecastsClient) List(options *ForecastsClientListOptions) *ForecastsClientListPager {
+	return &ForecastsClientListPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listCreateRequest(ctx, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return ForecastsClientListResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return ForecastsClientListResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_pagers.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_pagers.go
@@ -115,6 +115,46 @@ func (p *EventsClientListPager) NextPage(ctx context.Context) (EventsClientListR
 	return p.current, nil
 }
 
+// ForecastsClientListPager provides operations for iterating over paged responses.
+type ForecastsClientListPager struct {
+	client    *ForecastsClient
+	current   ForecastsClientListResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *ForecastsClientListPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *ForecastsClientListPager) NextPage(ctx context.Context) (ForecastsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return ForecastsClientListResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return ForecastsClientListResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return ForecastsClientListResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return ForecastsClientListResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listHandleResponse(resp)
+	if err != nil {
+		return ForecastsClientListResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
 // LotsClientListPager provides operations for iterating over paged responses.
 type LotsClientListPager struct {
 	client    *LotsClient

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_pagers.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_pagers.go
@@ -131,7 +131,7 @@ func (p *ForecastsClientListPager) More() bool {
 func (p *ForecastsClientListPager) NextPage(ctx context.Context) (ForecastsClientListResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return ForecastsClientListResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
@@ -260,19 +260,13 @@ func (client *ConnectionMonitorsClient) getHandleResponse(resp *http.Response) (
 // resourceGroupName - The name of the resource group containing Network Watcher.
 // networkWatcherName - The name of the Network Watcher resource.
 // options - ConnectionMonitorsClientListOptions contains the optional parameters for the ConnectionMonitorsClient.List method.
-func (client *ConnectionMonitorsClient) List(ctx context.Context, resourceGroupName string, networkWatcherName string, options *ConnectionMonitorsClientListOptions) (ConnectionMonitorsClientListResponse, error) {
-	req, err := client.listCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
-	if err != nil {
-		return ConnectionMonitorsClientListResponse{}, err
+func (client *ConnectionMonitorsClient) List(resourceGroupName string, networkWatcherName string, options *ConnectionMonitorsClientListOptions) *ConnectionMonitorsClientListPager {
+	return &ConnectionMonitorsClientListPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return ConnectionMonitorsClientListResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return ConnectionMonitorsClientListResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
@@ -332,19 +332,13 @@ func (client *PacketCapturesClient) getStatusCreateRequest(ctx context.Context, 
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the Network Watcher resource.
 // options - PacketCapturesClientListOptions contains the optional parameters for the PacketCapturesClient.List method.
-func (client *PacketCapturesClient) List(ctx context.Context, resourceGroupName string, networkWatcherName string, options *PacketCapturesClientListOptions) (PacketCapturesClientListResponse, error) {
-	req, err := client.listCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
-	if err != nil {
-		return PacketCapturesClientListResponse{}, err
+func (client *PacketCapturesClient) List(resourceGroupName string, networkWatcherName string, options *PacketCapturesClientListOptions) *PacketCapturesClientListPager {
+	return &PacketCapturesClientListPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return PacketCapturesClientListResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return PacketCapturesClientListResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.

--- a/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
@@ -899,6 +899,46 @@ func (p *BgpServiceCommunitiesClientListPager) NextPage(ctx context.Context) (Bg
 	return p.current, nil
 }
 
+// ConnectionMonitorsClientListPager provides operations for iterating over paged responses.
+type ConnectionMonitorsClientListPager struct {
+	client    *ConnectionMonitorsClient
+	current   ConnectionMonitorsClientListResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *ConnectionMonitorsClientListPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *ConnectionMonitorsClientListPager) NextPage(ctx context.Context) (ConnectionMonitorsClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return ConnectionMonitorsClientListResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return ConnectionMonitorsClientListResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return ConnectionMonitorsClientListResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return ConnectionMonitorsClientListResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listHandleResponse(resp)
+	if err != nil {
+		return ConnectionMonitorsClientListResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
 // DdosProtectionPlansClientListByResourceGroupPager provides operations for iterating over paged responses.
 type DdosProtectionPlansClientListByResourceGroupPager struct {
 	client    *DdosProtectionPlansClient
@@ -3438,6 +3478,46 @@ func (p *P2SVPNGatewaysClientListPager) NextPage(ctx context.Context) (P2SVPNGat
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
 		return P2SVPNGatewaysClientListResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
+// PacketCapturesClientListPager provides operations for iterating over paged responses.
+type PacketCapturesClientListPager struct {
+	client    *PacketCapturesClient
+	current   PacketCapturesClientListResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *PacketCapturesClientListPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *PacketCapturesClientListPager) NextPage(ctx context.Context) (PacketCapturesClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return PacketCapturesClientListResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return PacketCapturesClientListResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return PacketCapturesClientListResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return PacketCapturesClientListResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listHandleResponse(resp)
+	if err != nil {
+		return PacketCapturesClientListResponse{}, err
 	}
 	p.current = result
 	return p.current, nil
@@ -6427,6 +6507,86 @@ func (p *VirtualWansClientListPager) NextPage(ctx context.Context) (VirtualWansC
 	result, err := p.client.listHandleResponse(resp)
 	if err != nil {
 		return VirtualWansClientListResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
+// WatchersClientListAllPager provides operations for iterating over paged responses.
+type WatchersClientListAllPager struct {
+	client    *WatchersClient
+	current   WatchersClientListAllResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *WatchersClientListAllPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *WatchersClientListAllPager) NextPage(ctx context.Context) (WatchersClientListAllResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return WatchersClientListAllResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return WatchersClientListAllResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return WatchersClientListAllResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return WatchersClientListAllResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listAllHandleResponse(resp)
+	if err != nil {
+		return WatchersClientListAllResponse{}, err
+	}
+	p.current = result
+	return p.current, nil
+}
+
+// WatchersClientListPager provides operations for iterating over paged responses.
+type WatchersClientListPager struct {
+	client    *WatchersClient
+	current   WatchersClientListResponse
+	requester func(context.Context) (*policy.Request, error)
+}
+
+// More returns true if there are more pages to retrieve.
+func (p *WatchersClientListPager) More() bool {
+	return reflect.ValueOf(p.current).IsZero()
+}
+
+// NextPage advances the pager to the next page.
+func (p *WatchersClientListPager) NextPage(ctx context.Context) (WatchersClientListResponse, error) {
+	var req *policy.Request
+	var err error
+	if !reflect.ValueOf(p.current).IsZero() {
+		return WatchersClientListResponse{}, errors.New("no more pages")
+	} else {
+		req, err = p.requester(ctx)
+	}
+	if err != nil {
+		return WatchersClientListResponse{}, err
+	}
+	resp, err := p.client.pl.Do(req)
+	if err != nil {
+		return WatchersClientListResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+
+		return WatchersClientListResponse{}, runtime.NewResponseError(resp)
+	}
+	result, err := p.client.listHandleResponse(resp)
+	if err != nil {
+		return WatchersClientListResponse{}, err
 	}
 	p.current = result
 	return p.current, nil

--- a/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
@@ -915,7 +915,7 @@ func (p *ConnectionMonitorsClientListPager) More() bool {
 func (p *ConnectionMonitorsClientListPager) NextPage(ctx context.Context) (ConnectionMonitorsClientListResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return ConnectionMonitorsClientListResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)
@@ -3499,7 +3499,7 @@ func (p *PacketCapturesClientListPager) More() bool {
 func (p *PacketCapturesClientListPager) NextPage(ctx context.Context) (PacketCapturesClientListResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return PacketCapturesClientListResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)
@@ -6528,7 +6528,7 @@ func (p *WatchersClientListAllPager) More() bool {
 func (p *WatchersClientListAllPager) NextPage(ctx context.Context) (WatchersClientListAllResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return WatchersClientListAllResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)
@@ -6568,7 +6568,7 @@ func (p *WatchersClientListPager) More() bool {
 func (p *WatchersClientListPager) NextPage(ctx context.Context) (WatchersClientListResponse, error) {
 	var req *policy.Request
 	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
+	if !p.More() {
 		return WatchersClientListResponse{}, errors.New("no more pages")
 	} else {
 		req, err = p.requester(ctx)

--- a/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
@@ -843,19 +843,13 @@ func (client *WatchersClient) getVMSecurityRulesCreateRequest(ctx context.Contex
 // If the operation fails it returns an *azcore.ResponseError type.
 // resourceGroupName - The name of the resource group.
 // options - WatchersClientListOptions contains the optional parameters for the WatchersClient.List method.
-func (client *WatchersClient) List(ctx context.Context, resourceGroupName string, options *WatchersClientListOptions) (WatchersClientListResponse, error) {
-	req, err := client.listCreateRequest(ctx, resourceGroupName, options)
-	if err != nil {
-		return WatchersClientListResponse{}, err
+func (client *WatchersClient) List(resourceGroupName string, options *WatchersClientListOptions) *WatchersClientListPager {
+	return &WatchersClientListPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listCreateRequest(ctx, resourceGroupName, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return WatchersClientListResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return WatchersClientListResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -892,19 +886,13 @@ func (client *WatchersClient) listHandleResponse(resp *http.Response) (WatchersC
 // ListAll - Gets all network watchers by subscription.
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - WatchersClientListAllOptions contains the optional parameters for the WatchersClient.ListAll method.
-func (client *WatchersClient) ListAll(ctx context.Context, options *WatchersClientListAllOptions) (WatchersClientListAllResponse, error) {
-	req, err := client.listAllCreateRequest(ctx, options)
-	if err != nil {
-		return WatchersClientListAllResponse{}, err
+func (client *WatchersClient) ListAll(options *WatchersClientListAllOptions) *WatchersClientListAllPager {
+	return &WatchersClientListAllPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.listAllCreateRequest(ctx, options)
+		},
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return WatchersClientListAllResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return WatchersClientListAllResponse{}, runtime.NewResponseError(resp)
-	}
-	return client.listAllHandleResponse(resp)
 }
 
 // listAllCreateRequest creates the ListAll request.


### PR DESCRIPTION
When a pager's nextLinkName is null, it means that the API returns a
single page now but might return multiple in the future which shouldn't
be considered a breaking change.