### PR TITLE
Fix handling of client-side default values

### DIFF
--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -366,6 +366,12 @@ function processOperationRequests(session: Session<CodeModel>) {
         if (param.language.go!.description) {
           param.language.go!.description = parseComments(param.language.go!.description);
         }
+        if (param.clientDefaultValue && param.implementation === ImplementationLocation.Method) {
+          // we treat method params with a client-side default as optional
+          // since if you don't specify a value, a default is sent and the
+          // zero-value is ambiguous.
+          param.required = false;
+        }
         if (!param.required && param.schema.type === SchemaType.Constant && !param.language.go!.amendedDesc) {
           if (param.language.go!.description) {
             param.language.go!.description += '. ';

--- a/test/autorest/errorsgroup/zz_generated_pet_client.go
+++ b/test/autorest/errorsgroup/zz_generated_pet_client.go
@@ -150,9 +150,11 @@ func (client *PetClient) hasModelsParamCreateRequest(ctx context.Context, option
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
+	modelsDefault := "value1"
 	if options != nil && options.Models != nil {
-		reqQP.Set("models", *options.Models)
+		modelsDefault = *options.Models
 	}
+	reqQP.Set("models", modelsDefault)
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("Accept", "application/json")
 	return req, nil

--- a/test/maps/azalias/zz_generated_client.go
+++ b/test/maps/azalias/zz_generated_client.go
@@ -28,7 +28,7 @@ type client struct {
 // newClient creates a new instance of client with the specified values.
 // geography - This parameter specifies where the Azure Maps Creator resource is located. Valid values are us and eu.
 // clientVersion - Version number of Azure Maps API.
-// clientIndex - Version number of Azure Maps API.
+// clientIndex - Index number of Azure Maps API.
 // pl - the pipeline used for sending requests and handling responses.
 func newClient(geography *Geography, clientVersion *string, clientIndex *int32, pl runtime.Pipeline) *client {
 	hostURL := "https://{geography}.atlas.microsoft.com"

--- a/test/maps/azalias/zz_generated_client.go
+++ b/test/maps/azalias/zz_generated_client.go
@@ -14,30 +14,42 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
 type client struct {
-	endpoint   string
-	apiVersion *string
-	pl         runtime.Pipeline
+	endpoint      string
+	clientVersion string
+	clientIndex   int32
+	pl            runtime.Pipeline
 }
 
 // newClient creates a new instance of client with the specified values.
 // geography - This parameter specifies where the Azure Maps Creator resource is located. Valid values are us and eu.
-// apiVersion - Api Version. Specifying any value will set the value to 2.0.
+// clientVersion - Version number of Azure Maps API.
+// clientIndex - Version number of Azure Maps API.
 // pl - the pipeline used for sending requests and handling responses.
-func newClient(geography *Geography, apiVersion *string, pl runtime.Pipeline) *client {
+func newClient(geography *Geography, clientVersion *string, clientIndex *int32, pl runtime.Pipeline) *client {
 	hostURL := "https://{geography}.atlas.microsoft.com"
 	if geography == nil {
 		defaultValue := GeographyUs
 		geography = &defaultValue
 	}
 	hostURL = strings.ReplaceAll(hostURL, "{geography}", string(*geography))
+	if clientVersion == nil {
+		clientVersionDefault := "2.0"
+		clientVersion = &clientVersionDefault
+	}
+	if clientIndex == nil {
+		clientIndexDefault := int32(567)
+		clientIndex = &clientIndexDefault
+	}
 	client := &client{
-		endpoint:   hostURL,
-		apiVersion: apiVersion,
-		pl:         pl,
+		endpoint:      hostURL,
+		clientVersion: *clientVersion,
+		clientIndex:   *clientIndex,
+		pl:            pl,
 	}
 	return client
 }
@@ -81,18 +93,24 @@ func (client *client) createCreateRequest(ctx context.Context, options *clientCr
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if client.apiVersion != nil {
-		reqQP.Set("api-version", "2.0")
+	reqQP.Set("client-version", client.clientVersion)
+	creatorIDDefault := int32(123)
+	if options != nil && options.CreatorID != nil {
+		creatorIDDefault = *options.CreatorID
 	}
-	if options != nil && options.CreatorDataItemID != nil {
-		reqQP.Set("creatorDataItemId", *options.CreatorDataItemID)
-	}
+	reqQP.Set("creator-id", strconv.FormatInt(int64(creatorIDDefault), 10))
 	if options != nil && options.GroupBy != nil {
 		for _, qv := range options.GroupBy {
 			reqQP.Add("groupBy", fmt.Sprintf("%d", qv))
 		}
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header.Set("client-index", strconv.FormatInt(int64(client.clientIndex), 10))
+	assignedIDDefault := float32(8989)
+	if options != nil && options.AssignedID != nil {
+		assignedIDDefault = *options.AssignedID
+	}
+	req.Raw().Header.Set("assigned-id", strconv.FormatFloat(float64(assignedIDDefault), 'f', -1, 32))
 	req.Raw().Header.Set("Accept", "application/json")
 	return req, nil
 }
@@ -190,9 +208,7 @@ func (client *client) listCreateRequest(ctx context.Context, options *clientList
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if client.apiVersion != nil {
-		reqQP.Set("api-version", "2.0")
-	}
+	reqQP.Set("client-version", client.clientVersion)
 	if options != nil && options.GroupBy != nil {
 		for _, qv := range options.GroupBy {
 			reqQP.Add("groupBy", string(qv))

--- a/test/maps/azalias/zz_generated_models.go
+++ b/test/maps/azalias/zz_generated_models.go
@@ -148,9 +148,11 @@ type ScheduleCreateOrUpdateProperties struct {
 
 // clientCreateOptions contains the optional parameters for the client.Create method.
 type clientCreateOptions struct {
+	GroupBy []SomethingCount
 	// The unique id that references a creator data item to be aliased.
-	CreatorDataItemID *string
-	GroupBy           []SomethingCount
+	AssignedID *float32
+	// The unique id that references a creator data item to be aliased.
+	CreatorID *int32
 }
 
 // clientGetScriptOptions contains the optional parameters for the client.GetScript method.

--- a/test/maps/azalias/zz_generated_models.go
+++ b/test/maps/azalias/zz_generated_models.go
@@ -149,7 +149,7 @@ type ScheduleCreateOrUpdateProperties struct {
 // clientCreateOptions contains the optional parameters for the client.Create method.
 type clientCreateOptions struct {
 	GroupBy []SomethingCount
-	// The unique id that references a creator data item to be aliased.
+	// The unique id that references the assigned data item to be aliased.
 	AssignedID *float32
 	// The unique id that references a creator data item to be aliased.
 	CreatorID *int32

--- a/test/swagger/alias.json
+++ b/test/swagger/alias.json
@@ -51,28 +51,41 @@
   ],
   "responses": {},
   "parameters": {
-    "AliasApiVersionV2": {
-      "name": "api-version",
+    "SomeClientVersion": {
+      "name": "client-version",
       "description": "Version number of Azure Maps API.",
       "type": "string",
       "in": "query",
-      "default": "2.0",
-      "x-ms-parameter-location": "client"
+      "required": true,
+      "x-ms-parameter-location": "client",
+      "x-ms-client-default": "2.0"
+    },
+    "SomeClientIndex": {
+      "name": "client-index",
+      "description": "Version number of Azure Maps API.",
+      "type": "integer",
+      "in": "header",
+      "required": true,
+      "x-ms-parameter-location": "client",
+      "x-ms-client-default": "567"
     },
     "CreateCreatorDataItemId": {
-      "name": "creatorDataItemId",
+      "name": "creator-id",
       "description": "The unique id that references a creator data item to be aliased.",
-      "type": "string",
-      "in": "query",
-      "x-ms-parameter-location": "method"
-    },
-    "AssignCreatorDataItemId": {
-      "name": "creatorDataItemId",
-      "description": "The unique id that references a creator data item to be aliased.",
-      "type": "string",
+      "type": "integer",
       "in": "query",
       "required": true,
-      "x-ms-parameter-location": "method"
+      "x-ms-parameter-location": "method",
+      "x-ms-client-default": "123"
+    },
+    "AssignCreatorDataItemId": {
+      "name": "assigned-id",
+      "description": "The unique id that references a creator data item to be aliased.",
+      "type": "number",
+      "in": "header",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "x-ms-client-default": "8989"
     },
     "AliasId": {
       "name": "aliasId",
@@ -138,10 +151,16 @@
         },
         "parameters": [
           {
-            "$ref": "#/parameters/AliasApiVersionV2"
+            "$ref": "#/parameters/SomeClientVersion"
+          },
+          {
+            "$ref": "#/parameters/SomeClientIndex"
           },
           {
             "$ref": "#/parameters/CreateCreatorDataItemId"
+          },
+          {
+            "$ref": "#/parameters/AssignCreatorDataItemId"
           },
           {
             "name": "groupBy",
@@ -191,7 +210,7 @@
         },
         "parameters": [
           {
-            "$ref": "#/parameters/AliasApiVersionV2"
+            "$ref": "#/parameters/SomeClientVersion"
           },
           {
             "name": "groupBy",

--- a/test/swagger/alias.json
+++ b/test/swagger/alias.json
@@ -62,7 +62,7 @@
     },
     "SomeClientIndex": {
       "name": "client-index",
-      "description": "Version number of Azure Maps API.",
+      "description": "Index number of Azure Maps API.",
       "type": "integer",
       "in": "header",
       "required": true,
@@ -80,7 +80,7 @@
     },
     "AssignCreatorDataItemId": {
       "name": "assigned-id",
-      "description": "The unique id that references a creator data item to be aliased.",
+      "description": "The unique id that references the assigned data item to be aliased.",
       "type": "number",
       "in": "header",
       "required": true,


### PR DESCRIPTION
Method parameters with client-side default values weren't having their
default values set.
For client constructor parameters with default values, set the default
in the client constructor instead.
Split formatParamValue into two functions, formatValue, so that the
latter can be used to properly format local vars.