### PR TITLE
Fold result types into response types

### DIFF
--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -103,13 +103,13 @@ export function substituteDiscriminator(schema: Schema, elemByVal: boolean): str
   }
 }
 
-// if an LRO returns a discriminated type, unmarshall the response into the result envelope, else the property field
-export function discriminatorFinalResponse(resultEnv: Property): string {
-  const resultProp = <Property>resultEnv.language.go!.resultField;
+// if an LRO returns a discriminated type, unmarshall the response into the response envelope, else the property field
+export function discriminatorFinalResponse(respEnv: ObjectSchema): string {
+  const resultProp = <Property>respEnv.language.go!.resultProp;
   if (resultProp.schema.language.go!.discriminatorInterface) {
-    return resultEnv.language.go!.name;
+    return '';
   }
-  return resultProp.language.go!.name;
+  return '.' + resultProp.language.go!.name;
 }
 
 // returns the parameters for the internal request creator method.
@@ -321,11 +321,11 @@ export function getFinalResponseEnvelopeName(op: Operation): string {
   return op.language.go!.finalResponseEnv.language.go!.name;
 }
 
-// returns the result envelope for the operation or undefined if it doesn't return a model
-export function hasResultEnvelope(op: Operation): Property | undefined {
+// returns the result property for the operation or undefined if it doesn't return a model
+export function hasResultProperty(op: Operation): Property | undefined {
   const responseEnv = getResponseEnvelope(op);
-  if (responseEnv.language.go!.resultEnv) {
-    return responseEnv.language.go!.resultEnv;
+  if (responseEnv.language.go!.resultProp) {
+    return responseEnv.language.go!.resultProp;
   }
   return undefined;
 }
@@ -339,7 +339,7 @@ export function getResponseEnvelope(op: Operation): ObjectSchema {
   return responseEnv;
 }
 
-// returns the name of the response field within the result envelope
+// returns the name of the response field within the response envelope
 export function getResultFieldName(op: Operation): string {
   if (isMultiRespOperation(op)) {
     return 'Value';
@@ -349,12 +349,12 @@ export function getResultFieldName(op: Operation): string {
     // we need to consult the final response envelope for LROs
     responseEnv = op.language.go!.finalResponseEnv;
   }
-  if (responseEnv.language.go!.resultEnv.language.go!.resultField.schema.serialization?.xml?.name) {
-    // here we use the schema name instead of the result field name as it's anonymously embedded in the result envelope.
+  if (responseEnv.language.go!.resultProp.schema.serialization?.xml?.name) {
+    // here we use the schema name instead of the result field name as it's anonymously embedded in the response envelope.
     // this is to handle XML cases that specify a custom XML name for the propery within the result field.
-    return responseEnv.language.go!.resultEnv.language.go!.resultField.schema.language.go!.name;
+    return responseEnv.language.go!.resultProp.schema.language.go!.name;
   }
-  return responseEnv.language.go!.resultEnv.language.go!.resultField.language.go!.name;
+  return responseEnv.language.go!.resultProp.language.go!.name;
 }
 
 export function getStatusCodes(op: Operation): string[] {

--- a/src/generator/pollers.ts
+++ b/src/generator/pollers.ts
@@ -79,10 +79,10 @@ function finalResp(poller: PollerInfo): string {
     text += '\treturn respType, nil\n';
   } else {
     const finalRespEnv = <ObjectSchema>poller.op.language.go!.finalResponseEnv;
-    const resultEnv = <Property>finalRespEnv.language.go!.resultEnv;
+    const resultProp = <Property>finalRespEnv.language.go!.resultProp;
     text += `\trespType := ${finalRespEnv.language.go!.name}{}\n`;
-    if (resultEnv) {
-      text += `\tresp, err := p.pt.FinalResponse(ctx, &respType.${discriminatorFinalResponse(resultEnv)})\n`;
+    if (resultProp) {
+      text += `\tresp, err := p.pt.FinalResponse(ctx, &respType${discriminatorFinalResponse(finalRespEnv)})\n`;
     } else {
       // the operation doesn't return a model
       text += `\tresp, err := p.pt.FinalResponse(ctx, nil)\n`;

--- a/src/generator/polymorphics.ts
+++ b/src/generator/polymorphics.ts
@@ -6,7 +6,7 @@
 import { Session } from '@autorest/extension-base';
 import { CodeModel, ObjectSchema, Property } from '@autorest/codemodel';
 import { values } from '@azure-tools/linq';
-import { isArraySchema, isDictionarySchema, isObjectSchema } from '../common/helpers';
+import { isArraySchema, isDictionarySchema } from '../common/helpers';
 import { contentPreamble, sortAscending } from './helpers';
 import { ImportManager } from './imports';
 
@@ -52,15 +52,10 @@ export async function generatePolymorphicHelpers(session: Session<CodeModel>): P
     }
   }
   for (const respEnv of values(<Array<ObjectSchema>>session.model.language.go!.responseEnvelopes)) {
-    if (respEnv.language.go!.resultEnv) {
-      const resultEnv = <Property>respEnv.language.go!.resultEnv;
-      if (isObjectSchema(resultEnv.schema)) {
-        for (const prop of values(resultEnv.schema.properties)) {
-          if (prop.isDiscriminator) {
-            trackDisciminator(prop);
-            break;
-          }
-        }
+    if (respEnv.language.go!.resultProp) {
+      const resultProp = <Property>respEnv.language.go!.resultProp;
+      if (resultProp.isDiscriminator) {
+        trackDisciminator(resultProp);
       }
     }
   }

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -657,7 +657,7 @@ const scalarResponsePropName = 'Value';
 //   Header1 *string <== modeled header response
 //   Header2 *int    <== modeled header response
 //   Widget          <== this is the result property, i.e. the schema result if the operation returns a model
-//}
+// }
 //
 function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op: Operation) {
   // create the `type <type>Response struct` response

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -649,21 +649,16 @@ interface HttpHeaderWithDescription extends HttpHeader {
 // the name of the struct field for scalar responses (int, string, etc)
 const scalarResponsePropName = 'Value';
 
-// creates the response/result envelope types to be returned from an operation and updates the operation.
+// creates the response envelope type to be returned from an operation and updates the operation.
 // for LROs, this is also called to create the final response envelope.
-// the response envelope consists of two parts, the outer response envelope and the inner result envelope.
-// each operation gets its own response/result envelope pair
 //
-// type GetWidgetResponse struct { <== this is the response envelope, it groups the result with the raw HTTP response (to be replaced by Result[T any])
-//   GetWidgetResult
+// type GetWidgetResponse struct { <== this is the response envelope, it groups the raw HTTP response with any headers and body
 //   RawResponse *http.Response
-//}
-//
-// type GetWidgetResult struct { <== this is the result envelope, it groups the schema result along with any per-operation header values
-//   Widget <== this is the result field, i.e. the schema result
 //   Header1 *string <== modeled header response
 //   Header2 *int    <== modeled header response
+//   Widget          <== this is the result property, i.e. the schema result if the operation returns a model
 //}
+//
 function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op: Operation) {
   // create the `type <type>Response struct` response
   // type with a `RawResponse *http.Response` field
@@ -690,21 +685,7 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
       }
     }
   }
-  const addHeadersToSchema = function (resultEnv: ObjectSchema) {
-    if (headers.size === 0) {
-      return;
-    }
-    if (!resultEnv.properties) {
-      resultEnv.properties = new Array<Property>();
-    }
-    for (const item of items(headers)) {
-      const prop = newRespProperty(item.key, item.value.description, item.value.schema, false);
-      // propagate any extensions so we can access them through the property
-      prop.extensions = item.value.extensions;
-      prop.language.go!.fromHeader = item.value.header;
-      resultEnv.properties.push(prop);
-    }
-  }
+
   // contains all the response envelopes
   const responseEnvelopes = <Array<ObjectSchema>>codeModel.language.go!.responseEnvelopes;
   // first create the response envelope, each operation gets one
@@ -716,24 +697,23 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
   responseEnvelopes.push(respEnv);
   op.language.go!.responseEnv = respEnv;
 
-  // now create the appropriate result envelope
+  // add any headers to the response
+  for (const item of items(headers)) {
+    const prop = newRespProperty(item.key, item.value.description, item.value.schema, false);
+    // propagate any extensions so we can access them through the property
+    prop.extensions = item.value.extensions;
+    prop.language.go!.fromHeader = item.value.header;
+    respEnv.properties.push(prop);
+  }
+
+  // now create the result field
 
   if (codeModel.language.go!.headAsBoolean && op.requests![0].protocol.http!.method === 'head') {
     op.language.go!.headAsBoolean = true;
-    const name = ensureUniqueModelName(codeModel, `${group.language.go!.clientName}${op.language.go!.name}Result`, 'Envelope');
-    const resultEnv = newObject(name, `${name} contains the result from method ${group.language.go!.clientName}.${op.language.go!.name}.`);
-    resultEnv.language.go!.responseType = true;
     const successProp = newProperty('Success', 'Success indicates if the operation succeeded or failed.', newBoolean('bool', 'bool response'));
     successProp.language.go!.byValue = true;
-    resultEnv.properties = [
-      successProp,
-    ];
-    addHeadersToSchema(resultEnv);
-    // now add the result envelope to the response envelope
-    const resultProp = newRespProperty(name, 'Contains the result of the operation.', resultEnv, true);
-    respEnv.properties.push(resultProp);
-    respEnv.language.go!.resultEnv = resultProp;
-    op.language.go!.responseEnv = respEnv;
+    respEnv.properties.push(successProp);
+    respEnv.language.go!.resultProp = successProp;
     return;
   }
   if (isMultiRespOperation(op)) {
@@ -745,23 +725,16 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
         resultTypes.push(response.schema.language.go!.name);
       }
     }
-    // for multi-response operations, we don't create result envelopes.
-    // instead, we add the header responses to the response envelope.
-    addHeadersToSchema(respEnv);
     const resultProp = newRespProperty('Value', `// Possible types are ${resultTypes.join(', ')}\n`, newAny('multi-response value'), true);
     respEnv.properties.push(resultProp);
-    respEnv.language.go!.resultEnv = resultProp;
+    respEnv.language.go!.resultProp = resultProp;
     return;
   }
   const response = getSchemaResponse(op);
-  // if the response defines a schema then create a result envelope and add it to the response envelope.
+  // if the response defines a schema then add it to the response envelope
   if (response) {
-    const name = ensureUniqueModelName(codeModel, `${group.language.go!.clientName}${op.language.go!.name}Result`, 'Envelope');
-    const resultEnv = newObject(name, `${name} contains the result from method ${group.language.go!.clientName}.${op.language.go!.name}.`);
-    resultEnv.language.go!.responseType = true;
-    // propagate marshalling format to the result envelope
-    resultEnv.language.go!.marshallingFormat = response.schema.language.go!.marshallingFormat;
-    resultEnv.properties = new Array<Property>();
+    // propagate marshalling format to the response envelope
+    respEnv.language.go!.marshallingFormat = response.schema.language.go!.marshallingFormat;
     // for operations that return scalar types we use a fixed field name
     let propName = scalarResponsePropName;
     if (response.schema.type === SchemaType.Object) {
@@ -779,29 +752,11 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
       // always prefer the XML name
       propName = capitalize(response.schema.serialization.xml.name);
     }
-    // add any headers to the response type
-    addHeadersToSchema(resultEnv);
     // we want to pass integral types byref to maintain parity with struct fields
     const byValue = isTypePassedByValue(response.schema) || response.schema.type === SchemaType.Object;
-    const respProp = newRespProperty(propName, response.schema.language.go!.description, response.schema, byValue);
-    resultEnv.properties.push(respProp);
-    // now add the result type to the response envelope
-    const resultEnvProp = newRespProperty(name, 'Contains the result of the operation.', resultEnv, true);
-    respEnv.properties.push(resultEnvProp);
-    respEnv.language.go!.resultEnv = resultEnvProp;
-    // shortcut to aid finding the result property
-    resultEnvProp.language.go!.resultField = respProp;
-  } else if (headers.size > 0) {
-    // the response doesn't return a model.  if it returns
-    // headers then create a result envelope that contains them.
-    const name = ensureUniqueModelName(codeModel, `${group.language.go!.clientName}${op.language.go!.name}Result`, 'Envelope');
-    const resultEnv = newObject(name, `${name} contains the result from method ${group.language.go!.clientName}.${op.language.go!.name}.`);
-    resultEnv.language.go!.responseType = true;
-    resultEnv.properties = new Array<Property>();
-    addHeadersToSchema(resultEnv);
-    const resultEnvProp = newRespProperty(name, 'Contains the result of the operation.', resultEnv, true);
-    respEnv.properties.push(resultEnvProp);
-    respEnv.language.go!.resultEnv = resultEnvProp;
+    const resultProp = newRespProperty(propName, response.schema.language.go!.description, response.schema, byValue);
+    respEnv.properties.push(resultProp);
+    respEnv.language.go!.resultProp = resultProp;
   }
 }
 
@@ -932,7 +887,7 @@ function createLROResponseEnvelope(codeModel: CodeModel, group: OperationGroup, 
   }
   // LROs have two response envelopes.
   // the outer is the response envelope returned by the Begin* and Resume* methods, it depends on the poller.
-  // the inner is the response/result envelope returned by the PollUntilDone and FinalResponse methods, the poller depends on it.
+  // the inner is the response envelope returned by the PollUntilDone and FinalResponse methods, the poller depends on it.
   // so we create them in the following order: inner, poller, outer
 
   // contains all the response envelopes

--- a/test/autorest/additionalpropsgroup/zz_generated_response_types.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_response_types.go
@@ -12,72 +12,42 @@ import "net/http"
 
 // PetsClientCreateAPInPropertiesResponse contains the response from method PetsClient.CreateAPInProperties.
 type PetsClientCreateAPInPropertiesResponse struct {
-	PetsClientCreateAPInPropertiesResult
+	PetAPInProperties
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetsClientCreateAPInPropertiesResult contains the result from method PetsClient.CreateAPInProperties.
-type PetsClientCreateAPInPropertiesResult struct {
-	PetAPInProperties
 }
 
 // PetsClientCreateAPInPropertiesWithAPStringResponse contains the response from method PetsClient.CreateAPInPropertiesWithAPString.
 type PetsClientCreateAPInPropertiesWithAPStringResponse struct {
-	PetsClientCreateAPInPropertiesWithAPStringResult
+	PetAPInPropertiesWithAPString
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetsClientCreateAPInPropertiesWithAPStringResult contains the result from method PetsClient.CreateAPInPropertiesWithAPString.
-type PetsClientCreateAPInPropertiesWithAPStringResult struct {
-	PetAPInPropertiesWithAPString
 }
 
 // PetsClientCreateAPObjectResponse contains the response from method PetsClient.CreateAPObject.
 type PetsClientCreateAPObjectResponse struct {
-	PetsClientCreateAPObjectResult
+	PetAPObject
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetsClientCreateAPObjectResult contains the result from method PetsClient.CreateAPObject.
-type PetsClientCreateAPObjectResult struct {
-	PetAPObject
 }
 
 // PetsClientCreateAPStringResponse contains the response from method PetsClient.CreateAPString.
 type PetsClientCreateAPStringResponse struct {
-	PetsClientCreateAPStringResult
+	PetAPString
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetsClientCreateAPStringResult contains the result from method PetsClient.CreateAPString.
-type PetsClientCreateAPStringResult struct {
-	PetAPString
 }
 
 // PetsClientCreateAPTrueResponse contains the response from method PetsClient.CreateAPTrue.
 type PetsClientCreateAPTrueResponse struct {
-	PetsClientCreateAPTrueResult
+	PetAPTrue
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetsClientCreateAPTrueResult contains the result from method PetsClient.CreateAPTrue.
-type PetsClientCreateAPTrueResult struct {
-	PetAPTrue
 }
 
 // PetsClientCreateCatAPTrueResponse contains the response from method PetsClient.CreateCatAPTrue.
 type PetsClientCreateCatAPTrueResponse struct {
-	PetsClientCreateCatAPTrueResult
+	CatAPTrue
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetsClientCreateCatAPTrueResult contains the result from method PetsClient.CreateCatAPTrue.
-type PetsClientCreateCatAPTrueResult struct {
-	CatAPTrue
 }

--- a/test/autorest/arraygroup/zz_generated_response_types.go
+++ b/test/autorest/arraygroup/zz_generated_response_types.go
@@ -15,666 +15,462 @@ import (
 
 // ArrayClientGetArrayEmptyResponse contains the response from method ArrayClient.GetArrayEmpty.
 type ArrayClientGetArrayEmptyResponse struct {
-	ArrayClientGetArrayEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetArrayEmptyResult contains the result from method ArrayClient.GetArrayEmpty.
-type ArrayClientGetArrayEmptyResult struct {
 	// An empty array []
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetArrayItemEmptyResponse contains the response from method ArrayClient.GetArrayItemEmpty.
 type ArrayClientGetArrayItemEmptyResponse struct {
-	ArrayClientGetArrayItemEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetArrayItemEmptyResult contains the result from method ArrayClient.GetArrayItemEmpty.
-type ArrayClientGetArrayItemEmptyResult struct {
 	// An array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetArrayItemNullResponse contains the response from method ArrayClient.GetArrayItemNull.
 type ArrayClientGetArrayItemNullResponse struct {
-	ArrayClientGetArrayItemNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetArrayItemNullResult contains the result from method ArrayClient.GetArrayItemNull.
-type ArrayClientGetArrayItemNullResult struct {
 	// An array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetArrayNullResponse contains the response from method ArrayClient.GetArrayNull.
 type ArrayClientGetArrayNullResponse struct {
-	ArrayClientGetArrayNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetArrayNullResult contains the result from method ArrayClient.GetArrayNull.
-type ArrayClientGetArrayNullResult struct {
 	// a null array
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetArrayValidResponse contains the response from method ArrayClient.GetArrayValid.
 type ArrayClientGetArrayValidResponse struct {
-	ArrayClientGetArrayValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetArrayValidResult contains the result from method ArrayClient.GetArrayValid.
-type ArrayClientGetArrayValidResult struct {
 	// An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetBase64URLResponse contains the response from method ArrayClient.GetBase64URL.
 type ArrayClientGetBase64URLResponse struct {
-	ArrayClientGetBase64URLResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetBase64URLResult contains the result from method ArrayClient.GetBase64URL.
-type ArrayClientGetBase64URLResult struct {
 	// Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded
 	ByteArrayArray [][]byte
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetBooleanInvalidNullResponse contains the response from method ArrayClient.GetBooleanInvalidNull.
 type ArrayClientGetBooleanInvalidNullResponse struct {
-	ArrayClientGetBooleanInvalidNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetBooleanInvalidNullResult contains the result from method ArrayClient.GetBooleanInvalidNull.
-type ArrayClientGetBooleanInvalidNullResult struct {
 	// The array value [true, null, false]
 	BoolArray []*bool
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetBooleanInvalidStringResponse contains the response from method ArrayClient.GetBooleanInvalidString.
 type ArrayClientGetBooleanInvalidStringResponse struct {
-	ArrayClientGetBooleanInvalidStringResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetBooleanInvalidStringResult contains the result from method ArrayClient.GetBooleanInvalidString.
-type ArrayClientGetBooleanInvalidStringResult struct {
 	// The array value [true, 'boolean', false]
 	BoolArray []*bool
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetBooleanTfftResponse contains the response from method ArrayClient.GetBooleanTfft.
 type ArrayClientGetBooleanTfftResponse struct {
-	ArrayClientGetBooleanTfftResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetBooleanTfftResult contains the result from method ArrayClient.GetBooleanTfft.
-type ArrayClientGetBooleanTfftResult struct {
 	// The array value [true, false, false, true]
 	BoolArray []*bool
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetByteInvalidNullResponse contains the response from method ArrayClient.GetByteInvalidNull.
 type ArrayClientGetByteInvalidNullResponse struct {
-	ArrayClientGetByteInvalidNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetByteInvalidNullResult contains the result from method ArrayClient.GetByteInvalidNull.
-type ArrayClientGetByteInvalidNullResult struct {
 	// The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
 	ByteArrayArray [][]byte
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetByteValidResponse contains the response from method ArrayClient.GetByteValid.
 type ArrayClientGetByteValidResponse struct {
-	ArrayClientGetByteValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetByteValidResult contains the result from method ArrayClient.GetByteValid.
-type ArrayClientGetByteValidResult struct {
 	// The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
 	ByteArrayArray [][]byte
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexEmptyResponse contains the response from method ArrayClient.GetComplexEmpty.
 type ArrayClientGetComplexEmptyResponse struct {
-	ArrayClientGetComplexEmptyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetComplexEmptyResult contains the result from method ArrayClient.GetComplexEmpty.
-type ArrayClientGetComplexEmptyResult struct {
 	// Empty array of complex type []
 	ProductArray []*Product
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexItemEmptyResponse contains the response from method ArrayClient.GetComplexItemEmpty.
 type ArrayClientGetComplexItemEmptyResponse struct {
-	ArrayClientGetComplexItemEmptyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetComplexItemEmptyResult contains the result from method ArrayClient.GetComplexItemEmpty.
-type ArrayClientGetComplexItemEmptyResult struct {
 	// Array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
 	ProductArray []*Product
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexItemNullResponse contains the response from method ArrayClient.GetComplexItemNull.
 type ArrayClientGetComplexItemNullResponse struct {
-	ArrayClientGetComplexItemNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetComplexItemNullResult contains the result from method ArrayClient.GetComplexItemNull.
-type ArrayClientGetComplexItemNullResult struct {
 	// Array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
 	ProductArray []*Product
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexNullResponse contains the response from method ArrayClient.GetComplexNull.
 type ArrayClientGetComplexNullResponse struct {
-	ArrayClientGetComplexNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetComplexNullResult contains the result from method ArrayClient.GetComplexNull.
-type ArrayClientGetComplexNullResult struct {
 	// array of complex type with null value
 	ProductArray []*Product
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexValidResponse contains the response from method ArrayClient.GetComplexValid.
 type ArrayClientGetComplexValidResponse struct {
-	ArrayClientGetComplexValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetComplexValidResult contains the result from method ArrayClient.GetComplexValid.
-type ArrayClientGetComplexValidResult struct {
 	// array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
 	ProductArray []*Product
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDateInvalidCharsResponse contains the response from method ArrayClient.GetDateInvalidChars.
 type ArrayClientGetDateInvalidCharsResponse struct {
-	ArrayClientGetDateInvalidCharsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetDateInvalidCharsResult contains the result from method ArrayClient.GetDateInvalidChars.
-type ArrayClientGetDateInvalidCharsResult struct {
 	// The array value ['2011-03-22', 'date']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateInvalidNullResponse contains the response from method ArrayClient.GetDateInvalidNull.
 type ArrayClientGetDateInvalidNullResponse struct {
-	ArrayClientGetDateInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetDateInvalidNullResult contains the result from method ArrayClient.GetDateInvalidNull.
-type ArrayClientGetDateInvalidNullResult struct {
 	// The array value ['2012-01-01', null, '1776-07-04']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateTimeInvalidCharsResponse contains the response from method ArrayClient.GetDateTimeInvalidChars.
 type ArrayClientGetDateTimeInvalidCharsResponse struct {
-	ArrayClientGetDateTimeInvalidCharsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetDateTimeInvalidCharsResult contains the result from method ArrayClient.GetDateTimeInvalidChars.
-type ArrayClientGetDateTimeInvalidCharsResult struct {
 	// The array value ['2000-12-01t00:00:01z', 'date-time']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateTimeInvalidNullResponse contains the response from method ArrayClient.GetDateTimeInvalidNull.
 type ArrayClientGetDateTimeInvalidNullResponse struct {
-	ArrayClientGetDateTimeInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetDateTimeInvalidNullResult contains the result from method ArrayClient.GetDateTimeInvalidNull.
-type ArrayClientGetDateTimeInvalidNullResult struct {
 	// The array value ['2000-12-01t00:00:01z', null]
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateTimeRFC1123ValidResponse contains the response from method ArrayClient.GetDateTimeRFC1123Valid.
 type ArrayClientGetDateTimeRFC1123ValidResponse struct {
-	ArrayClientGetDateTimeRFC1123ValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetDateTimeRFC1123ValidResult contains the result from method ArrayClient.GetDateTimeRFC1123Valid.
-type ArrayClientGetDateTimeRFC1123ValidResult struct {
 	// The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateTimeValidResponse contains the response from method ArrayClient.GetDateTimeValid.
 type ArrayClientGetDateTimeValidResponse struct {
-	ArrayClientGetDateTimeValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetDateTimeValidResult contains the result from method ArrayClient.GetDateTimeValid.
-type ArrayClientGetDateTimeValidResult struct {
 	// The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateValidResponse contains the response from method ArrayClient.GetDateValid.
 type ArrayClientGetDateValidResponse struct {
-	ArrayClientGetDateValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetDateValidResult contains the result from method ArrayClient.GetDateValid.
-type ArrayClientGetDateValidResult struct {
 	// The array value ['2000-12-01', '1980-01-02', '1492-10-12']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDictionaryEmptyResponse contains the response from method ArrayClient.GetDictionaryEmpty.
 type ArrayClientGetDictionaryEmptyResponse struct {
-	ArrayClientGetDictionaryEmptyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetDictionaryEmptyResult contains the result from method ArrayClient.GetDictionaryEmpty.
-type ArrayClientGetDictionaryEmptyResult struct {
 	// An array of Dictionaries of type <string, string> with value []
 	MapOfStringArray []map[string]*string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDictionaryItemEmptyResponse contains the response from method ArrayClient.GetDictionaryItemEmpty.
 type ArrayClientGetDictionaryItemEmptyResponse struct {
-	ArrayClientGetDictionaryItemEmptyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetDictionaryItemEmptyResult contains the result from method ArrayClient.GetDictionaryItemEmpty.
-type ArrayClientGetDictionaryItemEmptyResult struct {
 	// An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven',
 	// '8': 'eight', '9': 'nine'}]
 	MapOfStringArray []map[string]*string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDictionaryItemNullResponse contains the response from method ArrayClient.GetDictionaryItemNull.
 type ArrayClientGetDictionaryItemNullResponse struct {
-	ArrayClientGetDictionaryItemNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetDictionaryItemNullResult contains the result from method ArrayClient.GetDictionaryItemNull.
-type ArrayClientGetDictionaryItemNullResult struct {
 	// An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven',
 	// '8': 'eight', '9': 'nine'}]
 	MapOfStringArray []map[string]*string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDictionaryNullResponse contains the response from method ArrayClient.GetDictionaryNull.
 type ArrayClientGetDictionaryNullResponse struct {
-	ArrayClientGetDictionaryNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetDictionaryNullResult contains the result from method ArrayClient.GetDictionaryNull.
-type ArrayClientGetDictionaryNullResult struct {
 	// An array of Dictionaries with value null
 	MapOfStringArray []map[string]*string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDictionaryValidResponse contains the response from method ArrayClient.GetDictionaryValid.
 type ArrayClientGetDictionaryValidResponse struct {
-	ArrayClientGetDictionaryValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetDictionaryValidResult contains the result from method ArrayClient.GetDictionaryValid.
-type ArrayClientGetDictionaryValidResult struct {
 	// An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5':
 	// 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 	MapOfStringArray []map[string]*string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDoubleInvalidNullResponse contains the response from method ArrayClient.GetDoubleInvalidNull.
 type ArrayClientGetDoubleInvalidNullResponse struct {
-	ArrayClientGetDoubleInvalidNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetDoubleInvalidNullResult contains the result from method ArrayClient.GetDoubleInvalidNull.
-type ArrayClientGetDoubleInvalidNullResult struct {
 	// The array value [0.0, null, -1.2e20]
 	Float64Array []*float64
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDoubleInvalidStringResponse contains the response from method ArrayClient.GetDoubleInvalidString.
 type ArrayClientGetDoubleInvalidStringResponse struct {
-	ArrayClientGetDoubleInvalidStringResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetDoubleInvalidStringResult contains the result from method ArrayClient.GetDoubleInvalidString.
-type ArrayClientGetDoubleInvalidStringResult struct {
 	// The array value [1.0, 'number', 0.0]
 	Float64Array []*float64
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDoubleValidResponse contains the response from method ArrayClient.GetDoubleValid.
 type ArrayClientGetDoubleValidResponse struct {
-	ArrayClientGetDoubleValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetDoubleValidResult contains the result from method ArrayClient.GetDoubleValid.
-type ArrayClientGetDoubleValidResult struct {
 	// The array value [0, -0.01, 1.2e20]
 	Float64Array []*float64
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetDurationValidResponse contains the response from method ArrayClient.GetDurationValid.
 type ArrayClientGetDurationValidResponse struct {
-	ArrayClientGetDurationValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetDurationValidResult contains the result from method ArrayClient.GetDurationValid.
-type ArrayClientGetDurationValidResult struct {
 	// The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 	StringArray []*string
 }
 
 // ArrayClientGetEmptyResponse contains the response from method ArrayClient.GetEmpty.
 type ArrayClientGetEmptyResponse struct {
-	ArrayClientGetEmptyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetEmptyResult contains the result from method ArrayClient.GetEmpty.
-type ArrayClientGetEmptyResult struct {
 	// The empty array value []
 	Int32Array []*int32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetEnumValidResponse contains the response from method ArrayClient.GetEnumValid.
 type ArrayClientGetEnumValidResponse struct {
-	ArrayClientGetEnumValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetEnumValidResult contains the result from method ArrayClient.GetEnumValid.
-type ArrayClientGetEnumValidResult struct {
 	// The array value ['foo1', 'foo2', 'foo3']
 	FooEnumArray []*FooEnum
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetFloatInvalidNullResponse contains the response from method ArrayClient.GetFloatInvalidNull.
 type ArrayClientGetFloatInvalidNullResponse struct {
-	ArrayClientGetFloatInvalidNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetFloatInvalidNullResult contains the result from method ArrayClient.GetFloatInvalidNull.
-type ArrayClientGetFloatInvalidNullResult struct {
 	// The array value [0.0, null, -1.2e20]
 	Float32Array []*float32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetFloatInvalidStringResponse contains the response from method ArrayClient.GetFloatInvalidString.
 type ArrayClientGetFloatInvalidStringResponse struct {
-	ArrayClientGetFloatInvalidStringResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetFloatInvalidStringResult contains the result from method ArrayClient.GetFloatInvalidString.
-type ArrayClientGetFloatInvalidStringResult struct {
 	// The array value [1.0, 'number', 0.0]
 	Float32Array []*float32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetFloatValidResponse contains the response from method ArrayClient.GetFloatValid.
 type ArrayClientGetFloatValidResponse struct {
-	ArrayClientGetFloatValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetFloatValidResult contains the result from method ArrayClient.GetFloatValid.
-type ArrayClientGetFloatValidResult struct {
 	// The array value [0, -0.01, 1.2e20]
 	Float32Array []*float32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetIntInvalidNullResponse contains the response from method ArrayClient.GetIntInvalidNull.
 type ArrayClientGetIntInvalidNullResponse struct {
-	ArrayClientGetIntInvalidNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetIntInvalidNullResult contains the result from method ArrayClient.GetIntInvalidNull.
-type ArrayClientGetIntInvalidNullResult struct {
 	// The array value [1, null, 0]
 	Int32Array []*int32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetIntInvalidStringResponse contains the response from method ArrayClient.GetIntInvalidString.
 type ArrayClientGetIntInvalidStringResponse struct {
-	ArrayClientGetIntInvalidStringResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetIntInvalidStringResult contains the result from method ArrayClient.GetIntInvalidString.
-type ArrayClientGetIntInvalidStringResult struct {
 	// The array value [1, 'integer', 0]
 	Int32Array []*int32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetIntegerValidResponse contains the response from method ArrayClient.GetIntegerValid.
 type ArrayClientGetIntegerValidResponse struct {
-	ArrayClientGetIntegerValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetIntegerValidResult contains the result from method ArrayClient.GetIntegerValid.
-type ArrayClientGetIntegerValidResult struct {
 	// The array value [1, -1, 3, 300]
 	Int32Array []*int32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetInvalidResponse contains the response from method ArrayClient.GetInvalid.
 type ArrayClientGetInvalidResponse struct {
-	ArrayClientGetInvalidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetInvalidResult contains the result from method ArrayClient.GetInvalid.
-type ArrayClientGetInvalidResult struct {
 	// The invalid Array [1, 2, 3
 	Int32Array []*int32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetLongInvalidNullResponse contains the response from method ArrayClient.GetLongInvalidNull.
 type ArrayClientGetLongInvalidNullResponse struct {
-	ArrayClientGetLongInvalidNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetLongInvalidNullResult contains the result from method ArrayClient.GetLongInvalidNull.
-type ArrayClientGetLongInvalidNullResult struct {
 	// The array value [1, null, 0]
 	Int64Array []*int64
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetLongInvalidStringResponse contains the response from method ArrayClient.GetLongInvalidString.
 type ArrayClientGetLongInvalidStringResponse struct {
-	ArrayClientGetLongInvalidStringResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetLongInvalidStringResult contains the result from method ArrayClient.GetLongInvalidString.
-type ArrayClientGetLongInvalidStringResult struct {
 	// The array value [1, 'integer', 0]
 	Int64Array []*int64
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetLongValidResponse contains the response from method ArrayClient.GetLongValid.
 type ArrayClientGetLongValidResponse struct {
-	ArrayClientGetLongValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetLongValidResult contains the result from method ArrayClient.GetLongValid.
-type ArrayClientGetLongValidResult struct {
 	// The array value [1, -1, 3, 300]
 	Int64Array []*int64
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetNullResponse contains the response from method ArrayClient.GetNull.
 type ArrayClientGetNullResponse struct {
-	ArrayClientGetNullResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetNullResult contains the result from method ArrayClient.GetNull.
-type ArrayClientGetNullResult struct {
 	// The null Array value
 	Int32Array []*int32
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetStringEnumValidResponse contains the response from method ArrayClient.GetStringEnumValid.
 type ArrayClientGetStringEnumValidResponse struct {
-	ArrayClientGetStringEnumValidResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ArrayClientGetStringEnumValidResult contains the result from method ArrayClient.GetStringEnumValid.
-type ArrayClientGetStringEnumValidResult struct {
 	// The array value ['foo1', 'foo2', 'foo3']
 	Enum0Array []*Enum0
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ArrayClientGetStringValidResponse contains the response from method ArrayClient.GetStringValid.
 type ArrayClientGetStringValidResponse struct {
-	ArrayClientGetStringValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetStringValidResult contains the result from method ArrayClient.GetStringValid.
-type ArrayClientGetStringValidResult struct {
 	// The array value ['foo1', 'foo2', 'foo3']
 	StringArray []*string
 }
 
 // ArrayClientGetStringWithInvalidResponse contains the response from method ArrayClient.GetStringWithInvalid.
 type ArrayClientGetStringWithInvalidResponse struct {
-	ArrayClientGetStringWithInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetStringWithInvalidResult contains the result from method ArrayClient.GetStringWithInvalid.
-type ArrayClientGetStringWithInvalidResult struct {
 	// The array value ['foo', 123, 'foo2']
 	StringArray []*string
 }
 
 // ArrayClientGetStringWithNullResponse contains the response from method ArrayClient.GetStringWithNull.
 type ArrayClientGetStringWithNullResponse struct {
-	ArrayClientGetStringWithNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetStringWithNullResult contains the result from method ArrayClient.GetStringWithNull.
-type ArrayClientGetStringWithNullResult struct {
 	// The array value ['foo', null, 'foo2']
 	StringArray []*string
 }
 
 // ArrayClientGetUUIDInvalidCharsResponse contains the response from method ArrayClient.GetUUIDInvalidChars.
 type ArrayClientGetUUIDInvalidCharsResponse struct {
-	ArrayClientGetUUIDInvalidCharsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetUUIDInvalidCharsResult contains the result from method ArrayClient.GetUUIDInvalidChars.
-type ArrayClientGetUUIDInvalidCharsResult struct {
 	// The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']
 	StringArray []*string
 }
 
 // ArrayClientGetUUIDValidResponse contains the response from method ArrayClient.GetUUIDValid.
 type ArrayClientGetUUIDValidResponse struct {
-	ArrayClientGetUUIDValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ArrayClientGetUUIDValidResult contains the result from method ArrayClient.GetUUIDValid.
-type ArrayClientGetUUIDValidResult struct {
 	// The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 	StringArray []*string
 }

--- a/test/autorest/azurereportgroup/zz_generated_response_types.go
+++ b/test/autorest/azurereportgroup/zz_generated_response_types.go
@@ -12,13 +12,9 @@ import "net/http"
 
 // AutoRestReportServiceForAzureClientGetReportResponse contains the response from method AutoRestReportServiceForAzureClient.GetReport.
 type AutoRestReportServiceForAzureClientGetReportResponse struct {
-	AutoRestReportServiceForAzureClientGetReportResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// AutoRestReportServiceForAzureClientGetReportResult contains the result from method AutoRestReportServiceForAzureClient.GetReport.
-type AutoRestReportServiceForAzureClientGetReportResult struct {
 	// Dictionary of <integer>
 	Value map[string]*int32
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_response_types.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_response_types.go
@@ -60,15 +60,11 @@ type APIVersionLocalClientGetSwaggerLocalValidResponse struct {
 
 // HeaderClientCustomNamedRequestIDHeadResponse contains the response from method HeaderClient.CustomNamedRequestIDHead.
 type HeaderClientCustomNamedRequestIDHeadResponse struct {
-	HeaderClientCustomNamedRequestIDHeadResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderClientCustomNamedRequestIDHeadResult contains the result from method HeaderClient.CustomNamedRequestIDHead.
-type HeaderClientCustomNamedRequestIDHeadResult struct {
 	// FooRequestID contains the information returned from the foo-request-id header response.
 	FooRequestID *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// Success indicates if the operation succeeded or failed.
 	Success bool
@@ -76,28 +72,20 @@ type HeaderClientCustomNamedRequestIDHeadResult struct {
 
 // HeaderClientCustomNamedRequestIDParamGroupingResponse contains the response from method HeaderClient.CustomNamedRequestIDParamGrouping.
 type HeaderClientCustomNamedRequestIDParamGroupingResponse struct {
-	HeaderClientCustomNamedRequestIDParamGroupingResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderClientCustomNamedRequestIDParamGroupingResult contains the result from method HeaderClient.CustomNamedRequestIDParamGrouping.
-type HeaderClientCustomNamedRequestIDParamGroupingResult struct {
 	// FooRequestID contains the information returned from the foo-request-id header response.
 	FooRequestID *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // HeaderClientCustomNamedRequestIDResponse contains the response from method HeaderClient.CustomNamedRequestID.
 type HeaderClientCustomNamedRequestIDResponse struct {
-	HeaderClientCustomNamedRequestIDResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderClientCustomNamedRequestIDResult contains the result from method HeaderClient.CustomNamedRequestID.
-type HeaderClientCustomNamedRequestIDResult struct {
 	// FooRequestID contains the information returned from the foo-request-id header response.
 	FooRequestID *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ODataClientGetWithFilterResponse contains the response from method ODataClient.GetWithFilter.

--- a/test/autorest/booleangroup/zz_generated_response_types.go
+++ b/test/autorest/booleangroup/zz_generated_response_types.go
@@ -12,50 +12,32 @@ import "net/http"
 
 // BoolClientGetFalseResponse contains the response from method BoolClient.GetFalse.
 type BoolClientGetFalseResponse struct {
-	BoolClientGetFalseResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// BoolClientGetFalseResult contains the result from method BoolClient.GetFalse.
-type BoolClientGetFalseResult struct {
 	// simple boolean
 	Value *bool
 }
 
 // BoolClientGetInvalidResponse contains the response from method BoolClient.GetInvalid.
 type BoolClientGetInvalidResponse struct {
-	BoolClientGetInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BoolClientGetInvalidResult contains the result from method BoolClient.GetInvalid.
-type BoolClientGetInvalidResult struct {
-	Value *bool
+	Value       *bool
 }
 
 // BoolClientGetNullResponse contains the response from method BoolClient.GetNull.
 type BoolClientGetNullResponse struct {
-	BoolClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BoolClientGetNullResult contains the result from method BoolClient.GetNull.
-type BoolClientGetNullResult struct {
-	Value *bool
+	Value       *bool
 }
 
 // BoolClientGetTrueResponse contains the response from method BoolClient.GetTrue.
 type BoolClientGetTrueResponse struct {
-	BoolClientGetTrueResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// BoolClientGetTrueResult contains the result from method BoolClient.GetTrue.
-type BoolClientGetTrueResult struct {
 	// simple boolean
 	Value *bool
 }

--- a/test/autorest/bytegroup/zz_generated_response_types.go
+++ b/test/autorest/bytegroup/zz_generated_response_types.go
@@ -12,52 +12,36 @@ import "net/http"
 
 // ByteClientGetEmptyResponse contains the response from method ByteClient.GetEmpty.
 type ByteClientGetEmptyResponse struct {
-	ByteClientGetEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ByteClientGetEmptyResult contains the result from method ByteClient.GetEmpty.
-type ByteClientGetEmptyResult struct {
 	// The empty byte value ''
 	Value []byte
 }
 
 // ByteClientGetInvalidResponse contains the response from method ByteClient.GetInvalid.
 type ByteClientGetInvalidResponse struct {
-	ByteClientGetInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ByteClientGetInvalidResult contains the result from method ByteClient.GetInvalid.
-type ByteClientGetInvalidResult struct {
 	// The invalid byte value '::::SWAGGER::::'
 	Value []byte
 }
 
 // ByteClientGetNonASCIIResponse contains the response from method ByteClient.GetNonASCII.
 type ByteClientGetNonASCIIResponse struct {
-	ByteClientGetNonASCIIResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ByteClientGetNonASCIIResult contains the result from method ByteClient.GetNonASCII.
-type ByteClientGetNonASCIIResult struct {
 	// Non-ascii base-64 encoded byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
 	Value []byte
 }
 
 // ByteClientGetNullResponse contains the response from method ByteClient.GetNull.
 type ByteClientGetNullResponse struct {
-	ByteClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ByteClientGetNullResult contains the result from method ByteClient.GetNull.
-type ByteClientGetNullResult struct {
 	// The null byte value
 	Value []byte
 }

--- a/test/autorest/complexgroup/zz_generated_response_types.go
+++ b/test/autorest/complexgroup/zz_generated_response_types.go
@@ -12,38 +12,23 @@ import "net/http"
 
 // ArrayClientGetEmptyResponse contains the response from method ArrayClient.GetEmpty.
 type ArrayClientGetEmptyResponse struct {
-	ArrayClientGetEmptyResult
+	ArrayWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ArrayClientGetEmptyResult contains the result from method ArrayClient.GetEmpty.
-type ArrayClientGetEmptyResult struct {
-	ArrayWrapper
 }
 
 // ArrayClientGetNotProvidedResponse contains the response from method ArrayClient.GetNotProvided.
 type ArrayClientGetNotProvidedResponse struct {
-	ArrayClientGetNotProvidedResult
+	ArrayWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ArrayClientGetNotProvidedResult contains the result from method ArrayClient.GetNotProvided.
-type ArrayClientGetNotProvidedResult struct {
-	ArrayWrapper
 }
 
 // ArrayClientGetValidResponse contains the response from method ArrayClient.GetValid.
 type ArrayClientGetValidResponse struct {
-	ArrayClientGetValidResult
+	ArrayWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ArrayClientGetValidResult contains the result from method ArrayClient.GetValid.
-type ArrayClientGetValidResult struct {
-	ArrayWrapper
 }
 
 // ArrayClientPutEmptyResponse contains the response from method ArrayClient.PutEmpty.
@@ -60,62 +45,37 @@ type ArrayClientPutValidResponse struct {
 
 // BasicClientGetEmptyResponse contains the response from method BasicClient.GetEmpty.
 type BasicClientGetEmptyResponse struct {
-	BasicClientGetEmptyResult
+	Basic
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BasicClientGetEmptyResult contains the result from method BasicClient.GetEmpty.
-type BasicClientGetEmptyResult struct {
-	Basic
 }
 
 // BasicClientGetInvalidResponse contains the response from method BasicClient.GetInvalid.
 type BasicClientGetInvalidResponse struct {
-	BasicClientGetInvalidResult
+	Basic
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BasicClientGetInvalidResult contains the result from method BasicClient.GetInvalid.
-type BasicClientGetInvalidResult struct {
-	Basic
 }
 
 // BasicClientGetNotProvidedResponse contains the response from method BasicClient.GetNotProvided.
 type BasicClientGetNotProvidedResponse struct {
-	BasicClientGetNotProvidedResult
+	Basic
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BasicClientGetNotProvidedResult contains the result from method BasicClient.GetNotProvided.
-type BasicClientGetNotProvidedResult struct {
-	Basic
 }
 
 // BasicClientGetNullResponse contains the response from method BasicClient.GetNull.
 type BasicClientGetNullResponse struct {
-	BasicClientGetNullResult
+	Basic
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BasicClientGetNullResult contains the result from method BasicClient.GetNull.
-type BasicClientGetNullResult struct {
-	Basic
 }
 
 // BasicClientGetValidResponse contains the response from method BasicClient.GetValid.
 type BasicClientGetValidResponse struct {
-	BasicClientGetValidResult
+	Basic
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BasicClientGetValidResult contains the result from method BasicClient.GetValid.
-type BasicClientGetValidResult struct {
-	Basic
 }
 
 // BasicClientPutValidResponse contains the response from method BasicClient.PutValid.
@@ -126,50 +86,30 @@ type BasicClientPutValidResponse struct {
 
 // DictionaryClientGetEmptyResponse contains the response from method DictionaryClient.GetEmpty.
 type DictionaryClientGetEmptyResponse struct {
-	DictionaryClientGetEmptyResult
+	DictionaryWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DictionaryClientGetEmptyResult contains the result from method DictionaryClient.GetEmpty.
-type DictionaryClientGetEmptyResult struct {
-	DictionaryWrapper
 }
 
 // DictionaryClientGetNotProvidedResponse contains the response from method DictionaryClient.GetNotProvided.
 type DictionaryClientGetNotProvidedResponse struct {
-	DictionaryClientGetNotProvidedResult
+	DictionaryWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DictionaryClientGetNotProvidedResult contains the result from method DictionaryClient.GetNotProvided.
-type DictionaryClientGetNotProvidedResult struct {
-	DictionaryWrapper
 }
 
 // DictionaryClientGetNullResponse contains the response from method DictionaryClient.GetNull.
 type DictionaryClientGetNullResponse struct {
-	DictionaryClientGetNullResult
+	DictionaryWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DictionaryClientGetNullResult contains the result from method DictionaryClient.GetNull.
-type DictionaryClientGetNullResult struct {
-	DictionaryWrapper
 }
 
 // DictionaryClientGetValidResponse contains the response from method DictionaryClient.GetValid.
 type DictionaryClientGetValidResponse struct {
-	DictionaryClientGetValidResult
+	DictionaryWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DictionaryClientGetValidResult contains the result from method DictionaryClient.GetValid.
-type DictionaryClientGetValidResult struct {
-	DictionaryWrapper
 }
 
 // DictionaryClientPutEmptyResponse contains the response from method DictionaryClient.PutEmpty.
@@ -186,18 +126,13 @@ type DictionaryClientPutValidResponse struct {
 
 // FlattencomplexClientGetValidResponse contains the response from method FlattencomplexClient.GetValid.
 type FlattencomplexClientGetValidResponse struct {
-	FlattencomplexClientGetValidResult
+	MyBaseTypeClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// FlattencomplexClientGetValidResult contains the result from method FlattencomplexClient.GetValid.
-type FlattencomplexClientGetValidResult struct {
-	MyBaseTypeClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type FlattencomplexClientGetValidResult.
-func (f *FlattencomplexClientGetValidResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type FlattencomplexClientGetValidResponse.
+func (f *FlattencomplexClientGetValidResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalMyBaseTypeClassification(data)
 	if err != nil {
 		return err
@@ -208,14 +143,9 @@ func (f *FlattencomplexClientGetValidResult) UnmarshalJSON(data []byte) error {
 
 // InheritanceClientGetValidResponse contains the response from method InheritanceClient.GetValid.
 type InheritanceClientGetValidResponse struct {
-	InheritanceClientGetValidResult
+	Siamese
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InheritanceClientGetValidResult contains the result from method InheritanceClient.GetValid.
-type InheritanceClientGetValidResult struct {
-	Siamese
 }
 
 // InheritanceClientPutValidResponse contains the response from method InheritanceClient.PutValid.
@@ -226,18 +156,13 @@ type InheritanceClientPutValidResponse struct {
 
 // PolymorphicrecursiveClientGetValidResponse contains the response from method PolymorphicrecursiveClient.GetValid.
 type PolymorphicrecursiveClientGetValidResponse struct {
-	PolymorphicrecursiveClientGetValidResult
+	FishClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// PolymorphicrecursiveClientGetValidResult contains the result from method PolymorphicrecursiveClient.GetValid.
-type PolymorphicrecursiveClientGetValidResult struct {
-	FishClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphicrecursiveClientGetValidResult.
-func (p *PolymorphicrecursiveClientGetValidResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphicrecursiveClientGetValidResponse.
+func (p *PolymorphicrecursiveClientGetValidResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalFishClassification(data)
 	if err != nil {
 		return err
@@ -254,18 +179,13 @@ type PolymorphicrecursiveClientPutValidResponse struct {
 
 // PolymorphismClientGetComplicatedResponse contains the response from method PolymorphismClient.GetComplicated.
 type PolymorphismClientGetComplicatedResponse struct {
-	PolymorphismClientGetComplicatedResult
+	SalmonClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// PolymorphismClientGetComplicatedResult contains the result from method PolymorphismClient.GetComplicated.
-type PolymorphismClientGetComplicatedResult struct {
-	SalmonClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetComplicatedResult.
-func (p *PolymorphismClientGetComplicatedResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetComplicatedResponse.
+func (p *PolymorphismClientGetComplicatedResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalSalmonClassification(data)
 	if err != nil {
 		return err
@@ -276,42 +196,27 @@ func (p *PolymorphismClientGetComplicatedResult) UnmarshalJSON(data []byte) erro
 
 // PolymorphismClientGetComposedWithDiscriminatorResponse contains the response from method PolymorphismClient.GetComposedWithDiscriminator.
 type PolymorphismClientGetComposedWithDiscriminatorResponse struct {
-	PolymorphismClientGetComposedWithDiscriminatorResult
+	DotFishMarket
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PolymorphismClientGetComposedWithDiscriminatorResult contains the result from method PolymorphismClient.GetComposedWithDiscriminator.
-type PolymorphismClientGetComposedWithDiscriminatorResult struct {
-	DotFishMarket
 }
 
 // PolymorphismClientGetComposedWithoutDiscriminatorResponse contains the response from method PolymorphismClient.GetComposedWithoutDiscriminator.
 type PolymorphismClientGetComposedWithoutDiscriminatorResponse struct {
-	PolymorphismClientGetComposedWithoutDiscriminatorResult
+	DotFishMarket
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PolymorphismClientGetComposedWithoutDiscriminatorResult contains the result from method PolymorphismClient.GetComposedWithoutDiscriminator.
-type PolymorphismClientGetComposedWithoutDiscriminatorResult struct {
-	DotFishMarket
 }
 
 // PolymorphismClientGetDotSyntaxResponse contains the response from method PolymorphismClient.GetDotSyntax.
 type PolymorphismClientGetDotSyntaxResponse struct {
-	PolymorphismClientGetDotSyntaxResult
+	DotFishClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// PolymorphismClientGetDotSyntaxResult contains the result from method PolymorphismClient.GetDotSyntax.
-type PolymorphismClientGetDotSyntaxResult struct {
-	DotFishClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetDotSyntaxResult.
-func (p *PolymorphismClientGetDotSyntaxResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetDotSyntaxResponse.
+func (p *PolymorphismClientGetDotSyntaxResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalDotFishClassification(data)
 	if err != nil {
 		return err
@@ -322,18 +227,13 @@ func (p *PolymorphismClientGetDotSyntaxResult) UnmarshalJSON(data []byte) error 
 
 // PolymorphismClientGetValidResponse contains the response from method PolymorphismClient.GetValid.
 type PolymorphismClientGetValidResponse struct {
-	PolymorphismClientGetValidResult
+	FishClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// PolymorphismClientGetValidResult contains the result from method PolymorphismClient.GetValid.
-type PolymorphismClientGetValidResult struct {
-	FishClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetValidResult.
-func (p *PolymorphismClientGetValidResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetValidResponse.
+func (p *PolymorphismClientGetValidResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalFishClassification(data)
 	if err != nil {
 		return err
@@ -350,18 +250,13 @@ type PolymorphismClientPutComplicatedResponse struct {
 
 // PolymorphismClientPutMissingDiscriminatorResponse contains the response from method PolymorphismClient.PutMissingDiscriminator.
 type PolymorphismClientPutMissingDiscriminatorResponse struct {
-	PolymorphismClientPutMissingDiscriminatorResult
+	SalmonClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// PolymorphismClientPutMissingDiscriminatorResult contains the result from method PolymorphismClient.PutMissingDiscriminator.
-type PolymorphismClientPutMissingDiscriminatorResult struct {
-	SalmonClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientPutMissingDiscriminatorResult.
-func (p *PolymorphismClientPutMissingDiscriminatorResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientPutMissingDiscriminatorResponse.
+func (p *PolymorphismClientPutMissingDiscriminatorResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalSalmonClassification(data)
 	if err != nil {
 		return err
@@ -384,134 +279,79 @@ type PolymorphismClientPutValidResponse struct {
 
 // PrimitiveClientGetBoolResponse contains the response from method PrimitiveClient.GetBool.
 type PrimitiveClientGetBoolResponse struct {
-	PrimitiveClientGetBoolResult
+	BooleanWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetBoolResult contains the result from method PrimitiveClient.GetBool.
-type PrimitiveClientGetBoolResult struct {
-	BooleanWrapper
 }
 
 // PrimitiveClientGetByteResponse contains the response from method PrimitiveClient.GetByte.
 type PrimitiveClientGetByteResponse struct {
-	PrimitiveClientGetByteResult
+	ByteWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetByteResult contains the result from method PrimitiveClient.GetByte.
-type PrimitiveClientGetByteResult struct {
-	ByteWrapper
 }
 
 // PrimitiveClientGetDateResponse contains the response from method PrimitiveClient.GetDate.
 type PrimitiveClientGetDateResponse struct {
-	PrimitiveClientGetDateResult
+	DateWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetDateResult contains the result from method PrimitiveClient.GetDate.
-type PrimitiveClientGetDateResult struct {
-	DateWrapper
 }
 
 // PrimitiveClientGetDateTimeRFC1123Response contains the response from method PrimitiveClient.GetDateTimeRFC1123.
 type PrimitiveClientGetDateTimeRFC1123Response struct {
-	PrimitiveClientGetDateTimeRFC1123Result
+	Datetimerfc1123Wrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetDateTimeRFC1123Result contains the result from method PrimitiveClient.GetDateTimeRFC1123.
-type PrimitiveClientGetDateTimeRFC1123Result struct {
-	Datetimerfc1123Wrapper
 }
 
 // PrimitiveClientGetDateTimeResponse contains the response from method PrimitiveClient.GetDateTime.
 type PrimitiveClientGetDateTimeResponse struct {
-	PrimitiveClientGetDateTimeResult
+	DatetimeWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetDateTimeResult contains the result from method PrimitiveClient.GetDateTime.
-type PrimitiveClientGetDateTimeResult struct {
-	DatetimeWrapper
 }
 
 // PrimitiveClientGetDoubleResponse contains the response from method PrimitiveClient.GetDouble.
 type PrimitiveClientGetDoubleResponse struct {
-	PrimitiveClientGetDoubleResult
+	DoubleWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetDoubleResult contains the result from method PrimitiveClient.GetDouble.
-type PrimitiveClientGetDoubleResult struct {
-	DoubleWrapper
 }
 
 // PrimitiveClientGetDurationResponse contains the response from method PrimitiveClient.GetDuration.
 type PrimitiveClientGetDurationResponse struct {
-	PrimitiveClientGetDurationResult
+	DurationWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetDurationResult contains the result from method PrimitiveClient.GetDuration.
-type PrimitiveClientGetDurationResult struct {
-	DurationWrapper
 }
 
 // PrimitiveClientGetFloatResponse contains the response from method PrimitiveClient.GetFloat.
 type PrimitiveClientGetFloatResponse struct {
-	PrimitiveClientGetFloatResult
+	FloatWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetFloatResult contains the result from method PrimitiveClient.GetFloat.
-type PrimitiveClientGetFloatResult struct {
-	FloatWrapper
 }
 
 // PrimitiveClientGetIntResponse contains the response from method PrimitiveClient.GetInt.
 type PrimitiveClientGetIntResponse struct {
-	PrimitiveClientGetIntResult
+	IntWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetIntResult contains the result from method PrimitiveClient.GetInt.
-type PrimitiveClientGetIntResult struct {
-	IntWrapper
 }
 
 // PrimitiveClientGetLongResponse contains the response from method PrimitiveClient.GetLong.
 type PrimitiveClientGetLongResponse struct {
-	PrimitiveClientGetLongResult
+	LongWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetLongResult contains the result from method PrimitiveClient.GetLong.
-type PrimitiveClientGetLongResult struct {
-	LongWrapper
 }
 
 // PrimitiveClientGetStringResponse contains the response from method PrimitiveClient.GetString.
 type PrimitiveClientGetStringResponse struct {
-	PrimitiveClientGetStringResult
+	StringWrapper
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrimitiveClientGetStringResult contains the result from method PrimitiveClient.GetString.
-type PrimitiveClientGetStringResult struct {
-	StringWrapper
 }
 
 // PrimitiveClientPutBoolResponse contains the response from method PrimitiveClient.PutBool.
@@ -582,14 +422,9 @@ type PrimitiveClientPutStringResponse struct {
 
 // ReadonlypropertyClientGetValidResponse contains the response from method ReadonlypropertyClient.GetValid.
 type ReadonlypropertyClientGetValidResponse struct {
-	ReadonlypropertyClientGetValidResult
+	ReadonlyObj
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReadonlypropertyClientGetValidResult contains the result from method ReadonlypropertyClient.GetValid.
-type ReadonlypropertyClientGetValidResult struct {
-	ReadonlyObj
 }
 
 // ReadonlypropertyClientPutValidResponse contains the response from method ReadonlypropertyClient.PutValid.

--- a/test/autorest/complexmodelgroup/zz_generated_response_types.go
+++ b/test/autorest/complexmodelgroup/zz_generated_response_types.go
@@ -12,36 +12,21 @@ import "net/http"
 
 // ComplexModelClientCreateResponse contains the response from method ComplexModelClient.Create.
 type ComplexModelClientCreateResponse struct {
-	ComplexModelClientCreateResult
+	CatalogDictionary
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ComplexModelClientCreateResult contains the result from method ComplexModelClient.Create.
-type ComplexModelClientCreateResult struct {
-	CatalogDictionary
 }
 
 // ComplexModelClientListResponse contains the response from method ComplexModelClient.List.
 type ComplexModelClientListResponse struct {
-	ComplexModelClientListResult
+	CatalogArray
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ComplexModelClientListResult contains the result from method ComplexModelClient.List.
-type ComplexModelClientListResult struct {
-	CatalogArray
 }
 
 // ComplexModelClientUpdateResponse contains the response from method ComplexModelClient.Update.
 type ComplexModelClientUpdateResponse struct {
-	ComplexModelClientUpdateResult
+	CatalogArray
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ComplexModelClientUpdateResult contains the result from method ComplexModelClient.Update.
-type ComplexModelClientUpdateResult struct {
-	CatalogArray
 }

--- a/test/autorest/dategroup/zz_generated_response_types.go
+++ b/test/autorest/dategroup/zz_generated_response_types.go
@@ -15,74 +15,44 @@ import (
 
 // DateClientGetInvalidDateResponse contains the response from method DateClient.GetInvalidDate.
 type DateClientGetInvalidDateResponse struct {
-	DateClientGetInvalidDateResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DateClientGetInvalidDateResult contains the result from method DateClient.GetInvalidDate.
-type DateClientGetInvalidDateResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DateClientGetMaxDateResponse contains the response from method DateClient.GetMaxDate.
 type DateClientGetMaxDateResponse struct {
-	DateClientGetMaxDateResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DateClientGetMaxDateResult contains the result from method DateClient.GetMaxDate.
-type DateClientGetMaxDateResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DateClientGetMinDateResponse contains the response from method DateClient.GetMinDate.
 type DateClientGetMinDateResponse struct {
-	DateClientGetMinDateResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DateClientGetMinDateResult contains the result from method DateClient.GetMinDate.
-type DateClientGetMinDateResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DateClientGetNullResponse contains the response from method DateClient.GetNull.
 type DateClientGetNullResponse struct {
-	DateClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DateClientGetNullResult contains the result from method DateClient.GetNull.
-type DateClientGetNullResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DateClientGetOverflowDateResponse contains the response from method DateClient.GetOverflowDate.
 type DateClientGetOverflowDateResponse struct {
-	DateClientGetOverflowDateResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DateClientGetOverflowDateResult contains the result from method DateClient.GetOverflowDate.
-type DateClientGetOverflowDateResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DateClientGetUnderflowDateResponse contains the response from method DateClient.GetUnderflowDate.
 type DateClientGetUnderflowDateResponse struct {
-	DateClientGetUnderflowDateResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DateClientGetUnderflowDateResult contains the result from method DateClient.GetUnderflowDate.
-type DateClientGetUnderflowDateResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DateClientPutMaxDateResponse contains the response from method DateClient.PutMaxDate.

--- a/test/autorest/datetimegroup/zz_generated_response_types.go
+++ b/test/autorest/datetimegroup/zz_generated_response_types.go
@@ -15,182 +15,107 @@ import (
 
 // DatetimeClientGetInvalidResponse contains the response from method DatetimeClient.GetInvalid.
 type DatetimeClientGetInvalidResponse struct {
-	DatetimeClientGetInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetInvalidResult contains the result from method DatetimeClient.GetInvalid.
-type DatetimeClientGetInvalidResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetLocalNegativeOffsetLowercaseMaxDateTime.
 type DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse struct {
-	DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResult contains the result from method DatetimeClient.GetLocalNegativeOffsetLowercaseMaxDateTime.
-type DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse contains the response from method DatetimeClient.GetLocalNegativeOffsetMinDateTime.
 type DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse struct {
-	DatetimeClientGetLocalNegativeOffsetMinDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetLocalNegativeOffsetMinDateTimeResult contains the result from method DatetimeClient.GetLocalNegativeOffsetMinDateTime.
-type DatetimeClientGetLocalNegativeOffsetMinDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetLocalNegativeOffsetUppercaseMaxDateTime.
 type DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse struct {
-	DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResult contains the result from method DatetimeClient.GetLocalNegativeOffsetUppercaseMaxDateTime.
-type DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetLocalNoOffsetMinDateTimeResponse contains the response from method DatetimeClient.GetLocalNoOffsetMinDateTime.
 type DatetimeClientGetLocalNoOffsetMinDateTimeResponse struct {
-	DatetimeClientGetLocalNoOffsetMinDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetLocalNoOffsetMinDateTimeResult contains the result from method DatetimeClient.GetLocalNoOffsetMinDateTime.
-type DatetimeClientGetLocalNoOffsetMinDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetLocalPositiveOffsetLowercaseMaxDateTime.
 type DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse struct {
-	DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResult contains the result from method DatetimeClient.GetLocalPositiveOffsetLowercaseMaxDateTime.
-type DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse contains the response from method DatetimeClient.GetLocalPositiveOffsetMinDateTime.
 type DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse struct {
-	DatetimeClientGetLocalPositiveOffsetMinDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetLocalPositiveOffsetMinDateTimeResult contains the result from method DatetimeClient.GetLocalPositiveOffsetMinDateTime.
-type DatetimeClientGetLocalPositiveOffsetMinDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetLocalPositiveOffsetUppercaseMaxDateTime.
 type DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse struct {
-	DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResult contains the result from method DatetimeClient.GetLocalPositiveOffsetUppercaseMaxDateTime.
-type DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetNullResponse contains the response from method DatetimeClient.GetNull.
 type DatetimeClientGetNullResponse struct {
-	DatetimeClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetNullResult contains the result from method DatetimeClient.GetNull.
-type DatetimeClientGetNullResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetOverflowResponse contains the response from method DatetimeClient.GetOverflow.
 type DatetimeClientGetOverflowResponse struct {
-	DatetimeClientGetOverflowResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetOverflowResult contains the result from method DatetimeClient.GetOverflow.
-type DatetimeClientGetOverflowResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetUTCLowercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetUTCLowercaseMaxDateTime.
 type DatetimeClientGetUTCLowercaseMaxDateTimeResponse struct {
-	DatetimeClientGetUTCLowercaseMaxDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetUTCLowercaseMaxDateTimeResult contains the result from method DatetimeClient.GetUTCLowercaseMaxDateTime.
-type DatetimeClientGetUTCLowercaseMaxDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetUTCMinDateTimeResponse contains the response from method DatetimeClient.GetUTCMinDateTime.
 type DatetimeClientGetUTCMinDateTimeResponse struct {
-	DatetimeClientGetUTCMinDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetUTCMinDateTimeResult contains the result from method DatetimeClient.GetUTCMinDateTime.
-type DatetimeClientGetUTCMinDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse contains the response from method DatetimeClient.GetUTCUppercaseMaxDateTime7Digits.
 type DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse struct {
-	DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResult contains the result from method DatetimeClient.GetUTCUppercaseMaxDateTime7Digits.
-type DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetUTCUppercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetUTCUppercaseMaxDateTime.
 type DatetimeClientGetUTCUppercaseMaxDateTimeResponse struct {
-	DatetimeClientGetUTCUppercaseMaxDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetUTCUppercaseMaxDateTimeResult contains the result from method DatetimeClient.GetUTCUppercaseMaxDateTime.
-type DatetimeClientGetUTCUppercaseMaxDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientGetUnderflowResponse contains the response from method DatetimeClient.GetUnderflow.
 type DatetimeClientGetUnderflowResponse struct {
-	DatetimeClientGetUnderflowResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DatetimeClientGetUnderflowResult contains the result from method DatetimeClient.GetUnderflow.
-type DatetimeClientGetUnderflowResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // DatetimeClientPutLocalNegativeOffsetMaxDateTimeResponse contains the response from method DatetimeClient.PutLocalNegativeOffsetMaxDateTime.

--- a/test/autorest/datetimerfc1123group/zz_generated_response_types.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_response_types.go
@@ -15,86 +15,51 @@ import (
 
 // Datetimerfc1123ClientGetInvalidResponse contains the response from method Datetimerfc1123Client.GetInvalid.
 type Datetimerfc1123ClientGetInvalidResponse struct {
-	Datetimerfc1123ClientGetInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// Datetimerfc1123ClientGetInvalidResult contains the result from method Datetimerfc1123Client.GetInvalid.
-type Datetimerfc1123ClientGetInvalidResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // Datetimerfc1123ClientGetNullResponse contains the response from method Datetimerfc1123Client.GetNull.
 type Datetimerfc1123ClientGetNullResponse struct {
-	Datetimerfc1123ClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// Datetimerfc1123ClientGetNullResult contains the result from method Datetimerfc1123Client.GetNull.
-type Datetimerfc1123ClientGetNullResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // Datetimerfc1123ClientGetOverflowResponse contains the response from method Datetimerfc1123Client.GetOverflow.
 type Datetimerfc1123ClientGetOverflowResponse struct {
-	Datetimerfc1123ClientGetOverflowResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// Datetimerfc1123ClientGetOverflowResult contains the result from method Datetimerfc1123Client.GetOverflow.
-type Datetimerfc1123ClientGetOverflowResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse contains the response from method Datetimerfc1123Client.GetUTCLowercaseMaxDateTime.
 type Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse struct {
-	Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResult contains the result from method Datetimerfc1123Client.GetUTCLowercaseMaxDateTime.
-type Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // Datetimerfc1123ClientGetUTCMinDateTimeResponse contains the response from method Datetimerfc1123Client.GetUTCMinDateTime.
 type Datetimerfc1123ClientGetUTCMinDateTimeResponse struct {
-	Datetimerfc1123ClientGetUTCMinDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// Datetimerfc1123ClientGetUTCMinDateTimeResult contains the result from method Datetimerfc1123Client.GetUTCMinDateTime.
-type Datetimerfc1123ClientGetUTCMinDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse contains the response from method Datetimerfc1123Client.GetUTCUppercaseMaxDateTime.
 type Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse struct {
-	Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResult contains the result from method Datetimerfc1123Client.GetUTCUppercaseMaxDateTime.
-type Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // Datetimerfc1123ClientGetUnderflowResponse contains the response from method Datetimerfc1123Client.GetUnderflow.
 type Datetimerfc1123ClientGetUnderflowResponse struct {
-	Datetimerfc1123ClientGetUnderflowResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// Datetimerfc1123ClientGetUnderflowResult contains the result from method Datetimerfc1123Client.GetUnderflow.
-type Datetimerfc1123ClientGetUnderflowResult struct {
-	Value *time.Time
+	Value       *time.Time
 }
 
 // Datetimerfc1123ClientPutUTCMaxDateTimeResponse contains the response from method Datetimerfc1123Client.PutUTCMaxDateTime.

--- a/test/autorest/dictionarygroup/zz_generated_response_types.go
+++ b/test/autorest/dictionarygroup/zz_generated_response_types.go
@@ -15,143 +15,99 @@ import (
 
 // DictionaryClientGetArrayEmptyResponse contains the response from method DictionaryClient.GetArrayEmpty.
 type DictionaryClientGetArrayEmptyResponse struct {
-	DictionaryClientGetArrayEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetArrayEmptyResult contains the result from method DictionaryClient.GetArrayEmpty.
-type DictionaryClientGetArrayEmptyResult struct {
 	// An empty dictionary {}
 	Value map[string][]*string
 }
 
 // DictionaryClientGetArrayItemEmptyResponse contains the response from method DictionaryClient.GetArrayItemEmpty.
 type DictionaryClientGetArrayItemEmptyResponse struct {
-	DictionaryClientGetArrayItemEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetArrayItemEmptyResult contains the result from method DictionaryClient.GetArrayItemEmpty.
-type DictionaryClientGetArrayItemEmptyResult struct {
 	// An array of array of strings {"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
 	Value map[string][]*string
 }
 
 // DictionaryClientGetArrayItemNullResponse contains the response from method DictionaryClient.GetArrayItemNull.
 type DictionaryClientGetArrayItemNullResponse struct {
-	DictionaryClientGetArrayItemNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetArrayItemNullResult contains the result from method DictionaryClient.GetArrayItemNull.
-type DictionaryClientGetArrayItemNullResult struct {
 	// An array of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
 	Value map[string][]*string
 }
 
 // DictionaryClientGetArrayNullResponse contains the response from method DictionaryClient.GetArrayNull.
 type DictionaryClientGetArrayNullResponse struct {
-	DictionaryClientGetArrayNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetArrayNullResult contains the result from method DictionaryClient.GetArrayNull.
-type DictionaryClientGetArrayNullResult struct {
 	// a null array
 	Value map[string][]*string
 }
 
 // DictionaryClientGetArrayValidResponse contains the response from method DictionaryClient.GetArrayValid.
 type DictionaryClientGetArrayValidResponse struct {
-	DictionaryClientGetArrayValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetArrayValidResult contains the result from method DictionaryClient.GetArrayValid.
-type DictionaryClientGetArrayValidResult struct {
 	// An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
 	Value map[string][]*string
 }
 
 // DictionaryClientGetBase64URLResponse contains the response from method DictionaryClient.GetBase64URL.
 type DictionaryClientGetBase64URLResponse struct {
-	DictionaryClientGetBase64URLResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetBase64URLResult contains the result from method DictionaryClient.GetBase64URL.
-type DictionaryClientGetBase64URLResult struct {
 	// The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}
 	Value map[string][]byte
 }
 
 // DictionaryClientGetBooleanInvalidNullResponse contains the response from method DictionaryClient.GetBooleanInvalidNull.
 type DictionaryClientGetBooleanInvalidNullResponse struct {
-	DictionaryClientGetBooleanInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetBooleanInvalidNullResult contains the result from method DictionaryClient.GetBooleanInvalidNull.
-type DictionaryClientGetBooleanInvalidNullResult struct {
 	// The dictionary value {"0": true, "1": null, "2": false }
 	Value map[string]*bool
 }
 
 // DictionaryClientGetBooleanInvalidStringResponse contains the response from method DictionaryClient.GetBooleanInvalidString.
 type DictionaryClientGetBooleanInvalidStringResponse struct {
-	DictionaryClientGetBooleanInvalidStringResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetBooleanInvalidStringResult contains the result from method DictionaryClient.GetBooleanInvalidString.
-type DictionaryClientGetBooleanInvalidStringResult struct {
 	// The dictionary value [true, 'boolean', false]
 	Value map[string]*bool
 }
 
 // DictionaryClientGetBooleanTfftResponse contains the response from method DictionaryClient.GetBooleanTfft.
 type DictionaryClientGetBooleanTfftResponse struct {
-	DictionaryClientGetBooleanTfftResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetBooleanTfftResult contains the result from method DictionaryClient.GetBooleanTfft.
-type DictionaryClientGetBooleanTfftResult struct {
 	// The dictionary value {"0": true, "1": false, "2": false, "3": true }
 	Value map[string]*bool
 }
 
 // DictionaryClientGetByteInvalidNullResponse contains the response from method DictionaryClient.GetByteInvalidNull.
 type DictionaryClientGetByteInvalidNullResponse struct {
-	DictionaryClientGetByteInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetByteInvalidNullResult contains the result from method DictionaryClient.GetByteInvalidNull.
-type DictionaryClientGetByteInvalidNullResult struct {
 	// The byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
 	Value map[string][]byte
 }
 
 // DictionaryClientGetByteValidResponse contains the response from method DictionaryClient.GetByteValid.
 type DictionaryClientGetByteValidResponse struct {
-	DictionaryClientGetByteValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetByteValidResult contains the result from method DictionaryClient.GetByteValid.
-type DictionaryClientGetByteValidResult struct {
 	// The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base
 	// 64
 	Value map[string][]byte
@@ -159,65 +115,45 @@ type DictionaryClientGetByteValidResult struct {
 
 // DictionaryClientGetComplexEmptyResponse contains the response from method DictionaryClient.GetComplexEmpty.
 type DictionaryClientGetComplexEmptyResponse struct {
-	DictionaryClientGetComplexEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetComplexEmptyResult contains the result from method DictionaryClient.GetComplexEmpty.
-type DictionaryClientGetComplexEmptyResult struct {
 	// Empty dictionary of complex type {}
 	Value map[string]*Widget
 }
 
 // DictionaryClientGetComplexItemEmptyResponse contains the response from method DictionaryClient.GetComplexItemEmpty.
 type DictionaryClientGetComplexItemEmptyResponse struct {
-	DictionaryClientGetComplexItemEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetComplexItemEmptyResult contains the result from method DictionaryClient.GetComplexItemEmpty.
-type DictionaryClientGetComplexItemEmptyResult struct {
 	// Dictionary of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
 	Value map[string]*Widget
 }
 
 // DictionaryClientGetComplexItemNullResponse contains the response from method DictionaryClient.GetComplexItemNull.
 type DictionaryClientGetComplexItemNullResponse struct {
-	DictionaryClientGetComplexItemNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetComplexItemNullResult contains the result from method DictionaryClient.GetComplexItemNull.
-type DictionaryClientGetComplexItemNullResult struct {
 	// Dictionary of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
 	Value map[string]*Widget
 }
 
 // DictionaryClientGetComplexNullResponse contains the response from method DictionaryClient.GetComplexNull.
 type DictionaryClientGetComplexNullResponse struct {
-	DictionaryClientGetComplexNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetComplexNullResult contains the result from method DictionaryClient.GetComplexNull.
-type DictionaryClientGetComplexNullResult struct {
 	// Dictionary of complex type with null value
 	Value map[string]*Widget
 }
 
 // DictionaryClientGetComplexValidResponse contains the response from method DictionaryClient.GetComplexValid.
 type DictionaryClientGetComplexValidResponse struct {
-	DictionaryClientGetComplexValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetComplexValidResult contains the result from method DictionaryClient.GetComplexValid.
-type DictionaryClientGetComplexValidResult struct {
 	// Dictionary of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string':
 	// '6'}]
 	Value map[string]*Widget
@@ -225,65 +161,45 @@ type DictionaryClientGetComplexValidResult struct {
 
 // DictionaryClientGetDateInvalidCharsResponse contains the response from method DictionaryClient.GetDateInvalidChars.
 type DictionaryClientGetDateInvalidCharsResponse struct {
-	DictionaryClientGetDateInvalidCharsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDateInvalidCharsResult contains the result from method DictionaryClient.GetDateInvalidChars.
-type DictionaryClientGetDateInvalidCharsResult struct {
 	// The dictionary value {"0": "2011-03-22", "1": "date"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateInvalidNullResponse contains the response from method DictionaryClient.GetDateInvalidNull.
 type DictionaryClientGetDateInvalidNullResponse struct {
-	DictionaryClientGetDateInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDateInvalidNullResult contains the result from method DictionaryClient.GetDateInvalidNull.
-type DictionaryClientGetDateInvalidNullResult struct {
 	// The dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateTimeInvalidCharsResponse contains the response from method DictionaryClient.GetDateTimeInvalidChars.
 type DictionaryClientGetDateTimeInvalidCharsResponse struct {
-	DictionaryClientGetDateTimeInvalidCharsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDateTimeInvalidCharsResult contains the result from method DictionaryClient.GetDateTimeInvalidChars.
-type DictionaryClientGetDateTimeInvalidCharsResult struct {
 	// The dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateTimeInvalidNullResponse contains the response from method DictionaryClient.GetDateTimeInvalidNull.
 type DictionaryClientGetDateTimeInvalidNullResponse struct {
-	DictionaryClientGetDateTimeInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDateTimeInvalidNullResult contains the result from method DictionaryClient.GetDateTimeInvalidNull.
-type DictionaryClientGetDateTimeInvalidNullResult struct {
 	// The dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateTimeRFC1123ValidResponse contains the response from method DictionaryClient.GetDateTimeRFC1123Valid.
 type DictionaryClientGetDateTimeRFC1123ValidResponse struct {
-	DictionaryClientGetDateTimeRFC1123ValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDateTimeRFC1123ValidResult contains the result from method DictionaryClient.GetDateTimeRFC1123Valid.
-type DictionaryClientGetDateTimeRFC1123ValidResult struct {
 	// The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492
 	// 10:15:01 GMT"}
 	Value map[string]*time.Time
@@ -291,52 +207,36 @@ type DictionaryClientGetDateTimeRFC1123ValidResult struct {
 
 // DictionaryClientGetDateTimeValidResponse contains the response from method DictionaryClient.GetDateTimeValid.
 type DictionaryClientGetDateTimeValidResponse struct {
-	DictionaryClientGetDateTimeValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDateTimeValidResult contains the result from method DictionaryClient.GetDateTimeValid.
-type DictionaryClientGetDateTimeValidResult struct {
 	// The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateValidResponse contains the response from method DictionaryClient.GetDateValid.
 type DictionaryClientGetDateValidResponse struct {
-	DictionaryClientGetDateValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDateValidResult contains the result from method DictionaryClient.GetDateValid.
-type DictionaryClientGetDateValidResult struct {
 	// The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDictionaryEmptyResponse contains the response from method DictionaryClient.GetDictionaryEmpty.
 type DictionaryClientGetDictionaryEmptyResponse struct {
-	DictionaryClientGetDictionaryEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDictionaryEmptyResult contains the result from method DictionaryClient.GetDictionaryEmpty.
-type DictionaryClientGetDictionaryEmptyResult struct {
 	// An dictionaries of dictionaries of type <string, string> with value {}
 	Value map[string]map[string]*string
 }
 
 // DictionaryClientGetDictionaryItemEmptyResponse contains the response from method DictionaryClient.GetDictionaryItemEmpty.
 type DictionaryClientGetDictionaryItemEmptyResponse struct {
-	DictionaryClientGetDictionaryItemEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDictionaryItemEmptyResult contains the result from method DictionaryClient.GetDictionaryItemEmpty.
-type DictionaryClientGetDictionaryItemEmptyResult struct {
 	// An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
 	// {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 	Value map[string]map[string]*string
@@ -344,13 +244,9 @@ type DictionaryClientGetDictionaryItemEmptyResult struct {
 
 // DictionaryClientGetDictionaryItemNullResponse contains the response from method DictionaryClient.GetDictionaryItemNull.
 type DictionaryClientGetDictionaryItemNullResponse struct {
-	DictionaryClientGetDictionaryItemNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDictionaryItemNullResult contains the result from method DictionaryClient.GetDictionaryItemNull.
-type DictionaryClientGetDictionaryItemNullResult struct {
 	// An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
 	// null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 	Value map[string]map[string]*string
@@ -358,26 +254,18 @@ type DictionaryClientGetDictionaryItemNullResult struct {
 
 // DictionaryClientGetDictionaryNullResponse contains the response from method DictionaryClient.GetDictionaryNull.
 type DictionaryClientGetDictionaryNullResponse struct {
-	DictionaryClientGetDictionaryNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDictionaryNullResult contains the result from method DictionaryClient.GetDictionaryNull.
-type DictionaryClientGetDictionaryNullResult struct {
 	// An dictionaries of dictionaries with value null
 	Value map[string]map[string]*string
 }
 
 // DictionaryClientGetDictionaryValidResponse contains the response from method DictionaryClient.GetDictionaryValid.
 type DictionaryClientGetDictionaryValidResponse struct {
-	DictionaryClientGetDictionaryValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDictionaryValidResult contains the result from method DictionaryClient.GetDictionaryValid.
-type DictionaryClientGetDictionaryValidResult struct {
 	// An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
 	// {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 	Value map[string]map[string]*string
@@ -385,286 +273,198 @@ type DictionaryClientGetDictionaryValidResult struct {
 
 // DictionaryClientGetDoubleInvalidNullResponse contains the response from method DictionaryClient.GetDoubleInvalidNull.
 type DictionaryClientGetDoubleInvalidNullResponse struct {
-	DictionaryClientGetDoubleInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDoubleInvalidNullResult contains the result from method DictionaryClient.GetDoubleInvalidNull.
-type DictionaryClientGetDoubleInvalidNullResult struct {
 	// The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 	Value map[string]*float64
 }
 
 // DictionaryClientGetDoubleInvalidStringResponse contains the response from method DictionaryClient.GetDoubleInvalidString.
 type DictionaryClientGetDoubleInvalidStringResponse struct {
-	DictionaryClientGetDoubleInvalidStringResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDoubleInvalidStringResult contains the result from method DictionaryClient.GetDoubleInvalidString.
-type DictionaryClientGetDoubleInvalidStringResult struct {
 	// The dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 	Value map[string]*float64
 }
 
 // DictionaryClientGetDoubleValidResponse contains the response from method DictionaryClient.GetDoubleValid.
 type DictionaryClientGetDoubleValidResponse struct {
-	DictionaryClientGetDoubleValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDoubleValidResult contains the result from method DictionaryClient.GetDoubleValid.
-type DictionaryClientGetDoubleValidResult struct {
 	// The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 	Value map[string]*float64
 }
 
 // DictionaryClientGetDurationValidResponse contains the response from method DictionaryClient.GetDurationValid.
 type DictionaryClientGetDurationValidResponse struct {
-	DictionaryClientGetDurationValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetDurationValidResult contains the result from method DictionaryClient.GetDurationValid.
-type DictionaryClientGetDurationValidResult struct {
 	// The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
 	Value map[string]*string
 }
 
 // DictionaryClientGetEmptyResponse contains the response from method DictionaryClient.GetEmpty.
 type DictionaryClientGetEmptyResponse struct {
-	DictionaryClientGetEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetEmptyResult contains the result from method DictionaryClient.GetEmpty.
-type DictionaryClientGetEmptyResult struct {
 	// The empty dictionary value {}
 	Value map[string]*int32
 }
 
 // DictionaryClientGetEmptyStringKeyResponse contains the response from method DictionaryClient.GetEmptyStringKey.
 type DictionaryClientGetEmptyStringKeyResponse struct {
-	DictionaryClientGetEmptyStringKeyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetEmptyStringKeyResult contains the result from method DictionaryClient.GetEmptyStringKey.
-type DictionaryClientGetEmptyStringKeyResult struct {
 	// Dictionary of <string>
 	Value map[string]*string
 }
 
 // DictionaryClientGetFloatInvalidNullResponse contains the response from method DictionaryClient.GetFloatInvalidNull.
 type DictionaryClientGetFloatInvalidNullResponse struct {
-	DictionaryClientGetFloatInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetFloatInvalidNullResult contains the result from method DictionaryClient.GetFloatInvalidNull.
-type DictionaryClientGetFloatInvalidNullResult struct {
 	// The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 	Value map[string]*float32
 }
 
 // DictionaryClientGetFloatInvalidStringResponse contains the response from method DictionaryClient.GetFloatInvalidString.
 type DictionaryClientGetFloatInvalidStringResponse struct {
-	DictionaryClientGetFloatInvalidStringResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetFloatInvalidStringResult contains the result from method DictionaryClient.GetFloatInvalidString.
-type DictionaryClientGetFloatInvalidStringResult struct {
 	// The dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 	Value map[string]*float32
 }
 
 // DictionaryClientGetFloatValidResponse contains the response from method DictionaryClient.GetFloatValid.
 type DictionaryClientGetFloatValidResponse struct {
-	DictionaryClientGetFloatValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetFloatValidResult contains the result from method DictionaryClient.GetFloatValid.
-type DictionaryClientGetFloatValidResult struct {
 	// The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 	Value map[string]*float32
 }
 
 // DictionaryClientGetIntInvalidNullResponse contains the response from method DictionaryClient.GetIntInvalidNull.
 type DictionaryClientGetIntInvalidNullResponse struct {
-	DictionaryClientGetIntInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetIntInvalidNullResult contains the result from method DictionaryClient.GetIntInvalidNull.
-type DictionaryClientGetIntInvalidNullResult struct {
 	// The dictionary value {"0": 1, "1": null, "2": 0}
 	Value map[string]*int32
 }
 
 // DictionaryClientGetIntInvalidStringResponse contains the response from method DictionaryClient.GetIntInvalidString.
 type DictionaryClientGetIntInvalidStringResponse struct {
-	DictionaryClientGetIntInvalidStringResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetIntInvalidStringResult contains the result from method DictionaryClient.GetIntInvalidString.
-type DictionaryClientGetIntInvalidStringResult struct {
 	// The dictionary value {"0": 1, "1": "integer", "2": 0}
 	Value map[string]*int32
 }
 
 // DictionaryClientGetIntegerValidResponse contains the response from method DictionaryClient.GetIntegerValid.
 type DictionaryClientGetIntegerValidResponse struct {
-	DictionaryClientGetIntegerValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetIntegerValidResult contains the result from method DictionaryClient.GetIntegerValid.
-type DictionaryClientGetIntegerValidResult struct {
 	// The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 	Value map[string]*int32
 }
 
 // DictionaryClientGetInvalidResponse contains the response from method DictionaryClient.GetInvalid.
 type DictionaryClientGetInvalidResponse struct {
-	DictionaryClientGetInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetInvalidResult contains the result from method DictionaryClient.GetInvalid.
-type DictionaryClientGetInvalidResult struct {
 	// Dictionary of <string>
 	Value map[string]*string
 }
 
 // DictionaryClientGetLongInvalidNullResponse contains the response from method DictionaryClient.GetLongInvalidNull.
 type DictionaryClientGetLongInvalidNullResponse struct {
-	DictionaryClientGetLongInvalidNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetLongInvalidNullResult contains the result from method DictionaryClient.GetLongInvalidNull.
-type DictionaryClientGetLongInvalidNullResult struct {
 	// The dictionary value {"0": 1, "1": null, "2": 0}
 	Value map[string]*int64
 }
 
 // DictionaryClientGetLongInvalidStringResponse contains the response from method DictionaryClient.GetLongInvalidString.
 type DictionaryClientGetLongInvalidStringResponse struct {
-	DictionaryClientGetLongInvalidStringResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetLongInvalidStringResult contains the result from method DictionaryClient.GetLongInvalidString.
-type DictionaryClientGetLongInvalidStringResult struct {
 	// The dictionary value {"0": 1, "1": "integer", "2": 0}
 	Value map[string]*int64
 }
 
 // DictionaryClientGetLongValidResponse contains the response from method DictionaryClient.GetLongValid.
 type DictionaryClientGetLongValidResponse struct {
-	DictionaryClientGetLongValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetLongValidResult contains the result from method DictionaryClient.GetLongValid.
-type DictionaryClientGetLongValidResult struct {
 	// The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 	Value map[string]*int64
 }
 
 // DictionaryClientGetNullKeyResponse contains the response from method DictionaryClient.GetNullKey.
 type DictionaryClientGetNullKeyResponse struct {
-	DictionaryClientGetNullKeyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetNullKeyResult contains the result from method DictionaryClient.GetNullKey.
-type DictionaryClientGetNullKeyResult struct {
 	// Dictionary of <string>
 	Value map[string]*string
 }
 
 // DictionaryClientGetNullResponse contains the response from method DictionaryClient.GetNull.
 type DictionaryClientGetNullResponse struct {
-	DictionaryClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetNullResult contains the result from method DictionaryClient.GetNull.
-type DictionaryClientGetNullResult struct {
 	// The null dictionary value
 	Value map[string]*int32
 }
 
 // DictionaryClientGetNullValueResponse contains the response from method DictionaryClient.GetNullValue.
 type DictionaryClientGetNullValueResponse struct {
-	DictionaryClientGetNullValueResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetNullValueResult contains the result from method DictionaryClient.GetNullValue.
-type DictionaryClientGetNullValueResult struct {
 	// Dictionary of <string>
 	Value map[string]*string
 }
 
 // DictionaryClientGetStringValidResponse contains the response from method DictionaryClient.GetStringValid.
 type DictionaryClientGetStringValidResponse struct {
-	DictionaryClientGetStringValidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetStringValidResult contains the result from method DictionaryClient.GetStringValid.
-type DictionaryClientGetStringValidResult struct {
 	// The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
 	Value map[string]*string
 }
 
 // DictionaryClientGetStringWithInvalidResponse contains the response from method DictionaryClient.GetStringWithInvalid.
 type DictionaryClientGetStringWithInvalidResponse struct {
-	DictionaryClientGetStringWithInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetStringWithInvalidResult contains the result from method DictionaryClient.GetStringWithInvalid.
-type DictionaryClientGetStringWithInvalidResult struct {
 	// The dictionary value {"0": "foo", "1": 123, "2": "foo2"}
 	Value map[string]*string
 }
 
 // DictionaryClientGetStringWithNullResponse contains the response from method DictionaryClient.GetStringWithNull.
 type DictionaryClientGetStringWithNullResponse struct {
-	DictionaryClientGetStringWithNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// DictionaryClientGetStringWithNullResult contains the result from method DictionaryClient.GetStringWithNull.
-type DictionaryClientGetStringWithNullResult struct {
 	// The dictionary value {"0": "foo", "1": null, "2": "foo2"}
 	Value map[string]*string
 }

--- a/test/autorest/durationgroup/zz_generated_response_types.go
+++ b/test/autorest/durationgroup/zz_generated_response_types.go
@@ -12,38 +12,23 @@ import "net/http"
 
 // DurationClientGetInvalidResponse contains the response from method DurationClient.GetInvalid.
 type DurationClientGetInvalidResponse struct {
-	DurationClientGetInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DurationClientGetInvalidResult contains the result from method DurationClient.GetInvalid.
-type DurationClientGetInvalidResult struct {
-	Value *string
+	Value       *string
 }
 
 // DurationClientGetNullResponse contains the response from method DurationClient.GetNull.
 type DurationClientGetNullResponse struct {
-	DurationClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DurationClientGetNullResult contains the result from method DurationClient.GetNull.
-type DurationClientGetNullResult struct {
-	Value *string
+	Value       *string
 }
 
 // DurationClientGetPositiveDurationResponse contains the response from method DurationClient.GetPositiveDuration.
 type DurationClientGetPositiveDurationResponse struct {
-	DurationClientGetPositiveDurationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DurationClientGetPositiveDurationResult contains the result from method DurationClient.GetPositiveDuration.
-type DurationClientGetPositiveDurationResult struct {
-	Value *string
+	Value       *string
 }
 
 // DurationClientPutPositiveDurationResponse contains the response from method DurationClient.PutPositiveDuration.

--- a/test/autorest/errorsgroup/zz_generated_response_types.go
+++ b/test/autorest/errorsgroup/zz_generated_response_types.go
@@ -12,26 +12,16 @@ import "net/http"
 
 // PetClientDoSomethingResponse contains the response from method PetClient.DoSomething.
 type PetClientDoSomethingResponse struct {
-	PetClientDoSomethingResult
+	PetAction
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetClientDoSomethingResult contains the result from method PetClient.DoSomething.
-type PetClientDoSomethingResult struct {
-	PetAction
 }
 
 // PetClientGetPetByIDResponse contains the response from method PetClient.GetPetByID.
 type PetClientGetPetByIDResponse struct {
-	PetClientGetPetByIDResult
+	Pet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetClientGetPetByIDResult contains the result from method PetClient.GetPetByID.
-type PetClientGetPetByIDResult struct {
-	Pet
 }
 
 // PetClientHasModelsParamResponse contains the response from method PetClient.HasModelsParam.

--- a/test/autorest/extenumsgroup/zz_generated_response_types.go
+++ b/test/autorest/extenumsgroup/zz_generated_response_types.go
@@ -12,24 +12,14 @@ import "net/http"
 
 // PetClientAddPetResponse contains the response from method PetClient.AddPet.
 type PetClientAddPetResponse struct {
-	PetClientAddPetResult
+	Pet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetClientAddPetResult contains the result from method PetClient.AddPet.
-type PetClientAddPetResult struct {
-	Pet
 }
 
 // PetClientGetByPetIDResponse contains the response from method PetClient.GetByPetID.
 type PetClientGetByPetIDResponse struct {
-	PetClientGetByPetIDResult
+	Pet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PetClientGetByPetIDResult contains the result from method PetClient.GetByPetID.
-type PetClientGetByPetIDResult struct {
-	Pet
 }

--- a/test/autorest/headergroup/zz_generated_response_types.go
+++ b/test/autorest/headergroup/zz_generated_response_types.go
@@ -105,182 +105,126 @@ type HeaderClientParamStringResponse struct {
 
 // HeaderClientResponseBoolResponse contains the response from method HeaderClient.ResponseBool.
 type HeaderClientResponseBoolResponse struct {
-	HeaderClientResponseBoolResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseBoolResult contains the result from method HeaderClient.ResponseBool.
-type HeaderClientResponseBoolResult struct {
 	// Value contains the information returned from the value header response.
 	Value *bool
 }
 
 // HeaderClientResponseByteResponse contains the response from method HeaderClient.ResponseByte.
 type HeaderClientResponseByteResponse struct {
-	HeaderClientResponseByteResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseByteResult contains the result from method HeaderClient.ResponseByte.
-type HeaderClientResponseByteResult struct {
 	// Value contains the information returned from the value header response.
 	Value []byte
 }
 
 // HeaderClientResponseDateResponse contains the response from method HeaderClient.ResponseDate.
 type HeaderClientResponseDateResponse struct {
-	HeaderClientResponseDateResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseDateResult contains the result from method HeaderClient.ResponseDate.
-type HeaderClientResponseDateResult struct {
 	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
 // HeaderClientResponseDatetimeRFC1123Response contains the response from method HeaderClient.ResponseDatetimeRFC1123.
 type HeaderClientResponseDatetimeRFC1123Response struct {
-	HeaderClientResponseDatetimeRFC1123Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseDatetimeRFC1123Result contains the result from method HeaderClient.ResponseDatetimeRFC1123.
-type HeaderClientResponseDatetimeRFC1123Result struct {
 	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
 // HeaderClientResponseDatetimeResponse contains the response from method HeaderClient.ResponseDatetime.
 type HeaderClientResponseDatetimeResponse struct {
-	HeaderClientResponseDatetimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseDatetimeResult contains the result from method HeaderClient.ResponseDatetime.
-type HeaderClientResponseDatetimeResult struct {
 	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
 // HeaderClientResponseDoubleResponse contains the response from method HeaderClient.ResponseDouble.
 type HeaderClientResponseDoubleResponse struct {
-	HeaderClientResponseDoubleResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseDoubleResult contains the result from method HeaderClient.ResponseDouble.
-type HeaderClientResponseDoubleResult struct {
 	// Value contains the information returned from the value header response.
 	Value *float64
 }
 
 // HeaderClientResponseDurationResponse contains the response from method HeaderClient.ResponseDuration.
 type HeaderClientResponseDurationResponse struct {
-	HeaderClientResponseDurationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseDurationResult contains the result from method HeaderClient.ResponseDuration.
-type HeaderClientResponseDurationResult struct {
 	// Value contains the information returned from the value header response.
 	Value *string
 }
 
 // HeaderClientResponseEnumResponse contains the response from method HeaderClient.ResponseEnum.
 type HeaderClientResponseEnumResponse struct {
-	HeaderClientResponseEnumResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseEnumResult contains the result from method HeaderClient.ResponseEnum.
-type HeaderClientResponseEnumResult struct {
 	// Value contains the information returned from the value header response.
 	Value *GreyscaleColors
 }
 
 // HeaderClientResponseExistingKeyResponse contains the response from method HeaderClient.ResponseExistingKey.
 type HeaderClientResponseExistingKeyResponse struct {
-	HeaderClientResponseExistingKeyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseExistingKeyResult contains the result from method HeaderClient.ResponseExistingKey.
-type HeaderClientResponseExistingKeyResult struct {
 	// UserAgent contains the information returned from the User-Agent header response.
 	UserAgent *string
 }
 
 // HeaderClientResponseFloatResponse contains the response from method HeaderClient.ResponseFloat.
 type HeaderClientResponseFloatResponse struct {
-	HeaderClientResponseFloatResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseFloatResult contains the result from method HeaderClient.ResponseFloat.
-type HeaderClientResponseFloatResult struct {
 	// Value contains the information returned from the value header response.
 	Value *float32
 }
 
 // HeaderClientResponseIntegerResponse contains the response from method HeaderClient.ResponseInteger.
 type HeaderClientResponseIntegerResponse struct {
-	HeaderClientResponseIntegerResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseIntegerResult contains the result from method HeaderClient.ResponseInteger.
-type HeaderClientResponseIntegerResult struct {
 	// Value contains the information returned from the value header response.
 	Value *int32
 }
 
 // HeaderClientResponseLongResponse contains the response from method HeaderClient.ResponseLong.
 type HeaderClientResponseLongResponse struct {
-	HeaderClientResponseLongResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseLongResult contains the result from method HeaderClient.ResponseLong.
-type HeaderClientResponseLongResult struct {
 	// Value contains the information returned from the value header response.
 	Value *int64
 }
 
 // HeaderClientResponseProtectedKeyResponse contains the response from method HeaderClient.ResponseProtectedKey.
 type HeaderClientResponseProtectedKeyResponse struct {
-	HeaderClientResponseProtectedKeyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderClientResponseProtectedKeyResult contains the result from method HeaderClient.ResponseProtectedKey.
-type HeaderClientResponseProtectedKeyResult struct {
 	// ContentType contains the information returned from the Content-Type header response.
 	ContentType *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // HeaderClientResponseStringResponse contains the response from method HeaderClient.ResponseString.
 type HeaderClientResponseStringResponse struct {
-	HeaderClientResponseStringResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HeaderClientResponseStringResult contains the result from method HeaderClient.ResponseString.
-type HeaderClientResponseStringResult struct {
 	// Value contains the information returned from the value header response.
 	Value *string
 }

--- a/test/autorest/headgroup/zz_generated_response_types.go
+++ b/test/autorest/headgroup/zz_generated_response_types.go
@@ -12,39 +12,27 @@ import "net/http"
 
 // HTTPSuccessClientHead200Response contains the response from method HTTPSuccessClient.Head200.
 type HTTPSuccessClientHead200Response struct {
-	HTTPSuccessClientHead200Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPSuccessClientHead200Result contains the result from method HTTPSuccessClient.Head200.
-type HTTPSuccessClientHead200Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientHead204Response contains the response from method HTTPSuccessClient.Head204.
 type HTTPSuccessClientHead204Response struct {
-	HTTPSuccessClientHead204Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPSuccessClientHead204Result contains the result from method HTTPSuccessClient.Head204.
-type HTTPSuccessClientHead204Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientHead404Response contains the response from method HTTPSuccessClient.Head404.
 type HTTPSuccessClientHead404Response struct {
-	HTTPSuccessClientHead404Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPSuccessClientHead404Result contains the result from method HTTPSuccessClient.Head404.
-type HTTPSuccessClientHead404Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_response_types.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_response_types.go
@@ -66,52 +66,36 @@ type HTTPClientFailureClientGet416Response struct {
 
 // HTTPClientFailureClientHead400Response contains the response from method HTTPClientFailureClient.Head400.
 type HTTPClientFailureClientHead400Response struct {
-	HTTPClientFailureClientHead400Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPClientFailureClientHead400Result contains the result from method HTTPClientFailureClient.Head400.
-type HTTPClientFailureClientHead400Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPClientFailureClientHead401Response contains the response from method HTTPClientFailureClient.Head401.
 type HTTPClientFailureClientHead401Response struct {
-	HTTPClientFailureClientHead401Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPClientFailureClientHead401Result contains the result from method HTTPClientFailureClient.Head401.
-type HTTPClientFailureClientHead401Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPClientFailureClientHead410Response contains the response from method HTTPClientFailureClient.Head410.
 type HTTPClientFailureClientHead410Response struct {
-	HTTPClientFailureClientHead410Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPClientFailureClientHead410Result contains the result from method HTTPClientFailureClient.Head410.
-type HTTPClientFailureClientHead410Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPClientFailureClientHead429Response contains the response from method HTTPClientFailureClient.Head429.
 type HTTPClientFailureClientHead429Response struct {
-	HTTPClientFailureClientHead429Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPClientFailureClientHead429Result contains the result from method HTTPClientFailureClient.Head429.
-type HTTPClientFailureClientHead429Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
@@ -196,39 +180,27 @@ type HTTPClientFailureClientPut413Response struct {
 
 // HTTPFailureClientGetEmptyErrorResponse contains the response from method HTTPFailureClient.GetEmptyError.
 type HTTPFailureClientGetEmptyErrorResponse struct {
-	HTTPFailureClientGetEmptyErrorResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPFailureClientGetEmptyErrorResult contains the result from method HTTPFailureClient.GetEmptyError.
-type HTTPFailureClientGetEmptyErrorResult struct {
 	// simple boolean
 	Value *bool
 }
 
 // HTTPFailureClientGetNoModelEmptyResponse contains the response from method HTTPFailureClient.GetNoModelEmpty.
 type HTTPFailureClientGetNoModelEmptyResponse struct {
-	HTTPFailureClientGetNoModelEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPFailureClientGetNoModelEmptyResult contains the result from method HTTPFailureClient.GetNoModelEmpty.
-type HTTPFailureClientGetNoModelEmptyResult struct {
 	// simple boolean
 	Value *bool
 }
 
 // HTTPFailureClientGetNoModelErrorResponse contains the response from method HTTPFailureClient.GetNoModelError.
 type HTTPFailureClientGetNoModelErrorResponse struct {
-	HTTPFailureClientGetNoModelErrorResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPFailureClientGetNoModelErrorResult contains the result from method HTTPFailureClient.GetNoModelError.
-type HTTPFailureClientGetNoModelErrorResult struct {
 	// simple boolean
 	Value *bool
 }
@@ -241,15 +213,11 @@ type HTTPRedirectsClientDelete307Response struct {
 
 // HTTPRedirectsClientGet300Response contains the response from method HTTPRedirectsClient.Get300.
 type HTTPRedirectsClientGet300Response struct {
-	HTTPRedirectsClientGet300Result
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsClientGet300Result contains the result from method HTTPRedirectsClient.Get300.
-type HTTPRedirectsClientGet300Result struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// A list of location options for the request ['/http/success/get/200']
 	StringArray []*string
@@ -275,15 +243,11 @@ type HTTPRedirectsClientGet307Response struct {
 
 // HTTPRedirectsClientHead300Response contains the response from method HTTPRedirectsClient.Head300.
 type HTTPRedirectsClientHead300Response struct {
-	HTTPRedirectsClientHead300Result
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsClientHead300Result contains the result from method HTTPRedirectsClient.Head300.
-type HTTPRedirectsClientHead300Result struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// Success indicates if the operation succeeded or failed.
 	Success bool
@@ -291,39 +255,27 @@ type HTTPRedirectsClientHead300Result struct {
 
 // HTTPRedirectsClientHead301Response contains the response from method HTTPRedirectsClient.Head301.
 type HTTPRedirectsClientHead301Response struct {
-	HTTPRedirectsClientHead301Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPRedirectsClientHead301Result contains the result from method HTTPRedirectsClient.Head301.
-type HTTPRedirectsClientHead301Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPRedirectsClientHead302Response contains the response from method HTTPRedirectsClient.Head302.
 type HTTPRedirectsClientHead302Response struct {
-	HTTPRedirectsClientHead302Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPRedirectsClientHead302Result contains the result from method HTTPRedirectsClient.Head302.
-type HTTPRedirectsClientHead302Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPRedirectsClientHead307Response contains the response from method HTTPRedirectsClient.Head307.
 type HTTPRedirectsClientHead307Response struct {
-	HTTPRedirectsClientHead307Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPRedirectsClientHead307Result contains the result from method HTTPRedirectsClient.Head307.
-type HTTPRedirectsClientHead307Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
@@ -336,15 +288,11 @@ type HTTPRedirectsClientOptions307Response struct {
 
 // HTTPRedirectsClientPatch302Response contains the response from method HTTPRedirectsClient.Patch302.
 type HTTPRedirectsClientPatch302Response struct {
-	HTTPRedirectsClientPatch302Result
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsClientPatch302Result contains the result from method HTTPRedirectsClient.Patch302.
-type HTTPRedirectsClientPatch302Result struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // HTTPRedirectsClientPatch307Response contains the response from method HTTPRedirectsClient.Patch307.
@@ -355,15 +303,11 @@ type HTTPRedirectsClientPatch307Response struct {
 
 // HTTPRedirectsClientPost303Response contains the response from method HTTPRedirectsClient.Post303.
 type HTTPRedirectsClientPost303Response struct {
-	HTTPRedirectsClientPost303Result
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsClientPost303Result contains the result from method HTTPRedirectsClient.Post303.
-type HTTPRedirectsClientPost303Result struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // HTTPRedirectsClientPost307Response contains the response from method HTTPRedirectsClient.Post307.
@@ -374,15 +318,11 @@ type HTTPRedirectsClientPost307Response struct {
 
 // HTTPRedirectsClientPut301Response contains the response from method HTTPRedirectsClient.Put301.
 type HTTPRedirectsClientPut301Response struct {
-	HTTPRedirectsClientPut301Result
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsClientPut301Result contains the result from method HTTPRedirectsClient.Put301.
-type HTTPRedirectsClientPut301Result struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // HTTPRedirectsClientPut307Response contains the response from method HTTPRedirectsClient.Put307.
@@ -405,26 +345,18 @@ type HTTPRetryClientGet502Response struct {
 
 // HTTPRetryClientHead408Response contains the response from method HTTPRetryClient.Head408.
 type HTTPRetryClientHead408Response struct {
-	HTTPRetryClientHead408Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPRetryClientHead408Result contains the result from method HTTPRetryClient.Head408.
-type HTTPRetryClientHead408Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPRetryClientOptions502Response contains the response from method HTTPRetryClient.Options502.
 type HTTPRetryClientOptions502Response struct {
-	HTTPRetryClientOptions502Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPRetryClientOptions502Result contains the result from method HTTPRetryClient.Options502.
-type HTTPRetryClientOptions502Result struct {
 	// simple boolean
 	Value *bool
 }
@@ -473,13 +405,9 @@ type HTTPServerFailureClientGet501Response struct {
 
 // HTTPServerFailureClientHead501Response contains the response from method HTTPServerFailureClient.Head501.
 type HTTPServerFailureClientHead501Response struct {
-	HTTPServerFailureClientHead501Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPServerFailureClientHead501Result contains the result from method HTTPServerFailureClient.Head501.
-type HTTPServerFailureClientHead501Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
@@ -510,65 +438,45 @@ type HTTPSuccessClientDelete204Response struct {
 
 // HTTPSuccessClientGet200Response contains the response from method HTTPSuccessClient.Get200.
 type HTTPSuccessClientGet200Response struct {
-	HTTPSuccessClientGet200Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPSuccessClientGet200Result contains the result from method HTTPSuccessClient.Get200.
-type HTTPSuccessClientGet200Result struct {
 	// simple boolean
 	Value *bool
 }
 
 // HTTPSuccessClientHead200Response contains the response from method HTTPSuccessClient.Head200.
 type HTTPSuccessClientHead200Response struct {
-	HTTPSuccessClientHead200Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPSuccessClientHead200Result contains the result from method HTTPSuccessClient.Head200.
-type HTTPSuccessClientHead200Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientHead204Response contains the response from method HTTPSuccessClient.Head204.
 type HTTPSuccessClientHead204Response struct {
-	HTTPSuccessClientHead204Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPSuccessClientHead204Result contains the result from method HTTPSuccessClient.Head204.
-type HTTPSuccessClientHead204Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientHead404Response contains the response from method HTTPSuccessClient.Head404.
 type HTTPSuccessClientHead404Response struct {
-	HTTPSuccessClientHead404Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPSuccessClientHead404Result contains the result from method HTTPSuccessClient.Head404.
-type HTTPSuccessClientHead404Result struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientOptions200Response contains the response from method HTTPSuccessClient.Options200.
 type HTTPSuccessClientOptions200Response struct {
-	HTTPSuccessClientOptions200Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// HTTPSuccessClientOptions200Result contains the result from method HTTPSuccessClient.Options200.
-type HTTPSuccessClientOptions200Result struct {
 	// simple boolean
 	Value *bool
 }
@@ -668,98 +576,58 @@ type MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse stru
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError200Valid.
 type MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse struct {
-	MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResult contains the result from method MultipleResponsesClient.Get200Model204NoModelDefaultError200Valid.
-type MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError201Invalid.
 type MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse struct {
-	MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResult contains the result from method MultipleResponsesClient.Get200Model204NoModelDefaultError201Invalid.
-type MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError202None.
 type MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse struct {
-	MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResult contains the result from method MultipleResponsesClient.Get200Model204NoModelDefaultError202None.
-type MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError204Valid.
 type MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse struct {
-	MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResult contains the result from method MultipleResponsesClient.Get200Model204NoModelDefaultError204Valid.
-type MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError400Valid.
 type MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse struct {
-	MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResult contains the result from method MultipleResponsesClient.Get200Model204NoModelDefaultError400Valid.
-type MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200ModelA200InvalidResponse contains the response from method MultipleResponsesClient.Get200ModelA200Invalid.
 type MultipleResponsesClientGet200ModelA200InvalidResponse struct {
-	MultipleResponsesClientGet200ModelA200InvalidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200ModelA200InvalidResult contains the result from method MultipleResponsesClient.Get200ModelA200Invalid.
-type MultipleResponsesClientGet200ModelA200InvalidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200ModelA200NoneResponse contains the response from method MultipleResponsesClient.Get200ModelA200None.
 type MultipleResponsesClientGet200ModelA200NoneResponse struct {
-	MultipleResponsesClientGet200ModelA200NoneResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200ModelA200NoneResult contains the result from method MultipleResponsesClient.Get200ModelA200None.
-type MultipleResponsesClientGet200ModelA200NoneResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200ModelA200ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA200Valid.
 type MultipleResponsesClientGet200ModelA200ValidResponse struct {
-	MultipleResponsesClientGet200ModelA200ValidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200ModelA200ValidResult contains the result from method MultipleResponsesClient.Get200ModelA200Valid.
-type MultipleResponsesClientGet200ModelA200ValidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError200ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA201ModelC404ModelDDefaultError200Valid.
@@ -800,50 +668,30 @@ type MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidRe
 
 // MultipleResponsesClientGet200ModelA202ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA202Valid.
 type MultipleResponsesClientGet200ModelA202ValidResponse struct {
-	MultipleResponsesClientGet200ModelA202ValidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200ModelA202ValidResult contains the result from method MultipleResponsesClient.Get200ModelA202Valid.
-type MultipleResponsesClientGet200ModelA202ValidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200ModelA400InvalidResponse contains the response from method MultipleResponsesClient.Get200ModelA400Invalid.
 type MultipleResponsesClientGet200ModelA400InvalidResponse struct {
-	MultipleResponsesClientGet200ModelA400InvalidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200ModelA400InvalidResult contains the result from method MultipleResponsesClient.Get200ModelA400Invalid.
-type MultipleResponsesClientGet200ModelA400InvalidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200ModelA400NoneResponse contains the response from method MultipleResponsesClient.Get200ModelA400None.
 type MultipleResponsesClientGet200ModelA400NoneResponse struct {
-	MultipleResponsesClientGet200ModelA400NoneResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200ModelA400NoneResult contains the result from method MultipleResponsesClient.Get200ModelA400None.
-type MultipleResponsesClientGet200ModelA400NoneResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet200ModelA400ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA400Valid.
 type MultipleResponsesClientGet200ModelA400ValidResponse struct {
-	MultipleResponsesClientGet200ModelA400ValidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGet200ModelA400ValidResult contains the result from method MultipleResponsesClient.Get200ModelA400Valid.
-type MultipleResponsesClientGet200ModelA400ValidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGet202None204NoneDefaultError202NoneResponse contains the response from method MultipleResponsesClient.Get202None204NoneDefaultError202None.
@@ -890,26 +738,16 @@ type MultipleResponsesClientGet202None204NoneDefaultNone400NoneResponse struct {
 
 // MultipleResponsesClientGetDefaultModelA200NoneResponse contains the response from method MultipleResponsesClient.GetDefaultModelA200None.
 type MultipleResponsesClientGetDefaultModelA200NoneResponse struct {
-	MultipleResponsesClientGetDefaultModelA200NoneResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGetDefaultModelA200NoneResult contains the result from method MultipleResponsesClient.GetDefaultModelA200None.
-type MultipleResponsesClientGetDefaultModelA200NoneResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGetDefaultModelA200ValidResponse contains the response from method MultipleResponsesClient.GetDefaultModelA200Valid.
 type MultipleResponsesClientGetDefaultModelA200ValidResponse struct {
-	MultipleResponsesClientGetDefaultModelA200ValidResult
+	MyException
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleResponsesClientGetDefaultModelA200ValidResult contains the result from method MultipleResponsesClient.GetDefaultModelA200Valid.
-type MultipleResponsesClientGetDefaultModelA200ValidResult struct {
-	MyException
 }
 
 // MultipleResponsesClientGetDefaultModelA400NoneResponse contains the response from method MultipleResponsesClient.GetDefaultModelA400None.

--- a/test/autorest/integergroup/zz_generated_response_types.go
+++ b/test/autorest/integergroup/zz_generated_response_types.go
@@ -15,111 +15,69 @@ import (
 
 // IntClientGetInvalidResponse contains the response from method IntClient.GetInvalid.
 type IntClientGetInvalidResponse struct {
-	IntClientGetInvalidResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IntClientGetInvalidResult contains the result from method IntClient.GetInvalid.
-type IntClientGetInvalidResult struct {
-	Value *int32
+	Value       *int32
 }
 
 // IntClientGetInvalidUnixTimeResponse contains the response from method IntClient.GetInvalidUnixTime.
 type IntClientGetInvalidUnixTimeResponse struct {
-	IntClientGetInvalidUnixTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// IntClientGetInvalidUnixTimeResult contains the result from method IntClient.GetInvalidUnixTime.
-type IntClientGetInvalidUnixTimeResult struct {
 	// date in seconds since 1970-01-01T00:00:00Z.
 	Value *time.Time
 }
 
 // IntClientGetNullResponse contains the response from method IntClient.GetNull.
 type IntClientGetNullResponse struct {
-	IntClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IntClientGetNullResult contains the result from method IntClient.GetNull.
-type IntClientGetNullResult struct {
-	Value *int32
+	Value       *int32
 }
 
 // IntClientGetNullUnixTimeResponse contains the response from method IntClient.GetNullUnixTime.
 type IntClientGetNullUnixTimeResponse struct {
-	IntClientGetNullUnixTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// IntClientGetNullUnixTimeResult contains the result from method IntClient.GetNullUnixTime.
-type IntClientGetNullUnixTimeResult struct {
 	// date in seconds since 1970-01-01T00:00:00Z.
 	Value *time.Time
 }
 
 // IntClientGetOverflowInt32Response contains the response from method IntClient.GetOverflowInt32.
 type IntClientGetOverflowInt32Response struct {
-	IntClientGetOverflowInt32Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IntClientGetOverflowInt32Result contains the result from method IntClient.GetOverflowInt32.
-type IntClientGetOverflowInt32Result struct {
-	Value *int32
+	Value       *int32
 }
 
 // IntClientGetOverflowInt64Response contains the response from method IntClient.GetOverflowInt64.
 type IntClientGetOverflowInt64Response struct {
-	IntClientGetOverflowInt64Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IntClientGetOverflowInt64Result contains the result from method IntClient.GetOverflowInt64.
-type IntClientGetOverflowInt64Result struct {
-	Value *int64
+	Value       *int64
 }
 
 // IntClientGetUnderflowInt32Response contains the response from method IntClient.GetUnderflowInt32.
 type IntClientGetUnderflowInt32Response struct {
-	IntClientGetUnderflowInt32Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IntClientGetUnderflowInt32Result contains the result from method IntClient.GetUnderflowInt32.
-type IntClientGetUnderflowInt32Result struct {
-	Value *int32
+	Value       *int32
 }
 
 // IntClientGetUnderflowInt64Response contains the response from method IntClient.GetUnderflowInt64.
 type IntClientGetUnderflowInt64Response struct {
-	IntClientGetUnderflowInt64Result
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IntClientGetUnderflowInt64Result contains the result from method IntClient.GetUnderflowInt64.
-type IntClientGetUnderflowInt64Result struct {
-	Value *int64
+	Value       *int64
 }
 
 // IntClientGetUnixTimeResponse contains the response from method IntClient.GetUnixTime.
 type IntClientGetUnixTimeResponse struct {
-	IntClientGetUnixTimeResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// IntClientGetUnixTimeResult contains the result from method IntClient.GetUnixTime.
-type IntClientGetUnixTimeResult struct {
 	// date in seconds since 1970-01-01T00:00:00Z.
 	Value *time.Time
 }

--- a/test/autorest/lrogroup/zz_generated_response_types.go
+++ b/test/autorest/lrogroup/zz_generated_response_types.go
@@ -148,14 +148,9 @@ func (l *LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse)
 
 // LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse contains the response from method LRORetrysClient.DeleteProvisioning202Accepted200Succeeded.
 type LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse struct {
-	LRORetrysClientDeleteProvisioning202Accepted200SucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LRORetrysClientDeleteProvisioning202Accepted200SucceededResult contains the result from method LRORetrysClient.DeleteProvisioning202Accepted200Succeeded.
-type LRORetrysClientDeleteProvisioning202Accepted200SucceededResult struct {
-	Product
 }
 
 // LRORetrysClientPost202Retry200PollerResponse contains the response from method LRORetrysClient.Post202Retry200.
@@ -289,14 +284,9 @@ func (l *LRORetrysClientPut201CreatingSucceeded200PollerResponse) Resume(ctx con
 
 // LRORetrysClientPut201CreatingSucceeded200Response contains the response from method LRORetrysClient.Put201CreatingSucceeded200.
 type LRORetrysClientPut201CreatingSucceeded200Response struct {
-	LRORetrysClientPut201CreatingSucceeded200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LRORetrysClientPut201CreatingSucceeded200Result contains the result from method LRORetrysClient.Put201CreatingSucceeded200.
-type LRORetrysClientPut201CreatingSucceeded200Result struct {
-	Product
 }
 
 // LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse contains the response from method LRORetrysClient.PutAsyncRelativeRetrySucceeded.
@@ -340,14 +330,9 @@ func (l *LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse) Resume(ctx
 
 // LRORetrysClientPutAsyncRelativeRetrySucceededResponse contains the response from method LRORetrysClient.PutAsyncRelativeRetrySucceeded.
 type LRORetrysClientPutAsyncRelativeRetrySucceededResponse struct {
-	LRORetrysClientPutAsyncRelativeRetrySucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LRORetrysClientPutAsyncRelativeRetrySucceededResult contains the result from method LRORetrysClient.PutAsyncRelativeRetrySucceeded.
-type LRORetrysClientPutAsyncRelativeRetrySucceededResult struct {
-	Product
 }
 
 // LROSADsClientDelete202NonRetry400PollerResponse contains the response from method LROSADsClient.Delete202NonRetry400.
@@ -1115,14 +1100,9 @@ func (l *LROSADsClientPut200InvalidJSONPollerResponse) Resume(ctx context.Contex
 
 // LROSADsClientPut200InvalidJSONResponse contains the response from method LROSADsClient.Put200InvalidJSON.
 type LROSADsClientPut200InvalidJSONResponse struct {
-	LROSADsClientPut200InvalidJSONResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPut200InvalidJSONResult contains the result from method LROSADsClient.Put200InvalidJSON.
-type LROSADsClientPut200InvalidJSONResult struct {
-	Product
 }
 
 // LROSADsClientPutAsyncRelativeRetry400PollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetry400.
@@ -1166,14 +1146,9 @@ func (l *LROSADsClientPutAsyncRelativeRetry400PollerResponse) Resume(ctx context
 
 // LROSADsClientPutAsyncRelativeRetry400Response contains the response from method LROSADsClient.PutAsyncRelativeRetry400.
 type LROSADsClientPutAsyncRelativeRetry400Response struct {
-	LROSADsClientPutAsyncRelativeRetry400Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutAsyncRelativeRetry400Result contains the result from method LROSADsClient.PutAsyncRelativeRetry400.
-type LROSADsClientPutAsyncRelativeRetry400Result struct {
-	Product
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidHeader.
@@ -1217,14 +1192,9 @@ func (l *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse) Resume(c
 
 // LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidHeader.
 type LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse struct {
-	LROSADsClientPutAsyncRelativeRetryInvalidHeaderResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutAsyncRelativeRetryInvalidHeaderResult contains the result from method LROSADsClient.PutAsyncRelativeRetryInvalidHeader.
-type LROSADsClientPutAsyncRelativeRetryInvalidHeaderResult struct {
-	Product
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling.
@@ -1269,14 +1239,9 @@ func (l *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse) Res
 
 // LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse struct {
-	LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResult contains the result from method LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling.
-type LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResult struct {
-	Product
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatusPayload.
@@ -1321,14 +1286,9 @@ func (l *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse) Resume
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatusPayload.
 type LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse struct {
-	LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResult contains the result from method LROSADsClient.PutAsyncRelativeRetryNoStatusPayload.
-type LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResult struct {
-	Product
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatus.
@@ -1372,14 +1332,9 @@ func (l *LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse) Resume(ctx co
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatus.
 type LROSADsClientPutAsyncRelativeRetryNoStatusResponse struct {
-	LROSADsClientPutAsyncRelativeRetryNoStatusResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutAsyncRelativeRetryNoStatusResult contains the result from method LROSADsClient.PutAsyncRelativeRetryNoStatus.
-type LROSADsClientPutAsyncRelativeRetryNoStatusResult struct {
-	Product
 }
 
 // LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse contains the response from method LROSADsClient.PutError201NoProvisioningStatePayload.
@@ -1424,14 +1379,9 @@ func (l *LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse) Resum
 
 // LROSADsClientPutError201NoProvisioningStatePayloadResponse contains the response from method LROSADsClient.PutError201NoProvisioningStatePayload.
 type LROSADsClientPutError201NoProvisioningStatePayloadResponse struct {
-	LROSADsClientPutError201NoProvisioningStatePayloadResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutError201NoProvisioningStatePayloadResult contains the result from method LROSADsClient.PutError201NoProvisioningStatePayload.
-type LROSADsClientPutError201NoProvisioningStatePayloadResult struct {
-	Product
 }
 
 // LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse contains the response from method LROSADsClient.PutNonRetry201Creating400InvalidJSON.
@@ -1476,14 +1426,9 @@ func (l *LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse) Resume
 
 // LROSADsClientPutNonRetry201Creating400InvalidJSONResponse contains the response from method LROSADsClient.PutNonRetry201Creating400InvalidJSON.
 type LROSADsClientPutNonRetry201Creating400InvalidJSONResponse struct {
-	LROSADsClientPutNonRetry201Creating400InvalidJSONResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutNonRetry201Creating400InvalidJSONResult contains the result from method LROSADsClient.PutNonRetry201Creating400InvalidJSON.
-type LROSADsClientPutNonRetry201Creating400InvalidJSONResult struct {
-	Product
 }
 
 // LROSADsClientPutNonRetry201Creating400PollerResponse contains the response from method LROSADsClient.PutNonRetry201Creating400.
@@ -1527,14 +1472,9 @@ func (l *LROSADsClientPutNonRetry201Creating400PollerResponse) Resume(ctx contex
 
 // LROSADsClientPutNonRetry201Creating400Response contains the response from method LROSADsClient.PutNonRetry201Creating400.
 type LROSADsClientPutNonRetry201Creating400Response struct {
-	LROSADsClientPutNonRetry201Creating400Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutNonRetry201Creating400Result contains the result from method LROSADsClient.PutNonRetry201Creating400.
-type LROSADsClientPutNonRetry201Creating400Result struct {
-	Product
 }
 
 // LROSADsClientPutNonRetry400PollerResponse contains the response from method LROSADsClient.PutNonRetry400.
@@ -1578,14 +1518,9 @@ func (l *LROSADsClientPutNonRetry400PollerResponse) Resume(ctx context.Context, 
 
 // LROSADsClientPutNonRetry400Response contains the response from method LROSADsClient.PutNonRetry400.
 type LROSADsClientPutNonRetry400Response struct {
-	LROSADsClientPutNonRetry400Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROSADsClientPutNonRetry400Result contains the result from method LROSADsClient.PutNonRetry400.
-type LROSADsClientPutNonRetry400Result struct {
-	Product
 }
 
 // LROsClientDelete202NoRetry204PollerResponse contains the response from method LROsClient.Delete202NoRetry204.
@@ -1629,14 +1564,9 @@ func (l *LROsClientDelete202NoRetry204PollerResponse) Resume(ctx context.Context
 
 // LROsClientDelete202NoRetry204Response contains the response from method LROsClient.Delete202NoRetry204.
 type LROsClientDelete202NoRetry204Response struct {
-	LROsClientDelete202NoRetry204Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientDelete202NoRetry204Result contains the result from method LROsClient.Delete202NoRetry204.
-type LROsClientDelete202NoRetry204Result struct {
-	Product
 }
 
 // LROsClientDelete202Retry200PollerResponse contains the response from method LROsClient.Delete202Retry200.
@@ -1680,14 +1610,9 @@ func (l *LROsClientDelete202Retry200PollerResponse) Resume(ctx context.Context, 
 
 // LROsClientDelete202Retry200Response contains the response from method LROsClient.Delete202Retry200.
 type LROsClientDelete202Retry200Response struct {
-	LROsClientDelete202Retry200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientDelete202Retry200Result contains the result from method LROsClient.Delete202Retry200.
-type LROsClientDelete202Retry200Result struct {
-	Product
 }
 
 // LROsClientDelete204SucceededPollerResponse contains the response from method LROsClient.Delete204Succeeded.
@@ -2047,14 +1972,9 @@ func (l *LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse) Resu
 
 // LROsClientDeleteProvisioning202Accepted200SucceededResponse contains the response from method LROsClient.DeleteProvisioning202Accepted200Succeeded.
 type LROsClientDeleteProvisioning202Accepted200SucceededResponse struct {
-	LROsClientDeleteProvisioning202Accepted200SucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientDeleteProvisioning202Accepted200SucceededResult contains the result from method LROsClient.DeleteProvisioning202Accepted200Succeeded.
-type LROsClientDeleteProvisioning202Accepted200SucceededResult struct {
-	Product
 }
 
 // LROsClientDeleteProvisioning202DeletingFailed200PollerResponse contains the response from method LROsClient.DeleteProvisioning202DeletingFailed200.
@@ -2099,14 +2019,9 @@ func (l *LROsClientDeleteProvisioning202DeletingFailed200PollerResponse) Resume(
 
 // LROsClientDeleteProvisioning202DeletingFailed200Response contains the response from method LROsClient.DeleteProvisioning202DeletingFailed200.
 type LROsClientDeleteProvisioning202DeletingFailed200Response struct {
-	LROsClientDeleteProvisioning202DeletingFailed200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientDeleteProvisioning202DeletingFailed200Result contains the result from method LROsClient.DeleteProvisioning202DeletingFailed200.
-type LROsClientDeleteProvisioning202DeletingFailed200Result struct {
-	Product
 }
 
 // LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse contains the response from method LROsClient.DeleteProvisioning202Deletingcanceled200.
@@ -2151,14 +2066,9 @@ func (l *LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse) Resum
 
 // LROsClientDeleteProvisioning202Deletingcanceled200Response contains the response from method LROsClient.DeleteProvisioning202Deletingcanceled200.
 type LROsClientDeleteProvisioning202Deletingcanceled200Response struct {
-	LROsClientDeleteProvisioning202Deletingcanceled200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientDeleteProvisioning202Deletingcanceled200Result contains the result from method LROsClient.DeleteProvisioning202Deletingcanceled200.
-type LROsClientDeleteProvisioning202Deletingcanceled200Result struct {
-	Product
 }
 
 // LROsClientPatch200SucceededIgnoreHeadersPollerResponse contains the response from method LROsClient.Patch200SucceededIgnoreHeaders.
@@ -2202,14 +2112,9 @@ func (l *LROsClientPatch200SucceededIgnoreHeadersPollerResponse) Resume(ctx cont
 
 // LROsClientPatch200SucceededIgnoreHeadersResponse contains the response from method LROsClient.Patch200SucceededIgnoreHeaders.
 type LROsClientPatch200SucceededIgnoreHeadersResponse struct {
-	LROsClientPatch200SucceededIgnoreHeadersResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPatch200SucceededIgnoreHeadersResult contains the result from method LROsClient.Patch200SucceededIgnoreHeaders.
-type LROsClientPatch200SucceededIgnoreHeadersResult struct {
-	Product
 }
 
 // LROsClientPost200WithPayloadPollerResponse contains the response from method LROsClient.Post200WithPayload.
@@ -2253,14 +2158,9 @@ func (l *LROsClientPost200WithPayloadPollerResponse) Resume(ctx context.Context,
 
 // LROsClientPost200WithPayloadResponse contains the response from method LROsClient.Post200WithPayload.
 type LROsClientPost200WithPayloadResponse struct {
-	LROsClientPost200WithPayloadResult
+	SKU
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPost200WithPayloadResult contains the result from method LROsClient.Post200WithPayload.
-type LROsClientPost200WithPayloadResult struct {
-	SKU
 }
 
 // LROsClientPost202ListPollerResponse contains the response from method LROsClient.Post202List.
@@ -2304,15 +2204,11 @@ func (l *LROsClientPost202ListPollerResponse) Resume(ctx context.Context, client
 
 // LROsClientPost202ListResponse contains the response from method LROsClient.Post202List.
 type LROsClientPost202ListResponse struct {
-	LROsClientPost202ListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// LROsClientPost202ListResult contains the result from method LROsClient.Post202List.
-type LROsClientPost202ListResult struct {
 	// Array of Product
 	ProductArray []*Product
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // LROsClientPost202NoRetry204PollerResponse contains the response from method LROsClient.Post202NoRetry204.
@@ -2356,14 +2252,9 @@ func (l *LROsClientPost202NoRetry204PollerResponse) Resume(ctx context.Context, 
 
 // LROsClientPost202NoRetry204Response contains the response from method LROsClient.Post202NoRetry204.
 type LROsClientPost202NoRetry204Response struct {
-	LROsClientPost202NoRetry204Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPost202NoRetry204Result contains the result from method LROsClient.Post202NoRetry204.
-type LROsClientPost202NoRetry204Result struct {
-	Product
 }
 
 // LROsClientPost202Retry200PollerResponse contains the response from method LROsClient.Post202Retry200.
@@ -2452,14 +2343,9 @@ func (l *LROsClientPostAsyncNoRetrySucceededPollerResponse) Resume(ctx context.C
 
 // LROsClientPostAsyncNoRetrySucceededResponse contains the response from method LROsClient.PostAsyncNoRetrySucceeded.
 type LROsClientPostAsyncNoRetrySucceededResponse struct {
-	LROsClientPostAsyncNoRetrySucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPostAsyncNoRetrySucceededResult contains the result from method LROsClient.PostAsyncNoRetrySucceeded.
-type LROsClientPostAsyncNoRetrySucceededResult struct {
-	Product
 }
 
 // LROsClientPostAsyncRetryFailedPollerResponse contains the response from method LROsClient.PostAsyncRetryFailed.
@@ -2548,14 +2434,9 @@ func (l *LROsClientPostAsyncRetrySucceededPollerResponse) Resume(ctx context.Con
 
 // LROsClientPostAsyncRetrySucceededResponse contains the response from method LROsClient.PostAsyncRetrySucceeded.
 type LROsClientPostAsyncRetrySucceededResponse struct {
-	LROsClientPostAsyncRetrySucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPostAsyncRetrySucceededResult contains the result from method LROsClient.PostAsyncRetrySucceeded.
-type LROsClientPostAsyncRetrySucceededResult struct {
-	Product
 }
 
 // LROsClientPostAsyncRetrycanceledPollerResponse contains the response from method LROsClient.PostAsyncRetrycanceled.
@@ -2645,14 +2526,9 @@ func (l *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse) Re
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault.
 type LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse struct {
-	LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResult contains the result from method LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault.
-type LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResult struct {
-	Product
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGet.
@@ -2696,14 +2572,9 @@ func (l *LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse) Resume(ct
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGet.
 type LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse struct {
-	LROsClientPostDoubleHeadersFinalAzureHeaderGetResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPostDoubleHeadersFinalAzureHeaderGetResult contains the result from method LROsClient.PostDoubleHeadersFinalAzureHeaderGet.
-type LROsClientPostDoubleHeadersFinalAzureHeaderGetResult struct {
-	Product
 }
 
 // LROsClientPostDoubleHeadersFinalLocationGetPollerResponse contains the response from method LROsClient.PostDoubleHeadersFinalLocationGet.
@@ -2747,14 +2618,9 @@ func (l *LROsClientPostDoubleHeadersFinalLocationGetPollerResponse) Resume(ctx c
 
 // LROsClientPostDoubleHeadersFinalLocationGetResponse contains the response from method LROsClient.PostDoubleHeadersFinalLocationGet.
 type LROsClientPostDoubleHeadersFinalLocationGetResponse struct {
-	LROsClientPostDoubleHeadersFinalLocationGetResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPostDoubleHeadersFinalLocationGetResult contains the result from method LROsClient.PostDoubleHeadersFinalLocationGet.
-type LROsClientPostDoubleHeadersFinalLocationGetResult struct {
-	Product
 }
 
 // LROsClientPut200Acceptedcanceled200PollerResponse contains the response from method LROsClient.Put200Acceptedcanceled200.
@@ -2798,14 +2664,9 @@ func (l *LROsClientPut200Acceptedcanceled200PollerResponse) Resume(ctx context.C
 
 // LROsClientPut200Acceptedcanceled200Response contains the response from method LROsClient.Put200Acceptedcanceled200.
 type LROsClientPut200Acceptedcanceled200Response struct {
-	LROsClientPut200Acceptedcanceled200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPut200Acceptedcanceled200Result contains the result from method LROsClient.Put200Acceptedcanceled200.
-type LROsClientPut200Acceptedcanceled200Result struct {
-	Product
 }
 
 // LROsClientPut200SucceededNoStatePollerResponse contains the response from method LROsClient.Put200SucceededNoState.
@@ -2849,14 +2710,9 @@ func (l *LROsClientPut200SucceededNoStatePollerResponse) Resume(ctx context.Cont
 
 // LROsClientPut200SucceededNoStateResponse contains the response from method LROsClient.Put200SucceededNoState.
 type LROsClientPut200SucceededNoStateResponse struct {
-	LROsClientPut200SucceededNoStateResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPut200SucceededNoStateResult contains the result from method LROsClient.Put200SucceededNoState.
-type LROsClientPut200SucceededNoStateResult struct {
-	Product
 }
 
 // LROsClientPut200SucceededPollerResponse contains the response from method LROsClient.Put200Succeeded.
@@ -2900,14 +2756,9 @@ func (l *LROsClientPut200SucceededPollerResponse) Resume(ctx context.Context, cl
 
 // LROsClientPut200SucceededResponse contains the response from method LROsClient.Put200Succeeded.
 type LROsClientPut200SucceededResponse struct {
-	LROsClientPut200SucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPut200SucceededResult contains the result from method LROsClient.Put200Succeeded.
-type LROsClientPut200SucceededResult struct {
-	Product
 }
 
 // LROsClientPut200UpdatingSucceeded204PollerResponse contains the response from method LROsClient.Put200UpdatingSucceeded204.
@@ -2951,14 +2802,9 @@ func (l *LROsClientPut200UpdatingSucceeded204PollerResponse) Resume(ctx context.
 
 // LROsClientPut200UpdatingSucceeded204Response contains the response from method LROsClient.Put200UpdatingSucceeded204.
 type LROsClientPut200UpdatingSucceeded204Response struct {
-	LROsClientPut200UpdatingSucceeded204Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPut200UpdatingSucceeded204Result contains the result from method LROsClient.Put200UpdatingSucceeded204.
-type LROsClientPut200UpdatingSucceeded204Result struct {
-	Product
 }
 
 // LROsClientPut201CreatingFailed200PollerResponse contains the response from method LROsClient.Put201CreatingFailed200.
@@ -3002,14 +2848,9 @@ func (l *LROsClientPut201CreatingFailed200PollerResponse) Resume(ctx context.Con
 
 // LROsClientPut201CreatingFailed200Response contains the response from method LROsClient.Put201CreatingFailed200.
 type LROsClientPut201CreatingFailed200Response struct {
-	LROsClientPut201CreatingFailed200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPut201CreatingFailed200Result contains the result from method LROsClient.Put201CreatingFailed200.
-type LROsClientPut201CreatingFailed200Result struct {
-	Product
 }
 
 // LROsClientPut201CreatingSucceeded200PollerResponse contains the response from method LROsClient.Put201CreatingSucceeded200.
@@ -3053,14 +2894,9 @@ func (l *LROsClientPut201CreatingSucceeded200PollerResponse) Resume(ctx context.
 
 // LROsClientPut201CreatingSucceeded200Response contains the response from method LROsClient.Put201CreatingSucceeded200.
 type LROsClientPut201CreatingSucceeded200Response struct {
-	LROsClientPut201CreatingSucceeded200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPut201CreatingSucceeded200Result contains the result from method LROsClient.Put201CreatingSucceeded200.
-type LROsClientPut201CreatingSucceeded200Result struct {
-	Product
 }
 
 // LROsClientPut201SucceededPollerResponse contains the response from method LROsClient.Put201Succeeded.
@@ -3104,14 +2940,9 @@ func (l *LROsClientPut201SucceededPollerResponse) Resume(ctx context.Context, cl
 
 // LROsClientPut201SucceededResponse contains the response from method LROsClient.Put201Succeeded.
 type LROsClientPut201SucceededResponse struct {
-	LROsClientPut201SucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPut201SucceededResult contains the result from method LROsClient.Put201Succeeded.
-type LROsClientPut201SucceededResult struct {
-	Product
 }
 
 // LROsClientPut202Retry200PollerResponse contains the response from method LROsClient.Put202Retry200.
@@ -3155,14 +2986,9 @@ func (l *LROsClientPut202Retry200PollerResponse) Resume(ctx context.Context, cli
 
 // LROsClientPut202Retry200Response contains the response from method LROsClient.Put202Retry200.
 type LROsClientPut202Retry200Response struct {
-	LROsClientPut202Retry200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPut202Retry200Result contains the result from method LROsClient.Put202Retry200.
-type LROsClientPut202Retry200Result struct {
-	Product
 }
 
 // LROsClientPutAsyncNoHeaderInRetryPollerResponse contains the response from method LROsClient.PutAsyncNoHeaderInRetry.
@@ -3206,14 +3032,9 @@ func (l *LROsClientPutAsyncNoHeaderInRetryPollerResponse) Resume(ctx context.Con
 
 // LROsClientPutAsyncNoHeaderInRetryResponse contains the response from method LROsClient.PutAsyncNoHeaderInRetry.
 type LROsClientPutAsyncNoHeaderInRetryResponse struct {
-	LROsClientPutAsyncNoHeaderInRetryResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutAsyncNoHeaderInRetryResult contains the result from method LROsClient.PutAsyncNoHeaderInRetry.
-type LROsClientPutAsyncNoHeaderInRetryResult struct {
-	Product
 }
 
 // LROsClientPutAsyncNoRetrySucceededPollerResponse contains the response from method LROsClient.PutAsyncNoRetrySucceeded.
@@ -3257,14 +3078,9 @@ func (l *LROsClientPutAsyncNoRetrySucceededPollerResponse) Resume(ctx context.Co
 
 // LROsClientPutAsyncNoRetrySucceededResponse contains the response from method LROsClient.PutAsyncNoRetrySucceeded.
 type LROsClientPutAsyncNoRetrySucceededResponse struct {
-	LROsClientPutAsyncNoRetrySucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutAsyncNoRetrySucceededResult contains the result from method LROsClient.PutAsyncNoRetrySucceeded.
-type LROsClientPutAsyncNoRetrySucceededResult struct {
-	Product
 }
 
 // LROsClientPutAsyncNoRetrycanceledPollerResponse contains the response from method LROsClient.PutAsyncNoRetrycanceled.
@@ -3308,14 +3124,9 @@ func (l *LROsClientPutAsyncNoRetrycanceledPollerResponse) Resume(ctx context.Con
 
 // LROsClientPutAsyncNoRetrycanceledResponse contains the response from method LROsClient.PutAsyncNoRetrycanceled.
 type LROsClientPutAsyncNoRetrycanceledResponse struct {
-	LROsClientPutAsyncNoRetrycanceledResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutAsyncNoRetrycanceledResult contains the result from method LROsClient.PutAsyncNoRetrycanceled.
-type LROsClientPutAsyncNoRetrycanceledResult struct {
-	Product
 }
 
 // LROsClientPutAsyncNonResourcePollerResponse contains the response from method LROsClient.PutAsyncNonResource.
@@ -3359,14 +3170,9 @@ func (l *LROsClientPutAsyncNonResourcePollerResponse) Resume(ctx context.Context
 
 // LROsClientPutAsyncNonResourceResponse contains the response from method LROsClient.PutAsyncNonResource.
 type LROsClientPutAsyncNonResourceResponse struct {
-	LROsClientPutAsyncNonResourceResult
+	SKU
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutAsyncNonResourceResult contains the result from method LROsClient.PutAsyncNonResource.
-type LROsClientPutAsyncNonResourceResult struct {
-	SKU
 }
 
 // LROsClientPutAsyncRetryFailedPollerResponse contains the response from method LROsClient.PutAsyncRetryFailed.
@@ -3410,14 +3216,9 @@ func (l *LROsClientPutAsyncRetryFailedPollerResponse) Resume(ctx context.Context
 
 // LROsClientPutAsyncRetryFailedResponse contains the response from method LROsClient.PutAsyncRetryFailed.
 type LROsClientPutAsyncRetryFailedResponse struct {
-	LROsClientPutAsyncRetryFailedResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutAsyncRetryFailedResult contains the result from method LROsClient.PutAsyncRetryFailed.
-type LROsClientPutAsyncRetryFailedResult struct {
-	Product
 }
 
 // LROsClientPutAsyncRetrySucceededPollerResponse contains the response from method LROsClient.PutAsyncRetrySucceeded.
@@ -3461,14 +3262,9 @@ func (l *LROsClientPutAsyncRetrySucceededPollerResponse) Resume(ctx context.Cont
 
 // LROsClientPutAsyncRetrySucceededResponse contains the response from method LROsClient.PutAsyncRetrySucceeded.
 type LROsClientPutAsyncRetrySucceededResponse struct {
-	LROsClientPutAsyncRetrySucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutAsyncRetrySucceededResult contains the result from method LROsClient.PutAsyncRetrySucceeded.
-type LROsClientPutAsyncRetrySucceededResult struct {
-	Product
 }
 
 // LROsClientPutAsyncSubResourcePollerResponse contains the response from method LROsClient.PutAsyncSubResource.
@@ -3512,14 +3308,9 @@ func (l *LROsClientPutAsyncSubResourcePollerResponse) Resume(ctx context.Context
 
 // LROsClientPutAsyncSubResourceResponse contains the response from method LROsClient.PutAsyncSubResource.
 type LROsClientPutAsyncSubResourceResponse struct {
-	LROsClientPutAsyncSubResourceResult
+	SubProduct
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutAsyncSubResourceResult contains the result from method LROsClient.PutAsyncSubResource.
-type LROsClientPutAsyncSubResourceResult struct {
-	SubProduct
 }
 
 // LROsClientPutNoHeaderInRetryPollerResponse contains the response from method LROsClient.PutNoHeaderInRetry.
@@ -3563,14 +3354,9 @@ func (l *LROsClientPutNoHeaderInRetryPollerResponse) Resume(ctx context.Context,
 
 // LROsClientPutNoHeaderInRetryResponse contains the response from method LROsClient.PutNoHeaderInRetry.
 type LROsClientPutNoHeaderInRetryResponse struct {
-	LROsClientPutNoHeaderInRetryResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutNoHeaderInRetryResult contains the result from method LROsClient.PutNoHeaderInRetry.
-type LROsClientPutNoHeaderInRetryResult struct {
-	Product
 }
 
 // LROsClientPutNonResourcePollerResponse contains the response from method LROsClient.PutNonResource.
@@ -3614,14 +3400,9 @@ func (l *LROsClientPutNonResourcePollerResponse) Resume(ctx context.Context, cli
 
 // LROsClientPutNonResourceResponse contains the response from method LROsClient.PutNonResource.
 type LROsClientPutNonResourceResponse struct {
-	LROsClientPutNonResourceResult
+	SKU
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutNonResourceResult contains the result from method LROsClient.PutNonResource.
-type LROsClientPutNonResourceResult struct {
-	SKU
 }
 
 // LROsClientPutSubResourcePollerResponse contains the response from method LROsClient.PutSubResource.
@@ -3665,14 +3446,9 @@ func (l *LROsClientPutSubResourcePollerResponse) Resume(ctx context.Context, cli
 
 // LROsClientPutSubResourceResponse contains the response from method LROsClient.PutSubResource.
 type LROsClientPutSubResourceResponse struct {
-	LROsClientPutSubResourceResult
+	SubProduct
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsClientPutSubResourceResult contains the result from method LROsClient.PutSubResource.
-type LROsClientPutSubResourceResult struct {
-	SubProduct
 }
 
 // LROsCustomHeaderClientPost202Retry200PollerResponse contains the response from method LROsCustomHeaderClient.Post202Retry200.
@@ -3807,14 +3583,9 @@ func (l *LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse) Resume(
 
 // LROsCustomHeaderClientPut201CreatingSucceeded200Response contains the response from method LROsCustomHeaderClient.Put201CreatingSucceeded200.
 type LROsCustomHeaderClientPut201CreatingSucceeded200Response struct {
-	LROsCustomHeaderClientPut201CreatingSucceeded200Result
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsCustomHeaderClientPut201CreatingSucceeded200Result contains the result from method LROsCustomHeaderClient.Put201CreatingSucceeded200.
-type LROsCustomHeaderClientPut201CreatingSucceeded200Result struct {
-	Product
 }
 
 // LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse contains the response from method LROsCustomHeaderClient.PutAsyncRetrySucceeded.
@@ -3858,12 +3629,7 @@ func (l *LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse) Resume(ctx 
 
 // LROsCustomHeaderClientPutAsyncRetrySucceededResponse contains the response from method LROsCustomHeaderClient.PutAsyncRetrySucceeded.
 type LROsCustomHeaderClientPutAsyncRetrySucceededResponse struct {
-	LROsCustomHeaderClientPutAsyncRetrySucceededResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LROsCustomHeaderClientPutAsyncRetrySucceededResult contains the result from method LROsCustomHeaderClient.PutAsyncRetrySucceeded.
-type LROsCustomHeaderClientPutAsyncRetrySucceededResult struct {
-	Product
 }

--- a/test/autorest/mediatypesgroup/zz_generated_response_types.go
+++ b/test/autorest/mediatypesgroup/zz_generated_response_types.go
@@ -24,96 +24,56 @@ type MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse struct {
 
 // MediaTypesClientAnalyzeBodyResponse contains the response from method MediaTypesClient.AnalyzeBody.
 type MediaTypesClientAnalyzeBodyResponse struct {
-	MediaTypesClientAnalyzeBodyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MediaTypesClientAnalyzeBodyResult contains the result from method MediaTypesClient.AnalyzeBody.
-type MediaTypesClientAnalyzeBodyResult struct {
-	Value *string
+	Value       *string
 }
 
 // MediaTypesClientAnalyzeBodyWithJSONResponse contains the response from method MediaTypesClient.AnalyzeBodyWithJSON.
 type MediaTypesClientAnalyzeBodyWithJSONResponse struct {
-	MediaTypesClientAnalyzeBodyWithJSONResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MediaTypesClientAnalyzeBodyWithJSONResult contains the result from method MediaTypesClient.AnalyzeBodyWithJSON.
-type MediaTypesClientAnalyzeBodyWithJSONResult struct {
-	Value *string
+	Value       *string
 }
 
 // MediaTypesClientBinaryBodyWithThreeContentTypesResponse contains the response from method MediaTypesClient.BinaryBodyWithThreeContentTypes.
 type MediaTypesClientBinaryBodyWithThreeContentTypesResponse struct {
-	MediaTypesClientBinaryBodyWithThreeContentTypesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MediaTypesClientBinaryBodyWithThreeContentTypesResult contains the result from method MediaTypesClient.BinaryBodyWithThreeContentTypes.
-type MediaTypesClientBinaryBodyWithThreeContentTypesResult struct {
-	Value *string
+	Value       *string
 }
 
 // MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse contains the response from method MediaTypesClient.BinaryBodyWithThreeContentTypesWithText.
 type MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse struct {
-	MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResult contains the result from method MediaTypesClient.BinaryBodyWithThreeContentTypesWithText.
-type MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResult struct {
-	Value *string
+	Value       *string
 }
 
 // MediaTypesClientBinaryBodyWithTwoContentTypesResponse contains the response from method MediaTypesClient.BinaryBodyWithTwoContentTypes.
 type MediaTypesClientBinaryBodyWithTwoContentTypesResponse struct {
-	MediaTypesClientBinaryBodyWithTwoContentTypesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MediaTypesClientBinaryBodyWithTwoContentTypesResult contains the result from method MediaTypesClient.BinaryBodyWithTwoContentTypes.
-type MediaTypesClientBinaryBodyWithTwoContentTypesResult struct {
-	Value *string
+	Value       *string
 }
 
 // MediaTypesClientContentTypeWithEncodingResponse contains the response from method MediaTypesClient.ContentTypeWithEncoding.
 type MediaTypesClientContentTypeWithEncodingResponse struct {
-	MediaTypesClientContentTypeWithEncodingResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MediaTypesClientContentTypeWithEncodingResult contains the result from method MediaTypesClient.ContentTypeWithEncoding.
-type MediaTypesClientContentTypeWithEncodingResult struct {
-	Value *string
+	Value       *string
 }
 
 // MediaTypesClientPutTextAndJSONBodyWithJSONResponse contains the response from method MediaTypesClient.PutTextAndJSONBodyWithJSON.
 type MediaTypesClientPutTextAndJSONBodyWithJSONResponse struct {
-	MediaTypesClientPutTextAndJSONBodyWithJSONResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MediaTypesClientPutTextAndJSONBodyWithJSONResult contains the result from method MediaTypesClient.PutTextAndJSONBodyWithJSON.
-type MediaTypesClientPutTextAndJSONBodyWithJSONResult struct {
-	Value *string
+	Value       *string
 }
 
 // MediaTypesClientPutTextAndJSONBodyWithTextResponse contains the response from method MediaTypesClient.PutTextAndJSONBodyWithText.
 type MediaTypesClientPutTextAndJSONBodyWithTextResponse struct {
-	MediaTypesClientPutTextAndJSONBodyWithTextResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MediaTypesClientPutTextAndJSONBodyWithTextResult contains the result from method MediaTypesClient.PutTextAndJSONBodyWithText.
-type MediaTypesClientPutTextAndJSONBodyWithTextResult struct {
-	Value *string
+	Value       *string
 }

--- a/test/autorest/migroup/zz_generated_response_types.go
+++ b/test/autorest/migroup/zz_generated_response_types.go
@@ -12,120 +12,70 @@ import "net/http"
 
 // MultipleInheritanceServiceClientGetCatResponse contains the response from method MultipleInheritanceServiceClient.GetCat.
 type MultipleInheritanceServiceClientGetCatResponse struct {
-	MultipleInheritanceServiceClientGetCatResult
+	Cat
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientGetCatResult contains the result from method MultipleInheritanceServiceClient.GetCat.
-type MultipleInheritanceServiceClientGetCatResult struct {
-	Cat
 }
 
 // MultipleInheritanceServiceClientGetFelineResponse contains the response from method MultipleInheritanceServiceClient.GetFeline.
 type MultipleInheritanceServiceClientGetFelineResponse struct {
-	MultipleInheritanceServiceClientGetFelineResult
+	Feline
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientGetFelineResult contains the result from method MultipleInheritanceServiceClient.GetFeline.
-type MultipleInheritanceServiceClientGetFelineResult struct {
-	Feline
 }
 
 // MultipleInheritanceServiceClientGetHorseResponse contains the response from method MultipleInheritanceServiceClient.GetHorse.
 type MultipleInheritanceServiceClientGetHorseResponse struct {
-	MultipleInheritanceServiceClientGetHorseResult
+	Horse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientGetHorseResult contains the result from method MultipleInheritanceServiceClient.GetHorse.
-type MultipleInheritanceServiceClientGetHorseResult struct {
-	Horse
 }
 
 // MultipleInheritanceServiceClientGetKittenResponse contains the response from method MultipleInheritanceServiceClient.GetKitten.
 type MultipleInheritanceServiceClientGetKittenResponse struct {
-	MultipleInheritanceServiceClientGetKittenResult
+	Kitten
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientGetKittenResult contains the result from method MultipleInheritanceServiceClient.GetKitten.
-type MultipleInheritanceServiceClientGetKittenResult struct {
-	Kitten
 }
 
 // MultipleInheritanceServiceClientGetPetResponse contains the response from method MultipleInheritanceServiceClient.GetPet.
 type MultipleInheritanceServiceClientGetPetResponse struct {
-	MultipleInheritanceServiceClientGetPetResult
+	Pet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientGetPetResult contains the result from method MultipleInheritanceServiceClient.GetPet.
-type MultipleInheritanceServiceClientGetPetResult struct {
-	Pet
 }
 
 // MultipleInheritanceServiceClientPutCatResponse contains the response from method MultipleInheritanceServiceClient.PutCat.
 type MultipleInheritanceServiceClientPutCatResponse struct {
-	MultipleInheritanceServiceClientPutCatResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientPutCatResult contains the result from method MultipleInheritanceServiceClient.PutCat.
-type MultipleInheritanceServiceClientPutCatResult struct {
-	Value *string
+	Value       *string
 }
 
 // MultipleInheritanceServiceClientPutFelineResponse contains the response from method MultipleInheritanceServiceClient.PutFeline.
 type MultipleInheritanceServiceClientPutFelineResponse struct {
-	MultipleInheritanceServiceClientPutFelineResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientPutFelineResult contains the result from method MultipleInheritanceServiceClient.PutFeline.
-type MultipleInheritanceServiceClientPutFelineResult struct {
-	Value *string
+	Value       *string
 }
 
 // MultipleInheritanceServiceClientPutHorseResponse contains the response from method MultipleInheritanceServiceClient.PutHorse.
 type MultipleInheritanceServiceClientPutHorseResponse struct {
-	MultipleInheritanceServiceClientPutHorseResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientPutHorseResult contains the result from method MultipleInheritanceServiceClient.PutHorse.
-type MultipleInheritanceServiceClientPutHorseResult struct {
-	Value *string
+	Value       *string
 }
 
 // MultipleInheritanceServiceClientPutKittenResponse contains the response from method MultipleInheritanceServiceClient.PutKitten.
 type MultipleInheritanceServiceClientPutKittenResponse struct {
-	MultipleInheritanceServiceClientPutKittenResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientPutKittenResult contains the result from method MultipleInheritanceServiceClient.PutKitten.
-type MultipleInheritanceServiceClientPutKittenResult struct {
-	Value *string
+	Value       *string
 }
 
 // MultipleInheritanceServiceClientPutPetResponse contains the response from method MultipleInheritanceServiceClient.PutPet.
 type MultipleInheritanceServiceClientPutPetResponse struct {
-	MultipleInheritanceServiceClientPutPetResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MultipleInheritanceServiceClientPutPetResult contains the result from method MultipleInheritanceServiceClient.PutPet.
-type MultipleInheritanceServiceClientPutPetResult struct {
-	Value *string
+	Value       *string
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_response_types.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_response_types.go
@@ -12,50 +12,32 @@ import "net/http"
 
 // FloatClientGetResponse contains the response from method FloatClient.Get.
 type FloatClientGetResponse struct {
-	FloatClientGetResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// FloatClientGetResult contains the result from method FloatClient.Get.
-type FloatClientGetResult struct {
 	// List of float enums
 	Value *FloatEnum
 }
 
 // FloatClientPutResponse contains the response from method FloatClient.Put.
 type FloatClientPutResponse struct {
-	FloatClientPutResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FloatClientPutResult contains the result from method FloatClient.Put.
-type FloatClientPutResult struct {
-	Value *string
+	Value       *string
 }
 
 // IntClientGetResponse contains the response from method IntClient.Get.
 type IntClientGetResponse struct {
-	IntClientGetResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// IntClientGetResult contains the result from method IntClient.Get.
-type IntClientGetResult struct {
 	// List of integer enums
 	Value *IntEnum
 }
 
 // IntClientPutResponse contains the response from method IntClient.Put.
 type IntClientPutResponse struct {
-	IntClientPutResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IntClientPutResult contains the result from method IntClient.Put.
-type IntClientPutResult struct {
-	Value *string
+	Value       *string
 }

--- a/test/autorest/numbergroup/zz_generated_response_types.go
+++ b/test/autorest/numbergroup/zz_generated_response_types.go
@@ -12,170 +12,100 @@ import "net/http"
 
 // NumberClientGetBigDecimalNegativeDecimalResponse contains the response from method NumberClient.GetBigDecimalNegativeDecimal.
 type NumberClientGetBigDecimalNegativeDecimalResponse struct {
-	NumberClientGetBigDecimalNegativeDecimalResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetBigDecimalNegativeDecimalResult contains the result from method NumberClient.GetBigDecimalNegativeDecimal.
-type NumberClientGetBigDecimalNegativeDecimalResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetBigDecimalPositiveDecimalResponse contains the response from method NumberClient.GetBigDecimalPositiveDecimal.
 type NumberClientGetBigDecimalPositiveDecimalResponse struct {
-	NumberClientGetBigDecimalPositiveDecimalResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetBigDecimalPositiveDecimalResult contains the result from method NumberClient.GetBigDecimalPositiveDecimal.
-type NumberClientGetBigDecimalPositiveDecimalResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetBigDecimalResponse contains the response from method NumberClient.GetBigDecimal.
 type NumberClientGetBigDecimalResponse struct {
-	NumberClientGetBigDecimalResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetBigDecimalResult contains the result from method NumberClient.GetBigDecimal.
-type NumberClientGetBigDecimalResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetBigDoubleNegativeDecimalResponse contains the response from method NumberClient.GetBigDoubleNegativeDecimal.
 type NumberClientGetBigDoubleNegativeDecimalResponse struct {
-	NumberClientGetBigDoubleNegativeDecimalResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetBigDoubleNegativeDecimalResult contains the result from method NumberClient.GetBigDoubleNegativeDecimal.
-type NumberClientGetBigDoubleNegativeDecimalResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetBigDoublePositiveDecimalResponse contains the response from method NumberClient.GetBigDoublePositiveDecimal.
 type NumberClientGetBigDoublePositiveDecimalResponse struct {
-	NumberClientGetBigDoublePositiveDecimalResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetBigDoublePositiveDecimalResult contains the result from method NumberClient.GetBigDoublePositiveDecimal.
-type NumberClientGetBigDoublePositiveDecimalResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetBigDoubleResponse contains the response from method NumberClient.GetBigDouble.
 type NumberClientGetBigDoubleResponse struct {
-	NumberClientGetBigDoubleResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetBigDoubleResult contains the result from method NumberClient.GetBigDouble.
-type NumberClientGetBigDoubleResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetBigFloatResponse contains the response from method NumberClient.GetBigFloat.
 type NumberClientGetBigFloatResponse struct {
-	NumberClientGetBigFloatResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetBigFloatResult contains the result from method NumberClient.GetBigFloat.
-type NumberClientGetBigFloatResult struct {
-	Value *float32
+	Value       *float32
 }
 
 // NumberClientGetInvalidDecimalResponse contains the response from method NumberClient.GetInvalidDecimal.
 type NumberClientGetInvalidDecimalResponse struct {
-	NumberClientGetInvalidDecimalResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetInvalidDecimalResult contains the result from method NumberClient.GetInvalidDecimal.
-type NumberClientGetInvalidDecimalResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetInvalidDoubleResponse contains the response from method NumberClient.GetInvalidDouble.
 type NumberClientGetInvalidDoubleResponse struct {
-	NumberClientGetInvalidDoubleResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetInvalidDoubleResult contains the result from method NumberClient.GetInvalidDouble.
-type NumberClientGetInvalidDoubleResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetInvalidFloatResponse contains the response from method NumberClient.GetInvalidFloat.
 type NumberClientGetInvalidFloatResponse struct {
-	NumberClientGetInvalidFloatResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetInvalidFloatResult contains the result from method NumberClient.GetInvalidFloat.
-type NumberClientGetInvalidFloatResult struct {
-	Value *float32
+	Value       *float32
 }
 
 // NumberClientGetNullResponse contains the response from method NumberClient.GetNull.
 type NumberClientGetNullResponse struct {
-	NumberClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetNullResult contains the result from method NumberClient.GetNull.
-type NumberClientGetNullResult struct {
-	Value *float32
+	Value       *float32
 }
 
 // NumberClientGetSmallDecimalResponse contains the response from method NumberClient.GetSmallDecimal.
 type NumberClientGetSmallDecimalResponse struct {
-	NumberClientGetSmallDecimalResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetSmallDecimalResult contains the result from method NumberClient.GetSmallDecimal.
-type NumberClientGetSmallDecimalResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetSmallDoubleResponse contains the response from method NumberClient.GetSmallDouble.
 type NumberClientGetSmallDoubleResponse struct {
-	NumberClientGetSmallDoubleResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetSmallDoubleResult contains the result from method NumberClient.GetSmallDouble.
-type NumberClientGetSmallDoubleResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientGetSmallFloatResponse contains the response from method NumberClient.GetSmallFloat.
 type NumberClientGetSmallFloatResponse struct {
-	NumberClientGetSmallFloatResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NumberClientGetSmallFloatResult contains the result from method NumberClient.GetSmallFloat.
-type NumberClientGetSmallFloatResult struct {
-	Value *float64
+	Value       *float64
 }
 
 // NumberClientPutBigDecimalNegativeDecimalResponse contains the response from method NumberClient.PutBigDecimalNegativeDecimal.

--- a/test/autorest/objectgroup/zz_generated_response_types.go
+++ b/test/autorest/objectgroup/zz_generated_response_types.go
@@ -12,15 +12,11 @@ import "net/http"
 
 // ObjectTypeClientGetResponse contains the response from method ObjectTypeClient.Get.
 type ObjectTypeClientGetResponse struct {
-	ObjectTypeClientGetResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ObjectTypeClientGetResult contains the result from method ObjectTypeClient.Get.
-type ObjectTypeClientGetResult struct {
 	// Anything
 	Interface interface{}
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // ObjectTypeClientPutResponse contains the response from method ObjectTypeClient.Put.

--- a/test/autorest/paginggroup/zz_generated_response_types.go
+++ b/test/autorest/paginggroup/zz_generated_response_types.go
@@ -17,62 +17,37 @@ import (
 
 // PagingClientFirstResponseEmptyResponse contains the response from method PagingClient.FirstResponseEmpty.
 type PagingClientFirstResponseEmptyResponse struct {
-	PagingClientFirstResponseEmptyResult
+	ProductResultValue
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientFirstResponseEmptyResult contains the result from method PagingClient.FirstResponseEmpty.
-type PagingClientFirstResponseEmptyResult struct {
-	ProductResultValue
 }
 
 // PagingClientGetMultiplePagesFailureResponse contains the response from method PagingClient.GetMultiplePagesFailure.
 type PagingClientGetMultiplePagesFailureResponse struct {
-	PagingClientGetMultiplePagesFailureResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesFailureResult contains the result from method PagingClient.GetMultiplePagesFailure.
-type PagingClientGetMultiplePagesFailureResult struct {
-	ProductResult
 }
 
 // PagingClientGetMultiplePagesFailureURIResponse contains the response from method PagingClient.GetMultiplePagesFailureURI.
 type PagingClientGetMultiplePagesFailureURIResponse struct {
-	PagingClientGetMultiplePagesFailureURIResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesFailureURIResult contains the result from method PagingClient.GetMultiplePagesFailureURI.
-type PagingClientGetMultiplePagesFailureURIResult struct {
-	ProductResult
 }
 
 // PagingClientGetMultiplePagesFragmentNextLinkResponse contains the response from method PagingClient.GetMultiplePagesFragmentNextLink.
 type PagingClientGetMultiplePagesFragmentNextLinkResponse struct {
-	PagingClientGetMultiplePagesFragmentNextLinkResult
+	ODataProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesFragmentNextLinkResult contains the result from method PagingClient.GetMultiplePagesFragmentNextLink.
-type PagingClientGetMultiplePagesFragmentNextLinkResult struct {
-	ODataProductResult
 }
 
 // PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse contains the response from method PagingClient.GetMultiplePagesFragmentWithGroupingNextLink.
 type PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse struct {
-	PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResult
+	ODataProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResult contains the result from method PagingClient.GetMultiplePagesFragmentWithGroupingNextLink.
-type PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResult struct {
-	ODataProductResult
 }
 
 // PagingClientGetMultiplePagesLROPollerResponse contains the response from method PagingClient.GetMultiplePagesLRO.
@@ -118,180 +93,105 @@ func (l *PagingClientGetMultiplePagesLROPollerResponse) Resume(ctx context.Conte
 
 // PagingClientGetMultiplePagesLROResponse contains the response from method PagingClient.GetMultiplePagesLRO.
 type PagingClientGetMultiplePagesLROResponse struct {
-	PagingClientGetMultiplePagesLROResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesLROResult contains the result from method PagingClient.GetMultiplePagesLRO.
-type PagingClientGetMultiplePagesLROResult struct {
-	ProductResult
 }
 
 // PagingClientGetMultiplePagesResponse contains the response from method PagingClient.GetMultiplePages.
 type PagingClientGetMultiplePagesResponse struct {
-	PagingClientGetMultiplePagesResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesResult contains the result from method PagingClient.GetMultiplePages.
-type PagingClientGetMultiplePagesResult struct {
-	ProductResult
 }
 
 // PagingClientGetMultiplePagesRetryFirstResponse contains the response from method PagingClient.GetMultiplePagesRetryFirst.
 type PagingClientGetMultiplePagesRetryFirstResponse struct {
-	PagingClientGetMultiplePagesRetryFirstResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesRetryFirstResult contains the result from method PagingClient.GetMultiplePagesRetryFirst.
-type PagingClientGetMultiplePagesRetryFirstResult struct {
-	ProductResult
 }
 
 // PagingClientGetMultiplePagesRetrySecondResponse contains the response from method PagingClient.GetMultiplePagesRetrySecond.
 type PagingClientGetMultiplePagesRetrySecondResponse struct {
-	PagingClientGetMultiplePagesRetrySecondResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesRetrySecondResult contains the result from method PagingClient.GetMultiplePagesRetrySecond.
-type PagingClientGetMultiplePagesRetrySecondResult struct {
-	ProductResult
 }
 
 // PagingClientGetMultiplePagesWithOffsetResponse contains the response from method PagingClient.GetMultiplePagesWithOffset.
 type PagingClientGetMultiplePagesWithOffsetResponse struct {
-	PagingClientGetMultiplePagesWithOffsetResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetMultiplePagesWithOffsetResult contains the result from method PagingClient.GetMultiplePagesWithOffset.
-type PagingClientGetMultiplePagesWithOffsetResult struct {
-	ProductResult
 }
 
 // PagingClientGetNoItemNamePagesResponse contains the response from method PagingClient.GetNoItemNamePages.
 type PagingClientGetNoItemNamePagesResponse struct {
-	PagingClientGetNoItemNamePagesResult
+	ProductResultValue
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetNoItemNamePagesResult contains the result from method PagingClient.GetNoItemNamePages.
-type PagingClientGetNoItemNamePagesResult struct {
-	ProductResultValue
 }
 
 // PagingClientGetNullNextLinkNamePagesResponse contains the response from method PagingClient.GetNullNextLinkNamePages.
 type PagingClientGetNullNextLinkNamePagesResponse struct {
-	PagingClientGetNullNextLinkNamePagesResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetNullNextLinkNamePagesResult contains the result from method PagingClient.GetNullNextLinkNamePages.
-type PagingClientGetNullNextLinkNamePagesResult struct {
-	ProductResult
 }
 
 // PagingClientGetODataMultiplePagesResponse contains the response from method PagingClient.GetODataMultiplePages.
 type PagingClientGetODataMultiplePagesResponse struct {
-	PagingClientGetODataMultiplePagesResult
+	ODataProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetODataMultiplePagesResult contains the result from method PagingClient.GetODataMultiplePages.
-type PagingClientGetODataMultiplePagesResult struct {
-	ODataProductResult
 }
 
 // PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse contains the response from method PagingClient.GetPagingModelWithItemNameWithXMSClientName.
 type PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse struct {
-	PagingClientGetPagingModelWithItemNameWithXMSClientNameResult
+	ProductResultValueWithXMSClientName
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetPagingModelWithItemNameWithXMSClientNameResult contains the result from method PagingClient.GetPagingModelWithItemNameWithXMSClientName.
-type PagingClientGetPagingModelWithItemNameWithXMSClientNameResult struct {
-	ProductResultValueWithXMSClientName
 }
 
 // PagingClientGetSinglePagesFailureResponse contains the response from method PagingClient.GetSinglePagesFailure.
 type PagingClientGetSinglePagesFailureResponse struct {
-	PagingClientGetSinglePagesFailureResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetSinglePagesFailureResult contains the result from method PagingClient.GetSinglePagesFailure.
-type PagingClientGetSinglePagesFailureResult struct {
-	ProductResult
 }
 
 // PagingClientGetSinglePagesResponse contains the response from method PagingClient.GetSinglePages.
 type PagingClientGetSinglePagesResponse struct {
-	PagingClientGetSinglePagesResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetSinglePagesResult contains the result from method PagingClient.GetSinglePages.
-type PagingClientGetSinglePagesResult struct {
-	ProductResult
 }
 
 // PagingClientGetWithQueryParamsResponse contains the response from method PagingClient.GetWithQueryParams.
 type PagingClientGetWithQueryParamsResponse struct {
-	PagingClientGetWithQueryParamsResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientGetWithQueryParamsResult contains the result from method PagingClient.GetWithQueryParams.
-type PagingClientGetWithQueryParamsResult struct {
-	ProductResult
 }
 
 // PagingClientNextFragmentResponse contains the response from method PagingClient.NextFragment.
 type PagingClientNextFragmentResponse struct {
-	PagingClientNextFragmentResult
+	ODataProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientNextFragmentResult contains the result from method PagingClient.NextFragment.
-type PagingClientNextFragmentResult struct {
-	ODataProductResult
 }
 
 // PagingClientNextFragmentWithGroupingResponse contains the response from method PagingClient.NextFragmentWithGrouping.
 type PagingClientNextFragmentWithGroupingResponse struct {
-	PagingClientNextFragmentWithGroupingResult
+	ODataProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientNextFragmentWithGroupingResult contains the result from method PagingClient.NextFragmentWithGrouping.
-type PagingClientNextFragmentWithGroupingResult struct {
-	ODataProductResult
 }
 
 // PagingClientNextOperationWithQueryParamsResponse contains the response from method PagingClient.NextOperationWithQueryParams.
 type PagingClientNextOperationWithQueryParamsResponse struct {
-	PagingClientNextOperationWithQueryParamsResult
+	ProductResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PagingClientNextOperationWithQueryParamsResult contains the result from method PagingClient.NextOperationWithQueryParams.
-type PagingClientNextOperationWithQueryParamsResult struct {
-	ProductResult
 }

--- a/test/autorest/reportgroup/zz_generated_response_types.go
+++ b/test/autorest/reportgroup/zz_generated_response_types.go
@@ -12,26 +12,18 @@ import "net/http"
 
 // AutoRestReportServiceClientGetOptionalReportResponse contains the response from method AutoRestReportServiceClient.GetOptionalReport.
 type AutoRestReportServiceClientGetOptionalReportResponse struct {
-	AutoRestReportServiceClientGetOptionalReportResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// AutoRestReportServiceClientGetOptionalReportResult contains the result from method AutoRestReportServiceClient.GetOptionalReport.
-type AutoRestReportServiceClientGetOptionalReportResult struct {
 	// Dictionary of <integer>
 	Value map[string]*int32
 }
 
 // AutoRestReportServiceClientGetReportResponse contains the response from method AutoRestReportServiceClient.GetReport.
 type AutoRestReportServiceClientGetReportResponse struct {
-	AutoRestReportServiceClientGetReportResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// AutoRestReportServiceClientGetReportResult contains the result from method AutoRestReportServiceClient.GetReport.
-type AutoRestReportServiceClientGetReportResult struct {
 	// Dictionary of <integer>
 	Value map[string]*int32
 }

--- a/test/autorest/stringgroup/zz_generated_response_types.go
+++ b/test/autorest/stringgroup/zz_generated_response_types.go
@@ -12,38 +12,25 @@ import "net/http"
 
 // EnumClientGetNotExpandableResponse contains the response from method EnumClient.GetNotExpandable.
 type EnumClientGetNotExpandableResponse struct {
-	EnumClientGetNotExpandableResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// EnumClientGetNotExpandableResult contains the result from method EnumClient.GetNotExpandable.
-type EnumClientGetNotExpandableResult struct {
 	// Referenced Color Enum Description.
 	Value *Colors
 }
 
 // EnumClientGetReferencedConstantResponse contains the response from method EnumClient.GetReferencedConstant.
 type EnumClientGetReferencedConstantResponse struct {
-	EnumClientGetReferencedConstantResult
+	RefColorConstant
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// EnumClientGetReferencedConstantResult contains the result from method EnumClient.GetReferencedConstant.
-type EnumClientGetReferencedConstantResult struct {
-	RefColorConstant
 }
 
 // EnumClientGetReferencedResponse contains the response from method EnumClient.GetReferenced.
 type EnumClientGetReferencedResponse struct {
-	EnumClientGetReferencedResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// EnumClientGetReferencedResult contains the result from method EnumClient.GetReferenced.
-type EnumClientGetReferencedResult struct {
 	// Referenced Color Enum Description.
 	Value *Colors
 }
@@ -68,99 +55,62 @@ type EnumClientPutReferencedResponse struct {
 
 // StringClientGetBase64EncodedResponse contains the response from method StringClient.GetBase64Encoded.
 type StringClientGetBase64EncodedResponse struct {
-	StringClientGetBase64EncodedResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StringClientGetBase64EncodedResult contains the result from method StringClient.GetBase64Encoded.
-type StringClientGetBase64EncodedResult struct {
-	Value []byte
+	Value       []byte
 }
 
 // StringClientGetBase64URLEncodedResponse contains the response from method StringClient.GetBase64URLEncoded.
 type StringClientGetBase64URLEncodedResponse struct {
-	StringClientGetBase64URLEncodedResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StringClientGetBase64URLEncodedResult contains the result from method StringClient.GetBase64URLEncoded.
-type StringClientGetBase64URLEncodedResult struct {
-	Value []byte
+	Value       []byte
 }
 
 // StringClientGetEmptyResponse contains the response from method StringClient.GetEmpty.
 type StringClientGetEmptyResponse struct {
-	StringClientGetEmptyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// StringClientGetEmptyResult contains the result from method StringClient.GetEmpty.
-type StringClientGetEmptyResult struct {
 	// simple string
 	Value *string
 }
 
 // StringClientGetMBCSResponse contains the response from method StringClient.GetMBCS.
 type StringClientGetMBCSResponse struct {
-	StringClientGetMBCSResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// StringClientGetMBCSResult contains the result from method StringClient.GetMBCS.
-type StringClientGetMBCSResult struct {
 	// simple string
 	Value *string
 }
 
 // StringClientGetNotProvidedResponse contains the response from method StringClient.GetNotProvided.
 type StringClientGetNotProvidedResponse struct {
-	StringClientGetNotProvidedResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StringClientGetNotProvidedResult contains the result from method StringClient.GetNotProvided.
-type StringClientGetNotProvidedResult struct {
-	Value *string
+	Value       *string
 }
 
 // StringClientGetNullBase64URLEncodedResponse contains the response from method StringClient.GetNullBase64URLEncoded.
 type StringClientGetNullBase64URLEncodedResponse struct {
-	StringClientGetNullBase64URLEncodedResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StringClientGetNullBase64URLEncodedResult contains the result from method StringClient.GetNullBase64URLEncoded.
-type StringClientGetNullBase64URLEncodedResult struct {
-	Value []byte
+	Value       []byte
 }
 
 // StringClientGetNullResponse contains the response from method StringClient.GetNull.
 type StringClientGetNullResponse struct {
-	StringClientGetNullResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StringClientGetNullResult contains the result from method StringClient.GetNull.
-type StringClientGetNullResult struct {
-	Value *string
+	Value       *string
 }
 
 // StringClientGetWhitespaceResponse contains the response from method StringClient.GetWhitespace.
 type StringClientGetWhitespaceResponse struct {
-	StringClientGetWhitespaceResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// StringClientGetWhitespaceResult contains the result from method StringClient.GetWhitespace.
-type StringClientGetWhitespaceResult struct {
 	// simple string
 	Value *string
 }

--- a/test/autorest/validationgroup/zz_generated_response_types.go
+++ b/test/autorest/validationgroup/zz_generated_response_types.go
@@ -18,36 +18,21 @@ type AutoRestValidationTestClientGetWithConstantInPathResponse struct {
 
 // AutoRestValidationTestClientPostWithConstantInBodyResponse contains the response from method AutoRestValidationTestClient.PostWithConstantInBody.
 type AutoRestValidationTestClientPostWithConstantInBodyResponse struct {
-	AutoRestValidationTestClientPostWithConstantInBodyResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AutoRestValidationTestClientPostWithConstantInBodyResult contains the result from method AutoRestValidationTestClient.PostWithConstantInBody.
-type AutoRestValidationTestClientPostWithConstantInBodyResult struct {
-	Product
 }
 
 // AutoRestValidationTestClientValidationOfBodyResponse contains the response from method AutoRestValidationTestClient.ValidationOfBody.
 type AutoRestValidationTestClientValidationOfBodyResponse struct {
-	AutoRestValidationTestClientValidationOfBodyResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AutoRestValidationTestClientValidationOfBodyResult contains the result from method AutoRestValidationTestClient.ValidationOfBody.
-type AutoRestValidationTestClientValidationOfBodyResult struct {
-	Product
 }
 
 // AutoRestValidationTestClientValidationOfMethodParametersResponse contains the response from method AutoRestValidationTestClient.ValidationOfMethodParameters.
 type AutoRestValidationTestClientValidationOfMethodParametersResponse struct {
-	AutoRestValidationTestClientValidationOfMethodParametersResult
+	Product
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AutoRestValidationTestClientValidationOfMethodParametersResult contains the result from method AutoRestValidationTestClient.ValidationOfMethodParameters.
-type AutoRestValidationTestClientValidationOfMethodParametersResult struct {
-	Product
 }

--- a/test/autorest/xmlgroup/zz_generated_response_types.go
+++ b/test/autorest/xmlgroup/zz_generated_response_types.go
@@ -12,199 +12,124 @@ import "net/http"
 
 // XMLClientGetACLsResponse contains the response from method XMLClient.GetACLs.
 type XMLClientGetACLsResponse struct {
-	XMLClientGetACLsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// XMLClientGetACLsResult contains the result from method XMLClient.GetACLs.
-type XMLClientGetACLsResult struct {
 	// a collection of signed identifiers
 	SignedIdentifiers []*SignedIdentifier `xml:"SignedIdentifier"`
 }
 
 // XMLClientGetBytesResponse contains the response from method XMLClient.GetBytes.
 type XMLClientGetBytesResponse struct {
-	XMLClientGetBytesResult
+	ModelWithByteProperty
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetBytesResult contains the result from method XMLClient.GetBytes.
-type XMLClientGetBytesResult struct {
-	ModelWithByteProperty
 }
 
 // XMLClientGetComplexTypeRefNoMetaResponse contains the response from method XMLClient.GetComplexTypeRefNoMeta.
 type XMLClientGetComplexTypeRefNoMetaResponse struct {
-	XMLClientGetComplexTypeRefNoMetaResult
+	RootWithRefAndNoMeta
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetComplexTypeRefNoMetaResult contains the result from method XMLClient.GetComplexTypeRefNoMeta.
-type XMLClientGetComplexTypeRefNoMetaResult struct {
-	RootWithRefAndNoMeta
 }
 
 // XMLClientGetComplexTypeRefWithMetaResponse contains the response from method XMLClient.GetComplexTypeRefWithMeta.
 type XMLClientGetComplexTypeRefWithMetaResponse struct {
-	XMLClientGetComplexTypeRefWithMetaResult
+	RootWithRefAndMeta
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetComplexTypeRefWithMetaResult contains the result from method XMLClient.GetComplexTypeRefWithMeta.
-type XMLClientGetComplexTypeRefWithMetaResult struct {
-	RootWithRefAndMeta
 }
 
 // XMLClientGetEmptyChildElementResponse contains the response from method XMLClient.GetEmptyChildElement.
 type XMLClientGetEmptyChildElementResponse struct {
-	XMLClientGetEmptyChildElementResult
+	Banana
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetEmptyChildElementResult contains the result from method XMLClient.GetEmptyChildElement.
-type XMLClientGetEmptyChildElementResult struct {
-	Banana
 }
 
 // XMLClientGetEmptyListResponse contains the response from method XMLClient.GetEmptyList.
 type XMLClientGetEmptyListResponse struct {
-	XMLClientGetEmptyListResult
+	Slideshow
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetEmptyListResult contains the result from method XMLClient.GetEmptyList.
-type XMLClientGetEmptyListResult struct {
-	Slideshow
 }
 
 // XMLClientGetEmptyRootListResponse contains the response from method XMLClient.GetEmptyRootList.
 type XMLClientGetEmptyRootListResponse struct {
-	XMLClientGetEmptyRootListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLClientGetEmptyRootListResult contains the result from method XMLClient.GetEmptyRootList.
-type XMLClientGetEmptyRootListResult struct {
 	// Array of Banana
 	Bananas []*Banana `xml:"banana"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // XMLClientGetEmptyWrappedListsResponse contains the response from method XMLClient.GetEmptyWrappedLists.
 type XMLClientGetEmptyWrappedListsResponse struct {
-	XMLClientGetEmptyWrappedListsResult
+	AppleBarrel
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetEmptyWrappedListsResult contains the result from method XMLClient.GetEmptyWrappedLists.
-type XMLClientGetEmptyWrappedListsResult struct {
-	AppleBarrel
 }
 
 // XMLClientGetHeadersResponse contains the response from method XMLClient.GetHeaders.
 type XMLClientGetHeadersResponse struct {
-	XMLClientGetHeadersResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLClientGetHeadersResult contains the result from method XMLClient.GetHeaders.
-type XMLClientGetHeadersResult struct {
 	// CustomHeader contains the information returned from the Custom-Header header response.
 	CustomHeader *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // XMLClientGetRootListResponse contains the response from method XMLClient.GetRootList.
 type XMLClientGetRootListResponse struct {
-	XMLClientGetRootListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLClientGetRootListResult contains the result from method XMLClient.GetRootList.
-type XMLClientGetRootListResult struct {
 	// Array of Banana
 	Bananas []*Banana `xml:"banana"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // XMLClientGetRootListSingleItemResponse contains the response from method XMLClient.GetRootListSingleItem.
 type XMLClientGetRootListSingleItemResponse struct {
-	XMLClientGetRootListSingleItemResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLClientGetRootListSingleItemResult contains the result from method XMLClient.GetRootListSingleItem.
-type XMLClientGetRootListSingleItemResult struct {
 	// Array of Banana
 	Bananas []*Banana `xml:"banana"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // XMLClientGetServicePropertiesResponse contains the response from method XMLClient.GetServiceProperties.
 type XMLClientGetServicePropertiesResponse struct {
-	XMLClientGetServicePropertiesResult
+	StorageServiceProperties
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetServicePropertiesResult contains the result from method XMLClient.GetServiceProperties.
-type XMLClientGetServicePropertiesResult struct {
-	StorageServiceProperties
 }
 
 // XMLClientGetSimpleResponse contains the response from method XMLClient.GetSimple.
 type XMLClientGetSimpleResponse struct {
-	XMLClientGetSimpleResult
+	Slideshow
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetSimpleResult contains the result from method XMLClient.GetSimple.
-type XMLClientGetSimpleResult struct {
-	Slideshow
 }
 
 // XMLClientGetURIResponse contains the response from method XMLClient.GetURI.
 type XMLClientGetURIResponse struct {
-	XMLClientGetURIResult
+	ModelWithURLProperty
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetURIResult contains the result from method XMLClient.GetURI.
-type XMLClientGetURIResult struct {
-	ModelWithURLProperty
 }
 
 // XMLClientGetWrappedListsResponse contains the response from method XMLClient.GetWrappedLists.
 type XMLClientGetWrappedListsResponse struct {
-	XMLClientGetWrappedListsResult
+	AppleBarrel
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetWrappedListsResult contains the result from method XMLClient.GetWrappedLists.
-type XMLClientGetWrappedListsResult struct {
-	AppleBarrel
 }
 
 // XMLClientGetXMsTextResponse contains the response from method XMLClient.GetXMsText.
 type XMLClientGetXMsTextResponse struct {
-	XMLClientGetXMsTextResult
+	ObjectWithXMsTextProperty
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientGetXMsTextResult contains the result from method XMLClient.GetXMsText.
-type XMLClientGetXMsTextResult struct {
-	ObjectWithXMsTextProperty
 }
 
 // XMLClientJSONInputResponse contains the response from method XMLClient.JSONInput.
@@ -215,38 +140,23 @@ type XMLClientJSONInputResponse struct {
 
 // XMLClientJSONOutputResponse contains the response from method XMLClient.JSONOutput.
 type XMLClientJSONOutputResponse struct {
-	XMLClientJSONOutputResult
+	JSONOutput
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientJSONOutputResult contains the result from method XMLClient.JSONOutput.
-type XMLClientJSONOutputResult struct {
-	JSONOutput
 }
 
 // XMLClientListBlobsResponse contains the response from method XMLClient.ListBlobs.
 type XMLClientListBlobsResponse struct {
-	XMLClientListBlobsResult
+	ListBlobsResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientListBlobsResult contains the result from method XMLClient.ListBlobs.
-type XMLClientListBlobsResult struct {
-	ListBlobsResponse
 }
 
 // XMLClientListContainersResponse contains the response from method XMLClient.ListContainers.
 type XMLClientListContainersResponse struct {
-	XMLClientListContainersResult
+	ListContainersResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// XMLClientListContainersResult contains the result from method XMLClient.ListContainers.
-type XMLClientListContainersResult struct {
-	ListContainersResponse
 }
 
 // XMLClientPutACLsResponse contains the response from method XMLClient.PutACLs.

--- a/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
@@ -17,14 +17,9 @@ import (
 
 // AvailabilitySetsClientCreateOrUpdateResponse contains the response from method AvailabilitySetsClient.CreateOrUpdate.
 type AvailabilitySetsClientCreateOrUpdateResponse struct {
-	AvailabilitySetsClientCreateOrUpdateResult
+	AvailabilitySet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailabilitySetsClientCreateOrUpdateResult contains the result from method AvailabilitySetsClient.CreateOrUpdate.
-type AvailabilitySetsClientCreateOrUpdateResult struct {
-	AvailabilitySet
 }
 
 // AvailabilitySetsClientDeleteResponse contains the response from method AvailabilitySetsClient.Delete.
@@ -35,62 +30,37 @@ type AvailabilitySetsClientDeleteResponse struct {
 
 // AvailabilitySetsClientGetResponse contains the response from method AvailabilitySetsClient.Get.
 type AvailabilitySetsClientGetResponse struct {
-	AvailabilitySetsClientGetResult
+	AvailabilitySet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailabilitySetsClientGetResult contains the result from method AvailabilitySetsClient.Get.
-type AvailabilitySetsClientGetResult struct {
-	AvailabilitySet
 }
 
 // AvailabilitySetsClientListAvailableSizesResponse contains the response from method AvailabilitySetsClient.ListAvailableSizes.
 type AvailabilitySetsClientListAvailableSizesResponse struct {
-	AvailabilitySetsClientListAvailableSizesResult
+	VirtualMachineSizeListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailabilitySetsClientListAvailableSizesResult contains the result from method AvailabilitySetsClient.ListAvailableSizes.
-type AvailabilitySetsClientListAvailableSizesResult struct {
-	VirtualMachineSizeListResult
 }
 
 // AvailabilitySetsClientListBySubscriptionResponse contains the response from method AvailabilitySetsClient.ListBySubscription.
 type AvailabilitySetsClientListBySubscriptionResponse struct {
-	AvailabilitySetsClientListBySubscriptionResult
+	AvailabilitySetListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailabilitySetsClientListBySubscriptionResult contains the result from method AvailabilitySetsClient.ListBySubscription.
-type AvailabilitySetsClientListBySubscriptionResult struct {
-	AvailabilitySetListResult
 }
 
 // AvailabilitySetsClientListResponse contains the response from method AvailabilitySetsClient.List.
 type AvailabilitySetsClientListResponse struct {
-	AvailabilitySetsClientListResult
+	AvailabilitySetListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailabilitySetsClientListResult contains the result from method AvailabilitySetsClient.List.
-type AvailabilitySetsClientListResult struct {
-	AvailabilitySetListResult
 }
 
 // AvailabilitySetsClientUpdateResponse contains the response from method AvailabilitySetsClient.Update.
 type AvailabilitySetsClientUpdateResponse struct {
-	AvailabilitySetsClientUpdateResult
+	AvailabilitySet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailabilitySetsClientUpdateResult contains the result from method AvailabilitySetsClient.Update.
-type AvailabilitySetsClientUpdateResult struct {
-	AvailabilitySet
 }
 
 // ContainerServicesClientCreateOrUpdatePollerResponse contains the response from method ContainerServicesClient.CreateOrUpdate.
@@ -135,14 +105,9 @@ func (l *ContainerServicesClientCreateOrUpdatePollerResponse) Resume(ctx context
 
 // ContainerServicesClientCreateOrUpdateResponse contains the response from method ContainerServicesClient.CreateOrUpdate.
 type ContainerServicesClientCreateOrUpdateResponse struct {
-	ContainerServicesClientCreateOrUpdateResult
+	ContainerService
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ContainerServicesClientCreateOrUpdateResult contains the result from method ContainerServicesClient.CreateOrUpdate.
-type ContainerServicesClientCreateOrUpdateResult struct {
-	ContainerService
 }
 
 // ContainerServicesClientDeletePollerResponse contains the response from method ContainerServicesClient.Delete.
@@ -193,50 +158,30 @@ type ContainerServicesClientDeleteResponse struct {
 
 // ContainerServicesClientGetResponse contains the response from method ContainerServicesClient.Get.
 type ContainerServicesClientGetResponse struct {
-	ContainerServicesClientGetResult
+	ContainerService
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ContainerServicesClientGetResult contains the result from method ContainerServicesClient.Get.
-type ContainerServicesClientGetResult struct {
-	ContainerService
 }
 
 // ContainerServicesClientListByResourceGroupResponse contains the response from method ContainerServicesClient.ListByResourceGroup.
 type ContainerServicesClientListByResourceGroupResponse struct {
-	ContainerServicesClientListByResourceGroupResult
+	ContainerServiceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ContainerServicesClientListByResourceGroupResult contains the result from method ContainerServicesClient.ListByResourceGroup.
-type ContainerServicesClientListByResourceGroupResult struct {
-	ContainerServiceListResult
 }
 
 // ContainerServicesClientListResponse contains the response from method ContainerServicesClient.List.
 type ContainerServicesClientListResponse struct {
-	ContainerServicesClientListResult
+	ContainerServiceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ContainerServicesClientListResult contains the result from method ContainerServicesClient.List.
-type ContainerServicesClientListResult struct {
-	ContainerServiceListResult
 }
 
 // DedicatedHostGroupsClientCreateOrUpdateResponse contains the response from method DedicatedHostGroupsClient.CreateOrUpdate.
 type DedicatedHostGroupsClientCreateOrUpdateResponse struct {
-	DedicatedHostGroupsClientCreateOrUpdateResult
+	DedicatedHostGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostGroupsClientCreateOrUpdateResult contains the result from method DedicatedHostGroupsClient.CreateOrUpdate.
-type DedicatedHostGroupsClientCreateOrUpdateResult struct {
-	DedicatedHostGroup
 }
 
 // DedicatedHostGroupsClientDeleteResponse contains the response from method DedicatedHostGroupsClient.Delete.
@@ -247,50 +192,30 @@ type DedicatedHostGroupsClientDeleteResponse struct {
 
 // DedicatedHostGroupsClientGetResponse contains the response from method DedicatedHostGroupsClient.Get.
 type DedicatedHostGroupsClientGetResponse struct {
-	DedicatedHostGroupsClientGetResult
+	DedicatedHostGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostGroupsClientGetResult contains the result from method DedicatedHostGroupsClient.Get.
-type DedicatedHostGroupsClientGetResult struct {
-	DedicatedHostGroup
 }
 
 // DedicatedHostGroupsClientListByResourceGroupResponse contains the response from method DedicatedHostGroupsClient.ListByResourceGroup.
 type DedicatedHostGroupsClientListByResourceGroupResponse struct {
-	DedicatedHostGroupsClientListByResourceGroupResult
+	DedicatedHostGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostGroupsClientListByResourceGroupResult contains the result from method DedicatedHostGroupsClient.ListByResourceGroup.
-type DedicatedHostGroupsClientListByResourceGroupResult struct {
-	DedicatedHostGroupListResult
 }
 
 // DedicatedHostGroupsClientListBySubscriptionResponse contains the response from method DedicatedHostGroupsClient.ListBySubscription.
 type DedicatedHostGroupsClientListBySubscriptionResponse struct {
-	DedicatedHostGroupsClientListBySubscriptionResult
+	DedicatedHostGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostGroupsClientListBySubscriptionResult contains the result from method DedicatedHostGroupsClient.ListBySubscription.
-type DedicatedHostGroupsClientListBySubscriptionResult struct {
-	DedicatedHostGroupListResult
 }
 
 // DedicatedHostGroupsClientUpdateResponse contains the response from method DedicatedHostGroupsClient.Update.
 type DedicatedHostGroupsClientUpdateResponse struct {
-	DedicatedHostGroupsClientUpdateResult
+	DedicatedHostGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostGroupsClientUpdateResult contains the result from method DedicatedHostGroupsClient.Update.
-type DedicatedHostGroupsClientUpdateResult struct {
-	DedicatedHostGroup
 }
 
 // DedicatedHostsClientCreateOrUpdatePollerResponse contains the response from method DedicatedHostsClient.CreateOrUpdate.
@@ -335,14 +260,9 @@ func (l *DedicatedHostsClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 
 // DedicatedHostsClientCreateOrUpdateResponse contains the response from method DedicatedHostsClient.CreateOrUpdate.
 type DedicatedHostsClientCreateOrUpdateResponse struct {
-	DedicatedHostsClientCreateOrUpdateResult
+	DedicatedHost
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostsClientCreateOrUpdateResult contains the result from method DedicatedHostsClient.CreateOrUpdate.
-type DedicatedHostsClientCreateOrUpdateResult struct {
-	DedicatedHost
 }
 
 // DedicatedHostsClientDeletePollerResponse contains the response from method DedicatedHostsClient.Delete.
@@ -393,26 +313,16 @@ type DedicatedHostsClientDeleteResponse struct {
 
 // DedicatedHostsClientGetResponse contains the response from method DedicatedHostsClient.Get.
 type DedicatedHostsClientGetResponse struct {
-	DedicatedHostsClientGetResult
+	DedicatedHost
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostsClientGetResult contains the result from method DedicatedHostsClient.Get.
-type DedicatedHostsClientGetResult struct {
-	DedicatedHost
 }
 
 // DedicatedHostsClientListByHostGroupResponse contains the response from method DedicatedHostsClient.ListByHostGroup.
 type DedicatedHostsClientListByHostGroupResponse struct {
-	DedicatedHostsClientListByHostGroupResult
+	DedicatedHostListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostsClientListByHostGroupResult contains the result from method DedicatedHostsClient.ListByHostGroup.
-type DedicatedHostsClientListByHostGroupResult struct {
-	DedicatedHostListResult
 }
 
 // DedicatedHostsClientUpdatePollerResponse contains the response from method DedicatedHostsClient.Update.
@@ -457,14 +367,9 @@ func (l *DedicatedHostsClientUpdatePollerResponse) Resume(ctx context.Context, c
 
 // DedicatedHostsClientUpdateResponse contains the response from method DedicatedHostsClient.Update.
 type DedicatedHostsClientUpdateResponse struct {
-	DedicatedHostsClientUpdateResult
+	DedicatedHost
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DedicatedHostsClientUpdateResult contains the result from method DedicatedHostsClient.Update.
-type DedicatedHostsClientUpdateResult struct {
-	DedicatedHost
 }
 
 // DiskEncryptionSetsClientCreateOrUpdatePollerResponse contains the response from method DiskEncryptionSetsClient.CreateOrUpdate.
@@ -509,14 +414,9 @@ func (l *DiskEncryptionSetsClientCreateOrUpdatePollerResponse) Resume(ctx contex
 
 // DiskEncryptionSetsClientCreateOrUpdateResponse contains the response from method DiskEncryptionSetsClient.CreateOrUpdate.
 type DiskEncryptionSetsClientCreateOrUpdateResponse struct {
-	DiskEncryptionSetsClientCreateOrUpdateResult
+	DiskEncryptionSet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DiskEncryptionSetsClientCreateOrUpdateResult contains the result from method DiskEncryptionSetsClient.CreateOrUpdate.
-type DiskEncryptionSetsClientCreateOrUpdateResult struct {
-	DiskEncryptionSet
 }
 
 // DiskEncryptionSetsClientDeletePollerResponse contains the response from method DiskEncryptionSetsClient.Delete.
@@ -567,38 +467,23 @@ type DiskEncryptionSetsClientDeleteResponse struct {
 
 // DiskEncryptionSetsClientGetResponse contains the response from method DiskEncryptionSetsClient.Get.
 type DiskEncryptionSetsClientGetResponse struct {
-	DiskEncryptionSetsClientGetResult
+	DiskEncryptionSet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DiskEncryptionSetsClientGetResult contains the result from method DiskEncryptionSetsClient.Get.
-type DiskEncryptionSetsClientGetResult struct {
-	DiskEncryptionSet
 }
 
 // DiskEncryptionSetsClientListByResourceGroupResponse contains the response from method DiskEncryptionSetsClient.ListByResourceGroup.
 type DiskEncryptionSetsClientListByResourceGroupResponse struct {
-	DiskEncryptionSetsClientListByResourceGroupResult
+	DiskEncryptionSetList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DiskEncryptionSetsClientListByResourceGroupResult contains the result from method DiskEncryptionSetsClient.ListByResourceGroup.
-type DiskEncryptionSetsClientListByResourceGroupResult struct {
-	DiskEncryptionSetList
 }
 
 // DiskEncryptionSetsClientListResponse contains the response from method DiskEncryptionSetsClient.List.
 type DiskEncryptionSetsClientListResponse struct {
-	DiskEncryptionSetsClientListResult
+	DiskEncryptionSetList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DiskEncryptionSetsClientListResult contains the result from method DiskEncryptionSetsClient.List.
-type DiskEncryptionSetsClientListResult struct {
-	DiskEncryptionSetList
 }
 
 // DiskEncryptionSetsClientUpdatePollerResponse contains the response from method DiskEncryptionSetsClient.Update.
@@ -643,14 +528,9 @@ func (l *DiskEncryptionSetsClientUpdatePollerResponse) Resume(ctx context.Contex
 
 // DiskEncryptionSetsClientUpdateResponse contains the response from method DiskEncryptionSetsClient.Update.
 type DiskEncryptionSetsClientUpdateResponse struct {
-	DiskEncryptionSetsClientUpdateResult
+	DiskEncryptionSet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DiskEncryptionSetsClientUpdateResult contains the result from method DiskEncryptionSetsClient.Update.
-type DiskEncryptionSetsClientUpdateResult struct {
-	DiskEncryptionSet
 }
 
 // DisksClientCreateOrUpdatePollerResponse contains the response from method DisksClient.CreateOrUpdate.
@@ -695,14 +575,9 @@ func (l *DisksClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, cl
 
 // DisksClientCreateOrUpdateResponse contains the response from method DisksClient.CreateOrUpdate.
 type DisksClientCreateOrUpdateResponse struct {
-	DisksClientCreateOrUpdateResult
+	Disk
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DisksClientCreateOrUpdateResult contains the result from method DisksClient.CreateOrUpdate.
-type DisksClientCreateOrUpdateResult struct {
-	Disk
 }
 
 // DisksClientDeletePollerResponse contains the response from method DisksClient.Delete.
@@ -753,14 +628,9 @@ type DisksClientDeleteResponse struct {
 
 // DisksClientGetResponse contains the response from method DisksClient.Get.
 type DisksClientGetResponse struct {
-	DisksClientGetResult
+	Disk
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DisksClientGetResult contains the result from method DisksClient.Get.
-type DisksClientGetResult struct {
-	Disk
 }
 
 // DisksClientGrantAccessPollerResponse contains the response from method DisksClient.GrantAccess.
@@ -805,38 +675,23 @@ func (l *DisksClientGrantAccessPollerResponse) Resume(ctx context.Context, clien
 
 // DisksClientGrantAccessResponse contains the response from method DisksClient.GrantAccess.
 type DisksClientGrantAccessResponse struct {
-	DisksClientGrantAccessResult
+	AccessURI
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DisksClientGrantAccessResult contains the result from method DisksClient.GrantAccess.
-type DisksClientGrantAccessResult struct {
-	AccessURI
 }
 
 // DisksClientListByResourceGroupResponse contains the response from method DisksClient.ListByResourceGroup.
 type DisksClientListByResourceGroupResponse struct {
-	DisksClientListByResourceGroupResult
+	DiskList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DisksClientListByResourceGroupResult contains the result from method DisksClient.ListByResourceGroup.
-type DisksClientListByResourceGroupResult struct {
-	DiskList
 }
 
 // DisksClientListResponse contains the response from method DisksClient.List.
 type DisksClientListResponse struct {
-	DisksClientListResult
+	DiskList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DisksClientListResult contains the result from method DisksClient.List.
-type DisksClientListResult struct {
-	DiskList
 }
 
 // DisksClientRevokeAccessPollerResponse contains the response from method DisksClient.RevokeAccess.
@@ -927,14 +782,9 @@ func (l *DisksClientUpdatePollerResponse) Resume(ctx context.Context, client *Di
 
 // DisksClientUpdateResponse contains the response from method DisksClient.Update.
 type DisksClientUpdateResponse struct {
-	DisksClientUpdateResult
+	Disk
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DisksClientUpdateResult contains the result from method DisksClient.Update.
-type DisksClientUpdateResult struct {
-	Disk
 }
 
 // GalleriesClientCreateOrUpdatePollerResponse contains the response from method GalleriesClient.CreateOrUpdate.
@@ -979,14 +829,9 @@ func (l *GalleriesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context
 
 // GalleriesClientCreateOrUpdateResponse contains the response from method GalleriesClient.CreateOrUpdate.
 type GalleriesClientCreateOrUpdateResponse struct {
-	GalleriesClientCreateOrUpdateResult
+	Gallery
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleriesClientCreateOrUpdateResult contains the result from method GalleriesClient.CreateOrUpdate.
-type GalleriesClientCreateOrUpdateResult struct {
-	Gallery
 }
 
 // GalleriesClientDeletePollerResponse contains the response from method GalleriesClient.Delete.
@@ -1037,38 +882,23 @@ type GalleriesClientDeleteResponse struct {
 
 // GalleriesClientGetResponse contains the response from method GalleriesClient.Get.
 type GalleriesClientGetResponse struct {
-	GalleriesClientGetResult
+	Gallery
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleriesClientGetResult contains the result from method GalleriesClient.Get.
-type GalleriesClientGetResult struct {
-	Gallery
 }
 
 // GalleriesClientListByResourceGroupResponse contains the response from method GalleriesClient.ListByResourceGroup.
 type GalleriesClientListByResourceGroupResponse struct {
-	GalleriesClientListByResourceGroupResult
+	GalleryList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleriesClientListByResourceGroupResult contains the result from method GalleriesClient.ListByResourceGroup.
-type GalleriesClientListByResourceGroupResult struct {
-	GalleryList
 }
 
 // GalleriesClientListResponse contains the response from method GalleriesClient.List.
 type GalleriesClientListResponse struct {
-	GalleriesClientListResult
+	GalleryList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleriesClientListResult contains the result from method GalleriesClient.List.
-type GalleriesClientListResult struct {
-	GalleryList
 }
 
 // GalleriesClientUpdatePollerResponse contains the response from method GalleriesClient.Update.
@@ -1113,14 +943,9 @@ func (l *GalleriesClientUpdatePollerResponse) Resume(ctx context.Context, client
 
 // GalleriesClientUpdateResponse contains the response from method GalleriesClient.Update.
 type GalleriesClientUpdateResponse struct {
-	GalleriesClientUpdateResult
+	Gallery
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleriesClientUpdateResult contains the result from method GalleriesClient.Update.
-type GalleriesClientUpdateResult struct {
-	Gallery
 }
 
 // GalleryApplicationVersionsClientCreateOrUpdatePollerResponse contains the response from method GalleryApplicationVersionsClient.CreateOrUpdate.
@@ -1165,14 +990,9 @@ func (l *GalleryApplicationVersionsClientCreateOrUpdatePollerResponse) Resume(ct
 
 // GalleryApplicationVersionsClientCreateOrUpdateResponse contains the response from method GalleryApplicationVersionsClient.CreateOrUpdate.
 type GalleryApplicationVersionsClientCreateOrUpdateResponse struct {
-	GalleryApplicationVersionsClientCreateOrUpdateResult
+	GalleryApplicationVersion
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryApplicationVersionsClientCreateOrUpdateResult contains the result from method GalleryApplicationVersionsClient.CreateOrUpdate.
-type GalleryApplicationVersionsClientCreateOrUpdateResult struct {
-	GalleryApplicationVersion
 }
 
 // GalleryApplicationVersionsClientDeletePollerResponse contains the response from method GalleryApplicationVersionsClient.Delete.
@@ -1223,26 +1043,16 @@ type GalleryApplicationVersionsClientDeleteResponse struct {
 
 // GalleryApplicationVersionsClientGetResponse contains the response from method GalleryApplicationVersionsClient.Get.
 type GalleryApplicationVersionsClientGetResponse struct {
-	GalleryApplicationVersionsClientGetResult
+	GalleryApplicationVersion
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryApplicationVersionsClientGetResult contains the result from method GalleryApplicationVersionsClient.Get.
-type GalleryApplicationVersionsClientGetResult struct {
-	GalleryApplicationVersion
 }
 
 // GalleryApplicationVersionsClientListByGalleryApplicationResponse contains the response from method GalleryApplicationVersionsClient.ListByGalleryApplication.
 type GalleryApplicationVersionsClientListByGalleryApplicationResponse struct {
-	GalleryApplicationVersionsClientListByGalleryApplicationResult
+	GalleryApplicationVersionList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryApplicationVersionsClientListByGalleryApplicationResult contains the result from method GalleryApplicationVersionsClient.ListByGalleryApplication.
-type GalleryApplicationVersionsClientListByGalleryApplicationResult struct {
-	GalleryApplicationVersionList
 }
 
 // GalleryApplicationVersionsClientUpdatePollerResponse contains the response from method GalleryApplicationVersionsClient.Update.
@@ -1287,14 +1097,9 @@ func (l *GalleryApplicationVersionsClientUpdatePollerResponse) Resume(ctx contex
 
 // GalleryApplicationVersionsClientUpdateResponse contains the response from method GalleryApplicationVersionsClient.Update.
 type GalleryApplicationVersionsClientUpdateResponse struct {
-	GalleryApplicationVersionsClientUpdateResult
+	GalleryApplicationVersion
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryApplicationVersionsClientUpdateResult contains the result from method GalleryApplicationVersionsClient.Update.
-type GalleryApplicationVersionsClientUpdateResult struct {
-	GalleryApplicationVersion
 }
 
 // GalleryApplicationsClientCreateOrUpdatePollerResponse contains the response from method GalleryApplicationsClient.CreateOrUpdate.
@@ -1339,14 +1144,9 @@ func (l *GalleryApplicationsClientCreateOrUpdatePollerResponse) Resume(ctx conte
 
 // GalleryApplicationsClientCreateOrUpdateResponse contains the response from method GalleryApplicationsClient.CreateOrUpdate.
 type GalleryApplicationsClientCreateOrUpdateResponse struct {
-	GalleryApplicationsClientCreateOrUpdateResult
+	GalleryApplication
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryApplicationsClientCreateOrUpdateResult contains the result from method GalleryApplicationsClient.CreateOrUpdate.
-type GalleryApplicationsClientCreateOrUpdateResult struct {
-	GalleryApplication
 }
 
 // GalleryApplicationsClientDeletePollerResponse contains the response from method GalleryApplicationsClient.Delete.
@@ -1397,26 +1197,16 @@ type GalleryApplicationsClientDeleteResponse struct {
 
 // GalleryApplicationsClientGetResponse contains the response from method GalleryApplicationsClient.Get.
 type GalleryApplicationsClientGetResponse struct {
-	GalleryApplicationsClientGetResult
+	GalleryApplication
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryApplicationsClientGetResult contains the result from method GalleryApplicationsClient.Get.
-type GalleryApplicationsClientGetResult struct {
-	GalleryApplication
 }
 
 // GalleryApplicationsClientListByGalleryResponse contains the response from method GalleryApplicationsClient.ListByGallery.
 type GalleryApplicationsClientListByGalleryResponse struct {
-	GalleryApplicationsClientListByGalleryResult
+	GalleryApplicationList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryApplicationsClientListByGalleryResult contains the result from method GalleryApplicationsClient.ListByGallery.
-type GalleryApplicationsClientListByGalleryResult struct {
-	GalleryApplicationList
 }
 
 // GalleryApplicationsClientUpdatePollerResponse contains the response from method GalleryApplicationsClient.Update.
@@ -1461,14 +1251,9 @@ func (l *GalleryApplicationsClientUpdatePollerResponse) Resume(ctx context.Conte
 
 // GalleryApplicationsClientUpdateResponse contains the response from method GalleryApplicationsClient.Update.
 type GalleryApplicationsClientUpdateResponse struct {
-	GalleryApplicationsClientUpdateResult
+	GalleryApplication
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryApplicationsClientUpdateResult contains the result from method GalleryApplicationsClient.Update.
-type GalleryApplicationsClientUpdateResult struct {
-	GalleryApplication
 }
 
 // GalleryImageVersionsClientCreateOrUpdatePollerResponse contains the response from method GalleryImageVersionsClient.CreateOrUpdate.
@@ -1513,14 +1298,9 @@ func (l *GalleryImageVersionsClientCreateOrUpdatePollerResponse) Resume(ctx cont
 
 // GalleryImageVersionsClientCreateOrUpdateResponse contains the response from method GalleryImageVersionsClient.CreateOrUpdate.
 type GalleryImageVersionsClientCreateOrUpdateResponse struct {
-	GalleryImageVersionsClientCreateOrUpdateResult
+	GalleryImageVersion
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryImageVersionsClientCreateOrUpdateResult contains the result from method GalleryImageVersionsClient.CreateOrUpdate.
-type GalleryImageVersionsClientCreateOrUpdateResult struct {
-	GalleryImageVersion
 }
 
 // GalleryImageVersionsClientDeletePollerResponse contains the response from method GalleryImageVersionsClient.Delete.
@@ -1571,26 +1351,16 @@ type GalleryImageVersionsClientDeleteResponse struct {
 
 // GalleryImageVersionsClientGetResponse contains the response from method GalleryImageVersionsClient.Get.
 type GalleryImageVersionsClientGetResponse struct {
-	GalleryImageVersionsClientGetResult
+	GalleryImageVersion
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryImageVersionsClientGetResult contains the result from method GalleryImageVersionsClient.Get.
-type GalleryImageVersionsClientGetResult struct {
-	GalleryImageVersion
 }
 
 // GalleryImageVersionsClientListByGalleryImageResponse contains the response from method GalleryImageVersionsClient.ListByGalleryImage.
 type GalleryImageVersionsClientListByGalleryImageResponse struct {
-	GalleryImageVersionsClientListByGalleryImageResult
+	GalleryImageVersionList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryImageVersionsClientListByGalleryImageResult contains the result from method GalleryImageVersionsClient.ListByGalleryImage.
-type GalleryImageVersionsClientListByGalleryImageResult struct {
-	GalleryImageVersionList
 }
 
 // GalleryImageVersionsClientUpdatePollerResponse contains the response from method GalleryImageVersionsClient.Update.
@@ -1635,14 +1405,9 @@ func (l *GalleryImageVersionsClientUpdatePollerResponse) Resume(ctx context.Cont
 
 // GalleryImageVersionsClientUpdateResponse contains the response from method GalleryImageVersionsClient.Update.
 type GalleryImageVersionsClientUpdateResponse struct {
-	GalleryImageVersionsClientUpdateResult
+	GalleryImageVersion
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryImageVersionsClientUpdateResult contains the result from method GalleryImageVersionsClient.Update.
-type GalleryImageVersionsClientUpdateResult struct {
-	GalleryImageVersion
 }
 
 // GalleryImagesClientCreateOrUpdatePollerResponse contains the response from method GalleryImagesClient.CreateOrUpdate.
@@ -1687,14 +1452,9 @@ func (l *GalleryImagesClientCreateOrUpdatePollerResponse) Resume(ctx context.Con
 
 // GalleryImagesClientCreateOrUpdateResponse contains the response from method GalleryImagesClient.CreateOrUpdate.
 type GalleryImagesClientCreateOrUpdateResponse struct {
-	GalleryImagesClientCreateOrUpdateResult
+	GalleryImage
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryImagesClientCreateOrUpdateResult contains the result from method GalleryImagesClient.CreateOrUpdate.
-type GalleryImagesClientCreateOrUpdateResult struct {
-	GalleryImage
 }
 
 // GalleryImagesClientDeletePollerResponse contains the response from method GalleryImagesClient.Delete.
@@ -1745,26 +1505,16 @@ type GalleryImagesClientDeleteResponse struct {
 
 // GalleryImagesClientGetResponse contains the response from method GalleryImagesClient.Get.
 type GalleryImagesClientGetResponse struct {
-	GalleryImagesClientGetResult
+	GalleryImage
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryImagesClientGetResult contains the result from method GalleryImagesClient.Get.
-type GalleryImagesClientGetResult struct {
-	GalleryImage
 }
 
 // GalleryImagesClientListByGalleryResponse contains the response from method GalleryImagesClient.ListByGallery.
 type GalleryImagesClientListByGalleryResponse struct {
-	GalleryImagesClientListByGalleryResult
+	GalleryImageList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryImagesClientListByGalleryResult contains the result from method GalleryImagesClient.ListByGallery.
-type GalleryImagesClientListByGalleryResult struct {
-	GalleryImageList
 }
 
 // GalleryImagesClientUpdatePollerResponse contains the response from method GalleryImagesClient.Update.
@@ -1809,14 +1559,9 @@ func (l *GalleryImagesClientUpdatePollerResponse) Resume(ctx context.Context, cl
 
 // GalleryImagesClientUpdateResponse contains the response from method GalleryImagesClient.Update.
 type GalleryImagesClientUpdateResponse struct {
-	GalleryImagesClientUpdateResult
+	GalleryImage
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// GalleryImagesClientUpdateResult contains the result from method GalleryImagesClient.Update.
-type GalleryImagesClientUpdateResult struct {
-	GalleryImage
 }
 
 // ImagesClientCreateOrUpdatePollerResponse contains the response from method ImagesClient.CreateOrUpdate.
@@ -1861,14 +1606,9 @@ func (l *ImagesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 
 // ImagesClientCreateOrUpdateResponse contains the response from method ImagesClient.CreateOrUpdate.
 type ImagesClientCreateOrUpdateResponse struct {
-	ImagesClientCreateOrUpdateResult
+	Image
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ImagesClientCreateOrUpdateResult contains the result from method ImagesClient.CreateOrUpdate.
-type ImagesClientCreateOrUpdateResult struct {
-	Image
 }
 
 // ImagesClientDeletePollerResponse contains the response from method ImagesClient.Delete.
@@ -1919,38 +1659,23 @@ type ImagesClientDeleteResponse struct {
 
 // ImagesClientGetResponse contains the response from method ImagesClient.Get.
 type ImagesClientGetResponse struct {
-	ImagesClientGetResult
+	Image
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ImagesClientGetResult contains the result from method ImagesClient.Get.
-type ImagesClientGetResult struct {
-	Image
 }
 
 // ImagesClientListByResourceGroupResponse contains the response from method ImagesClient.ListByResourceGroup.
 type ImagesClientListByResourceGroupResponse struct {
-	ImagesClientListByResourceGroupResult
+	ImageListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ImagesClientListByResourceGroupResult contains the result from method ImagesClient.ListByResourceGroup.
-type ImagesClientListByResourceGroupResult struct {
-	ImageListResult
 }
 
 // ImagesClientListResponse contains the response from method ImagesClient.List.
 type ImagesClientListResponse struct {
-	ImagesClientListResult
+	ImageListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ImagesClientListResult contains the result from method ImagesClient.List.
-type ImagesClientListResult struct {
-	ImageListResult
 }
 
 // ImagesClientUpdatePollerResponse contains the response from method ImagesClient.Update.
@@ -1995,14 +1720,9 @@ func (l *ImagesClientUpdatePollerResponse) Resume(ctx context.Context, client *I
 
 // ImagesClientUpdateResponse contains the response from method ImagesClient.Update.
 type ImagesClientUpdateResponse struct {
-	ImagesClientUpdateResult
+	Image
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ImagesClientUpdateResult contains the result from method ImagesClient.Update.
-type ImagesClientUpdateResult struct {
-	Image
 }
 
 // LogAnalyticsClientExportRequestRateByIntervalPollerResponse contains the response from method LogAnalyticsClient.ExportRequestRateByInterval.
@@ -2047,14 +1767,9 @@ func (l *LogAnalyticsClientExportRequestRateByIntervalPollerResponse) Resume(ctx
 
 // LogAnalyticsClientExportRequestRateByIntervalResponse contains the response from method LogAnalyticsClient.ExportRequestRateByInterval.
 type LogAnalyticsClientExportRequestRateByIntervalResponse struct {
-	LogAnalyticsClientExportRequestRateByIntervalResult
+	LogAnalyticsOperationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LogAnalyticsClientExportRequestRateByIntervalResult contains the result from method LogAnalyticsClient.ExportRequestRateByInterval.
-type LogAnalyticsClientExportRequestRateByIntervalResult struct {
-	LogAnalyticsOperationResult
 }
 
 // LogAnalyticsClientExportThrottledRequestsPollerResponse contains the response from method LogAnalyticsClient.ExportThrottledRequests.
@@ -2099,38 +1814,23 @@ func (l *LogAnalyticsClientExportThrottledRequestsPollerResponse) Resume(ctx con
 
 // LogAnalyticsClientExportThrottledRequestsResponse contains the response from method LogAnalyticsClient.ExportThrottledRequests.
 type LogAnalyticsClientExportThrottledRequestsResponse struct {
-	LogAnalyticsClientExportThrottledRequestsResult
+	LogAnalyticsOperationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LogAnalyticsClientExportThrottledRequestsResult contains the result from method LogAnalyticsClient.ExportThrottledRequests.
-type LogAnalyticsClientExportThrottledRequestsResult struct {
-	LogAnalyticsOperationResult
 }
 
 // OperationsClientListResponse contains the response from method OperationsClient.List.
 type OperationsClientListResponse struct {
-	OperationsClientListResult
+	OperationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OperationsClientListResult contains the result from method OperationsClient.List.
-type OperationsClientListResult struct {
-	OperationListResult
 }
 
 // ProximityPlacementGroupsClientCreateOrUpdateResponse contains the response from method ProximityPlacementGroupsClient.CreateOrUpdate.
 type ProximityPlacementGroupsClientCreateOrUpdateResponse struct {
-	ProximityPlacementGroupsClientCreateOrUpdateResult
+	ProximityPlacementGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProximityPlacementGroupsClientCreateOrUpdateResult contains the result from method ProximityPlacementGroupsClient.CreateOrUpdate.
-type ProximityPlacementGroupsClientCreateOrUpdateResult struct {
-	ProximityPlacementGroup
 }
 
 // ProximityPlacementGroupsClientDeleteResponse contains the response from method ProximityPlacementGroupsClient.Delete.
@@ -2141,74 +1841,44 @@ type ProximityPlacementGroupsClientDeleteResponse struct {
 
 // ProximityPlacementGroupsClientGetResponse contains the response from method ProximityPlacementGroupsClient.Get.
 type ProximityPlacementGroupsClientGetResponse struct {
-	ProximityPlacementGroupsClientGetResult
+	ProximityPlacementGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProximityPlacementGroupsClientGetResult contains the result from method ProximityPlacementGroupsClient.Get.
-type ProximityPlacementGroupsClientGetResult struct {
-	ProximityPlacementGroup
 }
 
 // ProximityPlacementGroupsClientListByResourceGroupResponse contains the response from method ProximityPlacementGroupsClient.ListByResourceGroup.
 type ProximityPlacementGroupsClientListByResourceGroupResponse struct {
-	ProximityPlacementGroupsClientListByResourceGroupResult
+	ProximityPlacementGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProximityPlacementGroupsClientListByResourceGroupResult contains the result from method ProximityPlacementGroupsClient.ListByResourceGroup.
-type ProximityPlacementGroupsClientListByResourceGroupResult struct {
-	ProximityPlacementGroupListResult
 }
 
 // ProximityPlacementGroupsClientListBySubscriptionResponse contains the response from method ProximityPlacementGroupsClient.ListBySubscription.
 type ProximityPlacementGroupsClientListBySubscriptionResponse struct {
-	ProximityPlacementGroupsClientListBySubscriptionResult
+	ProximityPlacementGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProximityPlacementGroupsClientListBySubscriptionResult contains the result from method ProximityPlacementGroupsClient.ListBySubscription.
-type ProximityPlacementGroupsClientListBySubscriptionResult struct {
-	ProximityPlacementGroupListResult
 }
 
 // ProximityPlacementGroupsClientUpdateResponse contains the response from method ProximityPlacementGroupsClient.Update.
 type ProximityPlacementGroupsClientUpdateResponse struct {
-	ProximityPlacementGroupsClientUpdateResult
+	ProximityPlacementGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProximityPlacementGroupsClientUpdateResult contains the result from method ProximityPlacementGroupsClient.Update.
-type ProximityPlacementGroupsClientUpdateResult struct {
-	ProximityPlacementGroup
 }
 
 // ResourceSKUsClientListResponse contains the response from method ResourceSKUsClient.List.
 type ResourceSKUsClientListResponse struct {
-	ResourceSKUsClientListResult
+	ResourceSKUsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ResourceSKUsClientListResult contains the result from method ResourceSKUsClient.List.
-type ResourceSKUsClientListResult struct {
-	ResourceSKUsResult
 }
 
 // SSHPublicKeysClientCreateResponse contains the response from method SSHPublicKeysClient.Create.
 type SSHPublicKeysClientCreateResponse struct {
-	SSHPublicKeysClientCreateResult
+	SSHPublicKeyResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SSHPublicKeysClientCreateResult contains the result from method SSHPublicKeysClient.Create.
-type SSHPublicKeysClientCreateResult struct {
-	SSHPublicKeyResource
 }
 
 // SSHPublicKeysClientDeleteResponse contains the response from method SSHPublicKeysClient.Delete.
@@ -2219,62 +1889,37 @@ type SSHPublicKeysClientDeleteResponse struct {
 
 // SSHPublicKeysClientGenerateKeyPairResponse contains the response from method SSHPublicKeysClient.GenerateKeyPair.
 type SSHPublicKeysClientGenerateKeyPairResponse struct {
-	SSHPublicKeysClientGenerateKeyPairResult
+	SSHPublicKeyGenerateKeyPairResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SSHPublicKeysClientGenerateKeyPairResult contains the result from method SSHPublicKeysClient.GenerateKeyPair.
-type SSHPublicKeysClientGenerateKeyPairResult struct {
-	SSHPublicKeyGenerateKeyPairResult
 }
 
 // SSHPublicKeysClientGetResponse contains the response from method SSHPublicKeysClient.Get.
 type SSHPublicKeysClientGetResponse struct {
-	SSHPublicKeysClientGetResult
+	SSHPublicKeyResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SSHPublicKeysClientGetResult contains the result from method SSHPublicKeysClient.Get.
-type SSHPublicKeysClientGetResult struct {
-	SSHPublicKeyResource
 }
 
 // SSHPublicKeysClientListByResourceGroupResponse contains the response from method SSHPublicKeysClient.ListByResourceGroup.
 type SSHPublicKeysClientListByResourceGroupResponse struct {
-	SSHPublicKeysClientListByResourceGroupResult
+	SSHPublicKeysGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SSHPublicKeysClientListByResourceGroupResult contains the result from method SSHPublicKeysClient.ListByResourceGroup.
-type SSHPublicKeysClientListByResourceGroupResult struct {
-	SSHPublicKeysGroupListResult
 }
 
 // SSHPublicKeysClientListBySubscriptionResponse contains the response from method SSHPublicKeysClient.ListBySubscription.
 type SSHPublicKeysClientListBySubscriptionResponse struct {
-	SSHPublicKeysClientListBySubscriptionResult
+	SSHPublicKeysGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SSHPublicKeysClientListBySubscriptionResult contains the result from method SSHPublicKeysClient.ListBySubscription.
-type SSHPublicKeysClientListBySubscriptionResult struct {
-	SSHPublicKeysGroupListResult
 }
 
 // SSHPublicKeysClientUpdateResponse contains the response from method SSHPublicKeysClient.Update.
 type SSHPublicKeysClientUpdateResponse struct {
-	SSHPublicKeysClientUpdateResult
+	SSHPublicKeyResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SSHPublicKeysClientUpdateResult contains the result from method SSHPublicKeysClient.Update.
-type SSHPublicKeysClientUpdateResult struct {
-	SSHPublicKeyResource
 }
 
 // SnapshotsClientCreateOrUpdatePollerResponse contains the response from method SnapshotsClient.CreateOrUpdate.
@@ -2319,14 +1964,9 @@ func (l *SnapshotsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context
 
 // SnapshotsClientCreateOrUpdateResponse contains the response from method SnapshotsClient.CreateOrUpdate.
 type SnapshotsClientCreateOrUpdateResponse struct {
-	SnapshotsClientCreateOrUpdateResult
+	Snapshot
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SnapshotsClientCreateOrUpdateResult contains the result from method SnapshotsClient.CreateOrUpdate.
-type SnapshotsClientCreateOrUpdateResult struct {
-	Snapshot
 }
 
 // SnapshotsClientDeletePollerResponse contains the response from method SnapshotsClient.Delete.
@@ -2377,14 +2017,9 @@ type SnapshotsClientDeleteResponse struct {
 
 // SnapshotsClientGetResponse contains the response from method SnapshotsClient.Get.
 type SnapshotsClientGetResponse struct {
-	SnapshotsClientGetResult
+	Snapshot
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SnapshotsClientGetResult contains the result from method SnapshotsClient.Get.
-type SnapshotsClientGetResult struct {
-	Snapshot
 }
 
 // SnapshotsClientGrantAccessPollerResponse contains the response from method SnapshotsClient.GrantAccess.
@@ -2429,38 +2064,23 @@ func (l *SnapshotsClientGrantAccessPollerResponse) Resume(ctx context.Context, c
 
 // SnapshotsClientGrantAccessResponse contains the response from method SnapshotsClient.GrantAccess.
 type SnapshotsClientGrantAccessResponse struct {
-	SnapshotsClientGrantAccessResult
+	AccessURI
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SnapshotsClientGrantAccessResult contains the result from method SnapshotsClient.GrantAccess.
-type SnapshotsClientGrantAccessResult struct {
-	AccessURI
 }
 
 // SnapshotsClientListByResourceGroupResponse contains the response from method SnapshotsClient.ListByResourceGroup.
 type SnapshotsClientListByResourceGroupResponse struct {
-	SnapshotsClientListByResourceGroupResult
+	SnapshotList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SnapshotsClientListByResourceGroupResult contains the result from method SnapshotsClient.ListByResourceGroup.
-type SnapshotsClientListByResourceGroupResult struct {
-	SnapshotList
 }
 
 // SnapshotsClientListResponse contains the response from method SnapshotsClient.List.
 type SnapshotsClientListResponse struct {
-	SnapshotsClientListResult
+	SnapshotList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SnapshotsClientListResult contains the result from method SnapshotsClient.List.
-type SnapshotsClientListResult struct {
-	SnapshotList
 }
 
 // SnapshotsClientRevokeAccessPollerResponse contains the response from method SnapshotsClient.RevokeAccess.
@@ -2551,62 +2171,39 @@ func (l *SnapshotsClientUpdatePollerResponse) Resume(ctx context.Context, client
 
 // SnapshotsClientUpdateResponse contains the response from method SnapshotsClient.Update.
 type SnapshotsClientUpdateResponse struct {
-	SnapshotsClientUpdateResult
+	Snapshot
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SnapshotsClientUpdateResult contains the result from method SnapshotsClient.Update.
-type SnapshotsClientUpdateResult struct {
-	Snapshot
 }
 
 // UsageClientListResponse contains the response from method UsageClient.List.
 type UsageClientListResponse struct {
-	UsageClientListResult
+	ListUsagesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// UsageClientListResult contains the result from method UsageClient.List.
-type UsageClientListResult struct {
-	ListUsagesResult
 }
 
 // VirtualMachineExtensionImagesClientGetResponse contains the response from method VirtualMachineExtensionImagesClient.Get.
 type VirtualMachineExtensionImagesClientGetResponse struct {
-	VirtualMachineExtensionImagesClientGetResult
+	VirtualMachineExtensionImage
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineExtensionImagesClientGetResult contains the result from method VirtualMachineExtensionImagesClient.Get.
-type VirtualMachineExtensionImagesClientGetResult struct {
-	VirtualMachineExtensionImage
 }
 
 // VirtualMachineExtensionImagesClientListTypesResponse contains the response from method VirtualMachineExtensionImagesClient.ListTypes.
 type VirtualMachineExtensionImagesClientListTypesResponse struct {
-	VirtualMachineExtensionImagesClientListTypesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// VirtualMachineExtensionImagesClientListTypesResult contains the result from method VirtualMachineExtensionImagesClient.ListTypes.
-type VirtualMachineExtensionImagesClientListTypesResult struct {
 	// Array of VirtualMachineExtensionImage
 	VirtualMachineExtensionImageArray []*VirtualMachineExtensionImage
 }
 
 // VirtualMachineExtensionImagesClientListVersionsResponse contains the response from method VirtualMachineExtensionImagesClient.ListVersions.
 type VirtualMachineExtensionImagesClientListVersionsResponse struct {
-	VirtualMachineExtensionImagesClientListVersionsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// VirtualMachineExtensionImagesClientListVersionsResult contains the result from method VirtualMachineExtensionImagesClient.ListVersions.
-type VirtualMachineExtensionImagesClientListVersionsResult struct {
 	// Array of VirtualMachineExtensionImage
 	VirtualMachineExtensionImageArray []*VirtualMachineExtensionImage
 }
@@ -2653,14 +2250,9 @@ func (l *VirtualMachineExtensionsClientCreateOrUpdatePollerResponse) Resume(ctx 
 
 // VirtualMachineExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineExtensionsClient.CreateOrUpdate.
 type VirtualMachineExtensionsClientCreateOrUpdateResponse struct {
-	VirtualMachineExtensionsClientCreateOrUpdateResult
+	VirtualMachineExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineExtensionsClientCreateOrUpdateResult contains the result from method VirtualMachineExtensionsClient.CreateOrUpdate.
-type VirtualMachineExtensionsClientCreateOrUpdateResult struct {
-	VirtualMachineExtension
 }
 
 // VirtualMachineExtensionsClientDeletePollerResponse contains the response from method VirtualMachineExtensionsClient.Delete.
@@ -2711,26 +2303,16 @@ type VirtualMachineExtensionsClientDeleteResponse struct {
 
 // VirtualMachineExtensionsClientGetResponse contains the response from method VirtualMachineExtensionsClient.Get.
 type VirtualMachineExtensionsClientGetResponse struct {
-	VirtualMachineExtensionsClientGetResult
+	VirtualMachineExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineExtensionsClientGetResult contains the result from method VirtualMachineExtensionsClient.Get.
-type VirtualMachineExtensionsClientGetResult struct {
-	VirtualMachineExtension
 }
 
 // VirtualMachineExtensionsClientListResponse contains the response from method VirtualMachineExtensionsClient.List.
 type VirtualMachineExtensionsClientListResponse struct {
-	VirtualMachineExtensionsClientListResult
+	VirtualMachineExtensionsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineExtensionsClientListResult contains the result from method VirtualMachineExtensionsClient.List.
-type VirtualMachineExtensionsClientListResult struct {
-	VirtualMachineExtensionsListResult
 }
 
 // VirtualMachineExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineExtensionsClient.Update.
@@ -2775,102 +2357,66 @@ func (l *VirtualMachineExtensionsClientUpdatePollerResponse) Resume(ctx context.
 
 // VirtualMachineExtensionsClientUpdateResponse contains the response from method VirtualMachineExtensionsClient.Update.
 type VirtualMachineExtensionsClientUpdateResponse struct {
-	VirtualMachineExtensionsClientUpdateResult
+	VirtualMachineExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineExtensionsClientUpdateResult contains the result from method VirtualMachineExtensionsClient.Update.
-type VirtualMachineExtensionsClientUpdateResult struct {
-	VirtualMachineExtension
 }
 
 // VirtualMachineImagesClientGetResponse contains the response from method VirtualMachineImagesClient.Get.
 type VirtualMachineImagesClientGetResponse struct {
-	VirtualMachineImagesClientGetResult
+	VirtualMachineImage
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineImagesClientGetResult contains the result from method VirtualMachineImagesClient.Get.
-type VirtualMachineImagesClientGetResult struct {
-	VirtualMachineImage
 }
 
 // VirtualMachineImagesClientListOffersResponse contains the response from method VirtualMachineImagesClient.ListOffers.
 type VirtualMachineImagesClientListOffersResponse struct {
-	VirtualMachineImagesClientListOffersResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// VirtualMachineImagesClientListOffersResult contains the result from method VirtualMachineImagesClient.ListOffers.
-type VirtualMachineImagesClientListOffersResult struct {
 	// Array of VirtualMachineImageResource
 	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
 
 // VirtualMachineImagesClientListPublishersResponse contains the response from method VirtualMachineImagesClient.ListPublishers.
 type VirtualMachineImagesClientListPublishersResponse struct {
-	VirtualMachineImagesClientListPublishersResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// VirtualMachineImagesClientListPublishersResult contains the result from method VirtualMachineImagesClient.ListPublishers.
-type VirtualMachineImagesClientListPublishersResult struct {
 	// Array of VirtualMachineImageResource
 	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
 
 // VirtualMachineImagesClientListResponse contains the response from method VirtualMachineImagesClient.List.
 type VirtualMachineImagesClientListResponse struct {
-	VirtualMachineImagesClientListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// VirtualMachineImagesClientListResult contains the result from method VirtualMachineImagesClient.List.
-type VirtualMachineImagesClientListResult struct {
 	// Array of VirtualMachineImageResource
 	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
 
 // VirtualMachineImagesClientListSKUsResponse contains the response from method VirtualMachineImagesClient.ListSKUs.
 type VirtualMachineImagesClientListSKUsResponse struct {
-	VirtualMachineImagesClientListSKUsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// VirtualMachineImagesClientListSKUsResult contains the result from method VirtualMachineImagesClient.ListSKUs.
-type VirtualMachineImagesClientListSKUsResult struct {
 	// Array of VirtualMachineImageResource
 	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
 
 // VirtualMachineRunCommandsClientGetResponse contains the response from method VirtualMachineRunCommandsClient.Get.
 type VirtualMachineRunCommandsClientGetResponse struct {
-	VirtualMachineRunCommandsClientGetResult
+	RunCommandDocument
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineRunCommandsClientGetResult contains the result from method VirtualMachineRunCommandsClient.Get.
-type VirtualMachineRunCommandsClientGetResult struct {
-	RunCommandDocument
 }
 
 // VirtualMachineRunCommandsClientListResponse contains the response from method VirtualMachineRunCommandsClient.List.
 type VirtualMachineRunCommandsClientListResponse struct {
-	VirtualMachineRunCommandsClientListResult
+	RunCommandListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineRunCommandsClientListResult contains the result from method VirtualMachineRunCommandsClient.List.
-type VirtualMachineRunCommandsClientListResult struct {
-	RunCommandListResult
 }
 
 // VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.CreateOrUpdate.
@@ -2916,14 +2462,9 @@ func (l *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse) Res
 
 // VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetExtensionsClient.CreateOrUpdate.
 type VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse struct {
-	VirtualMachineScaleSetExtensionsClientCreateOrUpdateResult
+	VirtualMachineScaleSetExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetExtensionsClientCreateOrUpdateResult contains the result from method VirtualMachineScaleSetExtensionsClient.CreateOrUpdate.
-type VirtualMachineScaleSetExtensionsClientCreateOrUpdateResult struct {
-	VirtualMachineScaleSetExtension
 }
 
 // VirtualMachineScaleSetExtensionsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Delete.
@@ -2974,26 +2515,16 @@ type VirtualMachineScaleSetExtensionsClientDeleteResponse struct {
 
 // VirtualMachineScaleSetExtensionsClientGetResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Get.
 type VirtualMachineScaleSetExtensionsClientGetResponse struct {
-	VirtualMachineScaleSetExtensionsClientGetResult
+	VirtualMachineScaleSetExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetExtensionsClientGetResult contains the result from method VirtualMachineScaleSetExtensionsClient.Get.
-type VirtualMachineScaleSetExtensionsClientGetResult struct {
-	VirtualMachineScaleSetExtension
 }
 
 // VirtualMachineScaleSetExtensionsClientListResponse contains the response from method VirtualMachineScaleSetExtensionsClient.List.
 type VirtualMachineScaleSetExtensionsClientListResponse struct {
-	VirtualMachineScaleSetExtensionsClientListResult
+	VirtualMachineScaleSetExtensionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetExtensionsClientListResult contains the result from method VirtualMachineScaleSetExtensionsClient.List.
-type VirtualMachineScaleSetExtensionsClientListResult struct {
-	VirtualMachineScaleSetExtensionListResult
 }
 
 // VirtualMachineScaleSetExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Update.
@@ -3038,14 +2569,9 @@ func (l *VirtualMachineScaleSetExtensionsClientUpdatePollerResponse) Resume(ctx 
 
 // VirtualMachineScaleSetExtensionsClientUpdateResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Update.
 type VirtualMachineScaleSetExtensionsClientUpdateResponse struct {
-	VirtualMachineScaleSetExtensionsClientUpdateResult
+	VirtualMachineScaleSetExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetExtensionsClientUpdateResult contains the result from method VirtualMachineScaleSetExtensionsClient.Update.
-type VirtualMachineScaleSetExtensionsClientUpdateResult struct {
-	VirtualMachineScaleSetExtension
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.Cancel.
@@ -3097,14 +2623,9 @@ type VirtualMachineScaleSetRollingUpgradesClientCancelResponse struct {
 
 // VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.GetLatest.
 type VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse struct {
-	VirtualMachineScaleSetRollingUpgradesClientGetLatestResult
+	RollingUpgradeStatusInfo
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetRollingUpgradesClientGetLatestResult contains the result from method VirtualMachineScaleSetRollingUpgradesClient.GetLatest.
-type VirtualMachineScaleSetRollingUpgradesClientGetLatestResult struct {
-	RollingUpgradeStatusInfo
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade.
@@ -3244,14 +2765,9 @@ func (l *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse) R
 
 // VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate.
 type VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse struct {
-	VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResult
+	VirtualMachineExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResult contains the result from method VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate.
-type VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResult struct {
-	VirtualMachineExtension
 }
 
 // VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Delete.
@@ -3302,26 +2818,16 @@ type VirtualMachineScaleSetVMExtensionsClientDeleteResponse struct {
 
 // VirtualMachineScaleSetVMExtensionsClientGetResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Get.
 type VirtualMachineScaleSetVMExtensionsClientGetResponse struct {
-	VirtualMachineScaleSetVMExtensionsClientGetResult
+	VirtualMachineExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMExtensionsClientGetResult contains the result from method VirtualMachineScaleSetVMExtensionsClient.Get.
-type VirtualMachineScaleSetVMExtensionsClientGetResult struct {
-	VirtualMachineExtension
 }
 
 // VirtualMachineScaleSetVMExtensionsClientListResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.List.
 type VirtualMachineScaleSetVMExtensionsClientListResponse struct {
-	VirtualMachineScaleSetVMExtensionsClientListResult
+	VirtualMachineExtensionsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMExtensionsClientListResult contains the result from method VirtualMachineScaleSetVMExtensionsClient.List.
-type VirtualMachineScaleSetVMExtensionsClientListResult struct {
-	VirtualMachineExtensionsListResult
 }
 
 // VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Update.
@@ -3366,14 +2872,9 @@ func (l *VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse) Resume(ct
 
 // VirtualMachineScaleSetVMExtensionsClientUpdateResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Update.
 type VirtualMachineScaleSetVMExtensionsClientUpdateResponse struct {
-	VirtualMachineScaleSetVMExtensionsClientUpdateResult
+	VirtualMachineExtension
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMExtensionsClientUpdateResult contains the result from method VirtualMachineScaleSetVMExtensionsClient.Update.
-type VirtualMachineScaleSetVMExtensionsClientUpdateResult struct {
-	VirtualMachineExtension
 }
 
 // VirtualMachineScaleSetVMsClientDeallocatePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Deallocate.
@@ -3470,38 +2971,23 @@ type VirtualMachineScaleSetVMsClientDeleteResponse struct {
 
 // VirtualMachineScaleSetVMsClientGetInstanceViewResponse contains the response from method VirtualMachineScaleSetVMsClient.GetInstanceView.
 type VirtualMachineScaleSetVMsClientGetInstanceViewResponse struct {
-	VirtualMachineScaleSetVMsClientGetInstanceViewResult
+	VirtualMachineScaleSetVMInstanceView
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMsClientGetInstanceViewResult contains the result from method VirtualMachineScaleSetVMsClient.GetInstanceView.
-type VirtualMachineScaleSetVMsClientGetInstanceViewResult struct {
-	VirtualMachineScaleSetVMInstanceView
 }
 
 // VirtualMachineScaleSetVMsClientGetResponse contains the response from method VirtualMachineScaleSetVMsClient.Get.
 type VirtualMachineScaleSetVMsClientGetResponse struct {
-	VirtualMachineScaleSetVMsClientGetResult
+	VirtualMachineScaleSetVM
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMsClientGetResult contains the result from method VirtualMachineScaleSetVMsClient.Get.
-type VirtualMachineScaleSetVMsClientGetResult struct {
-	VirtualMachineScaleSetVM
 }
 
 // VirtualMachineScaleSetVMsClientListResponse contains the response from method VirtualMachineScaleSetVMsClient.List.
 type VirtualMachineScaleSetVMsClientListResponse struct {
-	VirtualMachineScaleSetVMsClientListResult
+	VirtualMachineScaleSetVMListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMsClientListResult contains the result from method VirtualMachineScaleSetVMsClient.List.
-type VirtualMachineScaleSetVMsClientListResult struct {
-	VirtualMachineScaleSetVMListResult
 }
 
 // VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.PerformMaintenance.
@@ -3823,14 +3309,9 @@ func (l *VirtualMachineScaleSetVMsClientRunCommandPollerResponse) Resume(ctx con
 
 // VirtualMachineScaleSetVMsClientRunCommandResponse contains the response from method VirtualMachineScaleSetVMsClient.RunCommand.
 type VirtualMachineScaleSetVMsClientRunCommandResponse struct {
-	VirtualMachineScaleSetVMsClientRunCommandResult
+	RunCommandResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMsClientRunCommandResult contains the result from method VirtualMachineScaleSetVMsClient.RunCommand.
-type VirtualMachineScaleSetVMsClientRunCommandResult struct {
-	RunCommandResult
 }
 
 // VirtualMachineScaleSetVMsClientSimulateEvictionResponse contains the response from method VirtualMachineScaleSetVMsClient.SimulateEviction.
@@ -3927,14 +3408,9 @@ func (l *VirtualMachineScaleSetVMsClientUpdatePollerResponse) Resume(ctx context
 
 // VirtualMachineScaleSetVMsClientUpdateResponse contains the response from method VirtualMachineScaleSetVMsClient.Update.
 type VirtualMachineScaleSetVMsClientUpdateResponse struct {
-	VirtualMachineScaleSetVMsClientUpdateResult
+	VirtualMachineScaleSetVM
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetVMsClientUpdateResult contains the result from method VirtualMachineScaleSetVMsClient.Update.
-type VirtualMachineScaleSetVMsClientUpdateResult struct {
-	VirtualMachineScaleSetVM
 }
 
 // VirtualMachineScaleSetsClientConvertToSinglePlacementGroupResponse contains the response from method VirtualMachineScaleSetsClient.ConvertToSinglePlacementGroup.
@@ -3985,14 +3461,9 @@ func (l *VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse) Resume(ctx c
 
 // VirtualMachineScaleSetsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetsClient.CreateOrUpdate.
 type VirtualMachineScaleSetsClientCreateOrUpdateResponse struct {
-	VirtualMachineScaleSetsClientCreateOrUpdateResult
+	VirtualMachineScaleSet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientCreateOrUpdateResult contains the result from method VirtualMachineScaleSetsClient.CreateOrUpdate.
-type VirtualMachineScaleSetsClientCreateOrUpdateResult struct {
-	VirtualMachineScaleSet
 }
 
 // VirtualMachineScaleSetsClientDeallocatePollerResponse contains the response from method VirtualMachineScaleSetsClient.Deallocate.
@@ -4136,86 +3607,51 @@ type VirtualMachineScaleSetsClientDeleteResponse struct {
 // VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse contains the response from method
 // VirtualMachineScaleSetsClient.ForceRecoveryServiceFabricPlatformUpdateDomainWalk.
 type VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse struct {
-	VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResult
+	RecoveryWalkResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResult contains the result from method VirtualMachineScaleSetsClient.ForceRecoveryServiceFabricPlatformUpdateDomainWalk.
-type VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResult struct {
-	RecoveryWalkResponse
 }
 
 // VirtualMachineScaleSetsClientGetInstanceViewResponse contains the response from method VirtualMachineScaleSetsClient.GetInstanceView.
 type VirtualMachineScaleSetsClientGetInstanceViewResponse struct {
-	VirtualMachineScaleSetsClientGetInstanceViewResult
+	VirtualMachineScaleSetInstanceView
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientGetInstanceViewResult contains the result from method VirtualMachineScaleSetsClient.GetInstanceView.
-type VirtualMachineScaleSetsClientGetInstanceViewResult struct {
-	VirtualMachineScaleSetInstanceView
 }
 
 // VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse contains the response from method VirtualMachineScaleSetsClient.GetOSUpgradeHistory.
 type VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse struct {
-	VirtualMachineScaleSetsClientGetOSUpgradeHistoryResult
+	VirtualMachineScaleSetListOSUpgradeHistory
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientGetOSUpgradeHistoryResult contains the result from method VirtualMachineScaleSetsClient.GetOSUpgradeHistory.
-type VirtualMachineScaleSetsClientGetOSUpgradeHistoryResult struct {
-	VirtualMachineScaleSetListOSUpgradeHistory
 }
 
 // VirtualMachineScaleSetsClientGetResponse contains the response from method VirtualMachineScaleSetsClient.Get.
 type VirtualMachineScaleSetsClientGetResponse struct {
-	VirtualMachineScaleSetsClientGetResult
+	VirtualMachineScaleSet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientGetResult contains the result from method VirtualMachineScaleSetsClient.Get.
-type VirtualMachineScaleSetsClientGetResult struct {
-	VirtualMachineScaleSet
 }
 
 // VirtualMachineScaleSetsClientListAllResponse contains the response from method VirtualMachineScaleSetsClient.ListAll.
 type VirtualMachineScaleSetsClientListAllResponse struct {
-	VirtualMachineScaleSetsClientListAllResult
+	VirtualMachineScaleSetListWithLinkResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientListAllResult contains the result from method VirtualMachineScaleSetsClient.ListAll.
-type VirtualMachineScaleSetsClientListAllResult struct {
-	VirtualMachineScaleSetListWithLinkResult
 }
 
 // VirtualMachineScaleSetsClientListResponse contains the response from method VirtualMachineScaleSetsClient.List.
 type VirtualMachineScaleSetsClientListResponse struct {
-	VirtualMachineScaleSetsClientListResult
+	VirtualMachineScaleSetListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientListResult contains the result from method VirtualMachineScaleSetsClient.List.
-type VirtualMachineScaleSetsClientListResult struct {
-	VirtualMachineScaleSetListResult
 }
 
 // VirtualMachineScaleSetsClientListSKUsResponse contains the response from method VirtualMachineScaleSetsClient.ListSKUs.
 type VirtualMachineScaleSetsClientListSKUsResponse struct {
-	VirtualMachineScaleSetsClientListSKUsResult
+	VirtualMachineScaleSetListSKUsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientListSKUsResult contains the result from method VirtualMachineScaleSetsClient.ListSKUs.
-type VirtualMachineScaleSetsClientListSKUsResult struct {
-	VirtualMachineScaleSetListSKUsResult
 }
 
 // VirtualMachineScaleSetsClientPerformMaintenancePollerResponse contains the response from method VirtualMachineScaleSetsClient.PerformMaintenance.
@@ -4675,26 +4111,16 @@ func (l *VirtualMachineScaleSetsClientUpdatePollerResponse) Resume(ctx context.C
 
 // VirtualMachineScaleSetsClientUpdateResponse contains the response from method VirtualMachineScaleSetsClient.Update.
 type VirtualMachineScaleSetsClientUpdateResponse struct {
-	VirtualMachineScaleSetsClientUpdateResult
+	VirtualMachineScaleSet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineScaleSetsClientUpdateResult contains the result from method VirtualMachineScaleSetsClient.Update.
-type VirtualMachineScaleSetsClientUpdateResult struct {
-	VirtualMachineScaleSet
 }
 
 // VirtualMachineSizesClientListResponse contains the response from method VirtualMachineSizesClient.List.
 type VirtualMachineSizesClientListResponse struct {
-	VirtualMachineSizesClientListResult
+	VirtualMachineSizeListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachineSizesClientListResult contains the result from method VirtualMachineSizesClient.List.
-type VirtualMachineSizesClientListResult struct {
-	VirtualMachineSizeListResult
 }
 
 // VirtualMachinesClientCapturePollerResponse contains the response from method VirtualMachinesClient.Capture.
@@ -4739,14 +4165,9 @@ func (l *VirtualMachinesClientCapturePollerResponse) Resume(ctx context.Context,
 
 // VirtualMachinesClientCaptureResponse contains the response from method VirtualMachinesClient.Capture.
 type VirtualMachinesClientCaptureResponse struct {
-	VirtualMachinesClientCaptureResult
+	VirtualMachineCaptureResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientCaptureResult contains the result from method VirtualMachinesClient.Capture.
-type VirtualMachinesClientCaptureResult struct {
-	VirtualMachineCaptureResult
 }
 
 // VirtualMachinesClientConvertToManagedDisksPollerResponse contains the response from method VirtualMachinesClient.ConvertToManagedDisks.
@@ -4837,14 +4258,9 @@ func (l *VirtualMachinesClientCreateOrUpdatePollerResponse) Resume(ctx context.C
 
 // VirtualMachinesClientCreateOrUpdateResponse contains the response from method VirtualMachinesClient.CreateOrUpdate.
 type VirtualMachinesClientCreateOrUpdateResponse struct {
-	VirtualMachinesClientCreateOrUpdateResult
+	VirtualMachine
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientCreateOrUpdateResult contains the result from method VirtualMachinesClient.CreateOrUpdate.
-type VirtualMachinesClientCreateOrUpdateResult struct {
-	VirtualMachine
 }
 
 // VirtualMachinesClientDeallocatePollerResponse contains the response from method VirtualMachinesClient.Deallocate.
@@ -4947,74 +4363,44 @@ type VirtualMachinesClientGeneralizeResponse struct {
 
 // VirtualMachinesClientGetResponse contains the response from method VirtualMachinesClient.Get.
 type VirtualMachinesClientGetResponse struct {
-	VirtualMachinesClientGetResult
+	VirtualMachine
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientGetResult contains the result from method VirtualMachinesClient.Get.
-type VirtualMachinesClientGetResult struct {
-	VirtualMachine
 }
 
 // VirtualMachinesClientInstanceViewResponse contains the response from method VirtualMachinesClient.InstanceView.
 type VirtualMachinesClientInstanceViewResponse struct {
-	VirtualMachinesClientInstanceViewResult
+	VirtualMachineInstanceView
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientInstanceViewResult contains the result from method VirtualMachinesClient.InstanceView.
-type VirtualMachinesClientInstanceViewResult struct {
-	VirtualMachineInstanceView
 }
 
 // VirtualMachinesClientListAllResponse contains the response from method VirtualMachinesClient.ListAll.
 type VirtualMachinesClientListAllResponse struct {
-	VirtualMachinesClientListAllResult
+	VirtualMachineListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientListAllResult contains the result from method VirtualMachinesClient.ListAll.
-type VirtualMachinesClientListAllResult struct {
-	VirtualMachineListResult
 }
 
 // VirtualMachinesClientListAvailableSizesResponse contains the response from method VirtualMachinesClient.ListAvailableSizes.
 type VirtualMachinesClientListAvailableSizesResponse struct {
-	VirtualMachinesClientListAvailableSizesResult
+	VirtualMachineSizeListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientListAvailableSizesResult contains the result from method VirtualMachinesClient.ListAvailableSizes.
-type VirtualMachinesClientListAvailableSizesResult struct {
-	VirtualMachineSizeListResult
 }
 
 // VirtualMachinesClientListByLocationResponse contains the response from method VirtualMachinesClient.ListByLocation.
 type VirtualMachinesClientListByLocationResponse struct {
-	VirtualMachinesClientListByLocationResult
+	VirtualMachineListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientListByLocationResult contains the result from method VirtualMachinesClient.ListByLocation.
-type VirtualMachinesClientListByLocationResult struct {
-	VirtualMachineListResult
 }
 
 // VirtualMachinesClientListResponse contains the response from method VirtualMachinesClient.List.
 type VirtualMachinesClientListResponse struct {
-	VirtualMachinesClientListResult
+	VirtualMachineListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientListResult contains the result from method VirtualMachinesClient.List.
-type VirtualMachinesClientListResult struct {
-	VirtualMachineListResult
 }
 
 // VirtualMachinesClientPerformMaintenancePollerResponse contains the response from method VirtualMachinesClient.PerformMaintenance.
@@ -5335,14 +4721,9 @@ func (l *VirtualMachinesClientRunCommandPollerResponse) Resume(ctx context.Conte
 
 // VirtualMachinesClientRunCommandResponse contains the response from method VirtualMachinesClient.RunCommand.
 type VirtualMachinesClientRunCommandResponse struct {
-	VirtualMachinesClientRunCommandResult
+	RunCommandResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientRunCommandResult contains the result from method VirtualMachinesClient.RunCommand.
-type VirtualMachinesClientRunCommandResult struct {
-	RunCommandResult
 }
 
 // VirtualMachinesClientSimulateEvictionResponse contains the response from method VirtualMachinesClient.SimulateEviction.
@@ -5439,12 +4820,7 @@ func (l *VirtualMachinesClientUpdatePollerResponse) Resume(ctx context.Context, 
 
 // VirtualMachinesClientUpdateResponse contains the response from method VirtualMachinesClient.Update.
 type VirtualMachinesClientUpdateResponse struct {
-	VirtualMachinesClientUpdateResult
+	VirtualMachine
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualMachinesClientUpdateResult contains the result from method VirtualMachinesClient.Update.
-type VirtualMachinesClientUpdateResult struct {
-	VirtualMachine
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_response_types.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_response_types.go
@@ -12,62 +12,37 @@ import "net/http"
 
 // AggregatedCostClientGetByManagementGroupResponse contains the response from method AggregatedCostClient.GetByManagementGroup.
 type AggregatedCostClientGetByManagementGroupResponse struct {
-	AggregatedCostClientGetByManagementGroupResult
+	ManagementGroupAggregatedCostResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AggregatedCostClientGetByManagementGroupResult contains the result from method AggregatedCostClient.GetByManagementGroup.
-type AggregatedCostClientGetByManagementGroupResult struct {
-	ManagementGroupAggregatedCostResult
 }
 
 // AggregatedCostClientGetForBillingPeriodByManagementGroupResponse contains the response from method AggregatedCostClient.GetForBillingPeriodByManagementGroup.
 type AggregatedCostClientGetForBillingPeriodByManagementGroupResponse struct {
-	AggregatedCostClientGetForBillingPeriodByManagementGroupResult
+	ManagementGroupAggregatedCostResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AggregatedCostClientGetForBillingPeriodByManagementGroupResult contains the result from method AggregatedCostClient.GetForBillingPeriodByManagementGroup.
-type AggregatedCostClientGetForBillingPeriodByManagementGroupResult struct {
-	ManagementGroupAggregatedCostResult
 }
 
 // BalancesClientGetByBillingAccountResponse contains the response from method BalancesClient.GetByBillingAccount.
 type BalancesClientGetByBillingAccountResponse struct {
-	BalancesClientGetByBillingAccountResult
+	Balance
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BalancesClientGetByBillingAccountResult contains the result from method BalancesClient.GetByBillingAccount.
-type BalancesClientGetByBillingAccountResult struct {
-	Balance
 }
 
 // BalancesClientGetForBillingPeriodByBillingAccountResponse contains the response from method BalancesClient.GetForBillingPeriodByBillingAccount.
 type BalancesClientGetForBillingPeriodByBillingAccountResponse struct {
-	BalancesClientGetForBillingPeriodByBillingAccountResult
+	Balance
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BalancesClientGetForBillingPeriodByBillingAccountResult contains the result from method BalancesClient.GetForBillingPeriodByBillingAccount.
-type BalancesClientGetForBillingPeriodByBillingAccountResult struct {
-	Balance
 }
 
 // BudgetsClientCreateOrUpdateResponse contains the response from method BudgetsClient.CreateOrUpdate.
 type BudgetsClientCreateOrUpdateResponse struct {
-	BudgetsClientCreateOrUpdateResult
+	Budget
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BudgetsClientCreateOrUpdateResult contains the result from method BudgetsClient.CreateOrUpdate.
-type BudgetsClientCreateOrUpdateResult struct {
-	Budget
 }
 
 // BudgetsClientDeleteResponse contains the response from method BudgetsClient.Delete.
@@ -78,276 +53,161 @@ type BudgetsClientDeleteResponse struct {
 
 // BudgetsClientGetResponse contains the response from method BudgetsClient.Get.
 type BudgetsClientGetResponse struct {
-	BudgetsClientGetResult
+	Budget
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BudgetsClientGetResult contains the result from method BudgetsClient.Get.
-type BudgetsClientGetResult struct {
-	Budget
 }
 
 // BudgetsClientListResponse contains the response from method BudgetsClient.List.
 type BudgetsClientListResponse struct {
-	BudgetsClientListResult
+	BudgetsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BudgetsClientListResult contains the result from method BudgetsClient.List.
-type BudgetsClientListResult struct {
-	BudgetsListResult
 }
 
 // ChargesClientListResponse contains the response from method ChargesClient.List.
 type ChargesClientListResponse struct {
-	ChargesClientListResult
+	ChargesListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ChargesClientListResult contains the result from method ChargesClient.List.
-type ChargesClientListResult struct {
-	ChargesListResult
 }
 
 // CreditsClientGetResponse contains the response from method CreditsClient.Get.
 type CreditsClientGetResponse struct {
-	CreditsClientGetResult
+	CreditSummary
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// CreditsClientGetResult contains the result from method CreditsClient.Get.
-type CreditsClientGetResult struct {
-	CreditSummary
 }
 
 // EventsClientListResponse contains the response from method EventsClient.List.
 type EventsClientListResponse struct {
-	EventsClientListResult
+	Events
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// EventsClientListResult contains the result from method EventsClient.List.
-type EventsClientListResult struct {
-	Events
 }
 
 // ForecastsClientListResponse contains the response from method ForecastsClient.List.
 type ForecastsClientListResponse struct {
-	ForecastsClientListResult
+	ForecastsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ForecastsClientListResult contains the result from method ForecastsClient.List.
-type ForecastsClientListResult struct {
-	ForecastsListResult
 }
 
 // LotsClientListResponse contains the response from method LotsClient.List.
 type LotsClientListResponse struct {
-	LotsClientListResult
+	Lots
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LotsClientListResult contains the result from method LotsClient.List.
-type LotsClientListResult struct {
-	Lots
 }
 
 // MarketplacesClientListResponse contains the response from method MarketplacesClient.List.
 type MarketplacesClientListResponse struct {
-	MarketplacesClientListResult
+	MarketplacesListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MarketplacesClientListResult contains the result from method MarketplacesClient.List.
-type MarketplacesClientListResult struct {
-	MarketplacesListResult
 }
 
 // OperationsClientListResponse contains the response from method OperationsClient.List.
 type OperationsClientListResponse struct {
-	OperationsClientListResult
+	OperationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OperationsClientListResult contains the result from method OperationsClient.List.
-type OperationsClientListResult struct {
-	OperationListResult
 }
 
 // PriceSheetClientGetByBillingPeriodResponse contains the response from method PriceSheetClient.GetByBillingPeriod.
 type PriceSheetClientGetByBillingPeriodResponse struct {
-	PriceSheetClientGetByBillingPeriodResult
+	PriceSheetResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PriceSheetClientGetByBillingPeriodResult contains the result from method PriceSheetClient.GetByBillingPeriod.
-type PriceSheetClientGetByBillingPeriodResult struct {
-	PriceSheetResult
 }
 
 // PriceSheetClientGetResponse contains the response from method PriceSheetClient.Get.
 type PriceSheetClientGetResponse struct {
-	PriceSheetClientGetResult
+	PriceSheetResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PriceSheetClientGetResult contains the result from method PriceSheetClient.Get.
-type PriceSheetClientGetResult struct {
-	PriceSheetResult
 }
 
 // ReservationRecommendationDetailsClientGetResponse contains the response from method ReservationRecommendationDetailsClient.Get.
 type ReservationRecommendationDetailsClientGetResponse struct {
-	ReservationRecommendationDetailsClientGetResult
+	ReservationRecommendationDetailsModel
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationRecommendationDetailsClientGetResult contains the result from method ReservationRecommendationDetailsClient.Get.
-type ReservationRecommendationDetailsClientGetResult struct {
-	ReservationRecommendationDetailsModel
 }
 
 // ReservationRecommendationsClientListResponse contains the response from method ReservationRecommendationsClient.List.
 type ReservationRecommendationsClientListResponse struct {
-	ReservationRecommendationsClientListResult
+	ReservationRecommendationsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationRecommendationsClientListResult contains the result from method ReservationRecommendationsClient.List.
-type ReservationRecommendationsClientListResult struct {
-	ReservationRecommendationsListResult
 }
 
 // ReservationTransactionsClientListByBillingProfileResponse contains the response from method ReservationTransactionsClient.ListByBillingProfile.
 type ReservationTransactionsClientListByBillingProfileResponse struct {
-	ReservationTransactionsClientListByBillingProfileResult
+	ModernReservationTransactionsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationTransactionsClientListByBillingProfileResult contains the result from method ReservationTransactionsClient.ListByBillingProfile.
-type ReservationTransactionsClientListByBillingProfileResult struct {
-	ModernReservationTransactionsListResult
 }
 
 // ReservationTransactionsClientListResponse contains the response from method ReservationTransactionsClient.List.
 type ReservationTransactionsClientListResponse struct {
-	ReservationTransactionsClientListResult
+	ReservationTransactionsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationTransactionsClientListResult contains the result from method ReservationTransactionsClient.List.
-type ReservationTransactionsClientListResult struct {
-	ReservationTransactionsListResult
 }
 
 // ReservationsDetailsClientListByReservationOrderAndReservationResponse contains the response from method ReservationsDetailsClient.ListByReservationOrderAndReservation.
 type ReservationsDetailsClientListByReservationOrderAndReservationResponse struct {
-	ReservationsDetailsClientListByReservationOrderAndReservationResult
+	ReservationDetailsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationsDetailsClientListByReservationOrderAndReservationResult contains the result from method ReservationsDetailsClient.ListByReservationOrderAndReservation.
-type ReservationsDetailsClientListByReservationOrderAndReservationResult struct {
-	ReservationDetailsListResult
 }
 
 // ReservationsDetailsClientListByReservationOrderResponse contains the response from method ReservationsDetailsClient.ListByReservationOrder.
 type ReservationsDetailsClientListByReservationOrderResponse struct {
-	ReservationsDetailsClientListByReservationOrderResult
+	ReservationDetailsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationsDetailsClientListByReservationOrderResult contains the result from method ReservationsDetailsClient.ListByReservationOrder.
-type ReservationsDetailsClientListByReservationOrderResult struct {
-	ReservationDetailsListResult
 }
 
 // ReservationsDetailsClientListResponse contains the response from method ReservationsDetailsClient.List.
 type ReservationsDetailsClientListResponse struct {
-	ReservationsDetailsClientListResult
+	ReservationDetailsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationsDetailsClientListResult contains the result from method ReservationsDetailsClient.List.
-type ReservationsDetailsClientListResult struct {
-	ReservationDetailsListResult
 }
 
 // ReservationsSummariesClientListByReservationOrderAndReservationResponse contains the response from method ReservationsSummariesClient.ListByReservationOrderAndReservation.
 type ReservationsSummariesClientListByReservationOrderAndReservationResponse struct {
-	ReservationsSummariesClientListByReservationOrderAndReservationResult
+	ReservationSummariesListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationsSummariesClientListByReservationOrderAndReservationResult contains the result from method ReservationsSummariesClient.ListByReservationOrderAndReservation.
-type ReservationsSummariesClientListByReservationOrderAndReservationResult struct {
-	ReservationSummariesListResult
 }
 
 // ReservationsSummariesClientListByReservationOrderResponse contains the response from method ReservationsSummariesClient.ListByReservationOrder.
 type ReservationsSummariesClientListByReservationOrderResponse struct {
-	ReservationsSummariesClientListByReservationOrderResult
+	ReservationSummariesListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationsSummariesClientListByReservationOrderResult contains the result from method ReservationsSummariesClient.ListByReservationOrder.
-type ReservationsSummariesClientListByReservationOrderResult struct {
-	ReservationSummariesListResult
 }
 
 // ReservationsSummariesClientListResponse contains the response from method ReservationsSummariesClient.List.
 type ReservationsSummariesClientListResponse struct {
-	ReservationsSummariesClientListResult
+	ReservationSummariesListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ReservationsSummariesClientListResult contains the result from method ReservationsSummariesClient.List.
-type ReservationsSummariesClientListResult struct {
-	ReservationSummariesListResult
 }
 
 // TagsClientGetResponse contains the response from method TagsClient.Get.
 type TagsClientGetResponse struct {
-	TagsClientGetResult
+	TagsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// TagsClientGetResult contains the result from method TagsClient.Get.
-type TagsClientGetResult struct {
-	TagsResult
 }
 
 // UsageDetailsClientListResponse contains the response from method UsageDetailsClient.List.
 type UsageDetailsClientListResponse struct {
-	UsageDetailsClientListResult
+	UsageDetailsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// UsageDetailsClientListResult contains the result from method UsageDetailsClient.List.
-type UsageDetailsClientListResult struct {
-	UsageDetailsListResult
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/polymorphic_lro_test.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/polymorphic_lro_test.go
@@ -36,7 +36,7 @@ func TestPolymorphicLROResult(t *testing.T) {
 	// needs to be kept in sync with AddonsCreateOrUpdatePollerResponse.PollUntilDone
 	// TODO: having a recording would be a better way to test this end-to-end
 	respType := AddonsClientCreateOrUpdateResponse{}
-	err := json.Unmarshal([]byte(lroResp), &respType.AddonsClientCreateOrUpdateResult)
+	err := json.Unmarshal([]byte(lroResp), &respType)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pollers.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pollers.go
@@ -43,7 +43,7 @@ func (p *AddonsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final AddonsClientCreateOrUpdateResponse will be returned.
 func (p *AddonsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (AddonsClientCreateOrUpdateResponse, error) {
 	respType := AddonsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.AddonsClientCreateOrUpdateResult)
+	resp, err := p.pt.FinalResponse(ctx, &respType)
 	if err != nil {
 		return AddonsClientCreateOrUpdateResponse{}, err
 	}
@@ -817,7 +817,7 @@ func (p *RolesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final RolesClientCreateOrUpdateResponse will be returned.
 func (p *RolesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RolesClientCreateOrUpdateResponse, error) {
 	respType := RolesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.RolesClientCreateOrUpdateResult)
+	resp, err := p.pt.FinalResponse(ctx, &respType)
 	if err != nil {
 		return RolesClientCreateOrUpdateResponse{}, err
 	}
@@ -1247,7 +1247,7 @@ func (p *TriggersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final TriggersClientCreateOrUpdateResponse will be returned.
 func (p *TriggersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (TriggersClientCreateOrUpdateResponse, error) {
 	respType := TriggersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.TriggersClientCreateOrUpdateResult)
+	resp, err := p.pt.FinalResponse(ctx, &respType)
 	if err != nil {
 		return TriggersClientCreateOrUpdateResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_response_types.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_response_types.go
@@ -29,7 +29,7 @@ type AddonsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l AddonsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsClientCreateOrUpdateResponse, error) {
 	respType := AddonsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AddonsClientCreateOrUpdateResult)
+	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
 	if err != nil {
 		return respType, err
 	}
@@ -57,18 +57,13 @@ func (l *AddonsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 
 // AddonsClientCreateOrUpdateResponse contains the response from method AddonsClient.CreateOrUpdate.
 type AddonsClientCreateOrUpdateResponse struct {
-	AddonsClientCreateOrUpdateResult
+	AddonClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// AddonsClientCreateOrUpdateResult contains the result from method AddonsClient.CreateOrUpdate.
-type AddonsClientCreateOrUpdateResult struct {
-	AddonClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AddonsClientCreateOrUpdateResult.
-func (a *AddonsClientCreateOrUpdateResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type AddonsClientCreateOrUpdateResponse.
+func (a *AddonsClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalAddonClassification(data)
 	if err != nil {
 		return err
@@ -125,18 +120,13 @@ type AddonsClientDeleteResponse struct {
 
 // AddonsClientGetResponse contains the response from method AddonsClient.Get.
 type AddonsClientGetResponse struct {
-	AddonsClientGetResult
+	AddonClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// AddonsClientGetResult contains the result from method AddonsClient.Get.
-type AddonsClientGetResult struct {
-	AddonClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AddonsClientGetResult.
-func (a *AddonsClientGetResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type AddonsClientGetResponse.
+func (a *AddonsClientGetResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalAddonClassification(data)
 	if err != nil {
 		return err
@@ -147,50 +137,30 @@ func (a *AddonsClientGetResult) UnmarshalJSON(data []byte) error {
 
 // AddonsClientListByRoleResponse contains the response from method AddonsClient.ListByRole.
 type AddonsClientListByRoleResponse struct {
-	AddonsClientListByRoleResult
+	AddonList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AddonsClientListByRoleResult contains the result from method AddonsClient.ListByRole.
-type AddonsClientListByRoleResult struct {
-	AddonList
 }
 
 // AlertsClientGetResponse contains the response from method AlertsClient.Get.
 type AlertsClientGetResponse struct {
-	AlertsClientGetResult
+	Alert
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AlertsClientGetResult contains the result from method AlertsClient.Get.
-type AlertsClientGetResult struct {
-	Alert
 }
 
 // AlertsClientListByDataBoxEdgeDeviceResponse contains the response from method AlertsClient.ListByDataBoxEdgeDevice.
 type AlertsClientListByDataBoxEdgeDeviceResponse struct {
-	AlertsClientListByDataBoxEdgeDeviceResult
+	AlertList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AlertsClientListByDataBoxEdgeDeviceResult contains the result from method AlertsClient.ListByDataBoxEdgeDevice.
-type AlertsClientListByDataBoxEdgeDeviceResult struct {
-	AlertList
 }
 
 // AvailableSKUsClientListResponse contains the response from method AvailableSKUsClient.List.
 type AvailableSKUsClientListResponse struct {
-	AvailableSKUsClientListResult
+	SKUList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailableSKUsClientListResult contains the result from method AvailableSKUsClient.List.
-type AvailableSKUsClientListResult struct {
-	SKUList
 }
 
 // BandwidthSchedulesClientCreateOrUpdatePollerResponse contains the response from method BandwidthSchedulesClient.CreateOrUpdate.
@@ -235,14 +205,9 @@ func (l *BandwidthSchedulesClientCreateOrUpdatePollerResponse) Resume(ctx contex
 
 // BandwidthSchedulesClientCreateOrUpdateResponse contains the response from method BandwidthSchedulesClient.CreateOrUpdate.
 type BandwidthSchedulesClientCreateOrUpdateResponse struct {
-	BandwidthSchedulesClientCreateOrUpdateResult
+	BandwidthSchedule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BandwidthSchedulesClientCreateOrUpdateResult contains the result from method BandwidthSchedulesClient.CreateOrUpdate.
-type BandwidthSchedulesClientCreateOrUpdateResult struct {
-	BandwidthSchedule
 }
 
 // BandwidthSchedulesClientDeletePollerResponse contains the response from method BandwidthSchedulesClient.Delete.
@@ -293,26 +258,16 @@ type BandwidthSchedulesClientDeleteResponse struct {
 
 // BandwidthSchedulesClientGetResponse contains the response from method BandwidthSchedulesClient.Get.
 type BandwidthSchedulesClientGetResponse struct {
-	BandwidthSchedulesClientGetResult
+	BandwidthSchedule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BandwidthSchedulesClientGetResult contains the result from method BandwidthSchedulesClient.Get.
-type BandwidthSchedulesClientGetResult struct {
-	BandwidthSchedule
 }
 
 // BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse contains the response from method BandwidthSchedulesClient.ListByDataBoxEdgeDevice.
 type BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse struct {
-	BandwidthSchedulesClientListByDataBoxEdgeDeviceResult
+	BandwidthSchedulesList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BandwidthSchedulesClientListByDataBoxEdgeDeviceResult contains the result from method BandwidthSchedulesClient.ListByDataBoxEdgeDevice.
-type BandwidthSchedulesClientListByDataBoxEdgeDeviceResult struct {
-	BandwidthSchedulesList
 }
 
 // ContainersClientCreateOrUpdatePollerResponse contains the response from method ContainersClient.CreateOrUpdate.
@@ -357,14 +312,9 @@ func (l *ContainersClientCreateOrUpdatePollerResponse) Resume(ctx context.Contex
 
 // ContainersClientCreateOrUpdateResponse contains the response from method ContainersClient.CreateOrUpdate.
 type ContainersClientCreateOrUpdateResponse struct {
-	ContainersClientCreateOrUpdateResult
+	Container
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ContainersClientCreateOrUpdateResult contains the result from method ContainersClient.CreateOrUpdate.
-type ContainersClientCreateOrUpdateResult struct {
-	Container
 }
 
 // ContainersClientDeletePollerResponse contains the response from method ContainersClient.Delete.
@@ -415,26 +365,16 @@ type ContainersClientDeleteResponse struct {
 
 // ContainersClientGetResponse contains the response from method ContainersClient.Get.
 type ContainersClientGetResponse struct {
-	ContainersClientGetResult
+	Container
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ContainersClientGetResult contains the result from method ContainersClient.Get.
-type ContainersClientGetResult struct {
-	Container
 }
 
 // ContainersClientListByStorageAccountResponse contains the response from method ContainersClient.ListByStorageAccount.
 type ContainersClientListByStorageAccountResponse struct {
-	ContainersClientListByStorageAccountResult
+	ContainerList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ContainersClientListByStorageAccountResult contains the result from method ContainersClient.ListByStorageAccount.
-type ContainersClientListByStorageAccountResult struct {
-	ContainerList
 }
 
 // ContainersClientRefreshPollerResponse contains the response from method ContainersClient.Refresh.
@@ -485,14 +425,9 @@ type ContainersClientRefreshResponse struct {
 
 // DevicesClientCreateOrUpdateResponse contains the response from method DevicesClient.CreateOrUpdate.
 type DevicesClientCreateOrUpdateResponse struct {
-	DevicesClientCreateOrUpdateResult
+	Device
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientCreateOrUpdateResult contains the result from method DevicesClient.CreateOrUpdate.
-type DevicesClientCreateOrUpdateResult struct {
-	Device
 }
 
 // DevicesClientCreateOrUpdateSecuritySettingsPollerResponse contains the response from method DevicesClient.CreateOrUpdateSecuritySettings.
@@ -635,62 +570,37 @@ type DevicesClientDownloadUpdatesResponse struct {
 
 // DevicesClientGenerateCertificateResponse contains the response from method DevicesClient.GenerateCertificate.
 type DevicesClientGenerateCertificateResponse struct {
-	DevicesClientGenerateCertificateResult
+	GenerateCertResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientGenerateCertificateResult contains the result from method DevicesClient.GenerateCertificate.
-type DevicesClientGenerateCertificateResult struct {
-	GenerateCertResponse
 }
 
 // DevicesClientGetExtendedInformationResponse contains the response from method DevicesClient.GetExtendedInformation.
 type DevicesClientGetExtendedInformationResponse struct {
-	DevicesClientGetExtendedInformationResult
+	DeviceExtendedInfo
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientGetExtendedInformationResult contains the result from method DevicesClient.GetExtendedInformation.
-type DevicesClientGetExtendedInformationResult struct {
-	DeviceExtendedInfo
 }
 
 // DevicesClientGetNetworkSettingsResponse contains the response from method DevicesClient.GetNetworkSettings.
 type DevicesClientGetNetworkSettingsResponse struct {
-	DevicesClientGetNetworkSettingsResult
+	NetworkSettings
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientGetNetworkSettingsResult contains the result from method DevicesClient.GetNetworkSettings.
-type DevicesClientGetNetworkSettingsResult struct {
-	NetworkSettings
 }
 
 // DevicesClientGetResponse contains the response from method DevicesClient.Get.
 type DevicesClientGetResponse struct {
-	DevicesClientGetResult
+	Device
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientGetResult contains the result from method DevicesClient.Get.
-type DevicesClientGetResult struct {
-	Device
 }
 
 // DevicesClientGetUpdateSummaryResponse contains the response from method DevicesClient.GetUpdateSummary.
 type DevicesClientGetUpdateSummaryResponse struct {
-	DevicesClientGetUpdateSummaryResult
+	UpdateSummary
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientGetUpdateSummaryResult contains the result from method DevicesClient.GetUpdateSummary.
-type DevicesClientGetUpdateSummaryResult struct {
-	UpdateSummary
 }
 
 // DevicesClientInstallUpdatesPollerResponse contains the response from method DevicesClient.InstallUpdates.
@@ -741,26 +651,16 @@ type DevicesClientInstallUpdatesResponse struct {
 
 // DevicesClientListByResourceGroupResponse contains the response from method DevicesClient.ListByResourceGroup.
 type DevicesClientListByResourceGroupResponse struct {
-	DevicesClientListByResourceGroupResult
+	DeviceList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientListByResourceGroupResult contains the result from method DevicesClient.ListByResourceGroup.
-type DevicesClientListByResourceGroupResult struct {
-	DeviceList
 }
 
 // DevicesClientListBySubscriptionResponse contains the response from method DevicesClient.ListBySubscription.
 type DevicesClientListBySubscriptionResponse struct {
-	DevicesClientListBySubscriptionResult
+	DeviceList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientListBySubscriptionResult contains the result from method DevicesClient.ListBySubscription.
-type DevicesClientListBySubscriptionResult struct {
-	DeviceList
 }
 
 // DevicesClientScanForUpdatesPollerResponse contains the response from method DevicesClient.ScanForUpdates.
@@ -811,62 +711,37 @@ type DevicesClientScanForUpdatesResponse struct {
 
 // DevicesClientUpdateExtendedInformationResponse contains the response from method DevicesClient.UpdateExtendedInformation.
 type DevicesClientUpdateExtendedInformationResponse struct {
-	DevicesClientUpdateExtendedInformationResult
+	DeviceExtendedInfo
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientUpdateExtendedInformationResult contains the result from method DevicesClient.UpdateExtendedInformation.
-type DevicesClientUpdateExtendedInformationResult struct {
-	DeviceExtendedInfo
 }
 
 // DevicesClientUpdateResponse contains the response from method DevicesClient.Update.
 type DevicesClientUpdateResponse struct {
-	DevicesClientUpdateResult
+	Device
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientUpdateResult contains the result from method DevicesClient.Update.
-type DevicesClientUpdateResult struct {
-	Device
 }
 
 // DevicesClientUploadCertificateResponse contains the response from method DevicesClient.UploadCertificate.
 type DevicesClientUploadCertificateResponse struct {
-	DevicesClientUploadCertificateResult
+	UploadCertificateResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DevicesClientUploadCertificateResult contains the result from method DevicesClient.UploadCertificate.
-type DevicesClientUploadCertificateResult struct {
-	UploadCertificateResponse
 }
 
 // DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse contains the response from method DiagnosticSettingsClient.GetDiagnosticProactiveLogCollectionSettings.
 type DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse struct {
-	DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResult
+	DiagnosticProactiveLogCollectionSettings
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResult contains the result from method DiagnosticSettingsClient.GetDiagnosticProactiveLogCollectionSettings.
-type DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResult struct {
-	DiagnosticProactiveLogCollectionSettings
 }
 
 // DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse contains the response from method DiagnosticSettingsClient.GetDiagnosticRemoteSupportSettings.
 type DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse struct {
-	DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResult
+	DiagnosticRemoteSupportSettings
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResult contains the result from method DiagnosticSettingsClient.GetDiagnosticRemoteSupportSettings.
-type DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResult struct {
-	DiagnosticRemoteSupportSettings
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse contains the response from method
@@ -966,14 +841,9 @@ type DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse struc
 
 // JobsClientGetResponse contains the response from method JobsClient.Get.
 type JobsClientGetResponse struct {
-	JobsClientGetResult
+	Job
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// JobsClientGetResult contains the result from method JobsClient.Get.
-type JobsClientGetResult struct {
-	Job
 }
 
 // MonitoringConfigClientCreateOrUpdatePollerResponse contains the response from method MonitoringConfigClient.CreateOrUpdate.
@@ -1018,14 +888,9 @@ func (l *MonitoringConfigClientCreateOrUpdatePollerResponse) Resume(ctx context.
 
 // MonitoringConfigClientCreateOrUpdateResponse contains the response from method MonitoringConfigClient.CreateOrUpdate.
 type MonitoringConfigClientCreateOrUpdateResponse struct {
-	MonitoringConfigClientCreateOrUpdateResult
+	MonitoringMetricConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MonitoringConfigClientCreateOrUpdateResult contains the result from method MonitoringConfigClient.CreateOrUpdate.
-type MonitoringConfigClientCreateOrUpdateResult struct {
-	MonitoringMetricConfiguration
 }
 
 // MonitoringConfigClientDeletePollerResponse contains the response from method MonitoringConfigClient.Delete.
@@ -1076,62 +941,37 @@ type MonitoringConfigClientDeleteResponse struct {
 
 // MonitoringConfigClientGetResponse contains the response from method MonitoringConfigClient.Get.
 type MonitoringConfigClientGetResponse struct {
-	MonitoringConfigClientGetResult
+	MonitoringMetricConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MonitoringConfigClientGetResult contains the result from method MonitoringConfigClient.Get.
-type MonitoringConfigClientGetResult struct {
-	MonitoringMetricConfiguration
 }
 
 // MonitoringConfigClientListResponse contains the response from method MonitoringConfigClient.List.
 type MonitoringConfigClientListResponse struct {
-	MonitoringConfigClientListResult
+	MonitoringMetricConfigurationList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// MonitoringConfigClientListResult contains the result from method MonitoringConfigClient.List.
-type MonitoringConfigClientListResult struct {
-	MonitoringMetricConfigurationList
 }
 
 // NodesClientListByDataBoxEdgeDeviceResponse contains the response from method NodesClient.ListByDataBoxEdgeDevice.
 type NodesClientListByDataBoxEdgeDeviceResponse struct {
-	NodesClientListByDataBoxEdgeDeviceResult
+	NodeList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NodesClientListByDataBoxEdgeDeviceResult contains the result from method NodesClient.ListByDataBoxEdgeDevice.
-type NodesClientListByDataBoxEdgeDeviceResult struct {
-	NodeList
 }
 
 // OperationsClientListResponse contains the response from method OperationsClient.List.
 type OperationsClientListResponse struct {
-	OperationsClientListResult
+	OperationsList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OperationsClientListResult contains the result from method OperationsClient.List.
-type OperationsClientListResult struct {
-	OperationsList
 }
 
 // OperationsStatusClientGetResponse contains the response from method OperationsStatusClient.Get.
 type OperationsStatusClientGetResponse struct {
-	OperationsStatusClientGetResult
+	Job
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OperationsStatusClientGetResult contains the result from method OperationsStatusClient.Get.
-type OperationsStatusClientGetResult struct {
-	Job
 }
 
 // OrdersClientCreateOrUpdatePollerResponse contains the response from method OrdersClient.CreateOrUpdate.
@@ -1176,14 +1016,9 @@ func (l *OrdersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 
 // OrdersClientCreateOrUpdateResponse contains the response from method OrdersClient.CreateOrUpdate.
 type OrdersClientCreateOrUpdateResponse struct {
-	OrdersClientCreateOrUpdateResult
+	Order
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OrdersClientCreateOrUpdateResult contains the result from method OrdersClient.CreateOrUpdate.
-type OrdersClientCreateOrUpdateResult struct {
-	Order
 }
 
 // OrdersClientDeletePollerResponse contains the response from method OrdersClient.Delete.
@@ -1234,38 +1069,23 @@ type OrdersClientDeleteResponse struct {
 
 // OrdersClientGetResponse contains the response from method OrdersClient.Get.
 type OrdersClientGetResponse struct {
-	OrdersClientGetResult
+	Order
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OrdersClientGetResult contains the result from method OrdersClient.Get.
-type OrdersClientGetResult struct {
-	Order
 }
 
 // OrdersClientListByDataBoxEdgeDeviceResponse contains the response from method OrdersClient.ListByDataBoxEdgeDevice.
 type OrdersClientListByDataBoxEdgeDeviceResponse struct {
-	OrdersClientListByDataBoxEdgeDeviceResult
+	OrderList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OrdersClientListByDataBoxEdgeDeviceResult contains the result from method OrdersClient.ListByDataBoxEdgeDevice.
-type OrdersClientListByDataBoxEdgeDeviceResult struct {
-	OrderList
 }
 
 // OrdersClientListDCAccessCodeResponse contains the response from method OrdersClient.ListDCAccessCode.
 type OrdersClientListDCAccessCodeResponse struct {
-	OrdersClientListDCAccessCodeResult
+	DCAccessCode
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OrdersClientListDCAccessCodeResult contains the result from method OrdersClient.ListDCAccessCode.
-type OrdersClientListDCAccessCodeResult struct {
-	DCAccessCode
 }
 
 // RolesClientCreateOrUpdatePollerResponse contains the response from method RolesClient.CreateOrUpdate.
@@ -1282,7 +1102,7 @@ type RolesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RolesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RolesClientCreateOrUpdateResponse, error) {
 	respType := RolesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RolesClientCreateOrUpdateResult)
+	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
 	if err != nil {
 		return respType, err
 	}
@@ -1310,18 +1130,13 @@ func (l *RolesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, cl
 
 // RolesClientCreateOrUpdateResponse contains the response from method RolesClient.CreateOrUpdate.
 type RolesClientCreateOrUpdateResponse struct {
-	RolesClientCreateOrUpdateResult
+	RoleClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// RolesClientCreateOrUpdateResult contains the result from method RolesClient.CreateOrUpdate.
-type RolesClientCreateOrUpdateResult struct {
-	RoleClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type RolesClientCreateOrUpdateResult.
-func (r *RolesClientCreateOrUpdateResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type RolesClientCreateOrUpdateResponse.
+func (r *RolesClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalRoleClassification(data)
 	if err != nil {
 		return err
@@ -1378,18 +1193,13 @@ type RolesClientDeleteResponse struct {
 
 // RolesClientGetResponse contains the response from method RolesClient.Get.
 type RolesClientGetResponse struct {
-	RolesClientGetResult
+	RoleClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// RolesClientGetResult contains the result from method RolesClient.Get.
-type RolesClientGetResult struct {
-	RoleClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type RolesClientGetResult.
-func (r *RolesClientGetResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type RolesClientGetResponse.
+func (r *RolesClientGetResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalRoleClassification(data)
 	if err != nil {
 		return err
@@ -1400,14 +1210,9 @@ func (r *RolesClientGetResult) UnmarshalJSON(data []byte) error {
 
 // RolesClientListByDataBoxEdgeDeviceResponse contains the response from method RolesClient.ListByDataBoxEdgeDevice.
 type RolesClientListByDataBoxEdgeDeviceResponse struct {
-	RolesClientListByDataBoxEdgeDeviceResult
+	RoleList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RolesClientListByDataBoxEdgeDeviceResult contains the result from method RolesClient.ListByDataBoxEdgeDevice.
-type RolesClientListByDataBoxEdgeDeviceResult struct {
-	RoleList
 }
 
 // SharesClientCreateOrUpdatePollerResponse contains the response from method SharesClient.CreateOrUpdate.
@@ -1452,14 +1257,9 @@ func (l *SharesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 
 // SharesClientCreateOrUpdateResponse contains the response from method SharesClient.CreateOrUpdate.
 type SharesClientCreateOrUpdateResponse struct {
-	SharesClientCreateOrUpdateResult
+	Share
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SharesClientCreateOrUpdateResult contains the result from method SharesClient.CreateOrUpdate.
-type SharesClientCreateOrUpdateResult struct {
-	Share
 }
 
 // SharesClientDeletePollerResponse contains the response from method SharesClient.Delete.
@@ -1510,26 +1310,16 @@ type SharesClientDeleteResponse struct {
 
 // SharesClientGetResponse contains the response from method SharesClient.Get.
 type SharesClientGetResponse struct {
-	SharesClientGetResult
+	Share
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SharesClientGetResult contains the result from method SharesClient.Get.
-type SharesClientGetResult struct {
-	Share
 }
 
 // SharesClientListByDataBoxEdgeDeviceResponse contains the response from method SharesClient.ListByDataBoxEdgeDevice.
 type SharesClientListByDataBoxEdgeDeviceResponse struct {
-	SharesClientListByDataBoxEdgeDeviceResult
+	ShareList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SharesClientListByDataBoxEdgeDeviceResult contains the result from method SharesClient.ListByDataBoxEdgeDevice.
-type SharesClientListByDataBoxEdgeDeviceResult struct {
-	ShareList
 }
 
 // SharesClientRefreshPollerResponse contains the response from method SharesClient.Refresh.
@@ -1620,14 +1410,9 @@ func (l *StorageAccountCredentialsClientCreateOrUpdatePollerResponse) Resume(ctx
 
 // StorageAccountCredentialsClientCreateOrUpdateResponse contains the response from method StorageAccountCredentialsClient.CreateOrUpdate.
 type StorageAccountCredentialsClientCreateOrUpdateResponse struct {
-	StorageAccountCredentialsClientCreateOrUpdateResult
+	StorageAccountCredential
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StorageAccountCredentialsClientCreateOrUpdateResult contains the result from method StorageAccountCredentialsClient.CreateOrUpdate.
-type StorageAccountCredentialsClientCreateOrUpdateResult struct {
-	StorageAccountCredential
 }
 
 // StorageAccountCredentialsClientDeletePollerResponse contains the response from method StorageAccountCredentialsClient.Delete.
@@ -1678,26 +1463,16 @@ type StorageAccountCredentialsClientDeleteResponse struct {
 
 // StorageAccountCredentialsClientGetResponse contains the response from method StorageAccountCredentialsClient.Get.
 type StorageAccountCredentialsClientGetResponse struct {
-	StorageAccountCredentialsClientGetResult
+	StorageAccountCredential
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StorageAccountCredentialsClientGetResult contains the result from method StorageAccountCredentialsClient.Get.
-type StorageAccountCredentialsClientGetResult struct {
-	StorageAccountCredential
 }
 
 // StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse contains the response from method StorageAccountCredentialsClient.ListByDataBoxEdgeDevice.
 type StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse struct {
-	StorageAccountCredentialsClientListByDataBoxEdgeDeviceResult
+	StorageAccountCredentialList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StorageAccountCredentialsClientListByDataBoxEdgeDeviceResult contains the result from method StorageAccountCredentialsClient.ListByDataBoxEdgeDevice.
-type StorageAccountCredentialsClientListByDataBoxEdgeDeviceResult struct {
-	StorageAccountCredentialList
 }
 
 // StorageAccountsClientCreateOrUpdatePollerResponse contains the response from method StorageAccountsClient.CreateOrUpdate.
@@ -1742,14 +1517,9 @@ func (l *StorageAccountsClientCreateOrUpdatePollerResponse) Resume(ctx context.C
 
 // StorageAccountsClientCreateOrUpdateResponse contains the response from method StorageAccountsClient.CreateOrUpdate.
 type StorageAccountsClientCreateOrUpdateResponse struct {
-	StorageAccountsClientCreateOrUpdateResult
+	StorageAccount
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StorageAccountsClientCreateOrUpdateResult contains the result from method StorageAccountsClient.CreateOrUpdate.
-type StorageAccountsClientCreateOrUpdateResult struct {
-	StorageAccount
 }
 
 // StorageAccountsClientDeletePollerResponse contains the response from method StorageAccountsClient.Delete.
@@ -1800,26 +1570,16 @@ type StorageAccountsClientDeleteResponse struct {
 
 // StorageAccountsClientGetResponse contains the response from method StorageAccountsClient.Get.
 type StorageAccountsClientGetResponse struct {
-	StorageAccountsClientGetResult
+	StorageAccount
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StorageAccountsClientGetResult contains the result from method StorageAccountsClient.Get.
-type StorageAccountsClientGetResult struct {
-	StorageAccount
 }
 
 // StorageAccountsClientListByDataBoxEdgeDeviceResponse contains the response from method StorageAccountsClient.ListByDataBoxEdgeDevice.
 type StorageAccountsClientListByDataBoxEdgeDeviceResponse struct {
-	StorageAccountsClientListByDataBoxEdgeDeviceResult
+	StorageAccountList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// StorageAccountsClientListByDataBoxEdgeDeviceResult contains the result from method StorageAccountsClient.ListByDataBoxEdgeDevice.
-type StorageAccountsClientListByDataBoxEdgeDeviceResult struct {
-	StorageAccountList
 }
 
 // SupportPackagesClientTriggerSupportPackagePollerResponse contains the response from method SupportPackagesClient.TriggerSupportPackage.
@@ -1882,7 +1642,7 @@ type TriggersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l TriggersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersClientCreateOrUpdateResponse, error) {
 	respType := TriggersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggersClientCreateOrUpdateResult)
+	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
 	if err != nil {
 		return respType, err
 	}
@@ -1910,18 +1670,13 @@ func (l *TriggersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context,
 
 // TriggersClientCreateOrUpdateResponse contains the response from method TriggersClient.CreateOrUpdate.
 type TriggersClientCreateOrUpdateResponse struct {
-	TriggersClientCreateOrUpdateResult
+	TriggerClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// TriggersClientCreateOrUpdateResult contains the result from method TriggersClient.CreateOrUpdate.
-type TriggersClientCreateOrUpdateResult struct {
-	TriggerClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type TriggersClientCreateOrUpdateResult.
-func (t *TriggersClientCreateOrUpdateResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type TriggersClientCreateOrUpdateResponse.
+func (t *TriggersClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalTriggerClassification(data)
 	if err != nil {
 		return err
@@ -1978,18 +1733,13 @@ type TriggersClientDeleteResponse struct {
 
 // TriggersClientGetResponse contains the response from method TriggersClient.Get.
 type TriggersClientGetResponse struct {
-	TriggersClientGetResult
+	TriggerClassification
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// TriggersClientGetResult contains the result from method TriggersClient.Get.
-type TriggersClientGetResult struct {
-	TriggerClassification
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type TriggersClientGetResult.
-func (t *TriggersClientGetResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type TriggersClientGetResponse.
+func (t *TriggersClientGetResponse) UnmarshalJSON(data []byte) error {
 	res, err := unmarshalTriggerClassification(data)
 	if err != nil {
 		return err
@@ -2000,14 +1750,9 @@ func (t *TriggersClientGetResult) UnmarshalJSON(data []byte) error {
 
 // TriggersClientListByDataBoxEdgeDeviceResponse contains the response from method TriggersClient.ListByDataBoxEdgeDevice.
 type TriggersClientListByDataBoxEdgeDeviceResponse struct {
-	TriggersClientListByDataBoxEdgeDeviceResult
+	TriggerList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// TriggersClientListByDataBoxEdgeDeviceResult contains the result from method TriggersClient.ListByDataBoxEdgeDevice.
-type TriggersClientListByDataBoxEdgeDeviceResult struct {
-	TriggerList
 }
 
 // UsersClientCreateOrUpdatePollerResponse contains the response from method UsersClient.CreateOrUpdate.
@@ -2052,14 +1797,9 @@ func (l *UsersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, cl
 
 // UsersClientCreateOrUpdateResponse contains the response from method UsersClient.CreateOrUpdate.
 type UsersClientCreateOrUpdateResponse struct {
-	UsersClientCreateOrUpdateResult
+	User
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// UsersClientCreateOrUpdateResult contains the result from method UsersClient.CreateOrUpdate.
-type UsersClientCreateOrUpdateResult struct {
-	User
 }
 
 // UsersClientDeletePollerResponse contains the response from method UsersClient.Delete.
@@ -2110,24 +1850,14 @@ type UsersClientDeleteResponse struct {
 
 // UsersClientGetResponse contains the response from method UsersClient.Get.
 type UsersClientGetResponse struct {
-	UsersClientGetResult
+	User
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// UsersClientGetResult contains the result from method UsersClient.Get.
-type UsersClientGetResult struct {
-	User
 }
 
 // UsersClientListByDataBoxEdgeDeviceResponse contains the response from method UsersClient.ListByDataBoxEdgeDevice.
 type UsersClientListByDataBoxEdgeDeviceResponse struct {
-	UsersClientListByDataBoxEdgeDeviceResult
+	UserList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// UsersClientListByDataBoxEdgeDeviceResult contains the result from method UsersClient.ListByDataBoxEdgeDevice.
-type UsersClientListByDataBoxEdgeDeviceResult struct {
-	UserList
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
@@ -17,194 +17,114 @@ import (
 
 // ClientBackupCertificateResponse contains the response from method Client.BackupCertificate.
 type ClientBackupCertificateResponse struct {
-	ClientBackupCertificateResult
+	BackupCertificateResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientBackupCertificateResult contains the result from method Client.BackupCertificate.
-type ClientBackupCertificateResult struct {
-	BackupCertificateResult
 }
 
 // ClientBackupKeyResponse contains the response from method Client.BackupKey.
 type ClientBackupKeyResponse struct {
-	ClientBackupKeyResult
+	BackupKeyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientBackupKeyResult contains the result from method Client.BackupKey.
-type ClientBackupKeyResult struct {
-	BackupKeyResult
 }
 
 // ClientBackupSecretResponse contains the response from method Client.BackupSecret.
 type ClientBackupSecretResponse struct {
-	ClientBackupSecretResult
+	BackupSecretResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientBackupSecretResult contains the result from method Client.BackupSecret.
-type ClientBackupSecretResult struct {
-	BackupSecretResult
 }
 
 // ClientBackupStorageAccountResponse contains the response from method Client.BackupStorageAccount.
 type ClientBackupStorageAccountResponse struct {
-	ClientBackupStorageAccountResult
+	BackupStorageResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientBackupStorageAccountResult contains the result from method Client.BackupStorageAccount.
-type ClientBackupStorageAccountResult struct {
-	BackupStorageResult
 }
 
 // ClientCreateCertificateResponse contains the response from method Client.CreateCertificate.
 type ClientCreateCertificateResponse struct {
-	ClientCreateCertificateResult
+	CertificateOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientCreateCertificateResult contains the result from method Client.CreateCertificate.
-type ClientCreateCertificateResult struct {
-	CertificateOperation
 }
 
 // ClientCreateKeyResponse contains the response from method Client.CreateKey.
 type ClientCreateKeyResponse struct {
-	ClientCreateKeyResult
+	KeyBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientCreateKeyResult contains the result from method Client.CreateKey.
-type ClientCreateKeyResult struct {
-	KeyBundle
 }
 
 // ClientDecryptResponse contains the response from method Client.Decrypt.
 type ClientDecryptResponse struct {
-	ClientDecryptResult
+	KeyOperationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDecryptResult contains the result from method Client.Decrypt.
-type ClientDecryptResult struct {
-	KeyOperationResult
 }
 
 // ClientDeleteCertificateContactsResponse contains the response from method Client.DeleteCertificateContacts.
 type ClientDeleteCertificateContactsResponse struct {
-	ClientDeleteCertificateContactsResult
+	Contacts
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDeleteCertificateContactsResult contains the result from method Client.DeleteCertificateContacts.
-type ClientDeleteCertificateContactsResult struct {
-	Contacts
 }
 
 // ClientDeleteCertificateIssuerResponse contains the response from method Client.DeleteCertificateIssuer.
 type ClientDeleteCertificateIssuerResponse struct {
-	ClientDeleteCertificateIssuerResult
+	IssuerBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDeleteCertificateIssuerResult contains the result from method Client.DeleteCertificateIssuer.
-type ClientDeleteCertificateIssuerResult struct {
-	IssuerBundle
 }
 
 // ClientDeleteCertificateOperationResponse contains the response from method Client.DeleteCertificateOperation.
 type ClientDeleteCertificateOperationResponse struct {
-	ClientDeleteCertificateOperationResult
+	CertificateOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDeleteCertificateOperationResult contains the result from method Client.DeleteCertificateOperation.
-type ClientDeleteCertificateOperationResult struct {
-	CertificateOperation
 }
 
 // ClientDeleteCertificateResponse contains the response from method Client.DeleteCertificate.
 type ClientDeleteCertificateResponse struct {
-	ClientDeleteCertificateResult
+	DeletedCertificateBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDeleteCertificateResult contains the result from method Client.DeleteCertificate.
-type ClientDeleteCertificateResult struct {
-	DeletedCertificateBundle
 }
 
 // ClientDeleteKeyResponse contains the response from method Client.DeleteKey.
 type ClientDeleteKeyResponse struct {
-	ClientDeleteKeyResult
+	DeletedKeyBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDeleteKeyResult contains the result from method Client.DeleteKey.
-type ClientDeleteKeyResult struct {
-	DeletedKeyBundle
 }
 
 // ClientDeleteSasDefinitionResponse contains the response from method Client.DeleteSasDefinition.
 type ClientDeleteSasDefinitionResponse struct {
-	ClientDeleteSasDefinitionResult
+	DeletedSasDefinitionBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDeleteSasDefinitionResult contains the result from method Client.DeleteSasDefinition.
-type ClientDeleteSasDefinitionResult struct {
-	DeletedSasDefinitionBundle
 }
 
 // ClientDeleteSecretResponse contains the response from method Client.DeleteSecret.
 type ClientDeleteSecretResponse struct {
-	ClientDeleteSecretResult
+	DeletedSecretBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDeleteSecretResult contains the result from method Client.DeleteSecret.
-type ClientDeleteSecretResult struct {
-	DeletedSecretBundle
 }
 
 // ClientDeleteStorageAccountResponse contains the response from method Client.DeleteStorageAccount.
 type ClientDeleteStorageAccountResponse struct {
-	ClientDeleteStorageAccountResult
+	DeletedStorageBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientDeleteStorageAccountResult contains the result from method Client.DeleteStorageAccount.
-type ClientDeleteStorageAccountResult struct {
-	DeletedStorageBundle
 }
 
 // ClientEncryptResponse contains the response from method Client.Encrypt.
 type ClientEncryptResponse struct {
-	ClientEncryptResult
+	KeyOperationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientEncryptResult contains the result from method Client.Encrypt.
-type ClientEncryptResult struct {
-	KeyOperationResult
 }
 
 // ClientFullBackupPollerResponse contains the response from method Client.FullBackup.
@@ -248,26 +168,16 @@ func (l *ClientFullBackupPollerResponse) Resume(ctx context.Context, client *Cli
 
 // ClientFullBackupResponse contains the response from method Client.FullBackup.
 type ClientFullBackupResponse struct {
-	ClientFullBackupResult
+	FullBackupOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientFullBackupResult contains the result from method Client.FullBackup.
-type ClientFullBackupResult struct {
-	FullBackupOperation
 }
 
 // ClientFullBackupStatusResponse contains the response from method Client.FullBackupStatus.
 type ClientFullBackupStatusResponse struct {
-	ClientFullBackupStatusResult
+	FullBackupOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientFullBackupStatusResult contains the result from method Client.FullBackupStatus.
-type ClientFullBackupStatusResult struct {
-	FullBackupOperation
 }
 
 // ClientFullRestoreOperationPollerResponse contains the response from method Client.FullRestoreOperation.
@@ -311,386 +221,226 @@ func (l *ClientFullRestoreOperationPollerResponse) Resume(ctx context.Context, c
 
 // ClientFullRestoreOperationResponse contains the response from method Client.FullRestoreOperation.
 type ClientFullRestoreOperationResponse struct {
-	ClientFullRestoreOperationResult
+	RestoreOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientFullRestoreOperationResult contains the result from method Client.FullRestoreOperation.
-type ClientFullRestoreOperationResult struct {
-	RestoreOperation
 }
 
 // ClientGetCertificateContactsResponse contains the response from method Client.GetCertificateContacts.
 type ClientGetCertificateContactsResponse struct {
-	ClientGetCertificateContactsResult
+	Contacts
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetCertificateContactsResult contains the result from method Client.GetCertificateContacts.
-type ClientGetCertificateContactsResult struct {
-	Contacts
 }
 
 // ClientGetCertificateIssuerResponse contains the response from method Client.GetCertificateIssuer.
 type ClientGetCertificateIssuerResponse struct {
-	ClientGetCertificateIssuerResult
+	IssuerBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetCertificateIssuerResult contains the result from method Client.GetCertificateIssuer.
-type ClientGetCertificateIssuerResult struct {
-	IssuerBundle
 }
 
 // ClientGetCertificateIssuersResponse contains the response from method Client.GetCertificateIssuers.
 type ClientGetCertificateIssuersResponse struct {
-	ClientGetCertificateIssuersResult
+	CertificateIssuerListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetCertificateIssuersResult contains the result from method Client.GetCertificateIssuers.
-type ClientGetCertificateIssuersResult struct {
-	CertificateIssuerListResult
 }
 
 // ClientGetCertificateOperationResponse contains the response from method Client.GetCertificateOperation.
 type ClientGetCertificateOperationResponse struct {
-	ClientGetCertificateOperationResult
+	CertificateOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetCertificateOperationResult contains the result from method Client.GetCertificateOperation.
-type ClientGetCertificateOperationResult struct {
-	CertificateOperation
 }
 
 // ClientGetCertificatePolicyResponse contains the response from method Client.GetCertificatePolicy.
 type ClientGetCertificatePolicyResponse struct {
-	ClientGetCertificatePolicyResult
+	CertificatePolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetCertificatePolicyResult contains the result from method Client.GetCertificatePolicy.
-type ClientGetCertificatePolicyResult struct {
-	CertificatePolicy
 }
 
 // ClientGetCertificateResponse contains the response from method Client.GetCertificate.
 type ClientGetCertificateResponse struct {
-	ClientGetCertificateResult
+	CertificateBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetCertificateResult contains the result from method Client.GetCertificate.
-type ClientGetCertificateResult struct {
-	CertificateBundle
 }
 
 // ClientGetCertificateVersionsResponse contains the response from method Client.GetCertificateVersions.
 type ClientGetCertificateVersionsResponse struct {
-	ClientGetCertificateVersionsResult
+	CertificateListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetCertificateVersionsResult contains the result from method Client.GetCertificateVersions.
-type ClientGetCertificateVersionsResult struct {
-	CertificateListResult
 }
 
 // ClientGetCertificatesResponse contains the response from method Client.GetCertificates.
 type ClientGetCertificatesResponse struct {
-	ClientGetCertificatesResult
+	CertificateListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetCertificatesResult contains the result from method Client.GetCertificates.
-type ClientGetCertificatesResult struct {
-	CertificateListResult
 }
 
 // ClientGetDeletedCertificateResponse contains the response from method Client.GetDeletedCertificate.
 type ClientGetDeletedCertificateResponse struct {
-	ClientGetDeletedCertificateResult
+	DeletedCertificateBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedCertificateResult contains the result from method Client.GetDeletedCertificate.
-type ClientGetDeletedCertificateResult struct {
-	DeletedCertificateBundle
 }
 
 // ClientGetDeletedCertificatesResponse contains the response from method Client.GetDeletedCertificates.
 type ClientGetDeletedCertificatesResponse struct {
-	ClientGetDeletedCertificatesResult
+	DeletedCertificateListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedCertificatesResult contains the result from method Client.GetDeletedCertificates.
-type ClientGetDeletedCertificatesResult struct {
-	DeletedCertificateListResult
 }
 
 // ClientGetDeletedKeyResponse contains the response from method Client.GetDeletedKey.
 type ClientGetDeletedKeyResponse struct {
-	ClientGetDeletedKeyResult
+	DeletedKeyBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedKeyResult contains the result from method Client.GetDeletedKey.
-type ClientGetDeletedKeyResult struct {
-	DeletedKeyBundle
 }
 
 // ClientGetDeletedKeysResponse contains the response from method Client.GetDeletedKeys.
 type ClientGetDeletedKeysResponse struct {
-	ClientGetDeletedKeysResult
+	DeletedKeyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedKeysResult contains the result from method Client.GetDeletedKeys.
-type ClientGetDeletedKeysResult struct {
-	DeletedKeyListResult
 }
 
 // ClientGetDeletedSasDefinitionResponse contains the response from method Client.GetDeletedSasDefinition.
 type ClientGetDeletedSasDefinitionResponse struct {
-	ClientGetDeletedSasDefinitionResult
+	DeletedSasDefinitionBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedSasDefinitionResult contains the result from method Client.GetDeletedSasDefinition.
-type ClientGetDeletedSasDefinitionResult struct {
-	DeletedSasDefinitionBundle
 }
 
 // ClientGetDeletedSasDefinitionsResponse contains the response from method Client.GetDeletedSasDefinitions.
 type ClientGetDeletedSasDefinitionsResponse struct {
-	ClientGetDeletedSasDefinitionsResult
+	DeletedSasDefinitionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedSasDefinitionsResult contains the result from method Client.GetDeletedSasDefinitions.
-type ClientGetDeletedSasDefinitionsResult struct {
-	DeletedSasDefinitionListResult
 }
 
 // ClientGetDeletedSecretResponse contains the response from method Client.GetDeletedSecret.
 type ClientGetDeletedSecretResponse struct {
-	ClientGetDeletedSecretResult
+	DeletedSecretBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedSecretResult contains the result from method Client.GetDeletedSecret.
-type ClientGetDeletedSecretResult struct {
-	DeletedSecretBundle
 }
 
 // ClientGetDeletedSecretsResponse contains the response from method Client.GetDeletedSecrets.
 type ClientGetDeletedSecretsResponse struct {
-	ClientGetDeletedSecretsResult
+	DeletedSecretListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedSecretsResult contains the result from method Client.GetDeletedSecrets.
-type ClientGetDeletedSecretsResult struct {
-	DeletedSecretListResult
 }
 
 // ClientGetDeletedStorageAccountResponse contains the response from method Client.GetDeletedStorageAccount.
 type ClientGetDeletedStorageAccountResponse struct {
-	ClientGetDeletedStorageAccountResult
+	DeletedStorageBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedStorageAccountResult contains the result from method Client.GetDeletedStorageAccount.
-type ClientGetDeletedStorageAccountResult struct {
-	DeletedStorageBundle
 }
 
 // ClientGetDeletedStorageAccountsResponse contains the response from method Client.GetDeletedStorageAccounts.
 type ClientGetDeletedStorageAccountsResponse struct {
-	ClientGetDeletedStorageAccountsResult
+	DeletedStorageListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetDeletedStorageAccountsResult contains the result from method Client.GetDeletedStorageAccounts.
-type ClientGetDeletedStorageAccountsResult struct {
-	DeletedStorageListResult
 }
 
 // ClientGetKeyResponse contains the response from method Client.GetKey.
 type ClientGetKeyResponse struct {
-	ClientGetKeyResult
+	KeyBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetKeyResult contains the result from method Client.GetKey.
-type ClientGetKeyResult struct {
-	KeyBundle
 }
 
 // ClientGetKeyVersionsResponse contains the response from method Client.GetKeyVersions.
 type ClientGetKeyVersionsResponse struct {
-	ClientGetKeyVersionsResult
+	KeyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetKeyVersionsResult contains the result from method Client.GetKeyVersions.
-type ClientGetKeyVersionsResult struct {
-	KeyListResult
 }
 
 // ClientGetKeysResponse contains the response from method Client.GetKeys.
 type ClientGetKeysResponse struct {
-	ClientGetKeysResult
+	KeyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetKeysResult contains the result from method Client.GetKeys.
-type ClientGetKeysResult struct {
-	KeyListResult
 }
 
 // ClientGetSasDefinitionResponse contains the response from method Client.GetSasDefinition.
 type ClientGetSasDefinitionResponse struct {
-	ClientGetSasDefinitionResult
+	SasDefinitionBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetSasDefinitionResult contains the result from method Client.GetSasDefinition.
-type ClientGetSasDefinitionResult struct {
-	SasDefinitionBundle
 }
 
 // ClientGetSasDefinitionsResponse contains the response from method Client.GetSasDefinitions.
 type ClientGetSasDefinitionsResponse struct {
-	ClientGetSasDefinitionsResult
+	SasDefinitionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetSasDefinitionsResult contains the result from method Client.GetSasDefinitions.
-type ClientGetSasDefinitionsResult struct {
-	SasDefinitionListResult
 }
 
 // ClientGetSecretResponse contains the response from method Client.GetSecret.
 type ClientGetSecretResponse struct {
-	ClientGetSecretResult
+	SecretBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetSecretResult contains the result from method Client.GetSecret.
-type ClientGetSecretResult struct {
-	SecretBundle
 }
 
 // ClientGetSecretVersionsResponse contains the response from method Client.GetSecretVersions.
 type ClientGetSecretVersionsResponse struct {
-	ClientGetSecretVersionsResult
+	SecretListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetSecretVersionsResult contains the result from method Client.GetSecretVersions.
-type ClientGetSecretVersionsResult struct {
-	SecretListResult
 }
 
 // ClientGetSecretsResponse contains the response from method Client.GetSecrets.
 type ClientGetSecretsResponse struct {
-	ClientGetSecretsResult
+	SecretListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetSecretsResult contains the result from method Client.GetSecrets.
-type ClientGetSecretsResult struct {
-	SecretListResult
 }
 
 // ClientGetStorageAccountResponse contains the response from method Client.GetStorageAccount.
 type ClientGetStorageAccountResponse struct {
-	ClientGetStorageAccountResult
+	StorageBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetStorageAccountResult contains the result from method Client.GetStorageAccount.
-type ClientGetStorageAccountResult struct {
-	StorageBundle
 }
 
 // ClientGetStorageAccountsResponse contains the response from method Client.GetStorageAccounts.
 type ClientGetStorageAccountsResponse struct {
-	ClientGetStorageAccountsResult
+	StorageListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientGetStorageAccountsResult contains the result from method Client.GetStorageAccounts.
-type ClientGetStorageAccountsResult struct {
-	StorageListResult
 }
 
 // ClientImportCertificateResponse contains the response from method Client.ImportCertificate.
 type ClientImportCertificateResponse struct {
-	ClientImportCertificateResult
+	CertificateBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientImportCertificateResult contains the result from method Client.ImportCertificate.
-type ClientImportCertificateResult struct {
-	CertificateBundle
 }
 
 // ClientImportKeyResponse contains the response from method Client.ImportKey.
 type ClientImportKeyResponse struct {
-	ClientImportKeyResult
+	KeyBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientImportKeyResult contains the result from method Client.ImportKey.
-type ClientImportKeyResult struct {
-	KeyBundle
 }
 
 // ClientMergeCertificateResponse contains the response from method Client.MergeCertificate.
 type ClientMergeCertificateResponse struct {
-	ClientMergeCertificateResult
+	CertificateBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientMergeCertificateResult contains the result from method Client.MergeCertificate.
-type ClientMergeCertificateResult struct {
-	CertificateBundle
 }
 
 // ClientPurgeDeletedCertificateResponse contains the response from method Client.PurgeDeletedCertificate.
@@ -719,134 +469,79 @@ type ClientPurgeDeletedStorageAccountResponse struct {
 
 // ClientRecoverDeletedCertificateResponse contains the response from method Client.RecoverDeletedCertificate.
 type ClientRecoverDeletedCertificateResponse struct {
-	ClientRecoverDeletedCertificateResult
+	CertificateBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRecoverDeletedCertificateResult contains the result from method Client.RecoverDeletedCertificate.
-type ClientRecoverDeletedCertificateResult struct {
-	CertificateBundle
 }
 
 // ClientRecoverDeletedKeyResponse contains the response from method Client.RecoverDeletedKey.
 type ClientRecoverDeletedKeyResponse struct {
-	ClientRecoverDeletedKeyResult
+	KeyBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRecoverDeletedKeyResult contains the result from method Client.RecoverDeletedKey.
-type ClientRecoverDeletedKeyResult struct {
-	KeyBundle
 }
 
 // ClientRecoverDeletedSasDefinitionResponse contains the response from method Client.RecoverDeletedSasDefinition.
 type ClientRecoverDeletedSasDefinitionResponse struct {
-	ClientRecoverDeletedSasDefinitionResult
+	SasDefinitionBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRecoverDeletedSasDefinitionResult contains the result from method Client.RecoverDeletedSasDefinition.
-type ClientRecoverDeletedSasDefinitionResult struct {
-	SasDefinitionBundle
 }
 
 // ClientRecoverDeletedSecretResponse contains the response from method Client.RecoverDeletedSecret.
 type ClientRecoverDeletedSecretResponse struct {
-	ClientRecoverDeletedSecretResult
+	SecretBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRecoverDeletedSecretResult contains the result from method Client.RecoverDeletedSecret.
-type ClientRecoverDeletedSecretResult struct {
-	SecretBundle
 }
 
 // ClientRecoverDeletedStorageAccountResponse contains the response from method Client.RecoverDeletedStorageAccount.
 type ClientRecoverDeletedStorageAccountResponse struct {
-	ClientRecoverDeletedStorageAccountResult
+	StorageBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRecoverDeletedStorageAccountResult contains the result from method Client.RecoverDeletedStorageAccount.
-type ClientRecoverDeletedStorageAccountResult struct {
-	StorageBundle
 }
 
 // ClientRegenerateStorageAccountKeyResponse contains the response from method Client.RegenerateStorageAccountKey.
 type ClientRegenerateStorageAccountKeyResponse struct {
-	ClientRegenerateStorageAccountKeyResult
+	StorageBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRegenerateStorageAccountKeyResult contains the result from method Client.RegenerateStorageAccountKey.
-type ClientRegenerateStorageAccountKeyResult struct {
-	StorageBundle
 }
 
 // ClientRestoreCertificateResponse contains the response from method Client.RestoreCertificate.
 type ClientRestoreCertificateResponse struct {
-	ClientRestoreCertificateResult
+	CertificateBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRestoreCertificateResult contains the result from method Client.RestoreCertificate.
-type ClientRestoreCertificateResult struct {
-	CertificateBundle
 }
 
 // ClientRestoreKeyResponse contains the response from method Client.RestoreKey.
 type ClientRestoreKeyResponse struct {
-	ClientRestoreKeyResult
+	KeyBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRestoreKeyResult contains the result from method Client.RestoreKey.
-type ClientRestoreKeyResult struct {
-	KeyBundle
 }
 
 // ClientRestoreSecretResponse contains the response from method Client.RestoreSecret.
 type ClientRestoreSecretResponse struct {
-	ClientRestoreSecretResult
+	SecretBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRestoreSecretResult contains the result from method Client.RestoreSecret.
-type ClientRestoreSecretResult struct {
-	SecretBundle
 }
 
 // ClientRestoreStatusResponse contains the response from method Client.RestoreStatus.
 type ClientRestoreStatusResponse struct {
-	ClientRestoreStatusResult
+	RestoreOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRestoreStatusResult contains the result from method Client.RestoreStatus.
-type ClientRestoreStatusResult struct {
-	RestoreOperation
 }
 
 // ClientRestoreStorageAccountResponse contains the response from method Client.RestoreStorageAccount.
 type ClientRestoreStorageAccountResponse struct {
-	ClientRestoreStorageAccountResult
+	StorageBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientRestoreStorageAccountResult contains the result from method Client.RestoreStorageAccount.
-type ClientRestoreStorageAccountResult struct {
-	StorageBundle
 }
 
 // ClientSelectiveKeyRestoreOperationPollerResponse contains the response from method Client.SelectiveKeyRestoreOperation.
@@ -890,230 +585,135 @@ func (l *ClientSelectiveKeyRestoreOperationPollerResponse) Resume(ctx context.Co
 
 // ClientSelectiveKeyRestoreOperationResponse contains the response from method Client.SelectiveKeyRestoreOperation.
 type ClientSelectiveKeyRestoreOperationResponse struct {
-	ClientSelectiveKeyRestoreOperationResult
+	SelectiveKeyRestoreOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientSelectiveKeyRestoreOperationResult contains the result from method Client.SelectiveKeyRestoreOperation.
-type ClientSelectiveKeyRestoreOperationResult struct {
-	SelectiveKeyRestoreOperation
 }
 
 // ClientSetCertificateContactsResponse contains the response from method Client.SetCertificateContacts.
 type ClientSetCertificateContactsResponse struct {
-	ClientSetCertificateContactsResult
+	Contacts
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientSetCertificateContactsResult contains the result from method Client.SetCertificateContacts.
-type ClientSetCertificateContactsResult struct {
-	Contacts
 }
 
 // ClientSetCertificateIssuerResponse contains the response from method Client.SetCertificateIssuer.
 type ClientSetCertificateIssuerResponse struct {
-	ClientSetCertificateIssuerResult
+	IssuerBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientSetCertificateIssuerResult contains the result from method Client.SetCertificateIssuer.
-type ClientSetCertificateIssuerResult struct {
-	IssuerBundle
 }
 
 // ClientSetSasDefinitionResponse contains the response from method Client.SetSasDefinition.
 type ClientSetSasDefinitionResponse struct {
-	ClientSetSasDefinitionResult
+	SasDefinitionBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientSetSasDefinitionResult contains the result from method Client.SetSasDefinition.
-type ClientSetSasDefinitionResult struct {
-	SasDefinitionBundle
 }
 
 // ClientSetSecretResponse contains the response from method Client.SetSecret.
 type ClientSetSecretResponse struct {
-	ClientSetSecretResult
+	SecretBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientSetSecretResult contains the result from method Client.SetSecret.
-type ClientSetSecretResult struct {
-	SecretBundle
 }
 
 // ClientSetStorageAccountResponse contains the response from method Client.SetStorageAccount.
 type ClientSetStorageAccountResponse struct {
-	ClientSetStorageAccountResult
+	StorageBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientSetStorageAccountResult contains the result from method Client.SetStorageAccount.
-type ClientSetStorageAccountResult struct {
-	StorageBundle
 }
 
 // ClientSignResponse contains the response from method Client.Sign.
 type ClientSignResponse struct {
-	ClientSignResult
+	KeyOperationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientSignResult contains the result from method Client.Sign.
-type ClientSignResult struct {
-	KeyOperationResult
 }
 
 // ClientUnwrapKeyResponse contains the response from method Client.UnwrapKey.
 type ClientUnwrapKeyResponse struct {
-	ClientUnwrapKeyResult
+	KeyOperationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUnwrapKeyResult contains the result from method Client.UnwrapKey.
-type ClientUnwrapKeyResult struct {
-	KeyOperationResult
 }
 
 // ClientUpdateCertificateIssuerResponse contains the response from method Client.UpdateCertificateIssuer.
 type ClientUpdateCertificateIssuerResponse struct {
-	ClientUpdateCertificateIssuerResult
+	IssuerBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUpdateCertificateIssuerResult contains the result from method Client.UpdateCertificateIssuer.
-type ClientUpdateCertificateIssuerResult struct {
-	IssuerBundle
 }
 
 // ClientUpdateCertificateOperationResponse contains the response from method Client.UpdateCertificateOperation.
 type ClientUpdateCertificateOperationResponse struct {
-	ClientUpdateCertificateOperationResult
+	CertificateOperation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUpdateCertificateOperationResult contains the result from method Client.UpdateCertificateOperation.
-type ClientUpdateCertificateOperationResult struct {
-	CertificateOperation
 }
 
 // ClientUpdateCertificatePolicyResponse contains the response from method Client.UpdateCertificatePolicy.
 type ClientUpdateCertificatePolicyResponse struct {
-	ClientUpdateCertificatePolicyResult
+	CertificatePolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUpdateCertificatePolicyResult contains the result from method Client.UpdateCertificatePolicy.
-type ClientUpdateCertificatePolicyResult struct {
-	CertificatePolicy
 }
 
 // ClientUpdateCertificateResponse contains the response from method Client.UpdateCertificate.
 type ClientUpdateCertificateResponse struct {
-	ClientUpdateCertificateResult
+	CertificateBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUpdateCertificateResult contains the result from method Client.UpdateCertificate.
-type ClientUpdateCertificateResult struct {
-	CertificateBundle
 }
 
 // ClientUpdateKeyResponse contains the response from method Client.UpdateKey.
 type ClientUpdateKeyResponse struct {
-	ClientUpdateKeyResult
+	KeyBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUpdateKeyResult contains the result from method Client.UpdateKey.
-type ClientUpdateKeyResult struct {
-	KeyBundle
 }
 
 // ClientUpdateSasDefinitionResponse contains the response from method Client.UpdateSasDefinition.
 type ClientUpdateSasDefinitionResponse struct {
-	ClientUpdateSasDefinitionResult
+	SasDefinitionBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUpdateSasDefinitionResult contains the result from method Client.UpdateSasDefinition.
-type ClientUpdateSasDefinitionResult struct {
-	SasDefinitionBundle
 }
 
 // ClientUpdateSecretResponse contains the response from method Client.UpdateSecret.
 type ClientUpdateSecretResponse struct {
-	ClientUpdateSecretResult
+	SecretBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUpdateSecretResult contains the result from method Client.UpdateSecret.
-type ClientUpdateSecretResult struct {
-	SecretBundle
 }
 
 // ClientUpdateStorageAccountResponse contains the response from method Client.UpdateStorageAccount.
 type ClientUpdateStorageAccountResponse struct {
-	ClientUpdateStorageAccountResult
+	StorageBundle
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientUpdateStorageAccountResult contains the result from method Client.UpdateStorageAccount.
-type ClientUpdateStorageAccountResult struct {
-	StorageBundle
 }
 
 // ClientVerifyResponse contains the response from method Client.Verify.
 type ClientVerifyResponse struct {
-	ClientVerifyResult
+	KeyVerifyResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientVerifyResult contains the result from method Client.Verify.
-type ClientVerifyResult struct {
-	KeyVerifyResult
 }
 
 // ClientWrapKeyResponse contains the response from method Client.WrapKey.
 type ClientWrapKeyResponse struct {
-	ClientWrapKeyResult
+	KeyOperationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ClientWrapKeyResult contains the result from method Client.WrapKey.
-type ClientWrapKeyResult struct {
-	KeyOperationResult
 }
 
 // HSMSecurityDomainClientDownloadPendingResponse contains the response from method HSMSecurityDomainClient.DownloadPending.
 type HSMSecurityDomainClientDownloadPendingResponse struct {
-	HSMSecurityDomainClientDownloadPendingResult
+	SecurityDomainOperationStatus
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// HSMSecurityDomainClientDownloadPendingResult contains the result from method HSMSecurityDomainClient.DownloadPending.
-type HSMSecurityDomainClientDownloadPendingResult struct {
-	SecurityDomainOperationStatus
 }
 
 // HSMSecurityDomainClientDownloadPollerResponse contains the response from method HSMSecurityDomainClient.Download.
@@ -1157,38 +757,23 @@ func (l *HSMSecurityDomainClientDownloadPollerResponse) Resume(ctx context.Conte
 
 // HSMSecurityDomainClientDownloadResponse contains the response from method HSMSecurityDomainClient.Download.
 type HSMSecurityDomainClientDownloadResponse struct {
-	HSMSecurityDomainClientDownloadResult
+	SecurityDomainObject
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// HSMSecurityDomainClientDownloadResult contains the result from method HSMSecurityDomainClient.Download.
-type HSMSecurityDomainClientDownloadResult struct {
-	SecurityDomainObject
 }
 
 // HSMSecurityDomainClientTransferKeyResponse contains the response from method HSMSecurityDomainClient.TransferKey.
 type HSMSecurityDomainClientTransferKeyResponse struct {
-	HSMSecurityDomainClientTransferKeyResult
+	TransferKey
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// HSMSecurityDomainClientTransferKeyResult contains the result from method HSMSecurityDomainClient.TransferKey.
-type HSMSecurityDomainClientTransferKeyResult struct {
-	TransferKey
 }
 
 // HSMSecurityDomainClientUploadPendingResponse contains the response from method HSMSecurityDomainClient.UploadPending.
 type HSMSecurityDomainClientUploadPendingResponse struct {
-	HSMSecurityDomainClientUploadPendingResult
+	SecurityDomainOperationStatus
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// HSMSecurityDomainClientUploadPendingResult contains the result from method HSMSecurityDomainClient.UploadPending.
-type HSMSecurityDomainClientUploadPendingResult struct {
-	SecurityDomainOperationStatus
 }
 
 // HSMSecurityDomainClientUploadPollerResponse contains the response from method HSMSecurityDomainClient.Upload.
@@ -1232,108 +817,63 @@ func (l *HSMSecurityDomainClientUploadPollerResponse) Resume(ctx context.Context
 
 // HSMSecurityDomainClientUploadResponse contains the response from method HSMSecurityDomainClient.Upload.
 type HSMSecurityDomainClientUploadResponse struct {
-	HSMSecurityDomainClientUploadResult
+	SecurityDomainOperationStatus
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// HSMSecurityDomainClientUploadResult contains the result from method HSMSecurityDomainClient.Upload.
-type HSMSecurityDomainClientUploadResult struct {
-	SecurityDomainOperationStatus
 }
 
 // RoleAssignmentsClientCreateResponse contains the response from method RoleAssignmentsClient.Create.
 type RoleAssignmentsClientCreateResponse struct {
-	RoleAssignmentsClientCreateResult
+	RoleAssignment
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoleAssignmentsClientCreateResult contains the result from method RoleAssignmentsClient.Create.
-type RoleAssignmentsClientCreateResult struct {
-	RoleAssignment
 }
 
 // RoleAssignmentsClientDeleteResponse contains the response from method RoleAssignmentsClient.Delete.
 type RoleAssignmentsClientDeleteResponse struct {
-	RoleAssignmentsClientDeleteResult
+	RoleAssignment
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoleAssignmentsClientDeleteResult contains the result from method RoleAssignmentsClient.Delete.
-type RoleAssignmentsClientDeleteResult struct {
-	RoleAssignment
 }
 
 // RoleAssignmentsClientGetResponse contains the response from method RoleAssignmentsClient.Get.
 type RoleAssignmentsClientGetResponse struct {
-	RoleAssignmentsClientGetResult
+	RoleAssignment
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoleAssignmentsClientGetResult contains the result from method RoleAssignmentsClient.Get.
-type RoleAssignmentsClientGetResult struct {
-	RoleAssignment
 }
 
 // RoleAssignmentsClientListForScopeResponse contains the response from method RoleAssignmentsClient.ListForScope.
 type RoleAssignmentsClientListForScopeResponse struct {
-	RoleAssignmentsClientListForScopeResult
+	RoleAssignmentListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoleAssignmentsClientListForScopeResult contains the result from method RoleAssignmentsClient.ListForScope.
-type RoleAssignmentsClientListForScopeResult struct {
-	RoleAssignmentListResult
 }
 
 // RoleDefinitionsClientCreateOrUpdateResponse contains the response from method RoleDefinitionsClient.CreateOrUpdate.
 type RoleDefinitionsClientCreateOrUpdateResponse struct {
-	RoleDefinitionsClientCreateOrUpdateResult
+	RoleDefinition
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoleDefinitionsClientCreateOrUpdateResult contains the result from method RoleDefinitionsClient.CreateOrUpdate.
-type RoleDefinitionsClientCreateOrUpdateResult struct {
-	RoleDefinition
 }
 
 // RoleDefinitionsClientDeleteResponse contains the response from method RoleDefinitionsClient.Delete.
 type RoleDefinitionsClientDeleteResponse struct {
-	RoleDefinitionsClientDeleteResult
+	RoleDefinition
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoleDefinitionsClientDeleteResult contains the result from method RoleDefinitionsClient.Delete.
-type RoleDefinitionsClientDeleteResult struct {
-	RoleDefinition
 }
 
 // RoleDefinitionsClientGetResponse contains the response from method RoleDefinitionsClient.Get.
 type RoleDefinitionsClientGetResponse struct {
-	RoleDefinitionsClientGetResult
+	RoleDefinition
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoleDefinitionsClientGetResult contains the result from method RoleDefinitionsClient.Get.
-type RoleDefinitionsClientGetResult struct {
-	RoleDefinition
 }
 
 // RoleDefinitionsClientListResponse contains the response from method RoleDefinitionsClient.List.
 type RoleDefinitionsClientListResponse struct {
-	RoleDefinitionsClientListResult
+	RoleDefinitionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoleDefinitionsClientListResult contains the result from method RoleDefinitionsClient.List.
-type RoleDefinitionsClientListResult struct {
-	RoleDefinitionListResult
 }

--- a/test/maps/azalias/zz_generated_response_types.go
+++ b/test/maps/azalias/zz_generated_response_types.go
@@ -12,50 +12,31 @@ import "net/http"
 
 // clientCreateResponse contains the response from method client.Create.
 type clientCreateResponse struct {
-	clientCreateResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientCreateResult contains the result from method client.Create.
-type clientCreateResult struct {
 	AliasesCreateResponse
 	// AccessControlExposeHeaders contains the information returned from the Access-Control-Expose-Headers header response.
 	AccessControlExposeHeaders *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // clientGetScriptResponse contains the response from method client.GetScript.
 type clientGetScriptResponse struct {
-	clientGetScriptResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// clientGetScriptResult contains the result from method client.GetScript.
-type clientGetScriptResult struct {
-	Value *string
+	Value       *string
 }
 
 // clientListResponse contains the response from method client.List.
 type clientListResponse struct {
-	clientListResult
+	ListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// clientListResult contains the result from method client.List.
-type clientListResult struct {
-	ListResponse
 }
 
 // clientPolicyAssignmentResponse contains the response from method client.PolicyAssignment.
 type clientPolicyAssignmentResponse struct {
-	clientPolicyAssignmentResult
+	PolicyAssignmentProperties
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// clientPolicyAssignmentResult contains the result from method client.PolicyAssignment.
-type clientPolicyAssignmentResult struct {
-	PolicyAssignmentProperties
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
@@ -57,14 +57,9 @@ func (l *ApplicationGatewaysClientBackendHealthOnDemandPollerResponse) Resume(ct
 
 // ApplicationGatewaysClientBackendHealthOnDemandResponse contains the response from method ApplicationGatewaysClient.BackendHealthOnDemand.
 type ApplicationGatewaysClientBackendHealthOnDemandResponse struct {
-	ApplicationGatewaysClientBackendHealthOnDemandResult
+	ApplicationGatewayBackendHealthOnDemand
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientBackendHealthOnDemandResult contains the result from method ApplicationGatewaysClient.BackendHealthOnDemand.
-type ApplicationGatewaysClientBackendHealthOnDemandResult struct {
-	ApplicationGatewayBackendHealthOnDemand
 }
 
 // ApplicationGatewaysClientBackendHealthPollerResponse contains the response from method ApplicationGatewaysClient.BackendHealth.
@@ -109,14 +104,9 @@ func (l *ApplicationGatewaysClientBackendHealthPollerResponse) Resume(ctx contex
 
 // ApplicationGatewaysClientBackendHealthResponse contains the response from method ApplicationGatewaysClient.BackendHealth.
 type ApplicationGatewaysClientBackendHealthResponse struct {
-	ApplicationGatewaysClientBackendHealthResult
+	ApplicationGatewayBackendHealth
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientBackendHealthResult contains the result from method ApplicationGatewaysClient.BackendHealth.
-type ApplicationGatewaysClientBackendHealthResult struct {
-	ApplicationGatewayBackendHealth
 }
 
 // ApplicationGatewaysClientCreateOrUpdatePollerResponse contains the response from method ApplicationGatewaysClient.CreateOrUpdate.
@@ -161,14 +151,9 @@ func (l *ApplicationGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx conte
 
 // ApplicationGatewaysClientCreateOrUpdateResponse contains the response from method ApplicationGatewaysClient.CreateOrUpdate.
 type ApplicationGatewaysClientCreateOrUpdateResponse struct {
-	ApplicationGatewaysClientCreateOrUpdateResult
+	ApplicationGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientCreateOrUpdateResult contains the result from method ApplicationGatewaysClient.CreateOrUpdate.
-type ApplicationGatewaysClientCreateOrUpdateResult struct {
-	ApplicationGateway
 }
 
 // ApplicationGatewaysClientDeletePollerResponse contains the response from method ApplicationGatewaysClient.Delete.
@@ -219,125 +204,78 @@ type ApplicationGatewaysClientDeleteResponse struct {
 
 // ApplicationGatewaysClientGetResponse contains the response from method ApplicationGatewaysClient.Get.
 type ApplicationGatewaysClientGetResponse struct {
-	ApplicationGatewaysClientGetResult
+	ApplicationGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientGetResult contains the result from method ApplicationGatewaysClient.Get.
-type ApplicationGatewaysClientGetResult struct {
-	ApplicationGateway
 }
 
 // ApplicationGatewaysClientGetSSLPredefinedPolicyResponse contains the response from method ApplicationGatewaysClient.GetSSLPredefinedPolicy.
 type ApplicationGatewaysClientGetSSLPredefinedPolicyResponse struct {
-	ApplicationGatewaysClientGetSSLPredefinedPolicyResult
+	ApplicationGatewaySSLPredefinedPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientGetSSLPredefinedPolicyResult contains the result from method ApplicationGatewaysClient.GetSSLPredefinedPolicy.
-type ApplicationGatewaysClientGetSSLPredefinedPolicyResult struct {
-	ApplicationGatewaySSLPredefinedPolicy
 }
 
 // ApplicationGatewaysClientListAllResponse contains the response from method ApplicationGatewaysClient.ListAll.
 type ApplicationGatewaysClientListAllResponse struct {
-	ApplicationGatewaysClientListAllResult
+	ApplicationGatewayListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientListAllResult contains the result from method ApplicationGatewaysClient.ListAll.
-type ApplicationGatewaysClientListAllResult struct {
-	ApplicationGatewayListResult
 }
 
 // ApplicationGatewaysClientListAvailableRequestHeadersResponse contains the response from method ApplicationGatewaysClient.ListAvailableRequestHeaders.
 type ApplicationGatewaysClientListAvailableRequestHeadersResponse struct {
-	ApplicationGatewaysClientListAvailableRequestHeadersResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ApplicationGatewaysClientListAvailableRequestHeadersResult contains the result from method ApplicationGatewaysClient.ListAvailableRequestHeaders.
-type ApplicationGatewaysClientListAvailableRequestHeadersResult struct {
 	// Response for ApplicationGatewayAvailableRequestHeaders API service call.
 	StringArray []*string
 }
 
 // ApplicationGatewaysClientListAvailableResponseHeadersResponse contains the response from method ApplicationGatewaysClient.ListAvailableResponseHeaders.
 type ApplicationGatewaysClientListAvailableResponseHeadersResponse struct {
-	ApplicationGatewaysClientListAvailableResponseHeadersResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ApplicationGatewaysClientListAvailableResponseHeadersResult contains the result from method ApplicationGatewaysClient.ListAvailableResponseHeaders.
-type ApplicationGatewaysClientListAvailableResponseHeadersResult struct {
 	// Response for ApplicationGatewayAvailableResponseHeaders API service call.
 	StringArray []*string
 }
 
 // ApplicationGatewaysClientListAvailableSSLOptionsResponse contains the response from method ApplicationGatewaysClient.ListAvailableSSLOptions.
 type ApplicationGatewaysClientListAvailableSSLOptionsResponse struct {
-	ApplicationGatewaysClientListAvailableSSLOptionsResult
+	ApplicationGatewayAvailableSSLOptions
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientListAvailableSSLOptionsResult contains the result from method ApplicationGatewaysClient.ListAvailableSSLOptions.
-type ApplicationGatewaysClientListAvailableSSLOptionsResult struct {
-	ApplicationGatewayAvailableSSLOptions
 }
 
 // ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse contains the response from method ApplicationGatewaysClient.ListAvailableSSLPredefinedPolicies.
 type ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse struct {
-	ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResult
+	ApplicationGatewayAvailableSSLPredefinedPolicies
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResult contains the result from method ApplicationGatewaysClient.ListAvailableSSLPredefinedPolicies.
-type ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResult struct {
-	ApplicationGatewayAvailableSSLPredefinedPolicies
 }
 
 // ApplicationGatewaysClientListAvailableServerVariablesResponse contains the response from method ApplicationGatewaysClient.ListAvailableServerVariables.
 type ApplicationGatewaysClientListAvailableServerVariablesResponse struct {
-	ApplicationGatewaysClientListAvailableServerVariablesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
 
-// ApplicationGatewaysClientListAvailableServerVariablesResult contains the result from method ApplicationGatewaysClient.ListAvailableServerVariables.
-type ApplicationGatewaysClientListAvailableServerVariablesResult struct {
 	// Response for ApplicationGatewayAvailableServerVariables API service call.
 	StringArray []*string
 }
 
 // ApplicationGatewaysClientListAvailableWafRuleSetsResponse contains the response from method ApplicationGatewaysClient.ListAvailableWafRuleSets.
 type ApplicationGatewaysClientListAvailableWafRuleSetsResponse struct {
-	ApplicationGatewaysClientListAvailableWafRuleSetsResult
+	ApplicationGatewayAvailableWafRuleSetsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientListAvailableWafRuleSetsResult contains the result from method ApplicationGatewaysClient.ListAvailableWafRuleSets.
-type ApplicationGatewaysClientListAvailableWafRuleSetsResult struct {
-	ApplicationGatewayAvailableWafRuleSetsResult
 }
 
 // ApplicationGatewaysClientListResponse contains the response from method ApplicationGatewaysClient.List.
 type ApplicationGatewaysClientListResponse struct {
-	ApplicationGatewaysClientListResult
+	ApplicationGatewayListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientListResult contains the result from method ApplicationGatewaysClient.List.
-type ApplicationGatewaysClientListResult struct {
-	ApplicationGatewayListResult
 }
 
 // ApplicationGatewaysClientStartPollerResponse contains the response from method ApplicationGatewaysClient.Start.
@@ -434,14 +372,9 @@ type ApplicationGatewaysClientStopResponse struct {
 
 // ApplicationGatewaysClientUpdateTagsResponse contains the response from method ApplicationGatewaysClient.UpdateTags.
 type ApplicationGatewaysClientUpdateTagsResponse struct {
-	ApplicationGatewaysClientUpdateTagsResult
+	ApplicationGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationGatewaysClientUpdateTagsResult contains the result from method ApplicationGatewaysClient.UpdateTags.
-type ApplicationGatewaysClientUpdateTagsResult struct {
-	ApplicationGateway
 }
 
 // ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse contains the response from method ApplicationSecurityGroupsClient.CreateOrUpdate.
@@ -486,14 +419,9 @@ func (l *ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse) Resume(ctx
 
 // ApplicationSecurityGroupsClientCreateOrUpdateResponse contains the response from method ApplicationSecurityGroupsClient.CreateOrUpdate.
 type ApplicationSecurityGroupsClientCreateOrUpdateResponse struct {
-	ApplicationSecurityGroupsClientCreateOrUpdateResult
+	ApplicationSecurityGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationSecurityGroupsClientCreateOrUpdateResult contains the result from method ApplicationSecurityGroupsClient.CreateOrUpdate.
-type ApplicationSecurityGroupsClientCreateOrUpdateResult struct {
-	ApplicationSecurityGroup
 }
 
 // ApplicationSecurityGroupsClientDeletePollerResponse contains the response from method ApplicationSecurityGroupsClient.Delete.
@@ -544,146 +472,86 @@ type ApplicationSecurityGroupsClientDeleteResponse struct {
 
 // ApplicationSecurityGroupsClientGetResponse contains the response from method ApplicationSecurityGroupsClient.Get.
 type ApplicationSecurityGroupsClientGetResponse struct {
-	ApplicationSecurityGroupsClientGetResult
+	ApplicationSecurityGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationSecurityGroupsClientGetResult contains the result from method ApplicationSecurityGroupsClient.Get.
-type ApplicationSecurityGroupsClientGetResult struct {
-	ApplicationSecurityGroup
 }
 
 // ApplicationSecurityGroupsClientListAllResponse contains the response from method ApplicationSecurityGroupsClient.ListAll.
 type ApplicationSecurityGroupsClientListAllResponse struct {
-	ApplicationSecurityGroupsClientListAllResult
+	ApplicationSecurityGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationSecurityGroupsClientListAllResult contains the result from method ApplicationSecurityGroupsClient.ListAll.
-type ApplicationSecurityGroupsClientListAllResult struct {
-	ApplicationSecurityGroupListResult
 }
 
 // ApplicationSecurityGroupsClientListResponse contains the response from method ApplicationSecurityGroupsClient.List.
 type ApplicationSecurityGroupsClientListResponse struct {
-	ApplicationSecurityGroupsClientListResult
+	ApplicationSecurityGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationSecurityGroupsClientListResult contains the result from method ApplicationSecurityGroupsClient.List.
-type ApplicationSecurityGroupsClientListResult struct {
-	ApplicationSecurityGroupListResult
 }
 
 // ApplicationSecurityGroupsClientUpdateTagsResponse contains the response from method ApplicationSecurityGroupsClient.UpdateTags.
 type ApplicationSecurityGroupsClientUpdateTagsResponse struct {
-	ApplicationSecurityGroupsClientUpdateTagsResult
+	ApplicationSecurityGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ApplicationSecurityGroupsClientUpdateTagsResult contains the result from method ApplicationSecurityGroupsClient.UpdateTags.
-type ApplicationSecurityGroupsClientUpdateTagsResult struct {
-	ApplicationSecurityGroup
 }
 
 // AvailableDelegationsClientListResponse contains the response from method AvailableDelegationsClient.List.
 type AvailableDelegationsClientListResponse struct {
-	AvailableDelegationsClientListResult
+	AvailableDelegationsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailableDelegationsClientListResult contains the result from method AvailableDelegationsClient.List.
-type AvailableDelegationsClientListResult struct {
-	AvailableDelegationsResult
 }
 
 // AvailableEndpointServicesClientListResponse contains the response from method AvailableEndpointServicesClient.List.
 type AvailableEndpointServicesClientListResponse struct {
-	AvailableEndpointServicesClientListResult
+	EndpointServicesListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailableEndpointServicesClientListResult contains the result from method AvailableEndpointServicesClient.List.
-type AvailableEndpointServicesClientListResult struct {
-	EndpointServicesListResult
 }
 
 // AvailablePrivateEndpointTypesClientListByResourceGroupResponse contains the response from method AvailablePrivateEndpointTypesClient.ListByResourceGroup.
 type AvailablePrivateEndpointTypesClientListByResourceGroupResponse struct {
-	AvailablePrivateEndpointTypesClientListByResourceGroupResult
+	AvailablePrivateEndpointTypesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailablePrivateEndpointTypesClientListByResourceGroupResult contains the result from method AvailablePrivateEndpointTypesClient.ListByResourceGroup.
-type AvailablePrivateEndpointTypesClientListByResourceGroupResult struct {
-	AvailablePrivateEndpointTypesResult
 }
 
 // AvailablePrivateEndpointTypesClientListResponse contains the response from method AvailablePrivateEndpointTypesClient.List.
 type AvailablePrivateEndpointTypesClientListResponse struct {
-	AvailablePrivateEndpointTypesClientListResult
+	AvailablePrivateEndpointTypesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailablePrivateEndpointTypesClientListResult contains the result from method AvailablePrivateEndpointTypesClient.List.
-type AvailablePrivateEndpointTypesClientListResult struct {
-	AvailablePrivateEndpointTypesResult
 }
 
 // AvailableResourceGroupDelegationsClientListResponse contains the response from method AvailableResourceGroupDelegationsClient.List.
 type AvailableResourceGroupDelegationsClientListResponse struct {
-	AvailableResourceGroupDelegationsClientListResult
+	AvailableDelegationsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailableResourceGroupDelegationsClientListResult contains the result from method AvailableResourceGroupDelegationsClient.List.
-type AvailableResourceGroupDelegationsClientListResult struct {
-	AvailableDelegationsResult
 }
 
 // AvailableServiceAliasesClientListByResourceGroupResponse contains the response from method AvailableServiceAliasesClient.ListByResourceGroup.
 type AvailableServiceAliasesClientListByResourceGroupResponse struct {
-	AvailableServiceAliasesClientListByResourceGroupResult
+	AvailableServiceAliasesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailableServiceAliasesClientListByResourceGroupResult contains the result from method AvailableServiceAliasesClient.ListByResourceGroup.
-type AvailableServiceAliasesClientListByResourceGroupResult struct {
-	AvailableServiceAliasesResult
 }
 
 // AvailableServiceAliasesClientListResponse contains the response from method AvailableServiceAliasesClient.List.
 type AvailableServiceAliasesClientListResponse struct {
-	AvailableServiceAliasesClientListResult
+	AvailableServiceAliasesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AvailableServiceAliasesClientListResult contains the result from method AvailableServiceAliasesClient.List.
-type AvailableServiceAliasesClientListResult struct {
-	AvailableServiceAliasesResult
 }
 
 // AzureFirewallFqdnTagsClientListAllResponse contains the response from method AzureFirewallFqdnTagsClient.ListAll.
 type AzureFirewallFqdnTagsClientListAllResponse struct {
-	AzureFirewallFqdnTagsClientListAllResult
+	AzureFirewallFqdnTagListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AzureFirewallFqdnTagsClientListAllResult contains the result from method AzureFirewallFqdnTagsClient.ListAll.
-type AzureFirewallFqdnTagsClientListAllResult struct {
-	AzureFirewallFqdnTagListResult
 }
 
 // AzureFirewallsClientCreateOrUpdatePollerResponse contains the response from method AzureFirewallsClient.CreateOrUpdate.
@@ -728,14 +596,9 @@ func (l *AzureFirewallsClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 
 // AzureFirewallsClientCreateOrUpdateResponse contains the response from method AzureFirewallsClient.CreateOrUpdate.
 type AzureFirewallsClientCreateOrUpdateResponse struct {
-	AzureFirewallsClientCreateOrUpdateResult
+	AzureFirewall
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AzureFirewallsClientCreateOrUpdateResult contains the result from method AzureFirewallsClient.CreateOrUpdate.
-type AzureFirewallsClientCreateOrUpdateResult struct {
-	AzureFirewall
 }
 
 // AzureFirewallsClientDeletePollerResponse contains the response from method AzureFirewallsClient.Delete.
@@ -786,38 +649,23 @@ type AzureFirewallsClientDeleteResponse struct {
 
 // AzureFirewallsClientGetResponse contains the response from method AzureFirewallsClient.Get.
 type AzureFirewallsClientGetResponse struct {
-	AzureFirewallsClientGetResult
+	AzureFirewall
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AzureFirewallsClientGetResult contains the result from method AzureFirewallsClient.Get.
-type AzureFirewallsClientGetResult struct {
-	AzureFirewall
 }
 
 // AzureFirewallsClientListAllResponse contains the response from method AzureFirewallsClient.ListAll.
 type AzureFirewallsClientListAllResponse struct {
-	AzureFirewallsClientListAllResult
+	AzureFirewallListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AzureFirewallsClientListAllResult contains the result from method AzureFirewallsClient.ListAll.
-type AzureFirewallsClientListAllResult struct {
-	AzureFirewallListResult
 }
 
 // AzureFirewallsClientListResponse contains the response from method AzureFirewallsClient.List.
 type AzureFirewallsClientListResponse struct {
-	AzureFirewallsClientListResult
+	AzureFirewallListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AzureFirewallsClientListResult contains the result from method AzureFirewallsClient.List.
-type AzureFirewallsClientListResult struct {
-	AzureFirewallListResult
 }
 
 // AzureFirewallsClientUpdateTagsPollerResponse contains the response from method AzureFirewallsClient.UpdateTags.
@@ -862,14 +710,9 @@ func (l *AzureFirewallsClientUpdateTagsPollerResponse) Resume(ctx context.Contex
 
 // AzureFirewallsClientUpdateTagsResponse contains the response from method AzureFirewallsClient.UpdateTags.
 type AzureFirewallsClientUpdateTagsResponse struct {
-	AzureFirewallsClientUpdateTagsResult
+	AzureFirewall
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// AzureFirewallsClientUpdateTagsResult contains the result from method AzureFirewallsClient.UpdateTags.
-type AzureFirewallsClientUpdateTagsResult struct {
-	AzureFirewall
 }
 
 // BastionHostsClientCreateOrUpdatePollerResponse contains the response from method BastionHostsClient.CreateOrUpdate.
@@ -914,14 +757,9 @@ func (l *BastionHostsClientCreateOrUpdatePollerResponse) Resume(ctx context.Cont
 
 // BastionHostsClientCreateOrUpdateResponse contains the response from method BastionHostsClient.CreateOrUpdate.
 type BastionHostsClientCreateOrUpdateResponse struct {
-	BastionHostsClientCreateOrUpdateResult
+	BastionHost
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BastionHostsClientCreateOrUpdateResult contains the result from method BastionHostsClient.CreateOrUpdate.
-type BastionHostsClientCreateOrUpdateResult struct {
-	BastionHost
 }
 
 // BastionHostsClientDeletePollerResponse contains the response from method BastionHostsClient.Delete.
@@ -972,50 +810,30 @@ type BastionHostsClientDeleteResponse struct {
 
 // BastionHostsClientGetResponse contains the response from method BastionHostsClient.Get.
 type BastionHostsClientGetResponse struct {
-	BastionHostsClientGetResult
+	BastionHost
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BastionHostsClientGetResult contains the result from method BastionHostsClient.Get.
-type BastionHostsClientGetResult struct {
-	BastionHost
 }
 
 // BastionHostsClientListByResourceGroupResponse contains the response from method BastionHostsClient.ListByResourceGroup.
 type BastionHostsClientListByResourceGroupResponse struct {
-	BastionHostsClientListByResourceGroupResult
+	BastionHostListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BastionHostsClientListByResourceGroupResult contains the result from method BastionHostsClient.ListByResourceGroup.
-type BastionHostsClientListByResourceGroupResult struct {
-	BastionHostListResult
 }
 
 // BastionHostsClientListResponse contains the response from method BastionHostsClient.List.
 type BastionHostsClientListResponse struct {
-	BastionHostsClientListResult
+	BastionHostListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BastionHostsClientListResult contains the result from method BastionHostsClient.List.
-type BastionHostsClientListResult struct {
-	BastionHostListResult
 }
 
 // BgpServiceCommunitiesClientListResponse contains the response from method BgpServiceCommunitiesClient.List.
 type BgpServiceCommunitiesClientListResponse struct {
-	BgpServiceCommunitiesClientListResult
+	BgpServiceCommunityListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// BgpServiceCommunitiesClientListResult contains the result from method BgpServiceCommunitiesClient.List.
-type BgpServiceCommunitiesClientListResult struct {
-	BgpServiceCommunityListResult
 }
 
 // ConnectionMonitorsClientCreateOrUpdatePollerResponse contains the response from method ConnectionMonitorsClient.CreateOrUpdate.
@@ -1060,14 +878,9 @@ func (l *ConnectionMonitorsClientCreateOrUpdatePollerResponse) Resume(ctx contex
 
 // ConnectionMonitorsClientCreateOrUpdateResponse contains the response from method ConnectionMonitorsClient.CreateOrUpdate.
 type ConnectionMonitorsClientCreateOrUpdateResponse struct {
-	ConnectionMonitorsClientCreateOrUpdateResult
+	ConnectionMonitorResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ConnectionMonitorsClientCreateOrUpdateResult contains the result from method ConnectionMonitorsClient.CreateOrUpdate.
-type ConnectionMonitorsClientCreateOrUpdateResult struct {
-	ConnectionMonitorResult
 }
 
 // ConnectionMonitorsClientDeletePollerResponse contains the response from method ConnectionMonitorsClient.Delete.
@@ -1118,26 +931,16 @@ type ConnectionMonitorsClientDeleteResponse struct {
 
 // ConnectionMonitorsClientGetResponse contains the response from method ConnectionMonitorsClient.Get.
 type ConnectionMonitorsClientGetResponse struct {
-	ConnectionMonitorsClientGetResult
+	ConnectionMonitorResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ConnectionMonitorsClientGetResult contains the result from method ConnectionMonitorsClient.Get.
-type ConnectionMonitorsClientGetResult struct {
-	ConnectionMonitorResult
 }
 
 // ConnectionMonitorsClientListResponse contains the response from method ConnectionMonitorsClient.List.
 type ConnectionMonitorsClientListResponse struct {
-	ConnectionMonitorsClientListResult
+	ConnectionMonitorListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ConnectionMonitorsClientListResult contains the result from method ConnectionMonitorsClient.List.
-type ConnectionMonitorsClientListResult struct {
-	ConnectionMonitorListResult
 }
 
 // ConnectionMonitorsClientQueryPollerResponse contains the response from method ConnectionMonitorsClient.Query.
@@ -1182,14 +985,9 @@ func (l *ConnectionMonitorsClientQueryPollerResponse) Resume(ctx context.Context
 
 // ConnectionMonitorsClientQueryResponse contains the response from method ConnectionMonitorsClient.Query.
 type ConnectionMonitorsClientQueryResponse struct {
-	ConnectionMonitorsClientQueryResult
+	ConnectionMonitorQueryResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ConnectionMonitorsClientQueryResult contains the result from method ConnectionMonitorsClient.Query.
-type ConnectionMonitorsClientQueryResult struct {
-	ConnectionMonitorQueryResult
 }
 
 // ConnectionMonitorsClientStartPollerResponse contains the response from method ConnectionMonitorsClient.Start.
@@ -1286,14 +1084,9 @@ type ConnectionMonitorsClientStopResponse struct {
 
 // ConnectionMonitorsClientUpdateTagsResponse contains the response from method ConnectionMonitorsClient.UpdateTags.
 type ConnectionMonitorsClientUpdateTagsResponse struct {
-	ConnectionMonitorsClientUpdateTagsResult
+	ConnectionMonitorResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ConnectionMonitorsClientUpdateTagsResult contains the result from method ConnectionMonitorsClient.UpdateTags.
-type ConnectionMonitorsClientUpdateTagsResult struct {
-	ConnectionMonitorResult
 }
 
 // DdosCustomPoliciesClientCreateOrUpdatePollerResponse contains the response from method DdosCustomPoliciesClient.CreateOrUpdate.
@@ -1338,14 +1131,9 @@ func (l *DdosCustomPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx contex
 
 // DdosCustomPoliciesClientCreateOrUpdateResponse contains the response from method DdosCustomPoliciesClient.CreateOrUpdate.
 type DdosCustomPoliciesClientCreateOrUpdateResponse struct {
-	DdosCustomPoliciesClientCreateOrUpdateResult
+	DdosCustomPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DdosCustomPoliciesClientCreateOrUpdateResult contains the result from method DdosCustomPoliciesClient.CreateOrUpdate.
-type DdosCustomPoliciesClientCreateOrUpdateResult struct {
-	DdosCustomPolicy
 }
 
 // DdosCustomPoliciesClientDeletePollerResponse contains the response from method DdosCustomPoliciesClient.Delete.
@@ -1396,26 +1184,16 @@ type DdosCustomPoliciesClientDeleteResponse struct {
 
 // DdosCustomPoliciesClientGetResponse contains the response from method DdosCustomPoliciesClient.Get.
 type DdosCustomPoliciesClientGetResponse struct {
-	DdosCustomPoliciesClientGetResult
+	DdosCustomPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DdosCustomPoliciesClientGetResult contains the result from method DdosCustomPoliciesClient.Get.
-type DdosCustomPoliciesClientGetResult struct {
-	DdosCustomPolicy
 }
 
 // DdosCustomPoliciesClientUpdateTagsResponse contains the response from method DdosCustomPoliciesClient.UpdateTags.
 type DdosCustomPoliciesClientUpdateTagsResponse struct {
-	DdosCustomPoliciesClientUpdateTagsResult
+	DdosCustomPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DdosCustomPoliciesClientUpdateTagsResult contains the result from method DdosCustomPoliciesClient.UpdateTags.
-type DdosCustomPoliciesClientUpdateTagsResult struct {
-	DdosCustomPolicy
 }
 
 // DdosProtectionPlansClientCreateOrUpdatePollerResponse contains the response from method DdosProtectionPlansClient.CreateOrUpdate.
@@ -1460,14 +1238,9 @@ func (l *DdosProtectionPlansClientCreateOrUpdatePollerResponse) Resume(ctx conte
 
 // DdosProtectionPlansClientCreateOrUpdateResponse contains the response from method DdosProtectionPlansClient.CreateOrUpdate.
 type DdosProtectionPlansClientCreateOrUpdateResponse struct {
-	DdosProtectionPlansClientCreateOrUpdateResult
+	DdosProtectionPlan
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DdosProtectionPlansClientCreateOrUpdateResult contains the result from method DdosProtectionPlansClient.CreateOrUpdate.
-type DdosProtectionPlansClientCreateOrUpdateResult struct {
-	DdosProtectionPlan
 }
 
 // DdosProtectionPlansClientDeletePollerResponse contains the response from method DdosProtectionPlansClient.Delete.
@@ -1518,74 +1291,44 @@ type DdosProtectionPlansClientDeleteResponse struct {
 
 // DdosProtectionPlansClientGetResponse contains the response from method DdosProtectionPlansClient.Get.
 type DdosProtectionPlansClientGetResponse struct {
-	DdosProtectionPlansClientGetResult
+	DdosProtectionPlan
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DdosProtectionPlansClientGetResult contains the result from method DdosProtectionPlansClient.Get.
-type DdosProtectionPlansClientGetResult struct {
-	DdosProtectionPlan
 }
 
 // DdosProtectionPlansClientListByResourceGroupResponse contains the response from method DdosProtectionPlansClient.ListByResourceGroup.
 type DdosProtectionPlansClientListByResourceGroupResponse struct {
-	DdosProtectionPlansClientListByResourceGroupResult
+	DdosProtectionPlanListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DdosProtectionPlansClientListByResourceGroupResult contains the result from method DdosProtectionPlansClient.ListByResourceGroup.
-type DdosProtectionPlansClientListByResourceGroupResult struct {
-	DdosProtectionPlanListResult
 }
 
 // DdosProtectionPlansClientListResponse contains the response from method DdosProtectionPlansClient.List.
 type DdosProtectionPlansClientListResponse struct {
-	DdosProtectionPlansClientListResult
+	DdosProtectionPlanListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DdosProtectionPlansClientListResult contains the result from method DdosProtectionPlansClient.List.
-type DdosProtectionPlansClientListResult struct {
-	DdosProtectionPlanListResult
 }
 
 // DdosProtectionPlansClientUpdateTagsResponse contains the response from method DdosProtectionPlansClient.UpdateTags.
 type DdosProtectionPlansClientUpdateTagsResponse struct {
-	DdosProtectionPlansClientUpdateTagsResult
+	DdosProtectionPlan
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DdosProtectionPlansClientUpdateTagsResult contains the result from method DdosProtectionPlansClient.UpdateTags.
-type DdosProtectionPlansClientUpdateTagsResult struct {
-	DdosProtectionPlan
 }
 
 // DefaultSecurityRulesClientGetResponse contains the response from method DefaultSecurityRulesClient.Get.
 type DefaultSecurityRulesClientGetResponse struct {
-	DefaultSecurityRulesClientGetResult
+	SecurityRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DefaultSecurityRulesClientGetResult contains the result from method DefaultSecurityRulesClient.Get.
-type DefaultSecurityRulesClientGetResult struct {
-	SecurityRule
 }
 
 // DefaultSecurityRulesClientListResponse contains the response from method DefaultSecurityRulesClient.List.
 type DefaultSecurityRulesClientListResponse struct {
-	DefaultSecurityRulesClientListResult
+	SecurityRuleListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// DefaultSecurityRulesClientListResult contains the result from method DefaultSecurityRulesClient.List.
-type DefaultSecurityRulesClientListResult struct {
-	SecurityRuleListResult
 }
 
 // ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate.
@@ -1631,14 +1374,9 @@ func (l *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse) Re
 
 // ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate.
 type ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse struct {
-	ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResult
+	ExpressRouteCircuitAuthorization
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResult contains the result from method ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate.
-type ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResult struct {
-	ExpressRouteCircuitAuthorization
 }
 
 // ExpressRouteCircuitAuthorizationsClientDeletePollerResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.Delete.
@@ -1689,26 +1427,16 @@ type ExpressRouteCircuitAuthorizationsClientDeleteResponse struct {
 
 // ExpressRouteCircuitAuthorizationsClientGetResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.Get.
 type ExpressRouteCircuitAuthorizationsClientGetResponse struct {
-	ExpressRouteCircuitAuthorizationsClientGetResult
+	ExpressRouteCircuitAuthorization
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitAuthorizationsClientGetResult contains the result from method ExpressRouteCircuitAuthorizationsClient.Get.
-type ExpressRouteCircuitAuthorizationsClientGetResult struct {
-	ExpressRouteCircuitAuthorization
 }
 
 // ExpressRouteCircuitAuthorizationsClientListResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.List.
 type ExpressRouteCircuitAuthorizationsClientListResponse struct {
-	ExpressRouteCircuitAuthorizationsClientListResult
+	AuthorizationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitAuthorizationsClientListResult contains the result from method ExpressRouteCircuitAuthorizationsClient.List.
-type ExpressRouteCircuitAuthorizationsClientListResult struct {
-	AuthorizationListResult
 }
 
 // ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitConnectionsClient.CreateOrUpdate.
@@ -1754,14 +1482,9 @@ func (l *ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse) Resum
 
 // ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitConnectionsClient.CreateOrUpdate.
 type ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse struct {
-	ExpressRouteCircuitConnectionsClientCreateOrUpdateResult
+	ExpressRouteCircuitConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitConnectionsClientCreateOrUpdateResult contains the result from method ExpressRouteCircuitConnectionsClient.CreateOrUpdate.
-type ExpressRouteCircuitConnectionsClientCreateOrUpdateResult struct {
-	ExpressRouteCircuitConnection
 }
 
 // ExpressRouteCircuitConnectionsClientDeletePollerResponse contains the response from method ExpressRouteCircuitConnectionsClient.Delete.
@@ -1812,26 +1535,16 @@ type ExpressRouteCircuitConnectionsClientDeleteResponse struct {
 
 // ExpressRouteCircuitConnectionsClientGetResponse contains the response from method ExpressRouteCircuitConnectionsClient.Get.
 type ExpressRouteCircuitConnectionsClientGetResponse struct {
-	ExpressRouteCircuitConnectionsClientGetResult
+	ExpressRouteCircuitConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitConnectionsClientGetResult contains the result from method ExpressRouteCircuitConnectionsClient.Get.
-type ExpressRouteCircuitConnectionsClientGetResult struct {
-	ExpressRouteCircuitConnection
 }
 
 // ExpressRouteCircuitConnectionsClientListResponse contains the response from method ExpressRouteCircuitConnectionsClient.List.
 type ExpressRouteCircuitConnectionsClientListResponse struct {
-	ExpressRouteCircuitConnectionsClientListResult
+	ExpressRouteCircuitConnectionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitConnectionsClientListResult contains the result from method ExpressRouteCircuitConnectionsClient.List.
-type ExpressRouteCircuitConnectionsClientListResult struct {
-	ExpressRouteCircuitConnectionListResult
 }
 
 // ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitPeeringsClient.CreateOrUpdate.
@@ -1876,14 +1589,9 @@ func (l *ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse) Resume(c
 
 // ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitPeeringsClient.CreateOrUpdate.
 type ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse struct {
-	ExpressRouteCircuitPeeringsClientCreateOrUpdateResult
+	ExpressRouteCircuitPeering
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitPeeringsClientCreateOrUpdateResult contains the result from method ExpressRouteCircuitPeeringsClient.CreateOrUpdate.
-type ExpressRouteCircuitPeeringsClientCreateOrUpdateResult struct {
-	ExpressRouteCircuitPeering
 }
 
 // ExpressRouteCircuitPeeringsClientDeletePollerResponse contains the response from method ExpressRouteCircuitPeeringsClient.Delete.
@@ -1934,26 +1642,16 @@ type ExpressRouteCircuitPeeringsClientDeleteResponse struct {
 
 // ExpressRouteCircuitPeeringsClientGetResponse contains the response from method ExpressRouteCircuitPeeringsClient.Get.
 type ExpressRouteCircuitPeeringsClientGetResponse struct {
-	ExpressRouteCircuitPeeringsClientGetResult
+	ExpressRouteCircuitPeering
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitPeeringsClientGetResult contains the result from method ExpressRouteCircuitPeeringsClient.Get.
-type ExpressRouteCircuitPeeringsClientGetResult struct {
-	ExpressRouteCircuitPeering
 }
 
 // ExpressRouteCircuitPeeringsClientListResponse contains the response from method ExpressRouteCircuitPeeringsClient.List.
 type ExpressRouteCircuitPeeringsClientListResponse struct {
-	ExpressRouteCircuitPeeringsClientListResult
+	ExpressRouteCircuitPeeringListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitPeeringsClientListResult contains the result from method ExpressRouteCircuitPeeringsClient.List.
-type ExpressRouteCircuitPeeringsClientListResult struct {
-	ExpressRouteCircuitPeeringListResult
 }
 
 // ExpressRouteCircuitsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitsClient.CreateOrUpdate.
@@ -1998,14 +1696,9 @@ func (l *ExpressRouteCircuitsClientCreateOrUpdatePollerResponse) Resume(ctx cont
 
 // ExpressRouteCircuitsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitsClient.CreateOrUpdate.
 type ExpressRouteCircuitsClientCreateOrUpdateResponse struct {
-	ExpressRouteCircuitsClientCreateOrUpdateResult
+	ExpressRouteCircuit
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientCreateOrUpdateResult contains the result from method ExpressRouteCircuitsClient.CreateOrUpdate.
-type ExpressRouteCircuitsClientCreateOrUpdateResult struct {
-	ExpressRouteCircuit
 }
 
 // ExpressRouteCircuitsClientDeletePollerResponse contains the response from method ExpressRouteCircuitsClient.Delete.
@@ -2056,50 +1749,30 @@ type ExpressRouteCircuitsClientDeleteResponse struct {
 
 // ExpressRouteCircuitsClientGetPeeringStatsResponse contains the response from method ExpressRouteCircuitsClient.GetPeeringStats.
 type ExpressRouteCircuitsClientGetPeeringStatsResponse struct {
-	ExpressRouteCircuitsClientGetPeeringStatsResult
+	ExpressRouteCircuitStats
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientGetPeeringStatsResult contains the result from method ExpressRouteCircuitsClient.GetPeeringStats.
-type ExpressRouteCircuitsClientGetPeeringStatsResult struct {
-	ExpressRouteCircuitStats
 }
 
 // ExpressRouteCircuitsClientGetResponse contains the response from method ExpressRouteCircuitsClient.Get.
 type ExpressRouteCircuitsClientGetResponse struct {
-	ExpressRouteCircuitsClientGetResult
+	ExpressRouteCircuit
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientGetResult contains the result from method ExpressRouteCircuitsClient.Get.
-type ExpressRouteCircuitsClientGetResult struct {
-	ExpressRouteCircuit
 }
 
 // ExpressRouteCircuitsClientGetStatsResponse contains the response from method ExpressRouteCircuitsClient.GetStats.
 type ExpressRouteCircuitsClientGetStatsResponse struct {
-	ExpressRouteCircuitsClientGetStatsResult
+	ExpressRouteCircuitStats
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientGetStatsResult contains the result from method ExpressRouteCircuitsClient.GetStats.
-type ExpressRouteCircuitsClientGetStatsResult struct {
-	ExpressRouteCircuitStats
 }
 
 // ExpressRouteCircuitsClientListAllResponse contains the response from method ExpressRouteCircuitsClient.ListAll.
 type ExpressRouteCircuitsClientListAllResponse struct {
-	ExpressRouteCircuitsClientListAllResult
+	ExpressRouteCircuitListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientListAllResult contains the result from method ExpressRouteCircuitsClient.ListAll.
-type ExpressRouteCircuitsClientListAllResult struct {
-	ExpressRouteCircuitListResult
 }
 
 // ExpressRouteCircuitsClientListArpTablePollerResponse contains the response from method ExpressRouteCircuitsClient.ListArpTable.
@@ -2144,26 +1817,16 @@ func (l *ExpressRouteCircuitsClientListArpTablePollerResponse) Resume(ctx contex
 
 // ExpressRouteCircuitsClientListArpTableResponse contains the response from method ExpressRouteCircuitsClient.ListArpTable.
 type ExpressRouteCircuitsClientListArpTableResponse struct {
-	ExpressRouteCircuitsClientListArpTableResult
+	ExpressRouteCircuitsArpTableListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientListArpTableResult contains the result from method ExpressRouteCircuitsClient.ListArpTable.
-type ExpressRouteCircuitsClientListArpTableResult struct {
-	ExpressRouteCircuitsArpTableListResult
 }
 
 // ExpressRouteCircuitsClientListResponse contains the response from method ExpressRouteCircuitsClient.List.
 type ExpressRouteCircuitsClientListResponse struct {
-	ExpressRouteCircuitsClientListResult
+	ExpressRouteCircuitListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientListResult contains the result from method ExpressRouteCircuitsClient.List.
-type ExpressRouteCircuitsClientListResult struct {
-	ExpressRouteCircuitListResult
 }
 
 // ExpressRouteCircuitsClientListRoutesTablePollerResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTable.
@@ -2208,14 +1871,9 @@ func (l *ExpressRouteCircuitsClientListRoutesTablePollerResponse) Resume(ctx con
 
 // ExpressRouteCircuitsClientListRoutesTableResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTable.
 type ExpressRouteCircuitsClientListRoutesTableResponse struct {
-	ExpressRouteCircuitsClientListRoutesTableResult
+	ExpressRouteCircuitsRoutesTableListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientListRoutesTableResult contains the result from method ExpressRouteCircuitsClient.ListRoutesTable.
-type ExpressRouteCircuitsClientListRoutesTableResult struct {
-	ExpressRouteCircuitsRoutesTableListResult
 }
 
 // ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTableSummary.
@@ -2261,26 +1919,16 @@ func (l *ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse) Resume(
 
 // ExpressRouteCircuitsClientListRoutesTableSummaryResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTableSummary.
 type ExpressRouteCircuitsClientListRoutesTableSummaryResponse struct {
-	ExpressRouteCircuitsClientListRoutesTableSummaryResult
+	ExpressRouteCircuitsRoutesTableSummaryListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientListRoutesTableSummaryResult contains the result from method ExpressRouteCircuitsClient.ListRoutesTableSummary.
-type ExpressRouteCircuitsClientListRoutesTableSummaryResult struct {
-	ExpressRouteCircuitsRoutesTableSummaryListResult
 }
 
 // ExpressRouteCircuitsClientUpdateTagsResponse contains the response from method ExpressRouteCircuitsClient.UpdateTags.
 type ExpressRouteCircuitsClientUpdateTagsResponse struct {
-	ExpressRouteCircuitsClientUpdateTagsResult
+	ExpressRouteCircuit
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCircuitsClientUpdateTagsResult contains the result from method ExpressRouteCircuitsClient.UpdateTags.
-type ExpressRouteCircuitsClientUpdateTagsResult struct {
-	ExpressRouteCircuit
 }
 
 // ExpressRouteConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteConnectionsClient.CreateOrUpdate.
@@ -2325,14 +1973,9 @@ func (l *ExpressRouteConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx c
 
 // ExpressRouteConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteConnectionsClient.CreateOrUpdate.
 type ExpressRouteConnectionsClientCreateOrUpdateResponse struct {
-	ExpressRouteConnectionsClientCreateOrUpdateResult
+	ExpressRouteConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteConnectionsClientCreateOrUpdateResult contains the result from method ExpressRouteConnectionsClient.CreateOrUpdate.
-type ExpressRouteConnectionsClientCreateOrUpdateResult struct {
-	ExpressRouteConnection
 }
 
 // ExpressRouteConnectionsClientDeletePollerResponse contains the response from method ExpressRouteConnectionsClient.Delete.
@@ -2383,26 +2026,16 @@ type ExpressRouteConnectionsClientDeleteResponse struct {
 
 // ExpressRouteConnectionsClientGetResponse contains the response from method ExpressRouteConnectionsClient.Get.
 type ExpressRouteConnectionsClientGetResponse struct {
-	ExpressRouteConnectionsClientGetResult
+	ExpressRouteConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteConnectionsClientGetResult contains the result from method ExpressRouteConnectionsClient.Get.
-type ExpressRouteConnectionsClientGetResult struct {
-	ExpressRouteConnection
 }
 
 // ExpressRouteConnectionsClientListResponse contains the response from method ExpressRouteConnectionsClient.List.
 type ExpressRouteConnectionsClientListResponse struct {
-	ExpressRouteConnectionsClientListResult
+	ExpressRouteConnectionList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteConnectionsClientListResult contains the result from method ExpressRouteConnectionsClient.List.
-type ExpressRouteConnectionsClientListResult struct {
-	ExpressRouteConnectionList
 }
 
 // ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate.
@@ -2448,14 +2081,9 @@ func (l *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse) 
 
 // ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate.
 type ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse struct {
-	ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResult
+	ExpressRouteCrossConnectionPeering
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResult contains the result from method ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate.
-type ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResult struct {
-	ExpressRouteCrossConnectionPeering
 }
 
 // ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.Delete.
@@ -2506,26 +2134,16 @@ type ExpressRouteCrossConnectionPeeringsClientDeleteResponse struct {
 
 // ExpressRouteCrossConnectionPeeringsClientGetResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.Get.
 type ExpressRouteCrossConnectionPeeringsClientGetResponse struct {
-	ExpressRouteCrossConnectionPeeringsClientGetResult
+	ExpressRouteCrossConnectionPeering
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionPeeringsClientGetResult contains the result from method ExpressRouteCrossConnectionPeeringsClient.Get.
-type ExpressRouteCrossConnectionPeeringsClientGetResult struct {
-	ExpressRouteCrossConnectionPeering
 }
 
 // ExpressRouteCrossConnectionPeeringsClientListResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.List.
 type ExpressRouteCrossConnectionPeeringsClientListResponse struct {
-	ExpressRouteCrossConnectionPeeringsClientListResult
+	ExpressRouteCrossConnectionPeeringList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionPeeringsClientListResult contains the result from method ExpressRouteCrossConnectionPeeringsClient.List.
-type ExpressRouteCrossConnectionPeeringsClientListResult struct {
-	ExpressRouteCrossConnectionPeeringList
 }
 
 // ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.CreateOrUpdate.
@@ -2571,26 +2189,16 @@ func (l *ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse) Resume(
 
 // ExpressRouteCrossConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteCrossConnectionsClient.CreateOrUpdate.
 type ExpressRouteCrossConnectionsClientCreateOrUpdateResponse struct {
-	ExpressRouteCrossConnectionsClientCreateOrUpdateResult
+	ExpressRouteCrossConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionsClientCreateOrUpdateResult contains the result from method ExpressRouteCrossConnectionsClient.CreateOrUpdate.
-type ExpressRouteCrossConnectionsClientCreateOrUpdateResult struct {
-	ExpressRouteCrossConnection
 }
 
 // ExpressRouteCrossConnectionsClientGetResponse contains the response from method ExpressRouteCrossConnectionsClient.Get.
 type ExpressRouteCrossConnectionsClientGetResponse struct {
-	ExpressRouteCrossConnectionsClientGetResult
+	ExpressRouteCrossConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionsClientGetResult contains the result from method ExpressRouteCrossConnectionsClient.Get.
-type ExpressRouteCrossConnectionsClientGetResult struct {
-	ExpressRouteCrossConnection
 }
 
 // ExpressRouteCrossConnectionsClientListArpTablePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListArpTable.
@@ -2635,38 +2243,23 @@ func (l *ExpressRouteCrossConnectionsClientListArpTablePollerResponse) Resume(ct
 
 // ExpressRouteCrossConnectionsClientListArpTableResponse contains the response from method ExpressRouteCrossConnectionsClient.ListArpTable.
 type ExpressRouteCrossConnectionsClientListArpTableResponse struct {
-	ExpressRouteCrossConnectionsClientListArpTableResult
+	ExpressRouteCircuitsArpTableListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionsClientListArpTableResult contains the result from method ExpressRouteCrossConnectionsClient.ListArpTable.
-type ExpressRouteCrossConnectionsClientListArpTableResult struct {
-	ExpressRouteCircuitsArpTableListResult
 }
 
 // ExpressRouteCrossConnectionsClientListByResourceGroupResponse contains the response from method ExpressRouteCrossConnectionsClient.ListByResourceGroup.
 type ExpressRouteCrossConnectionsClientListByResourceGroupResponse struct {
-	ExpressRouteCrossConnectionsClientListByResourceGroupResult
+	ExpressRouteCrossConnectionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionsClientListByResourceGroupResult contains the result from method ExpressRouteCrossConnectionsClient.ListByResourceGroup.
-type ExpressRouteCrossConnectionsClientListByResourceGroupResult struct {
-	ExpressRouteCrossConnectionListResult
 }
 
 // ExpressRouteCrossConnectionsClientListResponse contains the response from method ExpressRouteCrossConnectionsClient.List.
 type ExpressRouteCrossConnectionsClientListResponse struct {
-	ExpressRouteCrossConnectionsClientListResult
+	ExpressRouteCrossConnectionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionsClientListResult contains the result from method ExpressRouteCrossConnectionsClient.List.
-type ExpressRouteCrossConnectionsClientListResult struct {
-	ExpressRouteCrossConnectionListResult
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTable.
@@ -2712,14 +2305,9 @@ func (l *ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse) Resume
 
 // ExpressRouteCrossConnectionsClientListRoutesTableResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTable.
 type ExpressRouteCrossConnectionsClientListRoutesTableResponse struct {
-	ExpressRouteCrossConnectionsClientListRoutesTableResult
+	ExpressRouteCircuitsRoutesTableListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionsClientListRoutesTableResult contains the result from method ExpressRouteCrossConnectionsClient.ListRoutesTable.
-type ExpressRouteCrossConnectionsClientListRoutesTableResult struct {
-	ExpressRouteCircuitsRoutesTableListResult
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTableSummary.
@@ -2765,26 +2353,16 @@ func (l *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse)
 
 // ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTableSummary.
 type ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse struct {
-	ExpressRouteCrossConnectionsClientListRoutesTableSummaryResult
+	ExpressRouteCrossConnectionsRoutesTableSummaryListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionsClientListRoutesTableSummaryResult contains the result from method ExpressRouteCrossConnectionsClient.ListRoutesTableSummary.
-type ExpressRouteCrossConnectionsClientListRoutesTableSummaryResult struct {
-	ExpressRouteCrossConnectionsRoutesTableSummaryListResult
 }
 
 // ExpressRouteCrossConnectionsClientUpdateTagsResponse contains the response from method ExpressRouteCrossConnectionsClient.UpdateTags.
 type ExpressRouteCrossConnectionsClientUpdateTagsResponse struct {
-	ExpressRouteCrossConnectionsClientUpdateTagsResult
+	ExpressRouteCrossConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteCrossConnectionsClientUpdateTagsResult contains the result from method ExpressRouteCrossConnectionsClient.UpdateTags.
-type ExpressRouteCrossConnectionsClientUpdateTagsResult struct {
-	ExpressRouteCrossConnection
 }
 
 // ExpressRouteGatewaysClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteGatewaysClient.CreateOrUpdate.
@@ -2829,14 +2407,9 @@ func (l *ExpressRouteGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx cont
 
 // ExpressRouteGatewaysClientCreateOrUpdateResponse contains the response from method ExpressRouteGatewaysClient.CreateOrUpdate.
 type ExpressRouteGatewaysClientCreateOrUpdateResponse struct {
-	ExpressRouteGatewaysClientCreateOrUpdateResult
+	ExpressRouteGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteGatewaysClientCreateOrUpdateResult contains the result from method ExpressRouteGatewaysClient.CreateOrUpdate.
-type ExpressRouteGatewaysClientCreateOrUpdateResult struct {
-	ExpressRouteGateway
 }
 
 // ExpressRouteGatewaysClientDeletePollerResponse contains the response from method ExpressRouteGatewaysClient.Delete.
@@ -2887,62 +2460,37 @@ type ExpressRouteGatewaysClientDeleteResponse struct {
 
 // ExpressRouteGatewaysClientGetResponse contains the response from method ExpressRouteGatewaysClient.Get.
 type ExpressRouteGatewaysClientGetResponse struct {
-	ExpressRouteGatewaysClientGetResult
+	ExpressRouteGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteGatewaysClientGetResult contains the result from method ExpressRouteGatewaysClient.Get.
-type ExpressRouteGatewaysClientGetResult struct {
-	ExpressRouteGateway
 }
 
 // ExpressRouteGatewaysClientListByResourceGroupResponse contains the response from method ExpressRouteGatewaysClient.ListByResourceGroup.
 type ExpressRouteGatewaysClientListByResourceGroupResponse struct {
-	ExpressRouteGatewaysClientListByResourceGroupResult
+	ExpressRouteGatewayList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteGatewaysClientListByResourceGroupResult contains the result from method ExpressRouteGatewaysClient.ListByResourceGroup.
-type ExpressRouteGatewaysClientListByResourceGroupResult struct {
-	ExpressRouteGatewayList
 }
 
 // ExpressRouteGatewaysClientListBySubscriptionResponse contains the response from method ExpressRouteGatewaysClient.ListBySubscription.
 type ExpressRouteGatewaysClientListBySubscriptionResponse struct {
-	ExpressRouteGatewaysClientListBySubscriptionResult
+	ExpressRouteGatewayList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteGatewaysClientListBySubscriptionResult contains the result from method ExpressRouteGatewaysClient.ListBySubscription.
-type ExpressRouteGatewaysClientListBySubscriptionResult struct {
-	ExpressRouteGatewayList
 }
 
 // ExpressRouteLinksClientGetResponse contains the response from method ExpressRouteLinksClient.Get.
 type ExpressRouteLinksClientGetResponse struct {
-	ExpressRouteLinksClientGetResult
+	ExpressRouteLink
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteLinksClientGetResult contains the result from method ExpressRouteLinksClient.Get.
-type ExpressRouteLinksClientGetResult struct {
-	ExpressRouteLink
 }
 
 // ExpressRouteLinksClientListResponse contains the response from method ExpressRouteLinksClient.List.
 type ExpressRouteLinksClientListResponse struct {
-	ExpressRouteLinksClientListResult
+	ExpressRouteLinkListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteLinksClientListResult contains the result from method ExpressRouteLinksClient.List.
-type ExpressRouteLinksClientListResult struct {
-	ExpressRouteLinkListResult
 }
 
 // ExpressRoutePortsClientCreateOrUpdatePollerResponse contains the response from method ExpressRoutePortsClient.CreateOrUpdate.
@@ -2987,14 +2535,9 @@ func (l *ExpressRoutePortsClientCreateOrUpdatePollerResponse) Resume(ctx context
 
 // ExpressRoutePortsClientCreateOrUpdateResponse contains the response from method ExpressRoutePortsClient.CreateOrUpdate.
 type ExpressRoutePortsClientCreateOrUpdateResponse struct {
-	ExpressRoutePortsClientCreateOrUpdateResult
+	ExpressRoutePort
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRoutePortsClientCreateOrUpdateResult contains the result from method ExpressRoutePortsClient.CreateOrUpdate.
-type ExpressRoutePortsClientCreateOrUpdateResult struct {
-	ExpressRoutePort
 }
 
 // ExpressRoutePortsClientDeletePollerResponse contains the response from method ExpressRoutePortsClient.Delete.
@@ -3045,86 +2588,51 @@ type ExpressRoutePortsClientDeleteResponse struct {
 
 // ExpressRoutePortsClientGetResponse contains the response from method ExpressRoutePortsClient.Get.
 type ExpressRoutePortsClientGetResponse struct {
-	ExpressRoutePortsClientGetResult
+	ExpressRoutePort
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRoutePortsClientGetResult contains the result from method ExpressRoutePortsClient.Get.
-type ExpressRoutePortsClientGetResult struct {
-	ExpressRoutePort
 }
 
 // ExpressRoutePortsClientListByResourceGroupResponse contains the response from method ExpressRoutePortsClient.ListByResourceGroup.
 type ExpressRoutePortsClientListByResourceGroupResponse struct {
-	ExpressRoutePortsClientListByResourceGroupResult
+	ExpressRoutePortListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRoutePortsClientListByResourceGroupResult contains the result from method ExpressRoutePortsClient.ListByResourceGroup.
-type ExpressRoutePortsClientListByResourceGroupResult struct {
-	ExpressRoutePortListResult
 }
 
 // ExpressRoutePortsClientListResponse contains the response from method ExpressRoutePortsClient.List.
 type ExpressRoutePortsClientListResponse struct {
-	ExpressRoutePortsClientListResult
+	ExpressRoutePortListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRoutePortsClientListResult contains the result from method ExpressRoutePortsClient.List.
-type ExpressRoutePortsClientListResult struct {
-	ExpressRoutePortListResult
 }
 
 // ExpressRoutePortsClientUpdateTagsResponse contains the response from method ExpressRoutePortsClient.UpdateTags.
 type ExpressRoutePortsClientUpdateTagsResponse struct {
-	ExpressRoutePortsClientUpdateTagsResult
+	ExpressRoutePort
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRoutePortsClientUpdateTagsResult contains the result from method ExpressRoutePortsClient.UpdateTags.
-type ExpressRoutePortsClientUpdateTagsResult struct {
-	ExpressRoutePort
 }
 
 // ExpressRoutePortsLocationsClientGetResponse contains the response from method ExpressRoutePortsLocationsClient.Get.
 type ExpressRoutePortsLocationsClientGetResponse struct {
-	ExpressRoutePortsLocationsClientGetResult
+	ExpressRoutePortsLocation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRoutePortsLocationsClientGetResult contains the result from method ExpressRoutePortsLocationsClient.Get.
-type ExpressRoutePortsLocationsClientGetResult struct {
-	ExpressRoutePortsLocation
 }
 
 // ExpressRoutePortsLocationsClientListResponse contains the response from method ExpressRoutePortsLocationsClient.List.
 type ExpressRoutePortsLocationsClientListResponse struct {
-	ExpressRoutePortsLocationsClientListResult
+	ExpressRoutePortsLocationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRoutePortsLocationsClientListResult contains the result from method ExpressRoutePortsLocationsClient.List.
-type ExpressRoutePortsLocationsClientListResult struct {
-	ExpressRoutePortsLocationListResult
 }
 
 // ExpressRouteServiceProvidersClientListResponse contains the response from method ExpressRouteServiceProvidersClient.List.
 type ExpressRouteServiceProvidersClientListResponse struct {
-	ExpressRouteServiceProvidersClientListResult
+	ExpressRouteServiceProviderListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ExpressRouteServiceProvidersClientListResult contains the result from method ExpressRouteServiceProvidersClient.List.
-type ExpressRouteServiceProvidersClientListResult struct {
-	ExpressRouteServiceProviderListResult
 }
 
 // FirewallPoliciesClientCreateOrUpdatePollerResponse contains the response from method FirewallPoliciesClient.CreateOrUpdate.
@@ -3169,14 +2677,9 @@ func (l *FirewallPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx context.
 
 // FirewallPoliciesClientCreateOrUpdateResponse contains the response from method FirewallPoliciesClient.CreateOrUpdate.
 type FirewallPoliciesClientCreateOrUpdateResponse struct {
-	FirewallPoliciesClientCreateOrUpdateResult
+	FirewallPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FirewallPoliciesClientCreateOrUpdateResult contains the result from method FirewallPoliciesClient.CreateOrUpdate.
-type FirewallPoliciesClientCreateOrUpdateResult struct {
-	FirewallPolicy
 }
 
 // FirewallPoliciesClientDeletePollerResponse contains the response from method FirewallPoliciesClient.Delete.
@@ -3227,38 +2730,23 @@ type FirewallPoliciesClientDeleteResponse struct {
 
 // FirewallPoliciesClientGetResponse contains the response from method FirewallPoliciesClient.Get.
 type FirewallPoliciesClientGetResponse struct {
-	FirewallPoliciesClientGetResult
+	FirewallPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FirewallPoliciesClientGetResult contains the result from method FirewallPoliciesClient.Get.
-type FirewallPoliciesClientGetResult struct {
-	FirewallPolicy
 }
 
 // FirewallPoliciesClientListAllResponse contains the response from method FirewallPoliciesClient.ListAll.
 type FirewallPoliciesClientListAllResponse struct {
-	FirewallPoliciesClientListAllResult
+	FirewallPolicyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FirewallPoliciesClientListAllResult contains the result from method FirewallPoliciesClient.ListAll.
-type FirewallPoliciesClientListAllResult struct {
-	FirewallPolicyListResult
 }
 
 // FirewallPoliciesClientListResponse contains the response from method FirewallPoliciesClient.List.
 type FirewallPoliciesClientListResponse struct {
-	FirewallPoliciesClientListResult
+	FirewallPolicyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FirewallPoliciesClientListResult contains the result from method FirewallPoliciesClient.List.
-type FirewallPoliciesClientListResult struct {
-	FirewallPolicyListResult
 }
 
 // FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse contains the response from method FirewallPolicyRuleGroupsClient.CreateOrUpdate.
@@ -3303,14 +2791,9 @@ func (l *FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse) Resume(ctx 
 
 // FirewallPolicyRuleGroupsClientCreateOrUpdateResponse contains the response from method FirewallPolicyRuleGroupsClient.CreateOrUpdate.
 type FirewallPolicyRuleGroupsClientCreateOrUpdateResponse struct {
-	FirewallPolicyRuleGroupsClientCreateOrUpdateResult
+	FirewallPolicyRuleGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FirewallPolicyRuleGroupsClientCreateOrUpdateResult contains the result from method FirewallPolicyRuleGroupsClient.CreateOrUpdate.
-type FirewallPolicyRuleGroupsClientCreateOrUpdateResult struct {
-	FirewallPolicyRuleGroup
 }
 
 // FirewallPolicyRuleGroupsClientDeletePollerResponse contains the response from method FirewallPolicyRuleGroupsClient.Delete.
@@ -3361,26 +2844,16 @@ type FirewallPolicyRuleGroupsClientDeleteResponse struct {
 
 // FirewallPolicyRuleGroupsClientGetResponse contains the response from method FirewallPolicyRuleGroupsClient.Get.
 type FirewallPolicyRuleGroupsClientGetResponse struct {
-	FirewallPolicyRuleGroupsClientGetResult
+	FirewallPolicyRuleGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FirewallPolicyRuleGroupsClientGetResult contains the result from method FirewallPolicyRuleGroupsClient.Get.
-type FirewallPolicyRuleGroupsClientGetResult struct {
-	FirewallPolicyRuleGroup
 }
 
 // FirewallPolicyRuleGroupsClientListResponse contains the response from method FirewallPolicyRuleGroupsClient.List.
 type FirewallPolicyRuleGroupsClientListResponse struct {
-	FirewallPolicyRuleGroupsClientListResult
+	FirewallPolicyRuleGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FirewallPolicyRuleGroupsClientListResult contains the result from method FirewallPolicyRuleGroupsClient.List.
-type FirewallPolicyRuleGroupsClientListResult struct {
-	FirewallPolicyRuleGroupListResult
 }
 
 // FlowLogsClientCreateOrUpdatePollerResponse contains the response from method FlowLogsClient.CreateOrUpdate.
@@ -3425,14 +2898,9 @@ func (l *FlowLogsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context,
 
 // FlowLogsClientCreateOrUpdateResponse contains the response from method FlowLogsClient.CreateOrUpdate.
 type FlowLogsClientCreateOrUpdateResponse struct {
-	FlowLogsClientCreateOrUpdateResult
+	FlowLog
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FlowLogsClientCreateOrUpdateResult contains the result from method FlowLogsClient.CreateOrUpdate.
-type FlowLogsClientCreateOrUpdateResult struct {
-	FlowLog
 }
 
 // FlowLogsClientDeletePollerResponse contains the response from method FlowLogsClient.Delete.
@@ -3483,50 +2951,30 @@ type FlowLogsClientDeleteResponse struct {
 
 // FlowLogsClientGetResponse contains the response from method FlowLogsClient.Get.
 type FlowLogsClientGetResponse struct {
-	FlowLogsClientGetResult
+	FlowLog
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FlowLogsClientGetResult contains the result from method FlowLogsClient.Get.
-type FlowLogsClientGetResult struct {
-	FlowLog
 }
 
 // FlowLogsClientListResponse contains the response from method FlowLogsClient.List.
 type FlowLogsClientListResponse struct {
-	FlowLogsClientListResult
+	FlowLogListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// FlowLogsClientListResult contains the result from method FlowLogsClient.List.
-type FlowLogsClientListResult struct {
-	FlowLogListResult
 }
 
 // HubVirtualNetworkConnectionsClientGetResponse contains the response from method HubVirtualNetworkConnectionsClient.Get.
 type HubVirtualNetworkConnectionsClientGetResponse struct {
-	HubVirtualNetworkConnectionsClientGetResult
+	HubVirtualNetworkConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// HubVirtualNetworkConnectionsClientGetResult contains the result from method HubVirtualNetworkConnectionsClient.Get.
-type HubVirtualNetworkConnectionsClientGetResult struct {
-	HubVirtualNetworkConnection
 }
 
 // HubVirtualNetworkConnectionsClientListResponse contains the response from method HubVirtualNetworkConnectionsClient.List.
 type HubVirtualNetworkConnectionsClientListResponse struct {
-	HubVirtualNetworkConnectionsClientListResult
+	ListHubVirtualNetworkConnectionsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// HubVirtualNetworkConnectionsClientListResult contains the result from method HubVirtualNetworkConnectionsClient.List.
-type HubVirtualNetworkConnectionsClientListResult struct {
-	ListHubVirtualNetworkConnectionsResult
 }
 
 // IPAllocationsClientCreateOrUpdatePollerResponse contains the response from method IPAllocationsClient.CreateOrUpdate.
@@ -3571,14 +3019,9 @@ func (l *IPAllocationsClientCreateOrUpdatePollerResponse) Resume(ctx context.Con
 
 // IPAllocationsClientCreateOrUpdateResponse contains the response from method IPAllocationsClient.CreateOrUpdate.
 type IPAllocationsClientCreateOrUpdateResponse struct {
-	IPAllocationsClientCreateOrUpdateResult
+	IPAllocation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPAllocationsClientCreateOrUpdateResult contains the result from method IPAllocationsClient.CreateOrUpdate.
-type IPAllocationsClientCreateOrUpdateResult struct {
-	IPAllocation
 }
 
 // IPAllocationsClientDeletePollerResponse contains the response from method IPAllocationsClient.Delete.
@@ -3629,50 +3072,30 @@ type IPAllocationsClientDeleteResponse struct {
 
 // IPAllocationsClientGetResponse contains the response from method IPAllocationsClient.Get.
 type IPAllocationsClientGetResponse struct {
-	IPAllocationsClientGetResult
+	IPAllocation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPAllocationsClientGetResult contains the result from method IPAllocationsClient.Get.
-type IPAllocationsClientGetResult struct {
-	IPAllocation
 }
 
 // IPAllocationsClientListByResourceGroupResponse contains the response from method IPAllocationsClient.ListByResourceGroup.
 type IPAllocationsClientListByResourceGroupResponse struct {
-	IPAllocationsClientListByResourceGroupResult
+	IPAllocationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPAllocationsClientListByResourceGroupResult contains the result from method IPAllocationsClient.ListByResourceGroup.
-type IPAllocationsClientListByResourceGroupResult struct {
-	IPAllocationListResult
 }
 
 // IPAllocationsClientListResponse contains the response from method IPAllocationsClient.List.
 type IPAllocationsClientListResponse struct {
-	IPAllocationsClientListResult
+	IPAllocationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPAllocationsClientListResult contains the result from method IPAllocationsClient.List.
-type IPAllocationsClientListResult struct {
-	IPAllocationListResult
 }
 
 // IPAllocationsClientUpdateTagsResponse contains the response from method IPAllocationsClient.UpdateTags.
 type IPAllocationsClientUpdateTagsResponse struct {
-	IPAllocationsClientUpdateTagsResult
+	IPAllocation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPAllocationsClientUpdateTagsResult contains the result from method IPAllocationsClient.UpdateTags.
-type IPAllocationsClientUpdateTagsResult struct {
-	IPAllocation
 }
 
 // IPGroupsClientCreateOrUpdatePollerResponse contains the response from method IPGroupsClient.CreateOrUpdate.
@@ -3717,14 +3140,9 @@ func (l *IPGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context,
 
 // IPGroupsClientCreateOrUpdateResponse contains the response from method IPGroupsClient.CreateOrUpdate.
 type IPGroupsClientCreateOrUpdateResponse struct {
-	IPGroupsClientCreateOrUpdateResult
+	IPGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPGroupsClientCreateOrUpdateResult contains the result from method IPGroupsClient.CreateOrUpdate.
-type IPGroupsClientCreateOrUpdateResult struct {
-	IPGroup
 }
 
 // IPGroupsClientDeletePollerResponse contains the response from method IPGroupsClient.Delete.
@@ -3775,50 +3193,30 @@ type IPGroupsClientDeleteResponse struct {
 
 // IPGroupsClientGetResponse contains the response from method IPGroupsClient.Get.
 type IPGroupsClientGetResponse struct {
-	IPGroupsClientGetResult
+	IPGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPGroupsClientGetResult contains the result from method IPGroupsClient.Get.
-type IPGroupsClientGetResult struct {
-	IPGroup
 }
 
 // IPGroupsClientListByResourceGroupResponse contains the response from method IPGroupsClient.ListByResourceGroup.
 type IPGroupsClientListByResourceGroupResponse struct {
-	IPGroupsClientListByResourceGroupResult
+	IPGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPGroupsClientListByResourceGroupResult contains the result from method IPGroupsClient.ListByResourceGroup.
-type IPGroupsClientListByResourceGroupResult struct {
-	IPGroupListResult
 }
 
 // IPGroupsClientListResponse contains the response from method IPGroupsClient.List.
 type IPGroupsClientListResponse struct {
-	IPGroupsClientListResult
+	IPGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPGroupsClientListResult contains the result from method IPGroupsClient.List.
-type IPGroupsClientListResult struct {
-	IPGroupListResult
 }
 
 // IPGroupsClientUpdateGroupsResponse contains the response from method IPGroupsClient.UpdateGroups.
 type IPGroupsClientUpdateGroupsResponse struct {
-	IPGroupsClientUpdateGroupsResult
+	IPGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// IPGroupsClientUpdateGroupsResult contains the result from method IPGroupsClient.UpdateGroups.
-type IPGroupsClientUpdateGroupsResult struct {
-	IPGroup
 }
 
 // InboundNatRulesClientCreateOrUpdatePollerResponse contains the response from method InboundNatRulesClient.CreateOrUpdate.
@@ -3863,14 +3261,9 @@ func (l *InboundNatRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.C
 
 // InboundNatRulesClientCreateOrUpdateResponse contains the response from method InboundNatRulesClient.CreateOrUpdate.
 type InboundNatRulesClientCreateOrUpdateResponse struct {
-	InboundNatRulesClientCreateOrUpdateResult
+	InboundNatRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InboundNatRulesClientCreateOrUpdateResult contains the result from method InboundNatRulesClient.CreateOrUpdate.
-type InboundNatRulesClientCreateOrUpdateResult struct {
-	InboundNatRule
 }
 
 // InboundNatRulesClientDeletePollerResponse contains the response from method InboundNatRulesClient.Delete.
@@ -3921,62 +3314,37 @@ type InboundNatRulesClientDeleteResponse struct {
 
 // InboundNatRulesClientGetResponse contains the response from method InboundNatRulesClient.Get.
 type InboundNatRulesClientGetResponse struct {
-	InboundNatRulesClientGetResult
+	InboundNatRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InboundNatRulesClientGetResult contains the result from method InboundNatRulesClient.Get.
-type InboundNatRulesClientGetResult struct {
-	InboundNatRule
 }
 
 // InboundNatRulesClientListResponse contains the response from method InboundNatRulesClient.List.
 type InboundNatRulesClientListResponse struct {
-	InboundNatRulesClientListResult
+	InboundNatRuleListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InboundNatRulesClientListResult contains the result from method InboundNatRulesClient.List.
-type InboundNatRulesClientListResult struct {
-	InboundNatRuleListResult
 }
 
 // InterfaceIPConfigurationsClientGetResponse contains the response from method InterfaceIPConfigurationsClient.Get.
 type InterfaceIPConfigurationsClientGetResponse struct {
-	InterfaceIPConfigurationsClientGetResult
+	InterfaceIPConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfaceIPConfigurationsClientGetResult contains the result from method InterfaceIPConfigurationsClient.Get.
-type InterfaceIPConfigurationsClientGetResult struct {
-	InterfaceIPConfiguration
 }
 
 // InterfaceIPConfigurationsClientListResponse contains the response from method InterfaceIPConfigurationsClient.List.
 type InterfaceIPConfigurationsClientListResponse struct {
-	InterfaceIPConfigurationsClientListResult
+	InterfaceIPConfigurationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfaceIPConfigurationsClientListResult contains the result from method InterfaceIPConfigurationsClient.List.
-type InterfaceIPConfigurationsClientListResult struct {
-	InterfaceIPConfigurationListResult
 }
 
 // InterfaceLoadBalancersClientListResponse contains the response from method InterfaceLoadBalancersClient.List.
 type InterfaceLoadBalancersClientListResponse struct {
-	InterfaceLoadBalancersClientListResult
+	InterfaceLoadBalancerListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfaceLoadBalancersClientListResult contains the result from method InterfaceLoadBalancersClient.List.
-type InterfaceLoadBalancersClientListResult struct {
-	InterfaceLoadBalancerListResult
 }
 
 // InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse contains the response from method InterfaceTapConfigurationsClient.CreateOrUpdate.
@@ -4021,14 +3389,9 @@ func (l *InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse) Resume(ct
 
 // InterfaceTapConfigurationsClientCreateOrUpdateResponse contains the response from method InterfaceTapConfigurationsClient.CreateOrUpdate.
 type InterfaceTapConfigurationsClientCreateOrUpdateResponse struct {
-	InterfaceTapConfigurationsClientCreateOrUpdateResult
+	InterfaceTapConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfaceTapConfigurationsClientCreateOrUpdateResult contains the result from method InterfaceTapConfigurationsClient.CreateOrUpdate.
-type InterfaceTapConfigurationsClientCreateOrUpdateResult struct {
-	InterfaceTapConfiguration
 }
 
 // InterfaceTapConfigurationsClientDeletePollerResponse contains the response from method InterfaceTapConfigurationsClient.Delete.
@@ -4079,26 +3442,16 @@ type InterfaceTapConfigurationsClientDeleteResponse struct {
 
 // InterfaceTapConfigurationsClientGetResponse contains the response from method InterfaceTapConfigurationsClient.Get.
 type InterfaceTapConfigurationsClientGetResponse struct {
-	InterfaceTapConfigurationsClientGetResult
+	InterfaceTapConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfaceTapConfigurationsClientGetResult contains the result from method InterfaceTapConfigurationsClient.Get.
-type InterfaceTapConfigurationsClientGetResult struct {
-	InterfaceTapConfiguration
 }
 
 // InterfaceTapConfigurationsClientListResponse contains the response from method InterfaceTapConfigurationsClient.List.
 type InterfaceTapConfigurationsClientListResponse struct {
-	InterfaceTapConfigurationsClientListResult
+	InterfaceTapConfigurationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfaceTapConfigurationsClientListResult contains the result from method InterfaceTapConfigurationsClient.List.
-type InterfaceTapConfigurationsClientListResult struct {
-	InterfaceTapConfigurationListResult
 }
 
 // InterfacesClientCreateOrUpdatePollerResponse contains the response from method InterfacesClient.CreateOrUpdate.
@@ -4143,14 +3496,9 @@ func (l *InterfacesClientCreateOrUpdatePollerResponse) Resume(ctx context.Contex
 
 // InterfacesClientCreateOrUpdateResponse contains the response from method InterfacesClient.CreateOrUpdate.
 type InterfacesClientCreateOrUpdateResponse struct {
-	InterfacesClientCreateOrUpdateResult
+	Interface
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientCreateOrUpdateResult contains the result from method InterfacesClient.CreateOrUpdate.
-type InterfacesClientCreateOrUpdateResult struct {
-	Interface
 }
 
 // InterfacesClientDeletePollerResponse contains the response from method InterfacesClient.Delete.
@@ -4241,62 +3589,37 @@ func (l *InterfacesClientGetEffectiveRouteTablePollerResponse) Resume(ctx contex
 
 // InterfacesClientGetEffectiveRouteTableResponse contains the response from method InterfacesClient.GetEffectiveRouteTable.
 type InterfacesClientGetEffectiveRouteTableResponse struct {
-	InterfacesClientGetEffectiveRouteTableResult
+	EffectiveRouteListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientGetEffectiveRouteTableResult contains the result from method InterfacesClient.GetEffectiveRouteTable.
-type InterfacesClientGetEffectiveRouteTableResult struct {
-	EffectiveRouteListResult
 }
 
 // InterfacesClientGetResponse contains the response from method InterfacesClient.Get.
 type InterfacesClientGetResponse struct {
-	InterfacesClientGetResult
+	Interface
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientGetResult contains the result from method InterfacesClient.Get.
-type InterfacesClientGetResult struct {
-	Interface
 }
 
 // InterfacesClientGetVirtualMachineScaleSetIPConfigurationResponse contains the response from method InterfacesClient.GetVirtualMachineScaleSetIPConfiguration.
 type InterfacesClientGetVirtualMachineScaleSetIPConfigurationResponse struct {
-	InterfacesClientGetVirtualMachineScaleSetIPConfigurationResult
+	InterfaceIPConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientGetVirtualMachineScaleSetIPConfigurationResult contains the result from method InterfacesClient.GetVirtualMachineScaleSetIPConfiguration.
-type InterfacesClientGetVirtualMachineScaleSetIPConfigurationResult struct {
-	InterfaceIPConfiguration
 }
 
 // InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse contains the response from method InterfacesClient.GetVirtualMachineScaleSetNetworkInterface.
 type InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse struct {
-	InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResult
+	Interface
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResult contains the result from method InterfacesClient.GetVirtualMachineScaleSetNetworkInterface.
-type InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResult struct {
-	Interface
 }
 
 // InterfacesClientListAllResponse contains the response from method InterfacesClient.ListAll.
 type InterfacesClientListAllResponse struct {
-	InterfacesClientListAllResult
+	InterfaceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientListAllResult contains the result from method InterfacesClient.ListAll.
-type InterfacesClientListAllResult struct {
-	InterfaceListResult
 }
 
 // InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse contains the response from method InterfacesClient.ListEffectiveNetworkSecurityGroups.
@@ -4342,206 +3665,121 @@ func (l *InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse) Resum
 
 // InterfacesClientListEffectiveNetworkSecurityGroupsResponse contains the response from method InterfacesClient.ListEffectiveNetworkSecurityGroups.
 type InterfacesClientListEffectiveNetworkSecurityGroupsResponse struct {
-	InterfacesClientListEffectiveNetworkSecurityGroupsResult
+	EffectiveNetworkSecurityGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientListEffectiveNetworkSecurityGroupsResult contains the result from method InterfacesClient.ListEffectiveNetworkSecurityGroups.
-type InterfacesClientListEffectiveNetworkSecurityGroupsResult struct {
-	EffectiveNetworkSecurityGroupListResult
 }
 
 // InterfacesClientListResponse contains the response from method InterfacesClient.List.
 type InterfacesClientListResponse struct {
-	InterfacesClientListResult
+	InterfaceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientListResult contains the result from method InterfacesClient.List.
-type InterfacesClientListResult struct {
-	InterfaceListResult
 }
 
 // InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse contains the response from method InterfacesClient.ListVirtualMachineScaleSetIPConfigurations.
 type InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse struct {
-	InterfacesClientListVirtualMachineScaleSetIPConfigurationsResult
+	InterfaceIPConfigurationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientListVirtualMachineScaleSetIPConfigurationsResult contains the result from method InterfacesClient.ListVirtualMachineScaleSetIPConfigurations.
-type InterfacesClientListVirtualMachineScaleSetIPConfigurationsResult struct {
-	InterfaceIPConfigurationListResult
 }
 
 // InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse contains the response from method InterfacesClient.ListVirtualMachineScaleSetNetworkInterfaces.
 type InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse struct {
-	InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResult
+	InterfaceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResult contains the result from method InterfacesClient.ListVirtualMachineScaleSetNetworkInterfaces.
-type InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResult struct {
-	InterfaceListResult
 }
 
 // InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse contains the response from method InterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfaces.
 type InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse struct {
-	InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResult
+	InterfaceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResult contains the result from method InterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfaces.
-type InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResult struct {
-	InterfaceListResult
 }
 
 // InterfacesClientUpdateTagsResponse contains the response from method InterfacesClient.UpdateTags.
 type InterfacesClientUpdateTagsResponse struct {
-	InterfacesClientUpdateTagsResult
+	Interface
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// InterfacesClientUpdateTagsResult contains the result from method InterfacesClient.UpdateTags.
-type InterfacesClientUpdateTagsResult struct {
-	Interface
 }
 
 // LoadBalancerBackendAddressPoolsClientGetResponse contains the response from method LoadBalancerBackendAddressPoolsClient.Get.
 type LoadBalancerBackendAddressPoolsClientGetResponse struct {
-	LoadBalancerBackendAddressPoolsClientGetResult
+	BackendAddressPool
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerBackendAddressPoolsClientGetResult contains the result from method LoadBalancerBackendAddressPoolsClient.Get.
-type LoadBalancerBackendAddressPoolsClientGetResult struct {
-	BackendAddressPool
 }
 
 // LoadBalancerBackendAddressPoolsClientListResponse contains the response from method LoadBalancerBackendAddressPoolsClient.List.
 type LoadBalancerBackendAddressPoolsClientListResponse struct {
-	LoadBalancerBackendAddressPoolsClientListResult
+	LoadBalancerBackendAddressPoolListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerBackendAddressPoolsClientListResult contains the result from method LoadBalancerBackendAddressPoolsClient.List.
-type LoadBalancerBackendAddressPoolsClientListResult struct {
-	LoadBalancerBackendAddressPoolListResult
 }
 
 // LoadBalancerFrontendIPConfigurationsClientGetResponse contains the response from method LoadBalancerFrontendIPConfigurationsClient.Get.
 type LoadBalancerFrontendIPConfigurationsClientGetResponse struct {
-	LoadBalancerFrontendIPConfigurationsClientGetResult
+	FrontendIPConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerFrontendIPConfigurationsClientGetResult contains the result from method LoadBalancerFrontendIPConfigurationsClient.Get.
-type LoadBalancerFrontendIPConfigurationsClientGetResult struct {
-	FrontendIPConfiguration
 }
 
 // LoadBalancerFrontendIPConfigurationsClientListResponse contains the response from method LoadBalancerFrontendIPConfigurationsClient.List.
 type LoadBalancerFrontendIPConfigurationsClientListResponse struct {
-	LoadBalancerFrontendIPConfigurationsClientListResult
+	LoadBalancerFrontendIPConfigurationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerFrontendIPConfigurationsClientListResult contains the result from method LoadBalancerFrontendIPConfigurationsClient.List.
-type LoadBalancerFrontendIPConfigurationsClientListResult struct {
-	LoadBalancerFrontendIPConfigurationListResult
 }
 
 // LoadBalancerLoadBalancingRulesClientGetResponse contains the response from method LoadBalancerLoadBalancingRulesClient.Get.
 type LoadBalancerLoadBalancingRulesClientGetResponse struct {
-	LoadBalancerLoadBalancingRulesClientGetResult
+	LoadBalancingRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerLoadBalancingRulesClientGetResult contains the result from method LoadBalancerLoadBalancingRulesClient.Get.
-type LoadBalancerLoadBalancingRulesClientGetResult struct {
-	LoadBalancingRule
 }
 
 // LoadBalancerLoadBalancingRulesClientListResponse contains the response from method LoadBalancerLoadBalancingRulesClient.List.
 type LoadBalancerLoadBalancingRulesClientListResponse struct {
-	LoadBalancerLoadBalancingRulesClientListResult
+	LoadBalancerLoadBalancingRuleListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerLoadBalancingRulesClientListResult contains the result from method LoadBalancerLoadBalancingRulesClient.List.
-type LoadBalancerLoadBalancingRulesClientListResult struct {
-	LoadBalancerLoadBalancingRuleListResult
 }
 
 // LoadBalancerNetworkInterfacesClientListResponse contains the response from method LoadBalancerNetworkInterfacesClient.List.
 type LoadBalancerNetworkInterfacesClientListResponse struct {
-	LoadBalancerNetworkInterfacesClientListResult
+	InterfaceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerNetworkInterfacesClientListResult contains the result from method LoadBalancerNetworkInterfacesClient.List.
-type LoadBalancerNetworkInterfacesClientListResult struct {
-	InterfaceListResult
 }
 
 // LoadBalancerOutboundRulesClientGetResponse contains the response from method LoadBalancerOutboundRulesClient.Get.
 type LoadBalancerOutboundRulesClientGetResponse struct {
-	LoadBalancerOutboundRulesClientGetResult
+	OutboundRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerOutboundRulesClientGetResult contains the result from method LoadBalancerOutboundRulesClient.Get.
-type LoadBalancerOutboundRulesClientGetResult struct {
-	OutboundRule
 }
 
 // LoadBalancerOutboundRulesClientListResponse contains the response from method LoadBalancerOutboundRulesClient.List.
 type LoadBalancerOutboundRulesClientListResponse struct {
-	LoadBalancerOutboundRulesClientListResult
+	LoadBalancerOutboundRuleListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerOutboundRulesClientListResult contains the result from method LoadBalancerOutboundRulesClient.List.
-type LoadBalancerOutboundRulesClientListResult struct {
-	LoadBalancerOutboundRuleListResult
 }
 
 // LoadBalancerProbesClientGetResponse contains the response from method LoadBalancerProbesClient.Get.
 type LoadBalancerProbesClientGetResponse struct {
-	LoadBalancerProbesClientGetResult
+	Probe
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerProbesClientGetResult contains the result from method LoadBalancerProbesClient.Get.
-type LoadBalancerProbesClientGetResult struct {
-	Probe
 }
 
 // LoadBalancerProbesClientListResponse contains the response from method LoadBalancerProbesClient.List.
 type LoadBalancerProbesClientListResponse struct {
-	LoadBalancerProbesClientListResult
+	LoadBalancerProbeListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancerProbesClientListResult contains the result from method LoadBalancerProbesClient.List.
-type LoadBalancerProbesClientListResult struct {
-	LoadBalancerProbeListResult
 }
 
 // LoadBalancersClientCreateOrUpdatePollerResponse contains the response from method LoadBalancersClient.CreateOrUpdate.
@@ -4586,14 +3824,9 @@ func (l *LoadBalancersClientCreateOrUpdatePollerResponse) Resume(ctx context.Con
 
 // LoadBalancersClientCreateOrUpdateResponse contains the response from method LoadBalancersClient.CreateOrUpdate.
 type LoadBalancersClientCreateOrUpdateResponse struct {
-	LoadBalancersClientCreateOrUpdateResult
+	LoadBalancer
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancersClientCreateOrUpdateResult contains the result from method LoadBalancersClient.CreateOrUpdate.
-type LoadBalancersClientCreateOrUpdateResult struct {
-	LoadBalancer
 }
 
 // LoadBalancersClientDeletePollerResponse contains the response from method LoadBalancersClient.Delete.
@@ -4644,50 +3877,30 @@ type LoadBalancersClientDeleteResponse struct {
 
 // LoadBalancersClientGetResponse contains the response from method LoadBalancersClient.Get.
 type LoadBalancersClientGetResponse struct {
-	LoadBalancersClientGetResult
+	LoadBalancer
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancersClientGetResult contains the result from method LoadBalancersClient.Get.
-type LoadBalancersClientGetResult struct {
-	LoadBalancer
 }
 
 // LoadBalancersClientListAllResponse contains the response from method LoadBalancersClient.ListAll.
 type LoadBalancersClientListAllResponse struct {
-	LoadBalancersClientListAllResult
+	LoadBalancerListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancersClientListAllResult contains the result from method LoadBalancersClient.ListAll.
-type LoadBalancersClientListAllResult struct {
-	LoadBalancerListResult
 }
 
 // LoadBalancersClientListResponse contains the response from method LoadBalancersClient.List.
 type LoadBalancersClientListResponse struct {
-	LoadBalancersClientListResult
+	LoadBalancerListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancersClientListResult contains the result from method LoadBalancersClient.List.
-type LoadBalancersClientListResult struct {
-	LoadBalancerListResult
 }
 
 // LoadBalancersClientUpdateTagsResponse contains the response from method LoadBalancersClient.UpdateTags.
 type LoadBalancersClientUpdateTagsResponse struct {
-	LoadBalancersClientUpdateTagsResult
+	LoadBalancer
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LoadBalancersClientUpdateTagsResult contains the result from method LoadBalancersClient.UpdateTags.
-type LoadBalancersClientUpdateTagsResult struct {
-	LoadBalancer
 }
 
 // LocalNetworkGatewaysClientCreateOrUpdatePollerResponse contains the response from method LocalNetworkGatewaysClient.CreateOrUpdate.
@@ -4732,14 +3945,9 @@ func (l *LocalNetworkGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx cont
 
 // LocalNetworkGatewaysClientCreateOrUpdateResponse contains the response from method LocalNetworkGatewaysClient.CreateOrUpdate.
 type LocalNetworkGatewaysClientCreateOrUpdateResponse struct {
-	LocalNetworkGatewaysClientCreateOrUpdateResult
+	LocalNetworkGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LocalNetworkGatewaysClientCreateOrUpdateResult contains the result from method LocalNetworkGatewaysClient.CreateOrUpdate.
-type LocalNetworkGatewaysClientCreateOrUpdateResult struct {
-	LocalNetworkGateway
 }
 
 // LocalNetworkGatewaysClientDeletePollerResponse contains the response from method LocalNetworkGatewaysClient.Delete.
@@ -4790,50 +3998,30 @@ type LocalNetworkGatewaysClientDeleteResponse struct {
 
 // LocalNetworkGatewaysClientGetResponse contains the response from method LocalNetworkGatewaysClient.Get.
 type LocalNetworkGatewaysClientGetResponse struct {
-	LocalNetworkGatewaysClientGetResult
+	LocalNetworkGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LocalNetworkGatewaysClientGetResult contains the result from method LocalNetworkGatewaysClient.Get.
-type LocalNetworkGatewaysClientGetResult struct {
-	LocalNetworkGateway
 }
 
 // LocalNetworkGatewaysClientListResponse contains the response from method LocalNetworkGatewaysClient.List.
 type LocalNetworkGatewaysClientListResponse struct {
-	LocalNetworkGatewaysClientListResult
+	LocalNetworkGatewayListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LocalNetworkGatewaysClientListResult contains the result from method LocalNetworkGatewaysClient.List.
-type LocalNetworkGatewaysClientListResult struct {
-	LocalNetworkGatewayListResult
 }
 
 // LocalNetworkGatewaysClientUpdateTagsResponse contains the response from method LocalNetworkGatewaysClient.UpdateTags.
 type LocalNetworkGatewaysClientUpdateTagsResponse struct {
-	LocalNetworkGatewaysClientUpdateTagsResult
+	LocalNetworkGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// LocalNetworkGatewaysClientUpdateTagsResult contains the result from method LocalNetworkGatewaysClient.UpdateTags.
-type LocalNetworkGatewaysClientUpdateTagsResult struct {
-	LocalNetworkGateway
 }
 
 // ManagementClientCheckDNSNameAvailabilityResponse contains the response from method ManagementClient.CheckDNSNameAvailability.
 type ManagementClientCheckDNSNameAvailabilityResponse struct {
-	ManagementClientCheckDNSNameAvailabilityResult
+	DNSNameAvailabilityResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ManagementClientCheckDNSNameAvailabilityResult contains the result from method ManagementClient.CheckDNSNameAvailability.
-type ManagementClientCheckDNSNameAvailabilityResult struct {
-	DNSNameAvailabilityResult
 }
 
 // ManagementClientDeleteBastionShareableLinkPollerResponse contains the response from method ManagementClient.DeleteBastionShareableLink.
@@ -4884,14 +4072,9 @@ type ManagementClientDeleteBastionShareableLinkResponse struct {
 
 // ManagementClientDisconnectActiveSessionsResponse contains the response from method ManagementClient.DisconnectActiveSessions.
 type ManagementClientDisconnectActiveSessionsResponse struct {
-	ManagementClientDisconnectActiveSessionsResult
+	BastionSessionDeleteResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ManagementClientDisconnectActiveSessionsResult contains the result from method ManagementClient.DisconnectActiveSessions.
-type ManagementClientDisconnectActiveSessionsResult struct {
-	BastionSessionDeleteResult
 }
 
 // ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse contains the response from method ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile.
@@ -4937,14 +4120,9 @@ func (l *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePolle
 
 // ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse contains the response from method ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile.
 type ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse struct {
-	ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResult
+	VPNProfileResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResult contains the result from method ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile.
-type ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResult struct {
-	VPNProfileResponse
 }
 
 // ManagementClientGetActiveSessionsPollerResponse contains the response from method ManagementClient.GetActiveSessions.
@@ -4991,26 +4169,16 @@ func (l *ManagementClientGetActiveSessionsPollerResponse) Resume(ctx context.Con
 
 // ManagementClientGetActiveSessionsResponse contains the response from method ManagementClient.GetActiveSessions.
 type ManagementClientGetActiveSessionsResponse struct {
-	ManagementClientGetActiveSessionsResult
+	BastionActiveSessionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ManagementClientGetActiveSessionsResult contains the result from method ManagementClient.GetActiveSessions.
-type ManagementClientGetActiveSessionsResult struct {
-	BastionActiveSessionListResult
 }
 
 // ManagementClientGetBastionShareableLinkResponse contains the response from method ManagementClient.GetBastionShareableLink.
 type ManagementClientGetBastionShareableLinkResponse struct {
-	ManagementClientGetBastionShareableLinkResult
+	BastionShareableLinkListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ManagementClientGetBastionShareableLinkResult contains the result from method ManagementClient.GetBastionShareableLink.
-type ManagementClientGetBastionShareableLinkResult struct {
-	BastionShareableLinkListResult
 }
 
 // ManagementClientPutBastionShareableLinkPollerResponse contains the response from method ManagementClient.PutBastionShareableLink.
@@ -5057,26 +4225,16 @@ func (l *ManagementClientPutBastionShareableLinkPollerResponse) Resume(ctx conte
 
 // ManagementClientPutBastionShareableLinkResponse contains the response from method ManagementClient.PutBastionShareableLink.
 type ManagementClientPutBastionShareableLinkResponse struct {
-	ManagementClientPutBastionShareableLinkResult
+	BastionShareableLinkListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ManagementClientPutBastionShareableLinkResult contains the result from method ManagementClient.PutBastionShareableLink.
-type ManagementClientPutBastionShareableLinkResult struct {
-	BastionShareableLinkListResult
 }
 
 // ManagementClientSupportedSecurityProvidersResponse contains the response from method ManagementClient.SupportedSecurityProviders.
 type ManagementClientSupportedSecurityProvidersResponse struct {
-	ManagementClientSupportedSecurityProvidersResult
+	VirtualWanSecurityProviders
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ManagementClientSupportedSecurityProvidersResult contains the result from method ManagementClient.SupportedSecurityProviders.
-type ManagementClientSupportedSecurityProvidersResult struct {
-	VirtualWanSecurityProviders
 }
 
 // NatGatewaysClientCreateOrUpdatePollerResponse contains the response from method NatGatewaysClient.CreateOrUpdate.
@@ -5121,14 +4279,9 @@ func (l *NatGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 
 // NatGatewaysClientCreateOrUpdateResponse contains the response from method NatGatewaysClient.CreateOrUpdate.
 type NatGatewaysClientCreateOrUpdateResponse struct {
-	NatGatewaysClientCreateOrUpdateResult
+	NatGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NatGatewaysClientCreateOrUpdateResult contains the result from method NatGatewaysClient.CreateOrUpdate.
-type NatGatewaysClientCreateOrUpdateResult struct {
-	NatGateway
 }
 
 // NatGatewaysClientDeletePollerResponse contains the response from method NatGatewaysClient.Delete.
@@ -5179,62 +4332,37 @@ type NatGatewaysClientDeleteResponse struct {
 
 // NatGatewaysClientGetResponse contains the response from method NatGatewaysClient.Get.
 type NatGatewaysClientGetResponse struct {
-	NatGatewaysClientGetResult
+	NatGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NatGatewaysClientGetResult contains the result from method NatGatewaysClient.Get.
-type NatGatewaysClientGetResult struct {
-	NatGateway
 }
 
 // NatGatewaysClientListAllResponse contains the response from method NatGatewaysClient.ListAll.
 type NatGatewaysClientListAllResponse struct {
-	NatGatewaysClientListAllResult
+	NatGatewayListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NatGatewaysClientListAllResult contains the result from method NatGatewaysClient.ListAll.
-type NatGatewaysClientListAllResult struct {
-	NatGatewayListResult
 }
 
 // NatGatewaysClientListResponse contains the response from method NatGatewaysClient.List.
 type NatGatewaysClientListResponse struct {
-	NatGatewaysClientListResult
+	NatGatewayListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NatGatewaysClientListResult contains the result from method NatGatewaysClient.List.
-type NatGatewaysClientListResult struct {
-	NatGatewayListResult
 }
 
 // NatGatewaysClientUpdateTagsResponse contains the response from method NatGatewaysClient.UpdateTags.
 type NatGatewaysClientUpdateTagsResponse struct {
-	NatGatewaysClientUpdateTagsResult
+	NatGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// NatGatewaysClientUpdateTagsResult contains the result from method NatGatewaysClient.UpdateTags.
-type NatGatewaysClientUpdateTagsResult struct {
-	NatGateway
 }
 
 // OperationsClientListResponse contains the response from method OperationsClient.List.
 type OperationsClientListResponse struct {
-	OperationsClientListResult
+	OperationListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// OperationsClientListResult contains the result from method OperationsClient.List.
-type OperationsClientListResult struct {
-	OperationListResult
 }
 
 // P2SVPNGatewaysClientCreateOrUpdatePollerResponse contains the response from method P2SVPNGatewaysClient.CreateOrUpdate.
@@ -5279,14 +4407,9 @@ func (l *P2SVPNGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 
 // P2SVPNGatewaysClientCreateOrUpdateResponse contains the response from method P2SVPNGatewaysClient.CreateOrUpdate.
 type P2SVPNGatewaysClientCreateOrUpdateResponse struct {
-	P2SVPNGatewaysClientCreateOrUpdateResult
+	P2SVPNGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// P2SVPNGatewaysClientCreateOrUpdateResult contains the result from method P2SVPNGatewaysClient.CreateOrUpdate.
-type P2SVPNGatewaysClientCreateOrUpdateResult struct {
-	P2SVPNGateway
 }
 
 // P2SVPNGatewaysClientDeletePollerResponse contains the response from method P2SVPNGatewaysClient.Delete.
@@ -5423,14 +4546,9 @@ func (l *P2SVPNGatewaysClientGenerateVPNProfilePollerResponse) Resume(ctx contex
 
 // P2SVPNGatewaysClientGenerateVPNProfileResponse contains the response from method P2SVPNGatewaysClient.GenerateVPNProfile.
 type P2SVPNGatewaysClientGenerateVPNProfileResponse struct {
-	P2SVPNGatewaysClientGenerateVPNProfileResult
+	VPNProfileResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// P2SVPNGatewaysClientGenerateVPNProfileResult contains the result from method P2SVPNGatewaysClient.GenerateVPNProfile.
-type P2SVPNGatewaysClientGenerateVPNProfileResult struct {
-	VPNProfileResponse
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed.
@@ -5476,14 +4594,9 @@ func (l *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse) Re
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed.
 type P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse struct {
-	P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResult
+	P2SVPNConnectionHealth
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResult contains the result from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed.
-type P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResult struct {
-	P2SVPNConnectionHealth
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealth.
@@ -5528,62 +4641,37 @@ func (l *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse) Resume(ctx
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealth.
 type P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse struct {
-	P2SVPNGatewaysClientGetP2SVPNConnectionHealthResult
+	P2SVPNGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// P2SVPNGatewaysClientGetP2SVPNConnectionHealthResult contains the result from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealth.
-type P2SVPNGatewaysClientGetP2SVPNConnectionHealthResult struct {
-	P2SVPNGateway
 }
 
 // P2SVPNGatewaysClientGetResponse contains the response from method P2SVPNGatewaysClient.Get.
 type P2SVPNGatewaysClientGetResponse struct {
-	P2SVPNGatewaysClientGetResult
+	P2SVPNGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// P2SVPNGatewaysClientGetResult contains the result from method P2SVPNGatewaysClient.Get.
-type P2SVPNGatewaysClientGetResult struct {
-	P2SVPNGateway
 }
 
 // P2SVPNGatewaysClientListByResourceGroupResponse contains the response from method P2SVPNGatewaysClient.ListByResourceGroup.
 type P2SVPNGatewaysClientListByResourceGroupResponse struct {
-	P2SVPNGatewaysClientListByResourceGroupResult
+	ListP2SVPNGatewaysResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// P2SVPNGatewaysClientListByResourceGroupResult contains the result from method P2SVPNGatewaysClient.ListByResourceGroup.
-type P2SVPNGatewaysClientListByResourceGroupResult struct {
-	ListP2SVPNGatewaysResult
 }
 
 // P2SVPNGatewaysClientListResponse contains the response from method P2SVPNGatewaysClient.List.
 type P2SVPNGatewaysClientListResponse struct {
-	P2SVPNGatewaysClientListResult
+	ListP2SVPNGatewaysResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// P2SVPNGatewaysClientListResult contains the result from method P2SVPNGatewaysClient.List.
-type P2SVPNGatewaysClientListResult struct {
-	ListP2SVPNGatewaysResult
 }
 
 // P2SVPNGatewaysClientUpdateTagsResponse contains the response from method P2SVPNGatewaysClient.UpdateTags.
 type P2SVPNGatewaysClientUpdateTagsResponse struct {
-	P2SVPNGatewaysClientUpdateTagsResult
+	P2SVPNGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// P2SVPNGatewaysClientUpdateTagsResult contains the result from method P2SVPNGatewaysClient.UpdateTags.
-type P2SVPNGatewaysClientUpdateTagsResult struct {
-	P2SVPNGateway
 }
 
 // PacketCapturesClientCreatePollerResponse contains the response from method PacketCapturesClient.Create.
@@ -5628,14 +4716,9 @@ func (l *PacketCapturesClientCreatePollerResponse) Resume(ctx context.Context, c
 
 // PacketCapturesClientCreateResponse contains the response from method PacketCapturesClient.Create.
 type PacketCapturesClientCreateResponse struct {
-	PacketCapturesClientCreateResult
+	PacketCaptureResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PacketCapturesClientCreateResult contains the result from method PacketCapturesClient.Create.
-type PacketCapturesClientCreateResult struct {
-	PacketCaptureResult
 }
 
 // PacketCapturesClientDeletePollerResponse contains the response from method PacketCapturesClient.Delete.
@@ -5686,14 +4769,9 @@ type PacketCapturesClientDeleteResponse struct {
 
 // PacketCapturesClientGetResponse contains the response from method PacketCapturesClient.Get.
 type PacketCapturesClientGetResponse struct {
-	PacketCapturesClientGetResult
+	PacketCaptureResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PacketCapturesClientGetResult contains the result from method PacketCapturesClient.Get.
-type PacketCapturesClientGetResult struct {
-	PacketCaptureResult
 }
 
 // PacketCapturesClientGetStatusPollerResponse contains the response from method PacketCapturesClient.GetStatus.
@@ -5738,26 +4816,16 @@ func (l *PacketCapturesClientGetStatusPollerResponse) Resume(ctx context.Context
 
 // PacketCapturesClientGetStatusResponse contains the response from method PacketCapturesClient.GetStatus.
 type PacketCapturesClientGetStatusResponse struct {
-	PacketCapturesClientGetStatusResult
+	PacketCaptureQueryStatusResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PacketCapturesClientGetStatusResult contains the result from method PacketCapturesClient.GetStatus.
-type PacketCapturesClientGetStatusResult struct {
-	PacketCaptureQueryStatusResult
 }
 
 // PacketCapturesClientListResponse contains the response from method PacketCapturesClient.List.
 type PacketCapturesClientListResponse struct {
-	PacketCapturesClientListResult
+	PacketCaptureListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PacketCapturesClientListResult contains the result from method PacketCapturesClient.List.
-type PacketCapturesClientListResult struct {
-	PacketCaptureListResult
 }
 
 // PacketCapturesClientStopPollerResponse contains the response from method PacketCapturesClient.Stop.
@@ -5808,26 +4876,16 @@ type PacketCapturesClientStopResponse struct {
 
 // PeerExpressRouteCircuitConnectionsClientGetResponse contains the response from method PeerExpressRouteCircuitConnectionsClient.Get.
 type PeerExpressRouteCircuitConnectionsClientGetResponse struct {
-	PeerExpressRouteCircuitConnectionsClientGetResult
+	PeerExpressRouteCircuitConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PeerExpressRouteCircuitConnectionsClientGetResult contains the result from method PeerExpressRouteCircuitConnectionsClient.Get.
-type PeerExpressRouteCircuitConnectionsClientGetResult struct {
-	PeerExpressRouteCircuitConnection
 }
 
 // PeerExpressRouteCircuitConnectionsClientListResponse contains the response from method PeerExpressRouteCircuitConnectionsClient.List.
 type PeerExpressRouteCircuitConnectionsClientListResponse struct {
-	PeerExpressRouteCircuitConnectionsClientListResult
+	PeerExpressRouteCircuitConnectionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PeerExpressRouteCircuitConnectionsClientListResult contains the result from method PeerExpressRouteCircuitConnectionsClient.List.
-type PeerExpressRouteCircuitConnectionsClientListResult struct {
-	PeerExpressRouteCircuitConnectionListResult
 }
 
 // PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse contains the response from method PrivateDNSZoneGroupsClient.CreateOrUpdate.
@@ -5872,14 +4930,9 @@ func (l *PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse) Resume(ctx cont
 
 // PrivateDNSZoneGroupsClientCreateOrUpdateResponse contains the response from method PrivateDNSZoneGroupsClient.CreateOrUpdate.
 type PrivateDNSZoneGroupsClientCreateOrUpdateResponse struct {
-	PrivateDNSZoneGroupsClientCreateOrUpdateResult
+	PrivateDNSZoneGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateDNSZoneGroupsClientCreateOrUpdateResult contains the result from method PrivateDNSZoneGroupsClient.CreateOrUpdate.
-type PrivateDNSZoneGroupsClientCreateOrUpdateResult struct {
-	PrivateDNSZoneGroup
 }
 
 // PrivateDNSZoneGroupsClientDeletePollerResponse contains the response from method PrivateDNSZoneGroupsClient.Delete.
@@ -5930,26 +4983,16 @@ type PrivateDNSZoneGroupsClientDeleteResponse struct {
 
 // PrivateDNSZoneGroupsClientGetResponse contains the response from method PrivateDNSZoneGroupsClient.Get.
 type PrivateDNSZoneGroupsClientGetResponse struct {
-	PrivateDNSZoneGroupsClientGetResult
+	PrivateDNSZoneGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateDNSZoneGroupsClientGetResult contains the result from method PrivateDNSZoneGroupsClient.Get.
-type PrivateDNSZoneGroupsClientGetResult struct {
-	PrivateDNSZoneGroup
 }
 
 // PrivateDNSZoneGroupsClientListResponse contains the response from method PrivateDNSZoneGroupsClient.List.
 type PrivateDNSZoneGroupsClientListResponse struct {
-	PrivateDNSZoneGroupsClientListResult
+	PrivateDNSZoneGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateDNSZoneGroupsClientListResult contains the result from method PrivateDNSZoneGroupsClient.List.
-type PrivateDNSZoneGroupsClientListResult struct {
-	PrivateDNSZoneGroupListResult
 }
 
 // PrivateEndpointsClientCreateOrUpdatePollerResponse contains the response from method PrivateEndpointsClient.CreateOrUpdate.
@@ -5994,14 +5037,9 @@ func (l *PrivateEndpointsClientCreateOrUpdatePollerResponse) Resume(ctx context.
 
 // PrivateEndpointsClientCreateOrUpdateResponse contains the response from method PrivateEndpointsClient.CreateOrUpdate.
 type PrivateEndpointsClientCreateOrUpdateResponse struct {
-	PrivateEndpointsClientCreateOrUpdateResult
+	PrivateEndpoint
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateEndpointsClientCreateOrUpdateResult contains the result from method PrivateEndpointsClient.CreateOrUpdate.
-type PrivateEndpointsClientCreateOrUpdateResult struct {
-	PrivateEndpoint
 }
 
 // PrivateEndpointsClientDeletePollerResponse contains the response from method PrivateEndpointsClient.Delete.
@@ -6052,38 +5090,23 @@ type PrivateEndpointsClientDeleteResponse struct {
 
 // PrivateEndpointsClientGetResponse contains the response from method PrivateEndpointsClient.Get.
 type PrivateEndpointsClientGetResponse struct {
-	PrivateEndpointsClientGetResult
+	PrivateEndpoint
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateEndpointsClientGetResult contains the result from method PrivateEndpointsClient.Get.
-type PrivateEndpointsClientGetResult struct {
-	PrivateEndpoint
 }
 
 // PrivateEndpointsClientListBySubscriptionResponse contains the response from method PrivateEndpointsClient.ListBySubscription.
 type PrivateEndpointsClientListBySubscriptionResponse struct {
-	PrivateEndpointsClientListBySubscriptionResult
+	PrivateEndpointListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateEndpointsClientListBySubscriptionResult contains the result from method PrivateEndpointsClient.ListBySubscription.
-type PrivateEndpointsClientListBySubscriptionResult struct {
-	PrivateEndpointListResult
 }
 
 // PrivateEndpointsClientListResponse contains the response from method PrivateEndpointsClient.List.
 type PrivateEndpointsClientListResponse struct {
-	PrivateEndpointsClientListResult
+	PrivateEndpointListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateEndpointsClientListResult contains the result from method PrivateEndpointsClient.List.
-type PrivateEndpointsClientListResult struct {
-	PrivateEndpointListResult
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse contains the response from method
@@ -6130,14 +5153,9 @@ func (l *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGro
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup.
 type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse struct {
-	PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResult
+	PrivateLinkServiceVisibility
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResult contains the result from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup.
-type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResult struct {
-	PrivateLinkServiceVisibility
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility.
@@ -6183,14 +5201,9 @@ func (l *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerRespons
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility.
 type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse struct {
-	PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResult
+	PrivateLinkServiceVisibility
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResult contains the result from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility.
-type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResult struct {
-	PrivateLinkServiceVisibility
 }
 
 // PrivateLinkServicesClientCreateOrUpdatePollerResponse contains the response from method PrivateLinkServicesClient.CreateOrUpdate.
@@ -6235,14 +5248,9 @@ func (l *PrivateLinkServicesClientCreateOrUpdatePollerResponse) Resume(ctx conte
 
 // PrivateLinkServicesClientCreateOrUpdateResponse contains the response from method PrivateLinkServicesClient.CreateOrUpdate.
 type PrivateLinkServicesClientCreateOrUpdateResponse struct {
-	PrivateLinkServicesClientCreateOrUpdateResult
+	PrivateLinkService
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientCreateOrUpdateResult contains the result from method PrivateLinkServicesClient.CreateOrUpdate.
-type PrivateLinkServicesClientCreateOrUpdateResult struct {
-	PrivateLinkService
 }
 
 // PrivateLinkServicesClientDeletePollerResponse contains the response from method PrivateLinkServicesClient.Delete.
@@ -6340,110 +5348,65 @@ type PrivateLinkServicesClientDeleteResponse struct {
 
 // PrivateLinkServicesClientGetPrivateEndpointConnectionResponse contains the response from method PrivateLinkServicesClient.GetPrivateEndpointConnection.
 type PrivateLinkServicesClientGetPrivateEndpointConnectionResponse struct {
-	PrivateLinkServicesClientGetPrivateEndpointConnectionResult
+	PrivateEndpointConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientGetPrivateEndpointConnectionResult contains the result from method PrivateLinkServicesClient.GetPrivateEndpointConnection.
-type PrivateLinkServicesClientGetPrivateEndpointConnectionResult struct {
-	PrivateEndpointConnection
 }
 
 // PrivateLinkServicesClientGetResponse contains the response from method PrivateLinkServicesClient.Get.
 type PrivateLinkServicesClientGetResponse struct {
-	PrivateLinkServicesClientGetResult
+	PrivateLinkService
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientGetResult contains the result from method PrivateLinkServicesClient.Get.
-type PrivateLinkServicesClientGetResult struct {
-	PrivateLinkService
 }
 
 // PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse contains the response from method PrivateLinkServicesClient.ListAutoApprovedPrivateLinkServicesByResourceGroup.
 type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse struct {
-	PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResult
+	AutoApprovedPrivateLinkServicesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResult contains the result from method PrivateLinkServicesClient.ListAutoApprovedPrivateLinkServicesByResourceGroup.
-type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResult struct {
-	AutoApprovedPrivateLinkServicesResult
 }
 
 // PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse contains the response from method PrivateLinkServicesClient.ListAutoApprovedPrivateLinkServices.
 type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse struct {
-	PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResult
+	AutoApprovedPrivateLinkServicesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResult contains the result from method PrivateLinkServicesClient.ListAutoApprovedPrivateLinkServices.
-type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResult struct {
-	AutoApprovedPrivateLinkServicesResult
 }
 
 // PrivateLinkServicesClientListBySubscriptionResponse contains the response from method PrivateLinkServicesClient.ListBySubscription.
 type PrivateLinkServicesClientListBySubscriptionResponse struct {
-	PrivateLinkServicesClientListBySubscriptionResult
+	PrivateLinkServiceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientListBySubscriptionResult contains the result from method PrivateLinkServicesClient.ListBySubscription.
-type PrivateLinkServicesClientListBySubscriptionResult struct {
-	PrivateLinkServiceListResult
 }
 
 // PrivateLinkServicesClientListPrivateEndpointConnectionsResponse contains the response from method PrivateLinkServicesClient.ListPrivateEndpointConnections.
 type PrivateLinkServicesClientListPrivateEndpointConnectionsResponse struct {
-	PrivateLinkServicesClientListPrivateEndpointConnectionsResult
+	PrivateEndpointConnectionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientListPrivateEndpointConnectionsResult contains the result from method PrivateLinkServicesClient.ListPrivateEndpointConnections.
-type PrivateLinkServicesClientListPrivateEndpointConnectionsResult struct {
-	PrivateEndpointConnectionListResult
 }
 
 // PrivateLinkServicesClientListResponse contains the response from method PrivateLinkServicesClient.List.
 type PrivateLinkServicesClientListResponse struct {
-	PrivateLinkServicesClientListResult
+	PrivateLinkServiceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientListResult contains the result from method PrivateLinkServicesClient.List.
-type PrivateLinkServicesClientListResult struct {
-	PrivateLinkServiceListResult
 }
 
 // PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse contains the response from method PrivateLinkServicesClient.UpdatePrivateEndpointConnection.
 type PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse struct {
-	PrivateLinkServicesClientUpdatePrivateEndpointConnectionResult
+	PrivateEndpointConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PrivateLinkServicesClientUpdatePrivateEndpointConnectionResult contains the result from method PrivateLinkServicesClient.UpdatePrivateEndpointConnection.
-type PrivateLinkServicesClientUpdatePrivateEndpointConnectionResult struct {
-	PrivateEndpointConnection
 }
 
 // ProfilesClientCreateOrUpdateResponse contains the response from method ProfilesClient.CreateOrUpdate.
 type ProfilesClientCreateOrUpdateResponse struct {
-	ProfilesClientCreateOrUpdateResult
+	Profile
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProfilesClientCreateOrUpdateResult contains the result from method ProfilesClient.CreateOrUpdate.
-type ProfilesClientCreateOrUpdateResult struct {
-	Profile
 }
 
 // ProfilesClientDeletePollerResponse contains the response from method ProfilesClient.Delete.
@@ -6494,50 +5457,30 @@ type ProfilesClientDeleteResponse struct {
 
 // ProfilesClientGetResponse contains the response from method ProfilesClient.Get.
 type ProfilesClientGetResponse struct {
-	ProfilesClientGetResult
+	Profile
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProfilesClientGetResult contains the result from method ProfilesClient.Get.
-type ProfilesClientGetResult struct {
-	Profile
 }
 
 // ProfilesClientListAllResponse contains the response from method ProfilesClient.ListAll.
 type ProfilesClientListAllResponse struct {
-	ProfilesClientListAllResult
+	ProfileListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProfilesClientListAllResult contains the result from method ProfilesClient.ListAll.
-type ProfilesClientListAllResult struct {
-	ProfileListResult
 }
 
 // ProfilesClientListResponse contains the response from method ProfilesClient.List.
 type ProfilesClientListResponse struct {
-	ProfilesClientListResult
+	ProfileListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProfilesClientListResult contains the result from method ProfilesClient.List.
-type ProfilesClientListResult struct {
-	ProfileListResult
 }
 
 // ProfilesClientUpdateTagsResponse contains the response from method ProfilesClient.UpdateTags.
 type ProfilesClientUpdateTagsResponse struct {
-	ProfilesClientUpdateTagsResult
+	Profile
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ProfilesClientUpdateTagsResult contains the result from method ProfilesClient.UpdateTags.
-type ProfilesClientUpdateTagsResult struct {
-	Profile
 }
 
 // PublicIPAddressesClientCreateOrUpdatePollerResponse contains the response from method PublicIPAddressesClient.CreateOrUpdate.
@@ -6582,14 +5525,9 @@ func (l *PublicIPAddressesClientCreateOrUpdatePollerResponse) Resume(ctx context
 
 // PublicIPAddressesClientCreateOrUpdateResponse contains the response from method PublicIPAddressesClient.CreateOrUpdate.
 type PublicIPAddressesClientCreateOrUpdateResponse struct {
-	PublicIPAddressesClientCreateOrUpdateResult
+	PublicIPAddress
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPAddressesClientCreateOrUpdateResult contains the result from method PublicIPAddressesClient.CreateOrUpdate.
-type PublicIPAddressesClientCreateOrUpdateResult struct {
-	PublicIPAddress
 }
 
 // PublicIPAddressesClientDeletePollerResponse contains the response from method PublicIPAddressesClient.Delete.
@@ -6640,86 +5578,51 @@ type PublicIPAddressesClientDeleteResponse struct {
 
 // PublicIPAddressesClientGetResponse contains the response from method PublicIPAddressesClient.Get.
 type PublicIPAddressesClientGetResponse struct {
-	PublicIPAddressesClientGetResult
+	PublicIPAddress
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPAddressesClientGetResult contains the result from method PublicIPAddressesClient.Get.
-type PublicIPAddressesClientGetResult struct {
-	PublicIPAddress
 }
 
 // PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse contains the response from method PublicIPAddressesClient.GetVirtualMachineScaleSetPublicIPAddress.
 type PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse struct {
-	PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResult
+	PublicIPAddress
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResult contains the result from method PublicIPAddressesClient.GetVirtualMachineScaleSetPublicIPAddress.
-type PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResult struct {
-	PublicIPAddress
 }
 
 // PublicIPAddressesClientListAllResponse contains the response from method PublicIPAddressesClient.ListAll.
 type PublicIPAddressesClientListAllResponse struct {
-	PublicIPAddressesClientListAllResult
+	PublicIPAddressListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPAddressesClientListAllResult contains the result from method PublicIPAddressesClient.ListAll.
-type PublicIPAddressesClientListAllResult struct {
-	PublicIPAddressListResult
 }
 
 // PublicIPAddressesClientListResponse contains the response from method PublicIPAddressesClient.List.
 type PublicIPAddressesClientListResponse struct {
-	PublicIPAddressesClientListResult
+	PublicIPAddressListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPAddressesClientListResult contains the result from method PublicIPAddressesClient.List.
-type PublicIPAddressesClientListResult struct {
-	PublicIPAddressListResult
 }
 
 // PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse contains the response from method PublicIPAddressesClient.ListVirtualMachineScaleSetPublicIPAddresses.
 type PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse struct {
-	PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResult
+	PublicIPAddressListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResult contains the result from method PublicIPAddressesClient.ListVirtualMachineScaleSetPublicIPAddresses.
-type PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResult struct {
-	PublicIPAddressListResult
 }
 
 // PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse contains the response from method PublicIPAddressesClient.ListVirtualMachineScaleSetVMPublicIPAddresses.
 type PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse struct {
-	PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResult
+	PublicIPAddressListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResult contains the result from method PublicIPAddressesClient.ListVirtualMachineScaleSetVMPublicIPAddresses.
-type PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResult struct {
-	PublicIPAddressListResult
 }
 
 // PublicIPAddressesClientUpdateTagsResponse contains the response from method PublicIPAddressesClient.UpdateTags.
 type PublicIPAddressesClientUpdateTagsResponse struct {
-	PublicIPAddressesClientUpdateTagsResult
+	PublicIPAddress
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPAddressesClientUpdateTagsResult contains the result from method PublicIPAddressesClient.UpdateTags.
-type PublicIPAddressesClientUpdateTagsResult struct {
-	PublicIPAddress
 }
 
 // PublicIPPrefixesClientCreateOrUpdatePollerResponse contains the response from method PublicIPPrefixesClient.CreateOrUpdate.
@@ -6764,14 +5667,9 @@ func (l *PublicIPPrefixesClientCreateOrUpdatePollerResponse) Resume(ctx context.
 
 // PublicIPPrefixesClientCreateOrUpdateResponse contains the response from method PublicIPPrefixesClient.CreateOrUpdate.
 type PublicIPPrefixesClientCreateOrUpdateResponse struct {
-	PublicIPPrefixesClientCreateOrUpdateResult
+	PublicIPPrefix
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPPrefixesClientCreateOrUpdateResult contains the result from method PublicIPPrefixesClient.CreateOrUpdate.
-type PublicIPPrefixesClientCreateOrUpdateResult struct {
-	PublicIPPrefix
 }
 
 // PublicIPPrefixesClientDeletePollerResponse contains the response from method PublicIPPrefixesClient.Delete.
@@ -6822,62 +5720,37 @@ type PublicIPPrefixesClientDeleteResponse struct {
 
 // PublicIPPrefixesClientGetResponse contains the response from method PublicIPPrefixesClient.Get.
 type PublicIPPrefixesClientGetResponse struct {
-	PublicIPPrefixesClientGetResult
+	PublicIPPrefix
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPPrefixesClientGetResult contains the result from method PublicIPPrefixesClient.Get.
-type PublicIPPrefixesClientGetResult struct {
-	PublicIPPrefix
 }
 
 // PublicIPPrefixesClientListAllResponse contains the response from method PublicIPPrefixesClient.ListAll.
 type PublicIPPrefixesClientListAllResponse struct {
-	PublicIPPrefixesClientListAllResult
+	PublicIPPrefixListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPPrefixesClientListAllResult contains the result from method PublicIPPrefixesClient.ListAll.
-type PublicIPPrefixesClientListAllResult struct {
-	PublicIPPrefixListResult
 }
 
 // PublicIPPrefixesClientListResponse contains the response from method PublicIPPrefixesClient.List.
 type PublicIPPrefixesClientListResponse struct {
-	PublicIPPrefixesClientListResult
+	PublicIPPrefixListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPPrefixesClientListResult contains the result from method PublicIPPrefixesClient.List.
-type PublicIPPrefixesClientListResult struct {
-	PublicIPPrefixListResult
 }
 
 // PublicIPPrefixesClientUpdateTagsResponse contains the response from method PublicIPPrefixesClient.UpdateTags.
 type PublicIPPrefixesClientUpdateTagsResponse struct {
-	PublicIPPrefixesClientUpdateTagsResult
+	PublicIPPrefix
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// PublicIPPrefixesClientUpdateTagsResult contains the result from method PublicIPPrefixesClient.UpdateTags.
-type PublicIPPrefixesClientUpdateTagsResult struct {
-	PublicIPPrefix
 }
 
 // ResourceNavigationLinksClientListResponse contains the response from method ResourceNavigationLinksClient.List.
 type ResourceNavigationLinksClientListResponse struct {
-	ResourceNavigationLinksClientListResult
+	ResourceNavigationLinksListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ResourceNavigationLinksClientListResult contains the result from method ResourceNavigationLinksClient.List.
-type ResourceNavigationLinksClientListResult struct {
-	ResourceNavigationLinksListResult
 }
 
 // RouteFilterRulesClientCreateOrUpdatePollerResponse contains the response from method RouteFilterRulesClient.CreateOrUpdate.
@@ -6922,14 +5795,9 @@ func (l *RouteFilterRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.
 
 // RouteFilterRulesClientCreateOrUpdateResponse contains the response from method RouteFilterRulesClient.CreateOrUpdate.
 type RouteFilterRulesClientCreateOrUpdateResponse struct {
-	RouteFilterRulesClientCreateOrUpdateResult
+	RouteFilterRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteFilterRulesClientCreateOrUpdateResult contains the result from method RouteFilterRulesClient.CreateOrUpdate.
-type RouteFilterRulesClientCreateOrUpdateResult struct {
-	RouteFilterRule
 }
 
 // RouteFilterRulesClientDeletePollerResponse contains the response from method RouteFilterRulesClient.Delete.
@@ -6980,26 +5848,16 @@ type RouteFilterRulesClientDeleteResponse struct {
 
 // RouteFilterRulesClientGetResponse contains the response from method RouteFilterRulesClient.Get.
 type RouteFilterRulesClientGetResponse struct {
-	RouteFilterRulesClientGetResult
+	RouteFilterRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteFilterRulesClientGetResult contains the result from method RouteFilterRulesClient.Get.
-type RouteFilterRulesClientGetResult struct {
-	RouteFilterRule
 }
 
 // RouteFilterRulesClientListByRouteFilterResponse contains the response from method RouteFilterRulesClient.ListByRouteFilter.
 type RouteFilterRulesClientListByRouteFilterResponse struct {
-	RouteFilterRulesClientListByRouteFilterResult
+	RouteFilterRuleListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteFilterRulesClientListByRouteFilterResult contains the result from method RouteFilterRulesClient.ListByRouteFilter.
-type RouteFilterRulesClientListByRouteFilterResult struct {
-	RouteFilterRuleListResult
 }
 
 // RouteFiltersClientCreateOrUpdatePollerResponse contains the response from method RouteFiltersClient.CreateOrUpdate.
@@ -7044,14 +5902,9 @@ func (l *RouteFiltersClientCreateOrUpdatePollerResponse) Resume(ctx context.Cont
 
 // RouteFiltersClientCreateOrUpdateResponse contains the response from method RouteFiltersClient.CreateOrUpdate.
 type RouteFiltersClientCreateOrUpdateResponse struct {
-	RouteFiltersClientCreateOrUpdateResult
+	RouteFilter
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteFiltersClientCreateOrUpdateResult contains the result from method RouteFiltersClient.CreateOrUpdate.
-type RouteFiltersClientCreateOrUpdateResult struct {
-	RouteFilter
 }
 
 // RouteFiltersClientDeletePollerResponse contains the response from method RouteFiltersClient.Delete.
@@ -7102,50 +5955,30 @@ type RouteFiltersClientDeleteResponse struct {
 
 // RouteFiltersClientGetResponse contains the response from method RouteFiltersClient.Get.
 type RouteFiltersClientGetResponse struct {
-	RouteFiltersClientGetResult
+	RouteFilter
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteFiltersClientGetResult contains the result from method RouteFiltersClient.Get.
-type RouteFiltersClientGetResult struct {
-	RouteFilter
 }
 
 // RouteFiltersClientListByResourceGroupResponse contains the response from method RouteFiltersClient.ListByResourceGroup.
 type RouteFiltersClientListByResourceGroupResponse struct {
-	RouteFiltersClientListByResourceGroupResult
+	RouteFilterListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteFiltersClientListByResourceGroupResult contains the result from method RouteFiltersClient.ListByResourceGroup.
-type RouteFiltersClientListByResourceGroupResult struct {
-	RouteFilterListResult
 }
 
 // RouteFiltersClientListResponse contains the response from method RouteFiltersClient.List.
 type RouteFiltersClientListResponse struct {
-	RouteFiltersClientListResult
+	RouteFilterListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteFiltersClientListResult contains the result from method RouteFiltersClient.List.
-type RouteFiltersClientListResult struct {
-	RouteFilterListResult
 }
 
 // RouteFiltersClientUpdateTagsResponse contains the response from method RouteFiltersClient.UpdateTags.
 type RouteFiltersClientUpdateTagsResponse struct {
-	RouteFiltersClientUpdateTagsResult
+	RouteFilter
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteFiltersClientUpdateTagsResult contains the result from method RouteFiltersClient.UpdateTags.
-type RouteFiltersClientUpdateTagsResult struct {
-	RouteFilter
 }
 
 // RouteTablesClientCreateOrUpdatePollerResponse contains the response from method RouteTablesClient.CreateOrUpdate.
@@ -7190,14 +6023,9 @@ func (l *RouteTablesClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 
 // RouteTablesClientCreateOrUpdateResponse contains the response from method RouteTablesClient.CreateOrUpdate.
 type RouteTablesClientCreateOrUpdateResponse struct {
-	RouteTablesClientCreateOrUpdateResult
+	RouteTable
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteTablesClientCreateOrUpdateResult contains the result from method RouteTablesClient.CreateOrUpdate.
-type RouteTablesClientCreateOrUpdateResult struct {
-	RouteTable
 }
 
 // RouteTablesClientDeletePollerResponse contains the response from method RouteTablesClient.Delete.
@@ -7248,50 +6076,30 @@ type RouteTablesClientDeleteResponse struct {
 
 // RouteTablesClientGetResponse contains the response from method RouteTablesClient.Get.
 type RouteTablesClientGetResponse struct {
-	RouteTablesClientGetResult
+	RouteTable
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteTablesClientGetResult contains the result from method RouteTablesClient.Get.
-type RouteTablesClientGetResult struct {
-	RouteTable
 }
 
 // RouteTablesClientListAllResponse contains the response from method RouteTablesClient.ListAll.
 type RouteTablesClientListAllResponse struct {
-	RouteTablesClientListAllResult
+	RouteTableListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteTablesClientListAllResult contains the result from method RouteTablesClient.ListAll.
-type RouteTablesClientListAllResult struct {
-	RouteTableListResult
 }
 
 // RouteTablesClientListResponse contains the response from method RouteTablesClient.List.
 type RouteTablesClientListResponse struct {
-	RouteTablesClientListResult
+	RouteTableListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteTablesClientListResult contains the result from method RouteTablesClient.List.
-type RouteTablesClientListResult struct {
-	RouteTableListResult
 }
 
 // RouteTablesClientUpdateTagsResponse contains the response from method RouteTablesClient.UpdateTags.
 type RouteTablesClientUpdateTagsResponse struct {
-	RouteTablesClientUpdateTagsResult
+	RouteTable
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RouteTablesClientUpdateTagsResult contains the result from method RouteTablesClient.UpdateTags.
-type RouteTablesClientUpdateTagsResult struct {
-	RouteTable
 }
 
 // RoutesClientCreateOrUpdatePollerResponse contains the response from method RoutesClient.CreateOrUpdate.
@@ -7336,14 +6144,9 @@ func (l *RoutesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 
 // RoutesClientCreateOrUpdateResponse contains the response from method RoutesClient.CreateOrUpdate.
 type RoutesClientCreateOrUpdateResponse struct {
-	RoutesClientCreateOrUpdateResult
+	Route
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoutesClientCreateOrUpdateResult contains the result from method RoutesClient.CreateOrUpdate.
-type RoutesClientCreateOrUpdateResult struct {
-	Route
 }
 
 // RoutesClientDeletePollerResponse contains the response from method RoutesClient.Delete.
@@ -7394,26 +6197,16 @@ type RoutesClientDeleteResponse struct {
 
 // RoutesClientGetResponse contains the response from method RoutesClient.Get.
 type RoutesClientGetResponse struct {
-	RoutesClientGetResult
+	Route
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoutesClientGetResult contains the result from method RoutesClient.Get.
-type RoutesClientGetResult struct {
-	Route
 }
 
 // RoutesClientListResponse contains the response from method RoutesClient.List.
 type RoutesClientListResponse struct {
-	RoutesClientListResult
+	RouteListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// RoutesClientListResult contains the result from method RoutesClient.List.
-type RoutesClientListResult struct {
-	RouteListResult
 }
 
 // SecurityGroupsClientCreateOrUpdatePollerResponse contains the response from method SecurityGroupsClient.CreateOrUpdate.
@@ -7458,14 +6251,9 @@ func (l *SecurityGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 
 // SecurityGroupsClientCreateOrUpdateResponse contains the response from method SecurityGroupsClient.CreateOrUpdate.
 type SecurityGroupsClientCreateOrUpdateResponse struct {
-	SecurityGroupsClientCreateOrUpdateResult
+	SecurityGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityGroupsClientCreateOrUpdateResult contains the result from method SecurityGroupsClient.CreateOrUpdate.
-type SecurityGroupsClientCreateOrUpdateResult struct {
-	SecurityGroup
 }
 
 // SecurityGroupsClientDeletePollerResponse contains the response from method SecurityGroupsClient.Delete.
@@ -7516,50 +6304,30 @@ type SecurityGroupsClientDeleteResponse struct {
 
 // SecurityGroupsClientGetResponse contains the response from method SecurityGroupsClient.Get.
 type SecurityGroupsClientGetResponse struct {
-	SecurityGroupsClientGetResult
+	SecurityGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityGroupsClientGetResult contains the result from method SecurityGroupsClient.Get.
-type SecurityGroupsClientGetResult struct {
-	SecurityGroup
 }
 
 // SecurityGroupsClientListAllResponse contains the response from method SecurityGroupsClient.ListAll.
 type SecurityGroupsClientListAllResponse struct {
-	SecurityGroupsClientListAllResult
+	SecurityGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityGroupsClientListAllResult contains the result from method SecurityGroupsClient.ListAll.
-type SecurityGroupsClientListAllResult struct {
-	SecurityGroupListResult
 }
 
 // SecurityGroupsClientListResponse contains the response from method SecurityGroupsClient.List.
 type SecurityGroupsClientListResponse struct {
-	SecurityGroupsClientListResult
+	SecurityGroupListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityGroupsClientListResult contains the result from method SecurityGroupsClient.List.
-type SecurityGroupsClientListResult struct {
-	SecurityGroupListResult
 }
 
 // SecurityGroupsClientUpdateTagsResponse contains the response from method SecurityGroupsClient.UpdateTags.
 type SecurityGroupsClientUpdateTagsResponse struct {
-	SecurityGroupsClientUpdateTagsResult
+	SecurityGroup
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityGroupsClientUpdateTagsResult contains the result from method SecurityGroupsClient.UpdateTags.
-type SecurityGroupsClientUpdateTagsResult struct {
-	SecurityGroup
 }
 
 // SecurityPartnerProvidersClientCreateOrUpdatePollerResponse contains the response from method SecurityPartnerProvidersClient.CreateOrUpdate.
@@ -7604,14 +6372,9 @@ func (l *SecurityPartnerProvidersClientCreateOrUpdatePollerResponse) Resume(ctx 
 
 // SecurityPartnerProvidersClientCreateOrUpdateResponse contains the response from method SecurityPartnerProvidersClient.CreateOrUpdate.
 type SecurityPartnerProvidersClientCreateOrUpdateResponse struct {
-	SecurityPartnerProvidersClientCreateOrUpdateResult
+	SecurityPartnerProvider
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityPartnerProvidersClientCreateOrUpdateResult contains the result from method SecurityPartnerProvidersClient.CreateOrUpdate.
-type SecurityPartnerProvidersClientCreateOrUpdateResult struct {
-	SecurityPartnerProvider
 }
 
 // SecurityPartnerProvidersClientDeletePollerResponse contains the response from method SecurityPartnerProvidersClient.Delete.
@@ -7662,50 +6425,30 @@ type SecurityPartnerProvidersClientDeleteResponse struct {
 
 // SecurityPartnerProvidersClientGetResponse contains the response from method SecurityPartnerProvidersClient.Get.
 type SecurityPartnerProvidersClientGetResponse struct {
-	SecurityPartnerProvidersClientGetResult
+	SecurityPartnerProvider
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityPartnerProvidersClientGetResult contains the result from method SecurityPartnerProvidersClient.Get.
-type SecurityPartnerProvidersClientGetResult struct {
-	SecurityPartnerProvider
 }
 
 // SecurityPartnerProvidersClientListByResourceGroupResponse contains the response from method SecurityPartnerProvidersClient.ListByResourceGroup.
 type SecurityPartnerProvidersClientListByResourceGroupResponse struct {
-	SecurityPartnerProvidersClientListByResourceGroupResult
+	SecurityPartnerProviderListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityPartnerProvidersClientListByResourceGroupResult contains the result from method SecurityPartnerProvidersClient.ListByResourceGroup.
-type SecurityPartnerProvidersClientListByResourceGroupResult struct {
-	SecurityPartnerProviderListResult
 }
 
 // SecurityPartnerProvidersClientListResponse contains the response from method SecurityPartnerProvidersClient.List.
 type SecurityPartnerProvidersClientListResponse struct {
-	SecurityPartnerProvidersClientListResult
+	SecurityPartnerProviderListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityPartnerProvidersClientListResult contains the result from method SecurityPartnerProvidersClient.List.
-type SecurityPartnerProvidersClientListResult struct {
-	SecurityPartnerProviderListResult
 }
 
 // SecurityPartnerProvidersClientUpdateTagsResponse contains the response from method SecurityPartnerProvidersClient.UpdateTags.
 type SecurityPartnerProvidersClientUpdateTagsResponse struct {
-	SecurityPartnerProvidersClientUpdateTagsResult
+	SecurityPartnerProvider
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityPartnerProvidersClientUpdateTagsResult contains the result from method SecurityPartnerProvidersClient.UpdateTags.
-type SecurityPartnerProvidersClientUpdateTagsResult struct {
-	SecurityPartnerProvider
 }
 
 // SecurityRulesClientCreateOrUpdatePollerResponse contains the response from method SecurityRulesClient.CreateOrUpdate.
@@ -7750,14 +6493,9 @@ func (l *SecurityRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.Con
 
 // SecurityRulesClientCreateOrUpdateResponse contains the response from method SecurityRulesClient.CreateOrUpdate.
 type SecurityRulesClientCreateOrUpdateResponse struct {
-	SecurityRulesClientCreateOrUpdateResult
+	SecurityRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityRulesClientCreateOrUpdateResult contains the result from method SecurityRulesClient.CreateOrUpdate.
-type SecurityRulesClientCreateOrUpdateResult struct {
-	SecurityRule
 }
 
 // SecurityRulesClientDeletePollerResponse contains the response from method SecurityRulesClient.Delete.
@@ -7808,38 +6546,23 @@ type SecurityRulesClientDeleteResponse struct {
 
 // SecurityRulesClientGetResponse contains the response from method SecurityRulesClient.Get.
 type SecurityRulesClientGetResponse struct {
-	SecurityRulesClientGetResult
+	SecurityRule
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityRulesClientGetResult contains the result from method SecurityRulesClient.Get.
-type SecurityRulesClientGetResult struct {
-	SecurityRule
 }
 
 // SecurityRulesClientListResponse contains the response from method SecurityRulesClient.List.
 type SecurityRulesClientListResponse struct {
-	SecurityRulesClientListResult
+	SecurityRuleListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SecurityRulesClientListResult contains the result from method SecurityRulesClient.List.
-type SecurityRulesClientListResult struct {
-	SecurityRuleListResult
 }
 
 // ServiceAssociationLinksClientListResponse contains the response from method ServiceAssociationLinksClient.List.
 type ServiceAssociationLinksClientListResponse struct {
-	ServiceAssociationLinksClientListResult
+	ServiceAssociationLinksListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceAssociationLinksClientListResult contains the result from method ServiceAssociationLinksClient.List.
-type ServiceAssociationLinksClientListResult struct {
-	ServiceAssociationLinksListResult
 }
 
 // ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse contains the response from method ServiceEndpointPoliciesClient.CreateOrUpdate.
@@ -7884,14 +6607,9 @@ func (l *ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx c
 
 // ServiceEndpointPoliciesClientCreateOrUpdateResponse contains the response from method ServiceEndpointPoliciesClient.CreateOrUpdate.
 type ServiceEndpointPoliciesClientCreateOrUpdateResponse struct {
-	ServiceEndpointPoliciesClientCreateOrUpdateResult
+	ServiceEndpointPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceEndpointPoliciesClientCreateOrUpdateResult contains the result from method ServiceEndpointPoliciesClient.CreateOrUpdate.
-type ServiceEndpointPoliciesClientCreateOrUpdateResult struct {
-	ServiceEndpointPolicy
 }
 
 // ServiceEndpointPoliciesClientDeletePollerResponse contains the response from method ServiceEndpointPoliciesClient.Delete.
@@ -7942,50 +6660,30 @@ type ServiceEndpointPoliciesClientDeleteResponse struct {
 
 // ServiceEndpointPoliciesClientGetResponse contains the response from method ServiceEndpointPoliciesClient.Get.
 type ServiceEndpointPoliciesClientGetResponse struct {
-	ServiceEndpointPoliciesClientGetResult
+	ServiceEndpointPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceEndpointPoliciesClientGetResult contains the result from method ServiceEndpointPoliciesClient.Get.
-type ServiceEndpointPoliciesClientGetResult struct {
-	ServiceEndpointPolicy
 }
 
 // ServiceEndpointPoliciesClientListByResourceGroupResponse contains the response from method ServiceEndpointPoliciesClient.ListByResourceGroup.
 type ServiceEndpointPoliciesClientListByResourceGroupResponse struct {
-	ServiceEndpointPoliciesClientListByResourceGroupResult
+	ServiceEndpointPolicyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceEndpointPoliciesClientListByResourceGroupResult contains the result from method ServiceEndpointPoliciesClient.ListByResourceGroup.
-type ServiceEndpointPoliciesClientListByResourceGroupResult struct {
-	ServiceEndpointPolicyListResult
 }
 
 // ServiceEndpointPoliciesClientListResponse contains the response from method ServiceEndpointPoliciesClient.List.
 type ServiceEndpointPoliciesClientListResponse struct {
-	ServiceEndpointPoliciesClientListResult
+	ServiceEndpointPolicyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceEndpointPoliciesClientListResult contains the result from method ServiceEndpointPoliciesClient.List.
-type ServiceEndpointPoliciesClientListResult struct {
-	ServiceEndpointPolicyListResult
 }
 
 // ServiceEndpointPoliciesClientUpdateTagsResponse contains the response from method ServiceEndpointPoliciesClient.UpdateTags.
 type ServiceEndpointPoliciesClientUpdateTagsResponse struct {
-	ServiceEndpointPoliciesClientUpdateTagsResult
+	ServiceEndpointPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceEndpointPoliciesClientUpdateTagsResult contains the result from method ServiceEndpointPoliciesClient.UpdateTags.
-type ServiceEndpointPoliciesClientUpdateTagsResult struct {
-	ServiceEndpointPolicy
 }
 
 // ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate.
@@ -8031,14 +6729,9 @@ func (l *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse) Res
 
 // ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate.
 type ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse struct {
-	ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResult
+	ServiceEndpointPolicyDefinition
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResult contains the result from method ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate.
-type ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResult struct {
-	ServiceEndpointPolicyDefinition
 }
 
 // ServiceEndpointPolicyDefinitionsClientDeletePollerResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.Delete.
@@ -8089,38 +6782,23 @@ type ServiceEndpointPolicyDefinitionsClientDeleteResponse struct {
 
 // ServiceEndpointPolicyDefinitionsClientGetResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.Get.
 type ServiceEndpointPolicyDefinitionsClientGetResponse struct {
-	ServiceEndpointPolicyDefinitionsClientGetResult
+	ServiceEndpointPolicyDefinition
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceEndpointPolicyDefinitionsClientGetResult contains the result from method ServiceEndpointPolicyDefinitionsClient.Get.
-type ServiceEndpointPolicyDefinitionsClientGetResult struct {
-	ServiceEndpointPolicyDefinition
 }
 
 // ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.ListByResourceGroup.
 type ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse struct {
-	ServiceEndpointPolicyDefinitionsClientListByResourceGroupResult
+	ServiceEndpointPolicyDefinitionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceEndpointPolicyDefinitionsClientListByResourceGroupResult contains the result from method ServiceEndpointPolicyDefinitionsClient.ListByResourceGroup.
-type ServiceEndpointPolicyDefinitionsClientListByResourceGroupResult struct {
-	ServiceEndpointPolicyDefinitionListResult
 }
 
 // ServiceTagsClientListResponse contains the response from method ServiceTagsClient.List.
 type ServiceTagsClientListResponse struct {
-	ServiceTagsClientListResult
+	ServiceTagsListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// ServiceTagsClientListResult contains the result from method ServiceTagsClient.List.
-type ServiceTagsClientListResult struct {
-	ServiceTagsListResult
 }
 
 // SubnetsClientCreateOrUpdatePollerResponse contains the response from method SubnetsClient.CreateOrUpdate.
@@ -8165,14 +6843,9 @@ func (l *SubnetsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, 
 
 // SubnetsClientCreateOrUpdateResponse contains the response from method SubnetsClient.CreateOrUpdate.
 type SubnetsClientCreateOrUpdateResponse struct {
-	SubnetsClientCreateOrUpdateResult
+	Subnet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SubnetsClientCreateOrUpdateResult contains the result from method SubnetsClient.CreateOrUpdate.
-type SubnetsClientCreateOrUpdateResult struct {
-	Subnet
 }
 
 // SubnetsClientDeletePollerResponse contains the response from method SubnetsClient.Delete.
@@ -8223,26 +6896,16 @@ type SubnetsClientDeleteResponse struct {
 
 // SubnetsClientGetResponse contains the response from method SubnetsClient.Get.
 type SubnetsClientGetResponse struct {
-	SubnetsClientGetResult
+	Subnet
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SubnetsClientGetResult contains the result from method SubnetsClient.Get.
-type SubnetsClientGetResult struct {
-	Subnet
 }
 
 // SubnetsClientListResponse contains the response from method SubnetsClient.List.
 type SubnetsClientListResponse struct {
-	SubnetsClientListResult
+	SubnetListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// SubnetsClientListResult contains the result from method SubnetsClient.List.
-type SubnetsClientListResult struct {
-	SubnetListResult
 }
 
 // SubnetsClientPrepareNetworkPoliciesPollerResponse contains the response from method SubnetsClient.PrepareNetworkPolicies.
@@ -8339,14 +7002,9 @@ type SubnetsClientUnprepareNetworkPoliciesResponse struct {
 
 // UsagesClientListResponse contains the response from method UsagesClient.List.
 type UsagesClientListResponse struct {
-	UsagesClientListResult
+	UsagesListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// UsagesClientListResult contains the result from method UsagesClient.List.
-type UsagesClientListResult struct {
-	UsagesListResult
 }
 
 // VPNConnectionsClientCreateOrUpdatePollerResponse contains the response from method VPNConnectionsClient.CreateOrUpdate.
@@ -8391,14 +7049,9 @@ func (l *VPNConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 
 // VPNConnectionsClientCreateOrUpdateResponse contains the response from method VPNConnectionsClient.CreateOrUpdate.
 type VPNConnectionsClientCreateOrUpdateResponse struct {
-	VPNConnectionsClientCreateOrUpdateResult
+	VPNConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNConnectionsClientCreateOrUpdateResult contains the result from method VPNConnectionsClient.CreateOrUpdate.
-type VPNConnectionsClientCreateOrUpdateResult struct {
-	VPNConnection
 }
 
 // VPNConnectionsClientDeletePollerResponse contains the response from method VPNConnectionsClient.Delete.
@@ -8449,26 +7102,16 @@ type VPNConnectionsClientDeleteResponse struct {
 
 // VPNConnectionsClientGetResponse contains the response from method VPNConnectionsClient.Get.
 type VPNConnectionsClientGetResponse struct {
-	VPNConnectionsClientGetResult
+	VPNConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNConnectionsClientGetResult contains the result from method VPNConnectionsClient.Get.
-type VPNConnectionsClientGetResult struct {
-	VPNConnection
 }
 
 // VPNConnectionsClientListByVPNGatewayResponse contains the response from method VPNConnectionsClient.ListByVPNGateway.
 type VPNConnectionsClientListByVPNGatewayResponse struct {
-	VPNConnectionsClientListByVPNGatewayResult
+	ListVPNConnectionsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNConnectionsClientListByVPNGatewayResult contains the result from method VPNConnectionsClient.ListByVPNGateway.
-type VPNConnectionsClientListByVPNGatewayResult struct {
-	ListVPNConnectionsResult
 }
 
 // VPNGatewaysClientCreateOrUpdatePollerResponse contains the response from method VPNGatewaysClient.CreateOrUpdate.
@@ -8513,14 +7156,9 @@ func (l *VPNGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 
 // VPNGatewaysClientCreateOrUpdateResponse contains the response from method VPNGatewaysClient.CreateOrUpdate.
 type VPNGatewaysClientCreateOrUpdateResponse struct {
-	VPNGatewaysClientCreateOrUpdateResult
+	VPNGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNGatewaysClientCreateOrUpdateResult contains the result from method VPNGatewaysClient.CreateOrUpdate.
-type VPNGatewaysClientCreateOrUpdateResult struct {
-	VPNGateway
 }
 
 // VPNGatewaysClientDeletePollerResponse contains the response from method VPNGatewaysClient.Delete.
@@ -8571,38 +7209,23 @@ type VPNGatewaysClientDeleteResponse struct {
 
 // VPNGatewaysClientGetResponse contains the response from method VPNGatewaysClient.Get.
 type VPNGatewaysClientGetResponse struct {
-	VPNGatewaysClientGetResult
+	VPNGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNGatewaysClientGetResult contains the result from method VPNGatewaysClient.Get.
-type VPNGatewaysClientGetResult struct {
-	VPNGateway
 }
 
 // VPNGatewaysClientListByResourceGroupResponse contains the response from method VPNGatewaysClient.ListByResourceGroup.
 type VPNGatewaysClientListByResourceGroupResponse struct {
-	VPNGatewaysClientListByResourceGroupResult
+	ListVPNGatewaysResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNGatewaysClientListByResourceGroupResult contains the result from method VPNGatewaysClient.ListByResourceGroup.
-type VPNGatewaysClientListByResourceGroupResult struct {
-	ListVPNGatewaysResult
 }
 
 // VPNGatewaysClientListResponse contains the response from method VPNGatewaysClient.List.
 type VPNGatewaysClientListResponse struct {
-	VPNGatewaysClientListResult
+	ListVPNGatewaysResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNGatewaysClientListResult contains the result from method VPNGatewaysClient.List.
-type VPNGatewaysClientListResult struct {
-	ListVPNGatewaysResult
 }
 
 // VPNGatewaysClientResetPollerResponse contains the response from method VPNGatewaysClient.Reset.
@@ -8647,38 +7270,23 @@ func (l *VPNGatewaysClientResetPollerResponse) Resume(ctx context.Context, clien
 
 // VPNGatewaysClientResetResponse contains the response from method VPNGatewaysClient.Reset.
 type VPNGatewaysClientResetResponse struct {
-	VPNGatewaysClientResetResult
+	VPNGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNGatewaysClientResetResult contains the result from method VPNGatewaysClient.Reset.
-type VPNGatewaysClientResetResult struct {
-	VPNGateway
 }
 
 // VPNGatewaysClientUpdateTagsResponse contains the response from method VPNGatewaysClient.UpdateTags.
 type VPNGatewaysClientUpdateTagsResponse struct {
-	VPNGatewaysClientUpdateTagsResult
+	VPNGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNGatewaysClientUpdateTagsResult contains the result from method VPNGatewaysClient.UpdateTags.
-type VPNGatewaysClientUpdateTagsResult struct {
-	VPNGateway
 }
 
 // VPNLinkConnectionsClientListByVPNConnectionResponse contains the response from method VPNLinkConnectionsClient.ListByVPNConnection.
 type VPNLinkConnectionsClientListByVPNConnectionResponse struct {
-	VPNLinkConnectionsClientListByVPNConnectionResult
+	ListVPNSiteLinkConnectionsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNLinkConnectionsClientListByVPNConnectionResult contains the result from method VPNLinkConnectionsClient.ListByVPNConnection.
-type VPNLinkConnectionsClientListByVPNConnectionResult struct {
-	ListVPNSiteLinkConnectionsResult
 }
 
 // VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse contains the response from method VPNServerConfigurationsAssociatedWithVirtualWanClient.List.
@@ -8724,14 +7332,9 @@ func (l *VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse
 
 // VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse contains the response from method VPNServerConfigurationsAssociatedWithVirtualWanClient.List.
 type VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse struct {
-	VPNServerConfigurationsAssociatedWithVirtualWanClientListResult
+	VPNServerConfigurationsResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNServerConfigurationsAssociatedWithVirtualWanClientListResult contains the result from method VPNServerConfigurationsAssociatedWithVirtualWanClient.List.
-type VPNServerConfigurationsAssociatedWithVirtualWanClientListResult struct {
-	VPNServerConfigurationsResponse
 }
 
 // VPNServerConfigurationsClientCreateOrUpdatePollerResponse contains the response from method VPNServerConfigurationsClient.CreateOrUpdate.
@@ -8776,14 +7379,9 @@ func (l *VPNServerConfigurationsClientCreateOrUpdatePollerResponse) Resume(ctx c
 
 // VPNServerConfigurationsClientCreateOrUpdateResponse contains the response from method VPNServerConfigurationsClient.CreateOrUpdate.
 type VPNServerConfigurationsClientCreateOrUpdateResponse struct {
-	VPNServerConfigurationsClientCreateOrUpdateResult
+	VPNServerConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNServerConfigurationsClientCreateOrUpdateResult contains the result from method VPNServerConfigurationsClient.CreateOrUpdate.
-type VPNServerConfigurationsClientCreateOrUpdateResult struct {
-	VPNServerConfiguration
 }
 
 // VPNServerConfigurationsClientDeletePollerResponse contains the response from method VPNServerConfigurationsClient.Delete.
@@ -8834,86 +7432,51 @@ type VPNServerConfigurationsClientDeleteResponse struct {
 
 // VPNServerConfigurationsClientGetResponse contains the response from method VPNServerConfigurationsClient.Get.
 type VPNServerConfigurationsClientGetResponse struct {
-	VPNServerConfigurationsClientGetResult
+	VPNServerConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNServerConfigurationsClientGetResult contains the result from method VPNServerConfigurationsClient.Get.
-type VPNServerConfigurationsClientGetResult struct {
-	VPNServerConfiguration
 }
 
 // VPNServerConfigurationsClientListByResourceGroupResponse contains the response from method VPNServerConfigurationsClient.ListByResourceGroup.
 type VPNServerConfigurationsClientListByResourceGroupResponse struct {
-	VPNServerConfigurationsClientListByResourceGroupResult
+	ListVPNServerConfigurationsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNServerConfigurationsClientListByResourceGroupResult contains the result from method VPNServerConfigurationsClient.ListByResourceGroup.
-type VPNServerConfigurationsClientListByResourceGroupResult struct {
-	ListVPNServerConfigurationsResult
 }
 
 // VPNServerConfigurationsClientListResponse contains the response from method VPNServerConfigurationsClient.List.
 type VPNServerConfigurationsClientListResponse struct {
-	VPNServerConfigurationsClientListResult
+	ListVPNServerConfigurationsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNServerConfigurationsClientListResult contains the result from method VPNServerConfigurationsClient.List.
-type VPNServerConfigurationsClientListResult struct {
-	ListVPNServerConfigurationsResult
 }
 
 // VPNServerConfigurationsClientUpdateTagsResponse contains the response from method VPNServerConfigurationsClient.UpdateTags.
 type VPNServerConfigurationsClientUpdateTagsResponse struct {
-	VPNServerConfigurationsClientUpdateTagsResult
+	VPNServerConfiguration
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNServerConfigurationsClientUpdateTagsResult contains the result from method VPNServerConfigurationsClient.UpdateTags.
-type VPNServerConfigurationsClientUpdateTagsResult struct {
-	VPNServerConfiguration
 }
 
 // VPNSiteLinkConnectionsClientGetResponse contains the response from method VPNSiteLinkConnectionsClient.Get.
 type VPNSiteLinkConnectionsClientGetResponse struct {
-	VPNSiteLinkConnectionsClientGetResult
+	VPNSiteLinkConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNSiteLinkConnectionsClientGetResult contains the result from method VPNSiteLinkConnectionsClient.Get.
-type VPNSiteLinkConnectionsClientGetResult struct {
-	VPNSiteLinkConnection
 }
 
 // VPNSiteLinksClientGetResponse contains the response from method VPNSiteLinksClient.Get.
 type VPNSiteLinksClientGetResponse struct {
-	VPNSiteLinksClientGetResult
+	VPNSiteLink
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNSiteLinksClientGetResult contains the result from method VPNSiteLinksClient.Get.
-type VPNSiteLinksClientGetResult struct {
-	VPNSiteLink
 }
 
 // VPNSiteLinksClientListByVPNSiteResponse contains the response from method VPNSiteLinksClient.ListByVPNSite.
 type VPNSiteLinksClientListByVPNSiteResponse struct {
-	VPNSiteLinksClientListByVPNSiteResult
+	ListVPNSiteLinksResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNSiteLinksClientListByVPNSiteResult contains the result from method VPNSiteLinksClient.ListByVPNSite.
-type VPNSiteLinksClientListByVPNSiteResult struct {
-	ListVPNSiteLinksResult
 }
 
 // VPNSitesClientCreateOrUpdatePollerResponse contains the response from method VPNSitesClient.CreateOrUpdate.
@@ -8958,14 +7521,9 @@ func (l *VPNSitesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context,
 
 // VPNSitesClientCreateOrUpdateResponse contains the response from method VPNSitesClient.CreateOrUpdate.
 type VPNSitesClientCreateOrUpdateResponse struct {
-	VPNSitesClientCreateOrUpdateResult
+	VPNSite
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNSitesClientCreateOrUpdateResult contains the result from method VPNSitesClient.CreateOrUpdate.
-type VPNSitesClientCreateOrUpdateResult struct {
-	VPNSite
 }
 
 // VPNSitesClientDeletePollerResponse contains the response from method VPNSitesClient.Delete.
@@ -9016,50 +7574,30 @@ type VPNSitesClientDeleteResponse struct {
 
 // VPNSitesClientGetResponse contains the response from method VPNSitesClient.Get.
 type VPNSitesClientGetResponse struct {
-	VPNSitesClientGetResult
+	VPNSite
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNSitesClientGetResult contains the result from method VPNSitesClient.Get.
-type VPNSitesClientGetResult struct {
-	VPNSite
 }
 
 // VPNSitesClientListByResourceGroupResponse contains the response from method VPNSitesClient.ListByResourceGroup.
 type VPNSitesClientListByResourceGroupResponse struct {
-	VPNSitesClientListByResourceGroupResult
+	ListVPNSitesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNSitesClientListByResourceGroupResult contains the result from method VPNSitesClient.ListByResourceGroup.
-type VPNSitesClientListByResourceGroupResult struct {
-	ListVPNSitesResult
 }
 
 // VPNSitesClientListResponse contains the response from method VPNSitesClient.List.
 type VPNSitesClientListResponse struct {
-	VPNSitesClientListResult
+	ListVPNSitesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNSitesClientListResult contains the result from method VPNSitesClient.List.
-type VPNSitesClientListResult struct {
-	ListVPNSitesResult
 }
 
 // VPNSitesClientUpdateTagsResponse contains the response from method VPNSitesClient.UpdateTags.
 type VPNSitesClientUpdateTagsResponse struct {
-	VPNSitesClientUpdateTagsResult
+	VPNSite
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VPNSitesClientUpdateTagsResult contains the result from method VPNSitesClient.UpdateTags.
-type VPNSitesClientUpdateTagsResult struct {
-	VPNSite
 }
 
 // VPNSitesConfigurationClientDownloadPollerResponse contains the response from method VPNSitesConfigurationClient.Download.
@@ -9150,14 +7688,9 @@ func (l *VirtualAppliancesClientCreateOrUpdatePollerResponse) Resume(ctx context
 
 // VirtualAppliancesClientCreateOrUpdateResponse contains the response from method VirtualAppliancesClient.CreateOrUpdate.
 type VirtualAppliancesClientCreateOrUpdateResponse struct {
-	VirtualAppliancesClientCreateOrUpdateResult
+	VirtualAppliance
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualAppliancesClientCreateOrUpdateResult contains the result from method VirtualAppliancesClient.CreateOrUpdate.
-type VirtualAppliancesClientCreateOrUpdateResult struct {
-	VirtualAppliance
 }
 
 // VirtualAppliancesClientDeletePollerResponse contains the response from method VirtualAppliancesClient.Delete.
@@ -9208,50 +7741,30 @@ type VirtualAppliancesClientDeleteResponse struct {
 
 // VirtualAppliancesClientGetResponse contains the response from method VirtualAppliancesClient.Get.
 type VirtualAppliancesClientGetResponse struct {
-	VirtualAppliancesClientGetResult
+	VirtualAppliance
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualAppliancesClientGetResult contains the result from method VirtualAppliancesClient.Get.
-type VirtualAppliancesClientGetResult struct {
-	VirtualAppliance
 }
 
 // VirtualAppliancesClientListByResourceGroupResponse contains the response from method VirtualAppliancesClient.ListByResourceGroup.
 type VirtualAppliancesClientListByResourceGroupResponse struct {
-	VirtualAppliancesClientListByResourceGroupResult
+	VirtualApplianceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualAppliancesClientListByResourceGroupResult contains the result from method VirtualAppliancesClient.ListByResourceGroup.
-type VirtualAppliancesClientListByResourceGroupResult struct {
-	VirtualApplianceListResult
 }
 
 // VirtualAppliancesClientListResponse contains the response from method VirtualAppliancesClient.List.
 type VirtualAppliancesClientListResponse struct {
-	VirtualAppliancesClientListResult
+	VirtualApplianceListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualAppliancesClientListResult contains the result from method VirtualAppliancesClient.List.
-type VirtualAppliancesClientListResult struct {
-	VirtualApplianceListResult
 }
 
 // VirtualAppliancesClientUpdateTagsResponse contains the response from method VirtualAppliancesClient.UpdateTags.
 type VirtualAppliancesClientUpdateTagsResponse struct {
-	VirtualAppliancesClientUpdateTagsResult
+	VirtualAppliance
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualAppliancesClientUpdateTagsResult contains the result from method VirtualAppliancesClient.UpdateTags.
-type VirtualAppliancesClientUpdateTagsResult struct {
-	VirtualAppliance
 }
 
 // VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse contains the response from method VirtualHubRouteTableV2SClient.CreateOrUpdate.
@@ -9296,14 +7809,9 @@ func (l *VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse) Resume(ctx c
 
 // VirtualHubRouteTableV2SClientCreateOrUpdateResponse contains the response from method VirtualHubRouteTableV2SClient.CreateOrUpdate.
 type VirtualHubRouteTableV2SClientCreateOrUpdateResponse struct {
-	VirtualHubRouteTableV2SClientCreateOrUpdateResult
+	VirtualHubRouteTableV2
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualHubRouteTableV2SClientCreateOrUpdateResult contains the result from method VirtualHubRouteTableV2SClient.CreateOrUpdate.
-type VirtualHubRouteTableV2SClientCreateOrUpdateResult struct {
-	VirtualHubRouteTableV2
 }
 
 // VirtualHubRouteTableV2SClientDeletePollerResponse contains the response from method VirtualHubRouteTableV2SClient.Delete.
@@ -9354,26 +7862,16 @@ type VirtualHubRouteTableV2SClientDeleteResponse struct {
 
 // VirtualHubRouteTableV2SClientGetResponse contains the response from method VirtualHubRouteTableV2SClient.Get.
 type VirtualHubRouteTableV2SClientGetResponse struct {
-	VirtualHubRouteTableV2SClientGetResult
+	VirtualHubRouteTableV2
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualHubRouteTableV2SClientGetResult contains the result from method VirtualHubRouteTableV2SClient.Get.
-type VirtualHubRouteTableV2SClientGetResult struct {
-	VirtualHubRouteTableV2
 }
 
 // VirtualHubRouteTableV2SClientListResponse contains the response from method VirtualHubRouteTableV2SClient.List.
 type VirtualHubRouteTableV2SClientListResponse struct {
-	VirtualHubRouteTableV2SClientListResult
+	ListVirtualHubRouteTableV2SResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualHubRouteTableV2SClientListResult contains the result from method VirtualHubRouteTableV2SClient.List.
-type VirtualHubRouteTableV2SClientListResult struct {
-	ListVirtualHubRouteTableV2SResult
 }
 
 // VirtualHubsClientCreateOrUpdatePollerResponse contains the response from method VirtualHubsClient.CreateOrUpdate.
@@ -9418,14 +7916,9 @@ func (l *VirtualHubsClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 
 // VirtualHubsClientCreateOrUpdateResponse contains the response from method VirtualHubsClient.CreateOrUpdate.
 type VirtualHubsClientCreateOrUpdateResponse struct {
-	VirtualHubsClientCreateOrUpdateResult
+	VirtualHub
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualHubsClientCreateOrUpdateResult contains the result from method VirtualHubsClient.CreateOrUpdate.
-type VirtualHubsClientCreateOrUpdateResult struct {
-	VirtualHub
 }
 
 // VirtualHubsClientDeletePollerResponse contains the response from method VirtualHubsClient.Delete.
@@ -9476,50 +7969,30 @@ type VirtualHubsClientDeleteResponse struct {
 
 // VirtualHubsClientGetResponse contains the response from method VirtualHubsClient.Get.
 type VirtualHubsClientGetResponse struct {
-	VirtualHubsClientGetResult
+	VirtualHub
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualHubsClientGetResult contains the result from method VirtualHubsClient.Get.
-type VirtualHubsClientGetResult struct {
-	VirtualHub
 }
 
 // VirtualHubsClientListByResourceGroupResponse contains the response from method VirtualHubsClient.ListByResourceGroup.
 type VirtualHubsClientListByResourceGroupResponse struct {
-	VirtualHubsClientListByResourceGroupResult
+	ListVirtualHubsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualHubsClientListByResourceGroupResult contains the result from method VirtualHubsClient.ListByResourceGroup.
-type VirtualHubsClientListByResourceGroupResult struct {
-	ListVirtualHubsResult
 }
 
 // VirtualHubsClientListResponse contains the response from method VirtualHubsClient.List.
 type VirtualHubsClientListResponse struct {
-	VirtualHubsClientListResult
+	ListVirtualHubsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualHubsClientListResult contains the result from method VirtualHubsClient.List.
-type VirtualHubsClientListResult struct {
-	ListVirtualHubsResult
 }
 
 // VirtualHubsClientUpdateTagsResponse contains the response from method VirtualHubsClient.UpdateTags.
 type VirtualHubsClientUpdateTagsResponse struct {
-	VirtualHubsClientUpdateTagsResult
+	VirtualHub
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualHubsClientUpdateTagsResult contains the result from method VirtualHubsClient.UpdateTags.
-type VirtualHubsClientUpdateTagsResult struct {
-	VirtualHub
 }
 
 // VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.CreateOrUpdate.
@@ -9565,14 +8038,9 @@ func (l *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse) Res
 
 // VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse contains the response from method VirtualNetworkGatewayConnectionsClient.CreateOrUpdate.
 type VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse struct {
-	VirtualNetworkGatewayConnectionsClientCreateOrUpdateResult
+	VirtualNetworkGatewayConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientCreateOrUpdateResult contains the result from method VirtualNetworkGatewayConnectionsClient.CreateOrUpdate.
-type VirtualNetworkGatewayConnectionsClientCreateOrUpdateResult struct {
-	VirtualNetworkGatewayConnection
 }
 
 // VirtualNetworkGatewayConnectionsClientDeletePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.Delete.
@@ -9623,38 +8091,23 @@ type VirtualNetworkGatewayConnectionsClientDeleteResponse struct {
 
 // VirtualNetworkGatewayConnectionsClientGetResponse contains the response from method VirtualNetworkGatewayConnectionsClient.Get.
 type VirtualNetworkGatewayConnectionsClientGetResponse struct {
-	VirtualNetworkGatewayConnectionsClientGetResult
+	VirtualNetworkGatewayConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientGetResult contains the result from method VirtualNetworkGatewayConnectionsClient.Get.
-type VirtualNetworkGatewayConnectionsClientGetResult struct {
-	VirtualNetworkGatewayConnection
 }
 
 // VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse contains the response from method VirtualNetworkGatewayConnectionsClient.GetSharedKey.
 type VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse struct {
-	VirtualNetworkGatewayConnectionsClientGetSharedKeyResult
+	ConnectionSharedKey
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientGetSharedKeyResult contains the result from method VirtualNetworkGatewayConnectionsClient.GetSharedKey.
-type VirtualNetworkGatewayConnectionsClientGetSharedKeyResult struct {
-	ConnectionSharedKey
 }
 
 // VirtualNetworkGatewayConnectionsClientListResponse contains the response from method VirtualNetworkGatewayConnectionsClient.List.
 type VirtualNetworkGatewayConnectionsClientListResponse struct {
-	VirtualNetworkGatewayConnectionsClientListResult
+	VirtualNetworkGatewayConnectionListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientListResult contains the result from method VirtualNetworkGatewayConnectionsClient.List.
-type VirtualNetworkGatewayConnectionsClientListResult struct {
-	VirtualNetworkGatewayConnectionListResult
 }
 
 // VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.ResetSharedKey.
@@ -9700,14 +8153,9 @@ func (l *VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse) Res
 
 // VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse contains the response from method VirtualNetworkGatewayConnectionsClient.ResetSharedKey.
 type VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse struct {
-	VirtualNetworkGatewayConnectionsClientResetSharedKeyResult
+	ConnectionResetSharedKey
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientResetSharedKeyResult contains the result from method VirtualNetworkGatewayConnectionsClient.ResetSharedKey.
-type VirtualNetworkGatewayConnectionsClientResetSharedKeyResult struct {
-	ConnectionResetSharedKey
 }
 
 // VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.SetSharedKey.
@@ -9753,14 +8201,9 @@ func (l *VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse) Resum
 
 // VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse contains the response from method VirtualNetworkGatewayConnectionsClient.SetSharedKey.
 type VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse struct {
-	VirtualNetworkGatewayConnectionsClientSetSharedKeyResult
+	ConnectionSharedKey
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientSetSharedKeyResult contains the result from method VirtualNetworkGatewayConnectionsClient.SetSharedKey.
-type VirtualNetworkGatewayConnectionsClientSetSharedKeyResult struct {
-	ConnectionSharedKey
 }
 
 // VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StartPacketCapture.
@@ -9806,14 +8249,9 @@ func (l *VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse)
 
 // VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StartPacketCapture.
 type VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse struct {
-	VirtualNetworkGatewayConnectionsClientStartPacketCaptureResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientStartPacketCaptureResult contains the result from method VirtualNetworkGatewayConnectionsClient.StartPacketCapture.
-type VirtualNetworkGatewayConnectionsClientStartPacketCaptureResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StopPacketCapture.
@@ -9859,14 +8297,9 @@ func (l *VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse) 
 
 // VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StopPacketCapture.
 type VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse struct {
-	VirtualNetworkGatewayConnectionsClientStopPacketCaptureResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientStopPacketCaptureResult contains the result from method VirtualNetworkGatewayConnectionsClient.StopPacketCapture.
-type VirtualNetworkGatewayConnectionsClientStopPacketCaptureResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.UpdateTags.
@@ -9912,14 +8345,9 @@ func (l *VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse) Resume(
 
 // VirtualNetworkGatewayConnectionsClientUpdateTagsResponse contains the response from method VirtualNetworkGatewayConnectionsClient.UpdateTags.
 type VirtualNetworkGatewayConnectionsClientUpdateTagsResponse struct {
-	VirtualNetworkGatewayConnectionsClientUpdateTagsResult
+	VirtualNetworkGatewayConnection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewayConnectionsClientUpdateTagsResult contains the result from method VirtualNetworkGatewayConnectionsClient.UpdateTags.
-type VirtualNetworkGatewayConnectionsClientUpdateTagsResult struct {
-	VirtualNetworkGatewayConnection
 }
 
 // VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkGatewaysClient.CreateOrUpdate.
@@ -9964,14 +8392,9 @@ func (l *VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx co
 
 // VirtualNetworkGatewaysClientCreateOrUpdateResponse contains the response from method VirtualNetworkGatewaysClient.CreateOrUpdate.
 type VirtualNetworkGatewaysClientCreateOrUpdateResponse struct {
-	VirtualNetworkGatewaysClientCreateOrUpdateResult
+	VirtualNetworkGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientCreateOrUpdateResult contains the result from method VirtualNetworkGatewaysClient.CreateOrUpdate.
-type VirtualNetworkGatewaysClientCreateOrUpdateResult struct {
-	VirtualNetworkGateway
 }
 
 // VirtualNetworkGatewaysClientDeletePollerResponse contains the response from method VirtualNetworkGatewaysClient.Delete.
@@ -10110,14 +8533,9 @@ func (l *VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse) Resume(ct
 
 // VirtualNetworkGatewaysClientGenerateVPNProfileResponse contains the response from method VirtualNetworkGatewaysClient.GenerateVPNProfile.
 type VirtualNetworkGatewaysClientGenerateVPNProfileResponse struct {
-	VirtualNetworkGatewaysClientGenerateVPNProfileResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGenerateVPNProfileResult contains the result from method VirtualNetworkGatewaysClient.GenerateVPNProfile.
-type VirtualNetworkGatewaysClientGenerateVPNProfileResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse contains the response from method VirtualNetworkGatewaysClient.Generatevpnclientpackage.
@@ -10163,14 +8581,9 @@ func (l *VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse) Res
 
 // VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse contains the response from method VirtualNetworkGatewaysClient.Generatevpnclientpackage.
 type VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse struct {
-	VirtualNetworkGatewaysClientGeneratevpnclientpackageResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGeneratevpnclientpackageResult contains the result from method VirtualNetworkGatewaysClient.Generatevpnclientpackage.
-type VirtualNetworkGatewaysClientGeneratevpnclientpackageResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetAdvertisedRoutes.
@@ -10215,14 +8628,9 @@ func (l *VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse) Resume(c
 
 // VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse contains the response from method VirtualNetworkGatewaysClient.GetAdvertisedRoutes.
 type VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse struct {
-	VirtualNetworkGatewaysClientGetAdvertisedRoutesResult
+	GatewayRouteListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGetAdvertisedRoutesResult contains the result from method VirtualNetworkGatewaysClient.GetAdvertisedRoutes.
-type VirtualNetworkGatewaysClientGetAdvertisedRoutesResult struct {
-	GatewayRouteListResult
 }
 
 // VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetBgpPeerStatus.
@@ -10267,14 +8675,9 @@ func (l *VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse) Resume(ctx 
 
 // VirtualNetworkGatewaysClientGetBgpPeerStatusResponse contains the response from method VirtualNetworkGatewaysClient.GetBgpPeerStatus.
 type VirtualNetworkGatewaysClientGetBgpPeerStatusResponse struct {
-	VirtualNetworkGatewaysClientGetBgpPeerStatusResult
+	BgpPeerStatusListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGetBgpPeerStatusResult contains the result from method VirtualNetworkGatewaysClient.GetBgpPeerStatus.
-type VirtualNetworkGatewaysClientGetBgpPeerStatusResult struct {
-	BgpPeerStatusListResult
 }
 
 // VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetLearnedRoutes.
@@ -10319,26 +8722,16 @@ func (l *VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse) Resume(ctx 
 
 // VirtualNetworkGatewaysClientGetLearnedRoutesResponse contains the response from method VirtualNetworkGatewaysClient.GetLearnedRoutes.
 type VirtualNetworkGatewaysClientGetLearnedRoutesResponse struct {
-	VirtualNetworkGatewaysClientGetLearnedRoutesResult
+	GatewayRouteListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGetLearnedRoutesResult contains the result from method VirtualNetworkGatewaysClient.GetLearnedRoutes.
-type VirtualNetworkGatewaysClientGetLearnedRoutesResult struct {
-	GatewayRouteListResult
 }
 
 // VirtualNetworkGatewaysClientGetResponse contains the response from method VirtualNetworkGatewaysClient.Get.
 type VirtualNetworkGatewaysClientGetResponse struct {
-	VirtualNetworkGatewaysClientGetResult
+	VirtualNetworkGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGetResult contains the result from method VirtualNetworkGatewaysClient.Get.
-type VirtualNetworkGatewaysClientGetResult struct {
-	VirtualNetworkGateway
 }
 
 // VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVPNProfilePackageURL.
@@ -10384,14 +8777,9 @@ func (l *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse) Resu
 
 // VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse contains the response from method VirtualNetworkGatewaysClient.GetVPNProfilePackageURL.
 type VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse struct {
-	VirtualNetworkGatewaysClientGetVPNProfilePackageURLResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGetVPNProfilePackageURLResult contains the result from method VirtualNetworkGatewaysClient.GetVPNProfilePackageURL.
-type VirtualNetworkGatewaysClientGetVPNProfilePackageURLResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth.
@@ -10437,14 +8825,9 @@ func (l *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse)
 
 // VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth.
 type VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse struct {
-	VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResult
+	VPNClientConnectionHealthDetailListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResult contains the result from method VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth.
-type VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResult struct {
-	VPNClientConnectionHealthDetailListResult
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters.
@@ -10490,38 +8873,23 @@ func (l *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse) 
 
 // VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters.
 type VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse struct {
-	VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResult
+	VPNClientIPsecParameters
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResult contains the result from method VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters.
-type VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResult struct {
-	VPNClientIPsecParameters
 }
 
 // VirtualNetworkGatewaysClientListConnectionsResponse contains the response from method VirtualNetworkGatewaysClient.ListConnections.
 type VirtualNetworkGatewaysClientListConnectionsResponse struct {
-	VirtualNetworkGatewaysClientListConnectionsResult
+	VirtualNetworkGatewayListConnectionsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientListConnectionsResult contains the result from method VirtualNetworkGatewaysClient.ListConnections.
-type VirtualNetworkGatewaysClientListConnectionsResult struct {
-	VirtualNetworkGatewayListConnectionsResult
 }
 
 // VirtualNetworkGatewaysClientListResponse contains the response from method VirtualNetworkGatewaysClient.List.
 type VirtualNetworkGatewaysClientListResponse struct {
-	VirtualNetworkGatewaysClientListResult
+	VirtualNetworkGatewayListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientListResult contains the result from method VirtualNetworkGatewaysClient.List.
-type VirtualNetworkGatewaysClientListResult struct {
-	VirtualNetworkGatewayListResult
 }
 
 // VirtualNetworkGatewaysClientResetPollerResponse contains the response from method VirtualNetworkGatewaysClient.Reset.
@@ -10566,14 +8934,9 @@ func (l *VirtualNetworkGatewaysClientResetPollerResponse) Resume(ctx context.Con
 
 // VirtualNetworkGatewaysClientResetResponse contains the response from method VirtualNetworkGatewaysClient.Reset.
 type VirtualNetworkGatewaysClientResetResponse struct {
-	VirtualNetworkGatewaysClientResetResult
+	VirtualNetworkGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientResetResult contains the result from method VirtualNetworkGatewaysClient.Reset.
-type VirtualNetworkGatewaysClientResetResult struct {
-	VirtualNetworkGateway
 }
 
 // VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse contains the response from method VirtualNetworkGatewaysClient.ResetVPNClientSharedKey.
@@ -10666,14 +9029,9 @@ func (l *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse) 
 
 // VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse contains the response from method VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters.
 type VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse struct {
-	VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResult
+	VPNClientIPsecParameters
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResult contains the result from method VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters.
-type VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResult struct {
-	VPNClientIPsecParameters
 }
 
 // VirtualNetworkGatewaysClientStartPacketCapturePollerResponse contains the response from method VirtualNetworkGatewaysClient.StartPacketCapture.
@@ -10718,14 +9076,9 @@ func (l *VirtualNetworkGatewaysClientStartPacketCapturePollerResponse) Resume(ct
 
 // VirtualNetworkGatewaysClientStartPacketCaptureResponse contains the response from method VirtualNetworkGatewaysClient.StartPacketCapture.
 type VirtualNetworkGatewaysClientStartPacketCaptureResponse struct {
-	VirtualNetworkGatewaysClientStartPacketCaptureResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientStartPacketCaptureResult contains the result from method VirtualNetworkGatewaysClient.StartPacketCapture.
-type VirtualNetworkGatewaysClientStartPacketCaptureResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkGatewaysClientStopPacketCapturePollerResponse contains the response from method VirtualNetworkGatewaysClient.StopPacketCapture.
@@ -10770,26 +9123,16 @@ func (l *VirtualNetworkGatewaysClientStopPacketCapturePollerResponse) Resume(ctx
 
 // VirtualNetworkGatewaysClientStopPacketCaptureResponse contains the response from method VirtualNetworkGatewaysClient.StopPacketCapture.
 type VirtualNetworkGatewaysClientStopPacketCaptureResponse struct {
-	VirtualNetworkGatewaysClientStopPacketCaptureResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientStopPacketCaptureResult contains the result from method VirtualNetworkGatewaysClient.StopPacketCapture.
-type VirtualNetworkGatewaysClientStopPacketCaptureResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkGatewaysClientSupportedVPNDevicesResponse contains the response from method VirtualNetworkGatewaysClient.SupportedVPNDevices.
 type VirtualNetworkGatewaysClientSupportedVPNDevicesResponse struct {
-	VirtualNetworkGatewaysClientSupportedVPNDevicesResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientSupportedVPNDevicesResult contains the result from method VirtualNetworkGatewaysClient.SupportedVPNDevices.
-type VirtualNetworkGatewaysClientSupportedVPNDevicesResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkGatewaysClientUpdateTagsPollerResponse contains the response from method VirtualNetworkGatewaysClient.UpdateTags.
@@ -10834,26 +9177,16 @@ func (l *VirtualNetworkGatewaysClientUpdateTagsPollerResponse) Resume(ctx contex
 
 // VirtualNetworkGatewaysClientUpdateTagsResponse contains the response from method VirtualNetworkGatewaysClient.UpdateTags.
 type VirtualNetworkGatewaysClientUpdateTagsResponse struct {
-	VirtualNetworkGatewaysClientUpdateTagsResult
+	VirtualNetworkGateway
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientUpdateTagsResult contains the result from method VirtualNetworkGatewaysClient.UpdateTags.
-type VirtualNetworkGatewaysClientUpdateTagsResult struct {
-	VirtualNetworkGateway
 }
 
 // VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse contains the response from method VirtualNetworkGatewaysClient.VPNDeviceConfigurationScript.
 type VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse struct {
-	VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResult contains the result from method VirtualNetworkGatewaysClient.VPNDeviceConfigurationScript.
-type VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResult struct {
-	Value *string
+	Value       *string
 }
 
 // VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkPeeringsClient.CreateOrUpdate.
@@ -10898,14 +9231,9 @@ func (l *VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse) Resume(ctx co
 
 // VirtualNetworkPeeringsClientCreateOrUpdateResponse contains the response from method VirtualNetworkPeeringsClient.CreateOrUpdate.
 type VirtualNetworkPeeringsClientCreateOrUpdateResponse struct {
-	VirtualNetworkPeeringsClientCreateOrUpdateResult
+	VirtualNetworkPeering
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkPeeringsClientCreateOrUpdateResult contains the result from method VirtualNetworkPeeringsClient.CreateOrUpdate.
-type VirtualNetworkPeeringsClientCreateOrUpdateResult struct {
-	VirtualNetworkPeering
 }
 
 // VirtualNetworkPeeringsClientDeletePollerResponse contains the response from method VirtualNetworkPeeringsClient.Delete.
@@ -10956,26 +9284,16 @@ type VirtualNetworkPeeringsClientDeleteResponse struct {
 
 // VirtualNetworkPeeringsClientGetResponse contains the response from method VirtualNetworkPeeringsClient.Get.
 type VirtualNetworkPeeringsClientGetResponse struct {
-	VirtualNetworkPeeringsClientGetResult
+	VirtualNetworkPeering
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkPeeringsClientGetResult contains the result from method VirtualNetworkPeeringsClient.Get.
-type VirtualNetworkPeeringsClientGetResult struct {
-	VirtualNetworkPeering
 }
 
 // VirtualNetworkPeeringsClientListResponse contains the response from method VirtualNetworkPeeringsClient.List.
 type VirtualNetworkPeeringsClientListResponse struct {
-	VirtualNetworkPeeringsClientListResult
+	VirtualNetworkPeeringListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkPeeringsClientListResult contains the result from method VirtualNetworkPeeringsClient.List.
-type VirtualNetworkPeeringsClientListResult struct {
-	VirtualNetworkPeeringListResult
 }
 
 // VirtualNetworkTapsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkTapsClient.CreateOrUpdate.
@@ -11020,14 +9338,9 @@ func (l *VirtualNetworkTapsClientCreateOrUpdatePollerResponse) Resume(ctx contex
 
 // VirtualNetworkTapsClientCreateOrUpdateResponse contains the response from method VirtualNetworkTapsClient.CreateOrUpdate.
 type VirtualNetworkTapsClientCreateOrUpdateResponse struct {
-	VirtualNetworkTapsClientCreateOrUpdateResult
+	VirtualNetworkTap
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkTapsClientCreateOrUpdateResult contains the result from method VirtualNetworkTapsClient.CreateOrUpdate.
-type VirtualNetworkTapsClientCreateOrUpdateResult struct {
-	VirtualNetworkTap
 }
 
 // VirtualNetworkTapsClientDeletePollerResponse contains the response from method VirtualNetworkTapsClient.Delete.
@@ -11078,62 +9391,37 @@ type VirtualNetworkTapsClientDeleteResponse struct {
 
 // VirtualNetworkTapsClientGetResponse contains the response from method VirtualNetworkTapsClient.Get.
 type VirtualNetworkTapsClientGetResponse struct {
-	VirtualNetworkTapsClientGetResult
+	VirtualNetworkTap
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkTapsClientGetResult contains the result from method VirtualNetworkTapsClient.Get.
-type VirtualNetworkTapsClientGetResult struct {
-	VirtualNetworkTap
 }
 
 // VirtualNetworkTapsClientListAllResponse contains the response from method VirtualNetworkTapsClient.ListAll.
 type VirtualNetworkTapsClientListAllResponse struct {
-	VirtualNetworkTapsClientListAllResult
+	VirtualNetworkTapListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkTapsClientListAllResult contains the result from method VirtualNetworkTapsClient.ListAll.
-type VirtualNetworkTapsClientListAllResult struct {
-	VirtualNetworkTapListResult
 }
 
 // VirtualNetworkTapsClientListByResourceGroupResponse contains the response from method VirtualNetworkTapsClient.ListByResourceGroup.
 type VirtualNetworkTapsClientListByResourceGroupResponse struct {
-	VirtualNetworkTapsClientListByResourceGroupResult
+	VirtualNetworkTapListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkTapsClientListByResourceGroupResult contains the result from method VirtualNetworkTapsClient.ListByResourceGroup.
-type VirtualNetworkTapsClientListByResourceGroupResult struct {
-	VirtualNetworkTapListResult
 }
 
 // VirtualNetworkTapsClientUpdateTagsResponse contains the response from method VirtualNetworkTapsClient.UpdateTags.
 type VirtualNetworkTapsClientUpdateTagsResponse struct {
-	VirtualNetworkTapsClientUpdateTagsResult
+	VirtualNetworkTap
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworkTapsClientUpdateTagsResult contains the result from method VirtualNetworkTapsClient.UpdateTags.
-type VirtualNetworkTapsClientUpdateTagsResult struct {
-	VirtualNetworkTap
 }
 
 // VirtualNetworksClientCheckIPAddressAvailabilityResponse contains the response from method VirtualNetworksClient.CheckIPAddressAvailability.
 type VirtualNetworksClientCheckIPAddressAvailabilityResponse struct {
-	VirtualNetworksClientCheckIPAddressAvailabilityResult
+	IPAddressAvailabilityResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworksClientCheckIPAddressAvailabilityResult contains the result from method VirtualNetworksClient.CheckIPAddressAvailability.
-type VirtualNetworksClientCheckIPAddressAvailabilityResult struct {
-	IPAddressAvailabilityResult
 }
 
 // VirtualNetworksClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworksClient.CreateOrUpdate.
@@ -11178,14 +9466,9 @@ func (l *VirtualNetworksClientCreateOrUpdatePollerResponse) Resume(ctx context.C
 
 // VirtualNetworksClientCreateOrUpdateResponse contains the response from method VirtualNetworksClient.CreateOrUpdate.
 type VirtualNetworksClientCreateOrUpdateResponse struct {
-	VirtualNetworksClientCreateOrUpdateResult
+	VirtualNetwork
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworksClientCreateOrUpdateResult contains the result from method VirtualNetworksClient.CreateOrUpdate.
-type VirtualNetworksClientCreateOrUpdateResult struct {
-	VirtualNetwork
 }
 
 // VirtualNetworksClientDeletePollerResponse contains the response from method VirtualNetworksClient.Delete.
@@ -11236,62 +9519,37 @@ type VirtualNetworksClientDeleteResponse struct {
 
 // VirtualNetworksClientGetResponse contains the response from method VirtualNetworksClient.Get.
 type VirtualNetworksClientGetResponse struct {
-	VirtualNetworksClientGetResult
+	VirtualNetwork
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworksClientGetResult contains the result from method VirtualNetworksClient.Get.
-type VirtualNetworksClientGetResult struct {
-	VirtualNetwork
 }
 
 // VirtualNetworksClientListAllResponse contains the response from method VirtualNetworksClient.ListAll.
 type VirtualNetworksClientListAllResponse struct {
-	VirtualNetworksClientListAllResult
+	VirtualNetworkListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworksClientListAllResult contains the result from method VirtualNetworksClient.ListAll.
-type VirtualNetworksClientListAllResult struct {
-	VirtualNetworkListResult
 }
 
 // VirtualNetworksClientListResponse contains the response from method VirtualNetworksClient.List.
 type VirtualNetworksClientListResponse struct {
-	VirtualNetworksClientListResult
+	VirtualNetworkListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworksClientListResult contains the result from method VirtualNetworksClient.List.
-type VirtualNetworksClientListResult struct {
-	VirtualNetworkListResult
 }
 
 // VirtualNetworksClientListUsageResponse contains the response from method VirtualNetworksClient.ListUsage.
 type VirtualNetworksClientListUsageResponse struct {
-	VirtualNetworksClientListUsageResult
+	VirtualNetworkListUsageResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworksClientListUsageResult contains the result from method VirtualNetworksClient.ListUsage.
-type VirtualNetworksClientListUsageResult struct {
-	VirtualNetworkListUsageResult
 }
 
 // VirtualNetworksClientUpdateTagsResponse contains the response from method VirtualNetworksClient.UpdateTags.
 type VirtualNetworksClientUpdateTagsResponse struct {
-	VirtualNetworksClientUpdateTagsResult
+	VirtualNetwork
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualNetworksClientUpdateTagsResult contains the result from method VirtualNetworksClient.UpdateTags.
-type VirtualNetworksClientUpdateTagsResult struct {
-	VirtualNetwork
 }
 
 // VirtualRouterPeeringsClientCreateOrUpdatePollerResponse contains the response from method VirtualRouterPeeringsClient.CreateOrUpdate.
@@ -11336,14 +9594,9 @@ func (l *VirtualRouterPeeringsClientCreateOrUpdatePollerResponse) Resume(ctx con
 
 // VirtualRouterPeeringsClientCreateOrUpdateResponse contains the response from method VirtualRouterPeeringsClient.CreateOrUpdate.
 type VirtualRouterPeeringsClientCreateOrUpdateResponse struct {
-	VirtualRouterPeeringsClientCreateOrUpdateResult
+	VirtualRouterPeering
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualRouterPeeringsClientCreateOrUpdateResult contains the result from method VirtualRouterPeeringsClient.CreateOrUpdate.
-type VirtualRouterPeeringsClientCreateOrUpdateResult struct {
-	VirtualRouterPeering
 }
 
 // VirtualRouterPeeringsClientDeletePollerResponse contains the response from method VirtualRouterPeeringsClient.Delete.
@@ -11394,26 +9647,16 @@ type VirtualRouterPeeringsClientDeleteResponse struct {
 
 // VirtualRouterPeeringsClientGetResponse contains the response from method VirtualRouterPeeringsClient.Get.
 type VirtualRouterPeeringsClientGetResponse struct {
-	VirtualRouterPeeringsClientGetResult
+	VirtualRouterPeering
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualRouterPeeringsClientGetResult contains the result from method VirtualRouterPeeringsClient.Get.
-type VirtualRouterPeeringsClientGetResult struct {
-	VirtualRouterPeering
 }
 
 // VirtualRouterPeeringsClientListResponse contains the response from method VirtualRouterPeeringsClient.List.
 type VirtualRouterPeeringsClientListResponse struct {
-	VirtualRouterPeeringsClientListResult
+	VirtualRouterPeeringListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualRouterPeeringsClientListResult contains the result from method VirtualRouterPeeringsClient.List.
-type VirtualRouterPeeringsClientListResult struct {
-	VirtualRouterPeeringListResult
 }
 
 // VirtualRoutersClientCreateOrUpdatePollerResponse contains the response from method VirtualRoutersClient.CreateOrUpdate.
@@ -11458,14 +9701,9 @@ func (l *VirtualRoutersClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 
 // VirtualRoutersClientCreateOrUpdateResponse contains the response from method VirtualRoutersClient.CreateOrUpdate.
 type VirtualRoutersClientCreateOrUpdateResponse struct {
-	VirtualRoutersClientCreateOrUpdateResult
+	VirtualRouter
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualRoutersClientCreateOrUpdateResult contains the result from method VirtualRoutersClient.CreateOrUpdate.
-type VirtualRoutersClientCreateOrUpdateResult struct {
-	VirtualRouter
 }
 
 // VirtualRoutersClientDeletePollerResponse contains the response from method VirtualRoutersClient.Delete.
@@ -11516,38 +9754,23 @@ type VirtualRoutersClientDeleteResponse struct {
 
 // VirtualRoutersClientGetResponse contains the response from method VirtualRoutersClient.Get.
 type VirtualRoutersClientGetResponse struct {
-	VirtualRoutersClientGetResult
+	VirtualRouter
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualRoutersClientGetResult contains the result from method VirtualRoutersClient.Get.
-type VirtualRoutersClientGetResult struct {
-	VirtualRouter
 }
 
 // VirtualRoutersClientListByResourceGroupResponse contains the response from method VirtualRoutersClient.ListByResourceGroup.
 type VirtualRoutersClientListByResourceGroupResponse struct {
-	VirtualRoutersClientListByResourceGroupResult
+	VirtualRouterListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualRoutersClientListByResourceGroupResult contains the result from method VirtualRoutersClient.ListByResourceGroup.
-type VirtualRoutersClientListByResourceGroupResult struct {
-	VirtualRouterListResult
 }
 
 // VirtualRoutersClientListResponse contains the response from method VirtualRoutersClient.List.
 type VirtualRoutersClientListResponse struct {
-	VirtualRoutersClientListResult
+	VirtualRouterListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualRoutersClientListResult contains the result from method VirtualRoutersClient.List.
-type VirtualRoutersClientListResult struct {
-	VirtualRouterListResult
 }
 
 // VirtualWansClientCreateOrUpdatePollerResponse contains the response from method VirtualWansClient.CreateOrUpdate.
@@ -11592,14 +9815,9 @@ func (l *VirtualWansClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 
 // VirtualWansClientCreateOrUpdateResponse contains the response from method VirtualWansClient.CreateOrUpdate.
 type VirtualWansClientCreateOrUpdateResponse struct {
-	VirtualWansClientCreateOrUpdateResult
+	VirtualWAN
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualWansClientCreateOrUpdateResult contains the result from method VirtualWansClient.CreateOrUpdate.
-type VirtualWansClientCreateOrUpdateResult struct {
-	VirtualWAN
 }
 
 // VirtualWansClientDeletePollerResponse contains the response from method VirtualWansClient.Delete.
@@ -11650,50 +9868,30 @@ type VirtualWansClientDeleteResponse struct {
 
 // VirtualWansClientGetResponse contains the response from method VirtualWansClient.Get.
 type VirtualWansClientGetResponse struct {
-	VirtualWansClientGetResult
+	VirtualWAN
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualWansClientGetResult contains the result from method VirtualWansClient.Get.
-type VirtualWansClientGetResult struct {
-	VirtualWAN
 }
 
 // VirtualWansClientListByResourceGroupResponse contains the response from method VirtualWansClient.ListByResourceGroup.
 type VirtualWansClientListByResourceGroupResponse struct {
-	VirtualWansClientListByResourceGroupResult
+	ListVirtualWANsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualWansClientListByResourceGroupResult contains the result from method VirtualWansClient.ListByResourceGroup.
-type VirtualWansClientListByResourceGroupResult struct {
-	ListVirtualWANsResult
 }
 
 // VirtualWansClientListResponse contains the response from method VirtualWansClient.List.
 type VirtualWansClientListResponse struct {
-	VirtualWansClientListResult
+	ListVirtualWANsResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualWansClientListResult contains the result from method VirtualWansClient.List.
-type VirtualWansClientListResult struct {
-	ListVirtualWANsResult
 }
 
 // VirtualWansClientUpdateTagsResponse contains the response from method VirtualWansClient.UpdateTags.
 type VirtualWansClientUpdateTagsResponse struct {
-	VirtualWansClientUpdateTagsResult
+	VirtualWAN
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// VirtualWansClientUpdateTagsResult contains the result from method VirtualWansClient.UpdateTags.
-type VirtualWansClientUpdateTagsResult struct {
-	VirtualWAN
 }
 
 // WatchersClientCheckConnectivityPollerResponse contains the response from method WatchersClient.CheckConnectivity.
@@ -11738,26 +9936,16 @@ func (l *WatchersClientCheckConnectivityPollerResponse) Resume(ctx context.Conte
 
 // WatchersClientCheckConnectivityResponse contains the response from method WatchersClient.CheckConnectivity.
 type WatchersClientCheckConnectivityResponse struct {
-	WatchersClientCheckConnectivityResult
+	ConnectivityInformation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientCheckConnectivityResult contains the result from method WatchersClient.CheckConnectivity.
-type WatchersClientCheckConnectivityResult struct {
-	ConnectivityInformation
 }
 
 // WatchersClientCreateOrUpdateResponse contains the response from method WatchersClient.CreateOrUpdate.
 type WatchersClientCreateOrUpdateResponse struct {
-	WatchersClientCreateOrUpdateResult
+	Watcher
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientCreateOrUpdateResult contains the result from method WatchersClient.CreateOrUpdate.
-type WatchersClientCreateOrUpdateResult struct {
-	Watcher
 }
 
 // WatchersClientDeletePollerResponse contains the response from method WatchersClient.Delete.
@@ -11848,14 +10036,9 @@ func (l *WatchersClientGetAzureReachabilityReportPollerResponse) Resume(ctx cont
 
 // WatchersClientGetAzureReachabilityReportResponse contains the response from method WatchersClient.GetAzureReachabilityReport.
 type WatchersClientGetAzureReachabilityReportResponse struct {
-	WatchersClientGetAzureReachabilityReportResult
+	AzureReachabilityReport
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetAzureReachabilityReportResult contains the result from method WatchersClient.GetAzureReachabilityReport.
-type WatchersClientGetAzureReachabilityReportResult struct {
-	AzureReachabilityReport
 }
 
 // WatchersClientGetFlowLogStatusPollerResponse contains the response from method WatchersClient.GetFlowLogStatus.
@@ -11900,14 +10083,9 @@ func (l *WatchersClientGetFlowLogStatusPollerResponse) Resume(ctx context.Contex
 
 // WatchersClientGetFlowLogStatusResponse contains the response from method WatchersClient.GetFlowLogStatus.
 type WatchersClientGetFlowLogStatusResponse struct {
-	WatchersClientGetFlowLogStatusResult
+	FlowLogInformation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetFlowLogStatusResult contains the result from method WatchersClient.GetFlowLogStatus.
-type WatchersClientGetFlowLogStatusResult struct {
-	FlowLogInformation
 }
 
 // WatchersClientGetNetworkConfigurationDiagnosticPollerResponse contains the response from method WatchersClient.GetNetworkConfigurationDiagnostic.
@@ -11952,14 +10130,9 @@ func (l *WatchersClientGetNetworkConfigurationDiagnosticPollerResponse) Resume(c
 
 // WatchersClientGetNetworkConfigurationDiagnosticResponse contains the response from method WatchersClient.GetNetworkConfigurationDiagnostic.
 type WatchersClientGetNetworkConfigurationDiagnosticResponse struct {
-	WatchersClientGetNetworkConfigurationDiagnosticResult
+	ConfigurationDiagnosticResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetNetworkConfigurationDiagnosticResult contains the result from method WatchersClient.GetNetworkConfigurationDiagnostic.
-type WatchersClientGetNetworkConfigurationDiagnosticResult struct {
-	ConfigurationDiagnosticResponse
 }
 
 // WatchersClientGetNextHopPollerResponse contains the response from method WatchersClient.GetNextHop.
@@ -12004,38 +10177,23 @@ func (l *WatchersClientGetNextHopPollerResponse) Resume(ctx context.Context, cli
 
 // WatchersClientGetNextHopResponse contains the response from method WatchersClient.GetNextHop.
 type WatchersClientGetNextHopResponse struct {
-	WatchersClientGetNextHopResult
+	NextHopResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetNextHopResult contains the result from method WatchersClient.GetNextHop.
-type WatchersClientGetNextHopResult struct {
-	NextHopResult
 }
 
 // WatchersClientGetResponse contains the response from method WatchersClient.Get.
 type WatchersClientGetResponse struct {
-	WatchersClientGetResult
+	Watcher
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetResult contains the result from method WatchersClient.Get.
-type WatchersClientGetResult struct {
-	Watcher
 }
 
 // WatchersClientGetTopologyResponse contains the response from method WatchersClient.GetTopology.
 type WatchersClientGetTopologyResponse struct {
-	WatchersClientGetTopologyResult
+	Topology
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetTopologyResult contains the result from method WatchersClient.GetTopology.
-type WatchersClientGetTopologyResult struct {
-	Topology
 }
 
 // WatchersClientGetTroubleshootingPollerResponse contains the response from method WatchersClient.GetTroubleshooting.
@@ -12080,14 +10238,9 @@ func (l *WatchersClientGetTroubleshootingPollerResponse) Resume(ctx context.Cont
 
 // WatchersClientGetTroubleshootingResponse contains the response from method WatchersClient.GetTroubleshooting.
 type WatchersClientGetTroubleshootingResponse struct {
-	WatchersClientGetTroubleshootingResult
+	TroubleshootingResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetTroubleshootingResult contains the result from method WatchersClient.GetTroubleshooting.
-type WatchersClientGetTroubleshootingResult struct {
-	TroubleshootingResult
 }
 
 // WatchersClientGetTroubleshootingResultPollerResponse contains the response from method WatchersClient.GetTroubleshootingResult.
@@ -12132,14 +10285,9 @@ func (l *WatchersClientGetTroubleshootingResultPollerResponse) Resume(ctx contex
 
 // WatchersClientGetTroubleshootingResultResponse contains the response from method WatchersClient.GetTroubleshootingResult.
 type WatchersClientGetTroubleshootingResultResponse struct {
-	WatchersClientGetTroubleshootingResultResult
+	TroubleshootingResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetTroubleshootingResultResult contains the result from method WatchersClient.GetTroubleshootingResult.
-type WatchersClientGetTroubleshootingResultResult struct {
-	TroubleshootingResult
 }
 
 // WatchersClientGetVMSecurityRulesPollerResponse contains the response from method WatchersClient.GetVMSecurityRules.
@@ -12184,26 +10332,16 @@ func (l *WatchersClientGetVMSecurityRulesPollerResponse) Resume(ctx context.Cont
 
 // WatchersClientGetVMSecurityRulesResponse contains the response from method WatchersClient.GetVMSecurityRules.
 type WatchersClientGetVMSecurityRulesResponse struct {
-	WatchersClientGetVMSecurityRulesResult
+	SecurityGroupViewResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientGetVMSecurityRulesResult contains the result from method WatchersClient.GetVMSecurityRules.
-type WatchersClientGetVMSecurityRulesResult struct {
-	SecurityGroupViewResult
 }
 
 // WatchersClientListAllResponse contains the response from method WatchersClient.ListAll.
 type WatchersClientListAllResponse struct {
-	WatchersClientListAllResult
+	WatcherListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientListAllResult contains the result from method WatchersClient.ListAll.
-type WatchersClientListAllResult struct {
-	WatcherListResult
 }
 
 // WatchersClientListAvailableProvidersPollerResponse contains the response from method WatchersClient.ListAvailableProviders.
@@ -12248,26 +10386,16 @@ func (l *WatchersClientListAvailableProvidersPollerResponse) Resume(ctx context.
 
 // WatchersClientListAvailableProvidersResponse contains the response from method WatchersClient.ListAvailableProviders.
 type WatchersClientListAvailableProvidersResponse struct {
-	WatchersClientListAvailableProvidersResult
+	AvailableProvidersList
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientListAvailableProvidersResult contains the result from method WatchersClient.ListAvailableProviders.
-type WatchersClientListAvailableProvidersResult struct {
-	AvailableProvidersList
 }
 
 // WatchersClientListResponse contains the response from method WatchersClient.List.
 type WatchersClientListResponse struct {
-	WatchersClientListResult
+	WatcherListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientListResult contains the result from method WatchersClient.List.
-type WatchersClientListResult struct {
-	WatcherListResult
 }
 
 // WatchersClientSetFlowLogConfigurationPollerResponse contains the response from method WatchersClient.SetFlowLogConfiguration.
@@ -12312,26 +10440,16 @@ func (l *WatchersClientSetFlowLogConfigurationPollerResponse) Resume(ctx context
 
 // WatchersClientSetFlowLogConfigurationResponse contains the response from method WatchersClient.SetFlowLogConfiguration.
 type WatchersClientSetFlowLogConfigurationResponse struct {
-	WatchersClientSetFlowLogConfigurationResult
+	FlowLogInformation
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientSetFlowLogConfigurationResult contains the result from method WatchersClient.SetFlowLogConfiguration.
-type WatchersClientSetFlowLogConfigurationResult struct {
-	FlowLogInformation
 }
 
 // WatchersClientUpdateTagsResponse contains the response from method WatchersClient.UpdateTags.
 type WatchersClientUpdateTagsResponse struct {
-	WatchersClientUpdateTagsResult
+	Watcher
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientUpdateTagsResult contains the result from method WatchersClient.UpdateTags.
-type WatchersClientUpdateTagsResult struct {
-	Watcher
 }
 
 // WatchersClientVerifyIPFlowPollerResponse contains the response from method WatchersClient.VerifyIPFlow.
@@ -12376,26 +10494,16 @@ func (l *WatchersClientVerifyIPFlowPollerResponse) Resume(ctx context.Context, c
 
 // WatchersClientVerifyIPFlowResponse contains the response from method WatchersClient.VerifyIPFlow.
 type WatchersClientVerifyIPFlowResponse struct {
-	WatchersClientVerifyIPFlowResult
+	VerificationIPFlowResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WatchersClientVerifyIPFlowResult contains the result from method WatchersClient.VerifyIPFlow.
-type WatchersClientVerifyIPFlowResult struct {
-	VerificationIPFlowResult
 }
 
 // WebApplicationFirewallPoliciesClientCreateOrUpdateResponse contains the response from method WebApplicationFirewallPoliciesClient.CreateOrUpdate.
 type WebApplicationFirewallPoliciesClientCreateOrUpdateResponse struct {
-	WebApplicationFirewallPoliciesClientCreateOrUpdateResult
+	WebApplicationFirewallPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WebApplicationFirewallPoliciesClientCreateOrUpdateResult contains the result from method WebApplicationFirewallPoliciesClient.CreateOrUpdate.
-type WebApplicationFirewallPoliciesClientCreateOrUpdateResult struct {
-	WebApplicationFirewallPolicy
 }
 
 // WebApplicationFirewallPoliciesClientDeletePollerResponse contains the response from method WebApplicationFirewallPoliciesClient.Delete.
@@ -12446,36 +10554,21 @@ type WebApplicationFirewallPoliciesClientDeleteResponse struct {
 
 // WebApplicationFirewallPoliciesClientGetResponse contains the response from method WebApplicationFirewallPoliciesClient.Get.
 type WebApplicationFirewallPoliciesClientGetResponse struct {
-	WebApplicationFirewallPoliciesClientGetResult
+	WebApplicationFirewallPolicy
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WebApplicationFirewallPoliciesClientGetResult contains the result from method WebApplicationFirewallPoliciesClient.Get.
-type WebApplicationFirewallPoliciesClientGetResult struct {
-	WebApplicationFirewallPolicy
 }
 
 // WebApplicationFirewallPoliciesClientListAllResponse contains the response from method WebApplicationFirewallPoliciesClient.ListAll.
 type WebApplicationFirewallPoliciesClientListAllResponse struct {
-	WebApplicationFirewallPoliciesClientListAllResult
+	WebApplicationFirewallPolicyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WebApplicationFirewallPoliciesClientListAllResult contains the result from method WebApplicationFirewallPoliciesClient.ListAll.
-type WebApplicationFirewallPoliciesClientListAllResult struct {
-	WebApplicationFirewallPolicyListResult
 }
 
 // WebApplicationFirewallPoliciesClientListResponse contains the response from method WebApplicationFirewallPoliciesClient.List.
 type WebApplicationFirewallPoliciesClientListResponse struct {
-	WebApplicationFirewallPoliciesClientListResult
+	WebApplicationFirewallPolicyListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// WebApplicationFirewallPoliciesClientListResult contains the result from method WebApplicationFirewallPoliciesClient.List.
-type WebApplicationFirewallPoliciesClientListResult struct {
-	WebApplicationFirewallPolicyListResult
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_response_types.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_response_types.go
@@ -15,13 +15,6 @@ import (
 
 // appendBlobClientAppendBlockFromURLResponse contains the response from method appendBlobClient.AppendBlockFromURL.
 type appendBlobClientAppendBlockFromURLResponse struct {
-	appendBlobClientAppendBlockFromURLResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// appendBlobClientAppendBlockFromURLResult contains the result from method appendBlobClient.AppendBlockFromURL.
-type appendBlobClientAppendBlockFromURLResult struct {
 	// BlobAppendOffset contains the information returned from the x-ms-blob-append-offset header response.
 	BlobAppendOffset *string
 
@@ -48,6 +41,9 @@ type appendBlobClientAppendBlockFromURLResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -61,13 +57,6 @@ type appendBlobClientAppendBlockFromURLResult struct {
 
 // appendBlobClientAppendBlockResponse contains the response from method appendBlobClient.AppendBlock.
 type appendBlobClientAppendBlockResponse struct {
-	appendBlobClientAppendBlockResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// appendBlobClientAppendBlockResult contains the result from method appendBlobClient.AppendBlock.
-type appendBlobClientAppendBlockResult struct {
 	// BlobAppendOffset contains the information returned from the x-ms-blob-append-offset header response.
 	BlobAppendOffset *string
 
@@ -98,6 +87,9 @@ type appendBlobClientAppendBlockResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -110,13 +102,6 @@ type appendBlobClientAppendBlockResult struct {
 
 // appendBlobClientCreateResponse contains the response from method appendBlobClient.Create.
 type appendBlobClientCreateResponse struct {
-	appendBlobClientCreateResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// appendBlobClientCreateResult contains the result from method appendBlobClient.Create.
-type appendBlobClientCreateResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -141,6 +126,9 @@ type appendBlobClientCreateResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -153,13 +141,6 @@ type appendBlobClientCreateResult struct {
 
 // appendBlobClientSealResponse contains the response from method appendBlobClient.Seal.
 type appendBlobClientSealResponse struct {
-	appendBlobClientSealResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// appendBlobClientSealResult contains the result from method appendBlobClient.Seal.
-type appendBlobClientSealResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -175,6 +156,9 @@ type appendBlobClientSealResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -184,13 +168,6 @@ type appendBlobClientSealResult struct {
 
 // blockBlobClientCommitBlockListResponse contains the response from method blockBlobClient.CommitBlockList.
 type blockBlobClientCommitBlockListResponse struct {
-	blockBlobClientCommitBlockListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// blockBlobClientCommitBlockListResult contains the result from method blockBlobClient.CommitBlockList.
-type blockBlobClientCommitBlockListResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -214,6 +191,9 @@ type blockBlobClientCommitBlockListResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -230,13 +210,6 @@ type blockBlobClientCommitBlockListResult struct {
 
 // blockBlobClientGetBlockListResponse contains the response from method blockBlobClient.GetBlockList.
 type blockBlobClientGetBlockListResponse struct {
-	blockBlobClientGetBlockListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// blockBlobClientGetBlockListResult contains the result from method blockBlobClient.GetBlockList.
-type blockBlobClientGetBlockListResult struct {
 	BlockList
 	// BlobContentLength contains the information returned from the x-ms-blob-content-length header response.
 	BlobContentLength *int64 `xml:"BlobContentLength"`
@@ -256,6 +229,9 @@ type blockBlobClientGetBlockListResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time `xml:"LastModified"`
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -265,13 +241,6 @@ type blockBlobClientGetBlockListResult struct {
 
 // blockBlobClientPutBlobFromURLResponse contains the response from method blockBlobClient.PutBlobFromURL.
 type blockBlobClientPutBlobFromURLResponse struct {
-	blockBlobClientPutBlobFromURLResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// blockBlobClientPutBlobFromURLResult contains the result from method blockBlobClient.PutBlobFromURL.
-type blockBlobClientPutBlobFromURLResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -295,6 +264,9 @@ type blockBlobClientPutBlobFromURLResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -308,13 +280,6 @@ type blockBlobClientPutBlobFromURLResult struct {
 
 // blockBlobClientStageBlockFromURLResponse contains the response from method blockBlobClient.StageBlockFromURL.
 type blockBlobClientStageBlockFromURLResponse struct {
-	blockBlobClientStageBlockFromURLResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// blockBlobClientStageBlockFromURLResult contains the result from method blockBlobClient.StageBlockFromURL.
-type blockBlobClientStageBlockFromURLResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -332,6 +297,9 @@ type blockBlobClientStageBlockFromURLResult struct {
 
 	// IsServerEncrypted contains the information returned from the x-ms-request-server-encrypted header response.
 	IsServerEncrypted *bool
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -345,13 +313,6 @@ type blockBlobClientStageBlockFromURLResult struct {
 
 // blockBlobClientStageBlockResponse contains the response from method blockBlobClient.StageBlock.
 type blockBlobClientStageBlockResponse struct {
-	blockBlobClientStageBlockResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// blockBlobClientStageBlockResult contains the result from method blockBlobClient.StageBlock.
-type blockBlobClientStageBlockResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -370,6 +331,9 @@ type blockBlobClientStageBlockResult struct {
 	// IsServerEncrypted contains the information returned from the x-ms-request-server-encrypted header response.
 	IsServerEncrypted *bool
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -382,13 +346,6 @@ type blockBlobClientStageBlockResult struct {
 
 // blockBlobClientUploadResponse contains the response from method blockBlobClient.Upload.
 type blockBlobClientUploadResponse struct {
-	blockBlobClientUploadResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// blockBlobClientUploadResult contains the result from method blockBlobClient.Upload.
-type blockBlobClientUploadResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -413,6 +370,9 @@ type blockBlobClientUploadResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -425,18 +385,14 @@ type blockBlobClientUploadResult struct {
 
 // clientAbortCopyFromURLResponse contains the response from method client.AbortCopyFromURL.
 type clientAbortCopyFromURLResponse struct {
-	clientAbortCopyFromURLResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientAbortCopyFromURLResult contains the result from method client.AbortCopyFromURL.
-type clientAbortCopyFromURLResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -447,13 +403,6 @@ type clientAbortCopyFromURLResult struct {
 
 // clientAcquireLeaseResponse contains the response from method client.AcquireLease.
 type clientAcquireLeaseResponse struct {
-	clientAcquireLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientAcquireLeaseResult contains the result from method client.AcquireLease.
-type clientAcquireLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -469,6 +418,9 @@ type clientAcquireLeaseResult struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -478,13 +430,6 @@ type clientAcquireLeaseResult struct {
 
 // clientBreakLeaseResponse contains the response from method client.BreakLease.
 type clientBreakLeaseResponse struct {
-	clientBreakLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientBreakLeaseResult contains the result from method client.BreakLease.
-type clientBreakLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -500,6 +445,9 @@ type clientBreakLeaseResult struct {
 	// LeaseTime contains the information returned from the x-ms-lease-time header response.
 	LeaseTime *int32
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -509,13 +457,6 @@ type clientBreakLeaseResult struct {
 
 // clientChangeLeaseResponse contains the response from method client.ChangeLease.
 type clientChangeLeaseResponse struct {
-	clientChangeLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientChangeLeaseResult contains the result from method client.ChangeLease.
-type clientChangeLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -531,6 +472,9 @@ type clientChangeLeaseResult struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -540,13 +484,6 @@ type clientChangeLeaseResult struct {
 
 // clientCopyFromURLResponse contains the response from method client.CopyFromURL.
 type clientCopyFromURLResponse struct {
-	clientCopyFromURLResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientCopyFromURLResult contains the result from method client.CopyFromURL.
-type clientCopyFromURLResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -568,6 +505,9 @@ type clientCopyFromURLResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -583,13 +523,6 @@ type clientCopyFromURLResult struct {
 
 // clientCreateSnapshotResponse contains the response from method client.CreateSnapshot.
 type clientCreateSnapshotResponse struct {
-	clientCreateSnapshotResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientCreateSnapshotResult contains the result from method client.CreateSnapshot.
-type clientCreateSnapshotResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -604,6 +537,9 @@ type clientCreateSnapshotResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -620,18 +556,14 @@ type clientCreateSnapshotResult struct {
 
 // clientDeleteImmutabilityPolicyResponse contains the response from method client.DeleteImmutabilityPolicy.
 type clientDeleteImmutabilityPolicyResponse struct {
-	clientDeleteImmutabilityPolicyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientDeleteImmutabilityPolicyResult contains the result from method client.DeleteImmutabilityPolicy.
-type clientDeleteImmutabilityPolicyResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -642,18 +574,14 @@ type clientDeleteImmutabilityPolicyResult struct {
 
 // clientDeleteResponse contains the response from method client.Delete.
 type clientDeleteResponse struct {
-	clientDeleteResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientDeleteResult contains the result from method client.Delete.
-type clientDeleteResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -664,13 +592,6 @@ type clientDeleteResult struct {
 
 // clientDownloadResponse contains the response from method client.Download.
 type clientDownloadResponse struct {
-	clientDownloadResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientDownloadResult contains the result from method client.Download.
-type clientDownloadResult struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
 
@@ -788,6 +709,9 @@ type clientDownloadResult struct {
 	// ObjectReplicationRules contains the information returned from the x-ms-or header response.
 	ObjectReplicationRules map[string]string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -803,13 +727,6 @@ type clientDownloadResult struct {
 
 // clientGetAccessControlResponse contains the response from method client.GetAccessControl.
 type clientGetAccessControlResponse struct {
-	clientGetAccessControlResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientGetAccessControlResult contains the result from method client.GetAccessControl.
-type clientGetAccessControlResult struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
@@ -818,6 +735,9 @@ type clientGetAccessControlResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -840,13 +760,6 @@ type clientGetAccessControlResult struct {
 
 // clientGetAccountInfoResponse contains the response from method client.GetAccountInfo.
 type clientGetAccountInfoResponse struct {
-	clientGetAccountInfoResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientGetAccountInfoResult contains the result from method client.GetAccountInfo.
-type clientGetAccountInfoResult struct {
 	// AccountKind contains the information returned from the x-ms-account-kind header response.
 	AccountKind *AccountKind
 
@@ -855,6 +768,9 @@ type clientGetAccountInfoResult struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -868,13 +784,6 @@ type clientGetAccountInfoResult struct {
 
 // clientGetPropertiesResponse contains the response from method client.GetProperties.
 type clientGetPropertiesResponse struct {
-	clientGetPropertiesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientGetPropertiesResult contains the result from method client.GetProperties.
-type clientGetPropertiesResult struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
 
@@ -1007,6 +916,9 @@ type clientGetPropertiesResult struct {
 	// ObjectReplicationRules contains the information returned from the x-ms-or header response.
 	ObjectReplicationRules map[string]string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RehydratePriority contains the information returned from the x-ms-rehydrate-priority header response.
 	RehydratePriority *string
 
@@ -1025,19 +937,15 @@ type clientGetPropertiesResult struct {
 
 // clientGetTagsResponse contains the response from method client.GetTags.
 type clientGetTagsResponse struct {
-	clientGetTagsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientGetTagsResult contains the result from method client.GetTags.
-type clientGetTagsResult struct {
 	Tags
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -1048,13 +956,6 @@ type clientGetTagsResult struct {
 
 // clientQueryResponse contains the response from method client.Query.
 type clientQueryResponse struct {
-	clientQueryResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientQueryResult contains the result from method client.Query.
-type clientQueryResult struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
 
@@ -1148,6 +1049,9 @@ type clientQueryResult struct {
 	// Metadata contains the information returned from the x-ms-meta header response.
 	Metadata map[string]string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1157,13 +1061,6 @@ type clientQueryResult struct {
 
 // clientReleaseLeaseResponse contains the response from method client.ReleaseLease.
 type clientReleaseLeaseResponse struct {
-	clientReleaseLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientReleaseLeaseResult contains the result from method client.ReleaseLease.
-type clientReleaseLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1176,6 +1073,9 @@ type clientReleaseLeaseResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1185,13 +1085,6 @@ type clientReleaseLeaseResult struct {
 
 // clientRenameResponse contains the response from method client.Rename.
 type clientRenameResponse struct {
-	clientRenameResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientRenameResult contains the result from method client.Rename.
-type clientRenameResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1207,6 +1100,9 @@ type clientRenameResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1216,13 +1112,6 @@ type clientRenameResult struct {
 
 // clientRenewLeaseResponse contains the response from method client.RenewLease.
 type clientRenewLeaseResponse struct {
-	clientRenewLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientRenewLeaseResult contains the result from method client.RenewLease.
-type clientRenewLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1238,6 +1127,9 @@ type clientRenewLeaseResult struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1247,13 +1139,6 @@ type clientRenewLeaseResult struct {
 
 // clientSetAccessControlResponse contains the response from method client.SetAccessControl.
 type clientSetAccessControlResponse struct {
-	clientSetAccessControlResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientSetAccessControlResult contains the result from method client.SetAccessControl.
-type clientSetAccessControlResult struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
@@ -1262,6 +1147,9 @@ type clientSetAccessControlResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1272,13 +1160,6 @@ type clientSetAccessControlResult struct {
 
 // clientSetExpiryResponse contains the response from method client.SetExpiry.
 type clientSetExpiryResponse struct {
-	clientSetExpiryResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientSetExpiryResult contains the result from method client.SetExpiry.
-type clientSetExpiryResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1291,6 +1172,9 @@ type clientSetExpiryResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1300,13 +1184,6 @@ type clientSetExpiryResult struct {
 
 // clientSetHTTPHeadersResponse contains the response from method client.SetHTTPHeaders.
 type clientSetHTTPHeadersResponse struct {
-	clientSetHTTPHeadersResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientSetHTTPHeadersResult contains the result from method client.SetHTTPHeaders.
-type clientSetHTTPHeadersResult struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
 
@@ -1322,6 +1199,9 @@ type clientSetHTTPHeadersResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1331,13 +1211,6 @@ type clientSetHTTPHeadersResult struct {
 
 // clientSetImmutabilityPolicyResponse contains the response from method client.SetImmutabilityPolicy.
 type clientSetImmutabilityPolicyResponse struct {
-	clientSetImmutabilityPolicyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientSetImmutabilityPolicyResult contains the result from method client.SetImmutabilityPolicy.
-type clientSetImmutabilityPolicyResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1350,6 +1223,9 @@ type clientSetImmutabilityPolicyResult struct {
 	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1359,13 +1235,6 @@ type clientSetImmutabilityPolicyResult struct {
 
 // clientSetLegalHoldResponse contains the response from method client.SetLegalHold.
 type clientSetLegalHoldResponse struct {
-	clientSetLegalHoldResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientSetLegalHoldResult contains the result from method client.SetLegalHold.
-type clientSetLegalHoldResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1374,6 +1243,9 @@ type clientSetLegalHoldResult struct {
 
 	// LegalHold contains the information returned from the x-ms-legal-hold header response.
 	LegalHold *bool
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1384,13 +1256,6 @@ type clientSetLegalHoldResult struct {
 
 // clientSetMetadataResponse contains the response from method client.SetMetadata.
 type clientSetMetadataResponse struct {
-	clientSetMetadataResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientSetMetadataResult contains the result from method client.SetMetadata.
-type clientSetMetadataResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1412,6 +1277,9 @@ type clientSetMetadataResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1424,18 +1292,14 @@ type clientSetMetadataResult struct {
 
 // clientSetTagsResponse contains the response from method client.SetTags.
 type clientSetTagsResponse struct {
-	clientSetTagsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientSetTagsResult contains the result from method client.SetTags.
-type clientSetTagsResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1446,15 +1310,11 @@ type clientSetTagsResult struct {
 
 // clientSetTierResponse contains the response from method client.SetTier.
 type clientSetTierResponse struct {
-	clientSetTierResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientSetTierResult contains the result from method client.SetTier.
-type clientSetTierResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1465,13 +1325,6 @@ type clientSetTierResult struct {
 
 // clientStartCopyFromURLResponse contains the response from method client.StartCopyFromURL.
 type clientStartCopyFromURLResponse struct {
-	clientStartCopyFromURLResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientStartCopyFromURLResult contains the result from method client.StartCopyFromURL.
-type clientStartCopyFromURLResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1490,6 +1343,9 @@ type clientStartCopyFromURLResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1502,18 +1358,14 @@ type clientStartCopyFromURLResult struct {
 
 // clientUndeleteResponse contains the response from method client.Undelete.
 type clientUndeleteResponse struct {
-	clientUndeleteResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// clientUndeleteResult contains the result from method client.Undelete.
-type clientUndeleteResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1524,13 +1376,6 @@ type clientUndeleteResult struct {
 
 // containerClientAcquireLeaseResponse contains the response from method containerClient.AcquireLease.
 type containerClientAcquireLeaseResponse struct {
-	containerClientAcquireLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientAcquireLeaseResult contains the result from method containerClient.AcquireLease.
-type containerClientAcquireLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1546,6 +1391,9 @@ type containerClientAcquireLeaseResult struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1555,13 +1403,6 @@ type containerClientAcquireLeaseResult struct {
 
 // containerClientBreakLeaseResponse contains the response from method containerClient.BreakLease.
 type containerClientBreakLeaseResponse struct {
-	containerClientBreakLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientBreakLeaseResult contains the result from method containerClient.BreakLease.
-type containerClientBreakLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1577,6 +1418,9 @@ type containerClientBreakLeaseResult struct {
 	// LeaseTime contains the information returned from the x-ms-lease-time header response.
 	LeaseTime *int32
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1586,13 +1430,6 @@ type containerClientBreakLeaseResult struct {
 
 // containerClientChangeLeaseResponse contains the response from method containerClient.ChangeLease.
 type containerClientChangeLeaseResponse struct {
-	containerClientChangeLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientChangeLeaseResult contains the result from method containerClient.ChangeLease.
-type containerClientChangeLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1608,6 +1445,9 @@ type containerClientChangeLeaseResult struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1617,13 +1457,6 @@ type containerClientChangeLeaseResult struct {
 
 // containerClientCreateResponse contains the response from method containerClient.Create.
 type containerClientCreateResponse struct {
-	containerClientCreateResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientCreateResult contains the result from method containerClient.Create.
-type containerClientCreateResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1636,6 +1469,9 @@ type containerClientCreateResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1645,18 +1481,14 @@ type containerClientCreateResult struct {
 
 // containerClientDeleteResponse contains the response from method containerClient.Delete.
 type containerClientDeleteResponse struct {
-	containerClientDeleteResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientDeleteResult contains the result from method containerClient.Delete.
-type containerClientDeleteResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1667,13 +1499,6 @@ type containerClientDeleteResult struct {
 
 // containerClientGetAccessPolicyResponse contains the response from method containerClient.GetAccessPolicy.
 type containerClientGetAccessPolicyResponse struct {
-	containerClientGetAccessPolicyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientGetAccessPolicyResult contains the result from method containerClient.GetAccessPolicy.
-type containerClientGetAccessPolicyResult struct {
 	// BlobPublicAccess contains the information returned from the x-ms-blob-public-access header response.
 	BlobPublicAccess *PublicAccessType `xml:"BlobPublicAccess"`
 
@@ -1689,6 +1514,9 @@ type containerClientGetAccessPolicyResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time `xml:"LastModified"`
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -1701,13 +1529,6 @@ type containerClientGetAccessPolicyResult struct {
 
 // containerClientGetAccountInfoResponse contains the response from method containerClient.GetAccountInfo.
 type containerClientGetAccountInfoResponse struct {
-	containerClientGetAccountInfoResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientGetAccountInfoResult contains the result from method containerClient.GetAccountInfo.
-type containerClientGetAccountInfoResult struct {
 	// AccountKind contains the information returned from the x-ms-account-kind header response.
 	AccountKind *AccountKind
 
@@ -1716,6 +1537,9 @@ type containerClientGetAccountInfoResult struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1729,13 +1553,6 @@ type containerClientGetAccountInfoResult struct {
 
 // containerClientGetPropertiesResponse contains the response from method containerClient.GetProperties.
 type containerClientGetPropertiesResponse struct {
-	containerClientGetPropertiesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientGetPropertiesResult contains the result from method containerClient.GetProperties.
-type containerClientGetPropertiesResult struct {
 	// BlobPublicAccess contains the information returned from the x-ms-blob-public-access header response.
 	BlobPublicAccess *PublicAccessType
 
@@ -1778,6 +1595,9 @@ type containerClientGetPropertiesResult struct {
 	// Metadata contains the information returned from the x-ms-meta header response.
 	Metadata map[string]string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1787,13 +1607,6 @@ type containerClientGetPropertiesResult struct {
 
 // containerClientListBlobFlatSegmentResponse contains the response from method containerClient.ListBlobFlatSegment.
 type containerClientListBlobFlatSegmentResponse struct {
-	containerClientListBlobFlatSegmentResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientListBlobFlatSegmentResult contains the result from method containerClient.ListBlobFlatSegment.
-type containerClientListBlobFlatSegmentResult struct {
 	ListBlobsFlatSegmentResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
@@ -1804,6 +1617,9 @@ type containerClientListBlobFlatSegmentResult struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -1813,13 +1629,6 @@ type containerClientListBlobFlatSegmentResult struct {
 
 // containerClientListBlobHierarchySegmentResponse contains the response from method containerClient.ListBlobHierarchySegment.
 type containerClientListBlobHierarchySegmentResponse struct {
-	containerClientListBlobHierarchySegmentResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientListBlobHierarchySegmentResult contains the result from method containerClient.ListBlobHierarchySegment.
-type containerClientListBlobHierarchySegmentResult struct {
 	ListBlobsHierarchySegmentResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
@@ -1830,6 +1639,9 @@ type containerClientListBlobHierarchySegmentResult struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -1839,13 +1651,6 @@ type containerClientListBlobHierarchySegmentResult struct {
 
 // containerClientReleaseLeaseResponse contains the response from method containerClient.ReleaseLease.
 type containerClientReleaseLeaseResponse struct {
-	containerClientReleaseLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientReleaseLeaseResult contains the result from method containerClient.ReleaseLease.
-type containerClientReleaseLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1858,6 +1663,9 @@ type containerClientReleaseLeaseResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1867,18 +1675,14 @@ type containerClientReleaseLeaseResult struct {
 
 // containerClientRenameResponse contains the response from method containerClient.Rename.
 type containerClientRenameResponse struct {
-	containerClientRenameResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientRenameResult contains the result from method containerClient.Rename.
-type containerClientRenameResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1889,13 +1693,6 @@ type containerClientRenameResult struct {
 
 // containerClientRenewLeaseResponse contains the response from method containerClient.RenewLease.
 type containerClientRenewLeaseResponse struct {
-	containerClientRenewLeaseResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientRenewLeaseResult contains the result from method containerClient.RenewLease.
-type containerClientRenewLeaseResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1911,6 +1708,9 @@ type containerClientRenewLeaseResult struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1920,18 +1720,14 @@ type containerClientRenewLeaseResult struct {
 
 // containerClientRestoreResponse contains the response from method containerClient.Restore.
 type containerClientRestoreResponse struct {
-	containerClientRestoreResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientRestoreResult contains the result from method containerClient.Restore.
-type containerClientRestoreResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1942,13 +1738,6 @@ type containerClientRestoreResult struct {
 
 // containerClientSetAccessPolicyResponse contains the response from method containerClient.SetAccessPolicy.
 type containerClientSetAccessPolicyResponse struct {
-	containerClientSetAccessPolicyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientSetAccessPolicyResult contains the result from method containerClient.SetAccessPolicy.
-type containerClientSetAccessPolicyResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1960,6 +1749,9 @@ type containerClientSetAccessPolicyResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1970,13 +1762,6 @@ type containerClientSetAccessPolicyResult struct {
 
 // containerClientSetMetadataResponse contains the response from method containerClient.SetMetadata.
 type containerClientSetMetadataResponse struct {
-	containerClientSetMetadataResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientSetMetadataResult contains the result from method containerClient.SetMetadata.
-type containerClientSetMetadataResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1989,6 +1774,9 @@ type containerClientSetMetadataResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1998,15 +1786,11 @@ type containerClientSetMetadataResult struct {
 
 // containerClientSubmitBatchResponse contains the response from method containerClient.SubmitBatch.
 type containerClientSubmitBatchResponse struct {
-	containerClientSubmitBatchResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// containerClientSubmitBatchResult contains the result from method containerClient.SubmitBatch.
-type containerClientSubmitBatchResult struct {
 	// ContentType contains the information returned from the Content-Type header response.
 	ContentType *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2017,13 +1801,6 @@ type containerClientSubmitBatchResult struct {
 
 // directoryClientCreateResponse contains the response from method directoryClient.Create.
 type directoryClientCreateResponse struct {
-	directoryClientCreateResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// directoryClientCreateResult contains the result from method directoryClient.Create.
-type directoryClientCreateResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -2039,6 +1816,9 @@ type directoryClientCreateResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2048,13 +1828,6 @@ type directoryClientCreateResult struct {
 
 // directoryClientDeleteResponse contains the response from method directoryClient.Delete.
 type directoryClientDeleteResponse struct {
-	directoryClientDeleteResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// directoryClientDeleteResult contains the result from method directoryClient.Delete.
-type directoryClientDeleteResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -2063,6 +1836,9 @@ type directoryClientDeleteResult struct {
 
 	// Marker contains the information returned from the x-ms-continuation header response.
 	Marker *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2073,13 +1849,6 @@ type directoryClientDeleteResult struct {
 
 // directoryClientGetAccessControlResponse contains the response from method directoryClient.GetAccessControl.
 type directoryClientGetAccessControlResponse struct {
-	directoryClientGetAccessControlResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// directoryClientGetAccessControlResult contains the result from method directoryClient.GetAccessControl.
-type directoryClientGetAccessControlResult struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
@@ -2088,6 +1857,9 @@ type directoryClientGetAccessControlResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2110,13 +1882,6 @@ type directoryClientGetAccessControlResult struct {
 
 // directoryClientRenameResponse contains the response from method directoryClient.Rename.
 type directoryClientRenameResponse struct {
-	directoryClientRenameResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// directoryClientRenameResult contains the result from method directoryClient.Rename.
-type directoryClientRenameResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -2135,6 +1900,9 @@ type directoryClientRenameResult struct {
 	// Marker contains the information returned from the x-ms-continuation header response.
 	Marker *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2144,13 +1912,6 @@ type directoryClientRenameResult struct {
 
 // directoryClientSetAccessControlResponse contains the response from method directoryClient.SetAccessControl.
 type directoryClientSetAccessControlResponse struct {
-	directoryClientSetAccessControlResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// directoryClientSetAccessControlResult contains the result from method directoryClient.SetAccessControl.
-type directoryClientSetAccessControlResult struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
@@ -2159,6 +1920,9 @@ type directoryClientSetAccessControlResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2169,13 +1933,6 @@ type directoryClientSetAccessControlResult struct {
 
 // pageBlobClientClearPagesResponse contains the response from method pageBlobClient.ClearPages.
 type pageBlobClientClearPagesResponse struct {
-	pageBlobClientClearPagesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientClearPagesResult contains the result from method pageBlobClient.ClearPages.
-type pageBlobClientClearPagesResult struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
 
@@ -2194,6 +1951,9 @@ type pageBlobClientClearPagesResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2206,13 +1966,6 @@ type pageBlobClientClearPagesResult struct {
 
 // pageBlobClientCopyIncrementalResponse contains the response from method pageBlobClient.CopyIncremental.
 type pageBlobClientCopyIncrementalResponse struct {
-	pageBlobClientCopyIncrementalResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientCopyIncrementalResult contains the result from method pageBlobClient.CopyIncremental.
-type pageBlobClientCopyIncrementalResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -2231,6 +1984,9 @@ type pageBlobClientCopyIncrementalResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2240,13 +1996,6 @@ type pageBlobClientCopyIncrementalResult struct {
 
 // pageBlobClientCreateResponse contains the response from method pageBlobClient.Create.
 type pageBlobClientCreateResponse struct {
-	pageBlobClientCreateResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientCreateResult contains the result from method pageBlobClient.Create.
-type pageBlobClientCreateResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -2270,6 +2019,9 @@ type pageBlobClientCreateResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2283,13 +2035,6 @@ type pageBlobClientCreateResult struct {
 
 // pageBlobClientGetPageRangesDiffResponse contains the response from method pageBlobClient.GetPageRangesDiff.
 type pageBlobClientGetPageRangesDiffResponse struct {
-	pageBlobClientGetPageRangesDiffResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientGetPageRangesDiffResult contains the result from method pageBlobClient.GetPageRangesDiff.
-type pageBlobClientGetPageRangesDiffResult struct {
 	PageList
 	// BlobContentLength contains the information returned from the x-ms-blob-content-length header response.
 	BlobContentLength *int64 `xml:"BlobContentLength"`
@@ -2305,6 +2050,9 @@ type pageBlobClientGetPageRangesDiffResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time `xml:"LastModified"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -2315,13 +2063,6 @@ type pageBlobClientGetPageRangesDiffResult struct {
 
 // pageBlobClientGetPageRangesResponse contains the response from method pageBlobClient.GetPageRanges.
 type pageBlobClientGetPageRangesResponse struct {
-	pageBlobClientGetPageRangesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientGetPageRangesResult contains the result from method pageBlobClient.GetPageRanges.
-type pageBlobClientGetPageRangesResult struct {
 	PageList
 	// BlobContentLength contains the information returned from the x-ms-blob-content-length header response.
 	BlobContentLength *int64 `xml:"BlobContentLength"`
@@ -2338,6 +2079,9 @@ type pageBlobClientGetPageRangesResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time `xml:"LastModified"`
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -2347,13 +2091,6 @@ type pageBlobClientGetPageRangesResult struct {
 
 // pageBlobClientResizeResponse contains the response from method pageBlobClient.Resize.
 type pageBlobClientResizeResponse struct {
-	pageBlobClientResizeResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientResizeResult contains the result from method pageBlobClient.Resize.
-type pageBlobClientResizeResult struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
 
@@ -2368,6 +2105,9 @@ type pageBlobClientResizeResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2378,13 +2118,6 @@ type pageBlobClientResizeResult struct {
 
 // pageBlobClientUpdateSequenceNumberResponse contains the response from method pageBlobClient.UpdateSequenceNumber.
 type pageBlobClientUpdateSequenceNumberResponse struct {
-	pageBlobClientUpdateSequenceNumberResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientUpdateSequenceNumberResult contains the result from method pageBlobClient.UpdateSequenceNumber.
-type pageBlobClientUpdateSequenceNumberResult struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
 
@@ -2400,6 +2133,9 @@ type pageBlobClientUpdateSequenceNumberResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2409,13 +2145,6 @@ type pageBlobClientUpdateSequenceNumberResult struct {
 
 // pageBlobClientUploadPagesFromURLResponse contains the response from method pageBlobClient.UploadPagesFromURL.
 type pageBlobClientUploadPagesFromURLResponse struct {
-	pageBlobClientUploadPagesFromURLResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientUploadPagesFromURLResult contains the result from method pageBlobClient.UploadPagesFromURL.
-type pageBlobClientUploadPagesFromURLResult struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
 
@@ -2439,6 +2168,9 @@ type pageBlobClientUploadPagesFromURLResult struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2452,13 +2184,6 @@ type pageBlobClientUploadPagesFromURLResult struct {
 
 // pageBlobClientUploadPagesResponse contains the response from method pageBlobClient.UploadPages.
 type pageBlobClientUploadPagesResponse struct {
-	pageBlobClientUploadPagesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// pageBlobClientUploadPagesResult contains the result from method pageBlobClient.UploadPages.
-type pageBlobClientUploadPagesResult struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
 
@@ -2486,6 +2211,9 @@ type pageBlobClientUploadPagesResult struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2498,19 +2226,15 @@ type pageBlobClientUploadPagesResult struct {
 
 // serviceClientFilterBlobsResponse contains the response from method serviceClient.FilterBlobs.
 type serviceClientFilterBlobsResponse struct {
-	serviceClientFilterBlobsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// serviceClientFilterBlobsResult contains the result from method serviceClient.FilterBlobs.
-type serviceClientFilterBlobsResult struct {
 	FilterBlobSegment
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -2521,13 +2245,6 @@ type serviceClientFilterBlobsResult struct {
 
 // serviceClientGetAccountInfoResponse contains the response from method serviceClient.GetAccountInfo.
 type serviceClientGetAccountInfoResponse struct {
-	serviceClientGetAccountInfoResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// serviceClientGetAccountInfoResult contains the result from method serviceClient.GetAccountInfo.
-type serviceClientGetAccountInfoResult struct {
 	// AccountKind contains the information returned from the x-ms-account-kind header response.
 	AccountKind *AccountKind
 
@@ -2539,6 +2256,9 @@ type serviceClientGetAccountInfoResult struct {
 
 	// IsHierarchicalNamespaceEnabled contains the information returned from the x-ms-is-hns-enabled header response.
 	IsHierarchicalNamespaceEnabled *bool
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2552,16 +2272,12 @@ type serviceClientGetAccountInfoResult struct {
 
 // serviceClientGetPropertiesResponse contains the response from method serviceClient.GetProperties.
 type serviceClientGetPropertiesResponse struct {
-	serviceClientGetPropertiesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// serviceClientGetPropertiesResult contains the result from method serviceClient.GetProperties.
-type serviceClientGetPropertiesResult struct {
 	StorageServiceProperties
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -2572,19 +2288,15 @@ type serviceClientGetPropertiesResult struct {
 
 // serviceClientGetStatisticsResponse contains the response from method serviceClient.GetStatistics.
 type serviceClientGetStatisticsResponse struct {
-	serviceClientGetStatisticsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// serviceClientGetStatisticsResult contains the result from method serviceClient.GetStatistics.
-type serviceClientGetStatisticsResult struct {
 	StorageServiceStats
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -2595,19 +2307,15 @@ type serviceClientGetStatisticsResult struct {
 
 // serviceClientGetUserDelegationKeyResponse contains the response from method serviceClient.GetUserDelegationKey.
 type serviceClientGetUserDelegationKeyResponse struct {
-	serviceClientGetUserDelegationKeyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// serviceClientGetUserDelegationKeyResult contains the result from method serviceClient.GetUserDelegationKey.
-type serviceClientGetUserDelegationKeyResult struct {
 	UserDelegationKey
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -2618,16 +2326,12 @@ type serviceClientGetUserDelegationKeyResult struct {
 
 // serviceClientListContainersSegmentResponse contains the response from method serviceClient.ListContainersSegment.
 type serviceClientListContainersSegmentResponse struct {
-	serviceClientListContainersSegmentResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// serviceClientListContainersSegmentResult contains the result from method serviceClient.ListContainersSegment.
-type serviceClientListContainersSegmentResult struct {
 	ListContainersSegmentResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -2638,15 +2342,11 @@ type serviceClientListContainersSegmentResult struct {
 
 // serviceClientSetPropertiesResponse contains the response from method serviceClient.SetProperties.
 type serviceClientSetPropertiesResponse struct {
-	serviceClientSetPropertiesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// serviceClientSetPropertiesResult contains the result from method serviceClient.SetProperties.
-type serviceClientSetPropertiesResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2657,15 +2357,11 @@ type serviceClientSetPropertiesResult struct {
 
 // serviceClientSubmitBatchResponse contains the response from method serviceClient.SubmitBatch.
 type serviceClientSubmitBatchResponse struct {
-	serviceClientSubmitBatchResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// serviceClientSubmitBatchResult contains the result from method serviceClient.SubmitBatch.
-type serviceClientSubmitBatchResult struct {
 	// ContentType contains the information returned from the Content-Type header response.
 	ContentType *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_response_types.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_response_types.go
@@ -17,26 +17,16 @@ import (
 
 // bigDataPoolsClientGetResponse contains the response from method bigDataPoolsClient.Get.
 type bigDataPoolsClientGetResponse struct {
-	bigDataPoolsClientGetResult
+	BigDataPoolResourceInfo
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// bigDataPoolsClientGetResult contains the result from method bigDataPoolsClient.Get.
-type bigDataPoolsClientGetResult struct {
-	BigDataPoolResourceInfo
 }
 
 // bigDataPoolsClientListResponse contains the response from method bigDataPoolsClient.List.
 type bigDataPoolsClientListResponse struct {
-	bigDataPoolsClientListResult
+	BigDataPoolResourceInfoListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// bigDataPoolsClientListResult contains the result from method bigDataPoolsClient.List.
-type bigDataPoolsClientListResult struct {
-	BigDataPoolResourceInfoListResult
 }
 
 // dataFlowClientCreateOrUpdateDataFlowPollerResponse contains the response from method dataFlowClient.CreateOrUpdateDataFlow.
@@ -80,14 +70,9 @@ func (l *dataFlowClientCreateOrUpdateDataFlowPollerResponse) Resume(ctx context.
 
 // dataFlowClientCreateOrUpdateDataFlowResponse contains the response from method dataFlowClient.CreateOrUpdateDataFlow.
 type dataFlowClientCreateOrUpdateDataFlowResponse struct {
-	dataFlowClientCreateOrUpdateDataFlowResult
+	DataFlowResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// dataFlowClientCreateOrUpdateDataFlowResult contains the result from method dataFlowClient.CreateOrUpdateDataFlow.
-type dataFlowClientCreateOrUpdateDataFlowResult struct {
-	DataFlowResource
 }
 
 // dataFlowClientDeleteDataFlowPollerResponse contains the response from method dataFlowClient.DeleteDataFlow.
@@ -137,26 +122,16 @@ type dataFlowClientDeleteDataFlowResponse struct {
 
 // dataFlowClientGetDataFlowResponse contains the response from method dataFlowClient.GetDataFlow.
 type dataFlowClientGetDataFlowResponse struct {
-	dataFlowClientGetDataFlowResult
+	DataFlowResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// dataFlowClientGetDataFlowResult contains the result from method dataFlowClient.GetDataFlow.
-type dataFlowClientGetDataFlowResult struct {
-	DataFlowResource
 }
 
 // dataFlowClientGetDataFlowsByWorkspaceResponse contains the response from method dataFlowClient.GetDataFlowsByWorkspace.
 type dataFlowClientGetDataFlowsByWorkspaceResponse struct {
-	dataFlowClientGetDataFlowsByWorkspaceResult
+	DataFlowListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// dataFlowClientGetDataFlowsByWorkspaceResult contains the result from method dataFlowClient.GetDataFlowsByWorkspace.
-type dataFlowClientGetDataFlowsByWorkspaceResult struct {
-	DataFlowListResponse
 }
 
 // dataFlowClientRenameDataFlowPollerResponse contains the response from method dataFlowClient.RenameDataFlow.
@@ -206,14 +181,9 @@ type dataFlowClientRenameDataFlowResponse struct {
 
 // dataFlowDebugSessionClientAddDataFlowResponse contains the response from method dataFlowDebugSessionClient.AddDataFlow.
 type dataFlowDebugSessionClientAddDataFlowResponse struct {
-	dataFlowDebugSessionClientAddDataFlowResult
+	AddDataFlowToDebugSessionResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// dataFlowDebugSessionClientAddDataFlowResult contains the result from method dataFlowDebugSessionClient.AddDataFlow.
-type dataFlowDebugSessionClientAddDataFlowResult struct {
-	AddDataFlowToDebugSessionResponse
 }
 
 // dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse contains the response from method dataFlowDebugSessionClient.CreateDataFlowDebugSession.
@@ -258,14 +228,9 @@ func (l *dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse) Res
 
 // dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse contains the response from method dataFlowDebugSessionClient.CreateDataFlowDebugSession.
 type dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse struct {
-	dataFlowDebugSessionClientCreateDataFlowDebugSessionResult
+	CreateDataFlowDebugSessionResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// dataFlowDebugSessionClientCreateDataFlowDebugSessionResult contains the result from method dataFlowDebugSessionClient.CreateDataFlowDebugSession.
-type dataFlowDebugSessionClientCreateDataFlowDebugSessionResult struct {
-	CreateDataFlowDebugSessionResponse
 }
 
 // dataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse contains the response from method dataFlowDebugSessionClient.DeleteDataFlowDebugSession.
@@ -315,26 +280,16 @@ func (l *dataFlowDebugSessionClientExecuteCommandPollerResponse) Resume(ctx cont
 
 // dataFlowDebugSessionClientExecuteCommandResponse contains the response from method dataFlowDebugSessionClient.ExecuteCommand.
 type dataFlowDebugSessionClientExecuteCommandResponse struct {
-	dataFlowDebugSessionClientExecuteCommandResult
+	DataFlowDebugCommandResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// dataFlowDebugSessionClientExecuteCommandResult contains the result from method dataFlowDebugSessionClient.ExecuteCommand.
-type dataFlowDebugSessionClientExecuteCommandResult struct {
-	DataFlowDebugCommandResponse
 }
 
 // dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse contains the response from method dataFlowDebugSessionClient.QueryDataFlowDebugSessionsByWorkspace.
 type dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse struct {
-	dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResult
+	QueryDataFlowDebugSessionsResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResult contains the result from method dataFlowDebugSessionClient.QueryDataFlowDebugSessionsByWorkspace.
-type dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResult struct {
-	QueryDataFlowDebugSessionsResponse
 }
 
 // datasetClientCreateOrUpdateDatasetPollerResponse contains the response from method datasetClient.CreateOrUpdateDataset.
@@ -378,14 +333,9 @@ func (l *datasetClientCreateOrUpdateDatasetPollerResponse) Resume(ctx context.Co
 
 // datasetClientCreateOrUpdateDatasetResponse contains the response from method datasetClient.CreateOrUpdateDataset.
 type datasetClientCreateOrUpdateDatasetResponse struct {
-	datasetClientCreateOrUpdateDatasetResult
+	DatasetResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// datasetClientCreateOrUpdateDatasetResult contains the result from method datasetClient.CreateOrUpdateDataset.
-type datasetClientCreateOrUpdateDatasetResult struct {
-	DatasetResource
 }
 
 // datasetClientDeleteDatasetPollerResponse contains the response from method datasetClient.DeleteDataset.
@@ -435,26 +385,16 @@ type datasetClientDeleteDatasetResponse struct {
 
 // datasetClientGetDatasetResponse contains the response from method datasetClient.GetDataset.
 type datasetClientGetDatasetResponse struct {
-	datasetClientGetDatasetResult
+	DatasetResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// datasetClientGetDatasetResult contains the result from method datasetClient.GetDataset.
-type datasetClientGetDatasetResult struct {
-	DatasetResource
 }
 
 // datasetClientGetDatasetsByWorkspaceResponse contains the response from method datasetClient.GetDatasetsByWorkspace.
 type datasetClientGetDatasetsByWorkspaceResponse struct {
-	datasetClientGetDatasetsByWorkspaceResult
+	DatasetListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// datasetClientGetDatasetsByWorkspaceResult contains the result from method datasetClient.GetDatasetsByWorkspace.
-type datasetClientGetDatasetsByWorkspaceResult struct {
-	DatasetListResponse
 }
 
 // datasetClientRenameDatasetPollerResponse contains the response from method datasetClient.RenameDataset.
@@ -504,26 +444,16 @@ type datasetClientRenameDatasetResponse struct {
 
 // integrationRuntimesClientGetResponse contains the response from method integrationRuntimesClient.Get.
 type integrationRuntimesClientGetResponse struct {
-	integrationRuntimesClientGetResult
+	IntegrationRuntimeResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// integrationRuntimesClientGetResult contains the result from method integrationRuntimesClient.Get.
-type integrationRuntimesClientGetResult struct {
-	IntegrationRuntimeResource
 }
 
 // integrationRuntimesClientListResponse contains the response from method integrationRuntimesClient.List.
 type integrationRuntimesClientListResponse struct {
-	integrationRuntimesClientListResult
+	IntegrationRuntimeListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// integrationRuntimesClientListResult contains the result from method integrationRuntimesClient.List.
-type integrationRuntimesClientListResult struct {
-	IntegrationRuntimeListResponse
 }
 
 // libraryClientAppendResponse contains the response from method libraryClient.Append.
@@ -573,14 +503,9 @@ func (l *libraryClientCreatePollerResponse) Resume(ctx context.Context, client *
 
 // libraryClientCreateResponse contains the response from method libraryClient.Create.
 type libraryClientCreateResponse struct {
-	libraryClientCreateResult
+	LibraryResourceInfo
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// libraryClientCreateResult contains the result from method libraryClient.Create.
-type libraryClientCreateResult struct {
-	LibraryResourceInfo
 }
 
 // libraryClientDeletePollerResponse contains the response from method libraryClient.Delete.
@@ -624,14 +549,9 @@ func (l *libraryClientDeletePollerResponse) Resume(ctx context.Context, client *
 
 // libraryClientDeleteResponse contains the response from method libraryClient.Delete.
 type libraryClientDeleteResponse struct {
-	libraryClientDeleteResult
+	LibraryResourceInfo
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// libraryClientDeleteResult contains the result from method libraryClient.Delete.
-type libraryClientDeleteResult struct {
-	LibraryResourceInfo
 }
 
 // libraryClientFlushPollerResponse contains the response from method libraryClient.Flush.
@@ -675,14 +595,9 @@ func (l *libraryClientFlushPollerResponse) Resume(ctx context.Context, client *l
 
 // libraryClientFlushResponse contains the response from method libraryClient.Flush.
 type libraryClientFlushResponse struct {
-	libraryClientFlushResult
+	LibraryResourceInfo
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// libraryClientFlushResult contains the result from method libraryClient.Flush.
-type libraryClientFlushResult struct {
-	LibraryResourceInfo
 }
 
 // libraryClientGetOperationResultResponse contains the response from method libraryClient.GetOperationResult.
@@ -696,26 +611,16 @@ type libraryClientGetOperationResultResponse struct {
 
 // libraryClientGetResponse contains the response from method libraryClient.Get.
 type libraryClientGetResponse struct {
-	libraryClientGetResult
+	LibraryResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// libraryClientGetResult contains the result from method libraryClient.Get.
-type libraryClientGetResult struct {
-	LibraryResource
 }
 
 // libraryClientListResponse contains the response from method libraryClient.List.
 type libraryClientListResponse struct {
-	libraryClientListResult
+	LibraryListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// libraryClientListResult contains the result from method libraryClient.List.
-type libraryClientListResult struct {
-	LibraryListResponse
 }
 
 // linkedServiceClientCreateOrUpdateLinkedServicePollerResponse contains the response from method linkedServiceClient.CreateOrUpdateLinkedService.
@@ -759,14 +664,9 @@ func (l *linkedServiceClientCreateOrUpdateLinkedServicePollerResponse) Resume(ct
 
 // linkedServiceClientCreateOrUpdateLinkedServiceResponse contains the response from method linkedServiceClient.CreateOrUpdateLinkedService.
 type linkedServiceClientCreateOrUpdateLinkedServiceResponse struct {
-	linkedServiceClientCreateOrUpdateLinkedServiceResult
+	LinkedServiceResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// linkedServiceClientCreateOrUpdateLinkedServiceResult contains the result from method linkedServiceClient.CreateOrUpdateLinkedService.
-type linkedServiceClientCreateOrUpdateLinkedServiceResult struct {
-	LinkedServiceResource
 }
 
 // linkedServiceClientDeleteLinkedServicePollerResponse contains the response from method linkedServiceClient.DeleteLinkedService.
@@ -816,26 +716,16 @@ type linkedServiceClientDeleteLinkedServiceResponse struct {
 
 // linkedServiceClientGetLinkedServiceResponse contains the response from method linkedServiceClient.GetLinkedService.
 type linkedServiceClientGetLinkedServiceResponse struct {
-	linkedServiceClientGetLinkedServiceResult
+	LinkedServiceResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// linkedServiceClientGetLinkedServiceResult contains the result from method linkedServiceClient.GetLinkedService.
-type linkedServiceClientGetLinkedServiceResult struct {
-	LinkedServiceResource
 }
 
 // linkedServiceClientGetLinkedServicesByWorkspaceResponse contains the response from method linkedServiceClient.GetLinkedServicesByWorkspace.
 type linkedServiceClientGetLinkedServicesByWorkspaceResponse struct {
-	linkedServiceClientGetLinkedServicesByWorkspaceResult
+	LinkedServiceListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// linkedServiceClientGetLinkedServicesByWorkspaceResult contains the result from method linkedServiceClient.GetLinkedServicesByWorkspace.
-type linkedServiceClientGetLinkedServicesByWorkspaceResult struct {
-	LinkedServiceListResponse
 }
 
 // linkedServiceClientRenameLinkedServicePollerResponse contains the response from method linkedServiceClient.RenameLinkedService.
@@ -924,14 +814,9 @@ func (l *notebookClientCreateOrUpdateNotebookPollerResponse) Resume(ctx context.
 
 // notebookClientCreateOrUpdateNotebookResponse contains the response from method notebookClient.CreateOrUpdateNotebook.
 type notebookClientCreateOrUpdateNotebookResponse struct {
-	notebookClientCreateOrUpdateNotebookResult
+	NotebookResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// notebookClientCreateOrUpdateNotebookResult contains the result from method notebookClient.CreateOrUpdateNotebook.
-type notebookClientCreateOrUpdateNotebookResult struct {
-	NotebookResource
 }
 
 // notebookClientDeleteNotebookPollerResponse contains the response from method notebookClient.DeleteNotebook.
@@ -981,38 +866,23 @@ type notebookClientDeleteNotebookResponse struct {
 
 // notebookClientGetNotebookResponse contains the response from method notebookClient.GetNotebook.
 type notebookClientGetNotebookResponse struct {
-	notebookClientGetNotebookResult
+	NotebookResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// notebookClientGetNotebookResult contains the result from method notebookClient.GetNotebook.
-type notebookClientGetNotebookResult struct {
-	NotebookResource
 }
 
 // notebookClientGetNotebookSummaryByWorkSpaceResponse contains the response from method notebookClient.GetNotebookSummaryByWorkSpace.
 type notebookClientGetNotebookSummaryByWorkSpaceResponse struct {
-	notebookClientGetNotebookSummaryByWorkSpaceResult
+	NotebookListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// notebookClientGetNotebookSummaryByWorkSpaceResult contains the result from method notebookClient.GetNotebookSummaryByWorkSpace.
-type notebookClientGetNotebookSummaryByWorkSpaceResult struct {
-	NotebookListResponse
 }
 
 // notebookClientGetNotebooksByWorkspaceResponse contains the response from method notebookClient.GetNotebooksByWorkspace.
 type notebookClientGetNotebooksByWorkspaceResponse struct {
-	notebookClientGetNotebooksByWorkspaceResult
+	NotebookListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// notebookClientGetNotebooksByWorkspaceResult contains the result from method notebookClient.GetNotebooksByWorkspace.
-type notebookClientGetNotebooksByWorkspaceResult struct {
-	NotebookListResponse
 }
 
 // notebookClientRenameNotebookPollerResponse contains the response from method notebookClient.RenameNotebook.
@@ -1101,26 +971,16 @@ func (l *pipelineClientCreateOrUpdatePipelinePollerResponse) Resume(ctx context.
 
 // pipelineClientCreateOrUpdatePipelineResponse contains the response from method pipelineClient.CreateOrUpdatePipeline.
 type pipelineClientCreateOrUpdatePipelineResponse struct {
-	pipelineClientCreateOrUpdatePipelineResult
+	PipelineResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// pipelineClientCreateOrUpdatePipelineResult contains the result from method pipelineClient.CreateOrUpdatePipeline.
-type pipelineClientCreateOrUpdatePipelineResult struct {
-	PipelineResource
 }
 
 // pipelineClientCreatePipelineRunResponse contains the response from method pipelineClient.CreatePipelineRun.
 type pipelineClientCreatePipelineRunResponse struct {
-	pipelineClientCreatePipelineRunResult
+	CreateRunResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// pipelineClientCreatePipelineRunResult contains the result from method pipelineClient.CreatePipelineRun.
-type pipelineClientCreatePipelineRunResult struct {
-	CreateRunResponse
 }
 
 // pipelineClientDeletePipelinePollerResponse contains the response from method pipelineClient.DeletePipeline.
@@ -1170,26 +1030,16 @@ type pipelineClientDeletePipelineResponse struct {
 
 // pipelineClientGetPipelineResponse contains the response from method pipelineClient.GetPipeline.
 type pipelineClientGetPipelineResponse struct {
-	pipelineClientGetPipelineResult
+	PipelineResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// pipelineClientGetPipelineResult contains the result from method pipelineClient.GetPipeline.
-type pipelineClientGetPipelineResult struct {
-	PipelineResource
 }
 
 // pipelineClientGetPipelinesByWorkspaceResponse contains the response from method pipelineClient.GetPipelinesByWorkspace.
 type pipelineClientGetPipelinesByWorkspaceResponse struct {
-	pipelineClientGetPipelinesByWorkspaceResult
+	PipelineListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// pipelineClientGetPipelinesByWorkspaceResult contains the result from method pipelineClient.GetPipelinesByWorkspace.
-type pipelineClientGetPipelinesByWorkspaceResult struct {
-	PipelineListResponse
 }
 
 // pipelineClientRenamePipelinePollerResponse contains the response from method pipelineClient.RenamePipeline.
@@ -1245,38 +1095,23 @@ type pipelineRunClientCancelPipelineRunResponse struct {
 
 // pipelineRunClientGetPipelineRunResponse contains the response from method pipelineRunClient.GetPipelineRun.
 type pipelineRunClientGetPipelineRunResponse struct {
-	pipelineRunClientGetPipelineRunResult
+	PipelineRun
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// pipelineRunClientGetPipelineRunResult contains the result from method pipelineRunClient.GetPipelineRun.
-type pipelineRunClientGetPipelineRunResult struct {
-	PipelineRun
 }
 
 // pipelineRunClientQueryActivityRunsResponse contains the response from method pipelineRunClient.QueryActivityRuns.
 type pipelineRunClientQueryActivityRunsResponse struct {
-	pipelineRunClientQueryActivityRunsResult
+	ActivityRunsQueryResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// pipelineRunClientQueryActivityRunsResult contains the result from method pipelineRunClient.QueryActivityRuns.
-type pipelineRunClientQueryActivityRunsResult struct {
-	ActivityRunsQueryResponse
 }
 
 // pipelineRunClientQueryPipelineRunsByWorkspaceResponse contains the response from method pipelineRunClient.QueryPipelineRunsByWorkspace.
 type pipelineRunClientQueryPipelineRunsByWorkspaceResponse struct {
-	pipelineRunClientQueryPipelineRunsByWorkspaceResult
+	PipelineRunsQueryResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// pipelineRunClientQueryPipelineRunsByWorkspaceResult contains the result from method pipelineRunClient.QueryPipelineRunsByWorkspace.
-type pipelineRunClientQueryPipelineRunsByWorkspaceResult struct {
-	PipelineRunsQueryResponse
 }
 
 // sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition.
@@ -1321,14 +1156,9 @@ func (l *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse)
 
 // sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition.
 type sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse struct {
-	sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResult
+	SparkJobDefinitionResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResult contains the result from method sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition.
-type sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResult struct {
-	SparkJobDefinitionResource
 }
 
 // sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.DebugSparkJobDefinition.
@@ -1372,14 +1202,9 @@ func (l *sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse) Resume(c
 
 // sparkJobDefinitionClientDebugSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.DebugSparkJobDefinition.
 type sparkJobDefinitionClientDebugSparkJobDefinitionResponse struct {
-	sparkJobDefinitionClientDebugSparkJobDefinitionResult
+	SparkBatchJob
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sparkJobDefinitionClientDebugSparkJobDefinitionResult contains the result from method sparkJobDefinitionClient.DebugSparkJobDefinition.
-type sparkJobDefinitionClientDebugSparkJobDefinitionResult struct {
-	SparkBatchJob
 }
 
 // sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.DeleteSparkJobDefinition.
@@ -1470,38 +1295,23 @@ func (l *sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse) Resume
 
 // sparkJobDefinitionClientExecuteSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.ExecuteSparkJobDefinition.
 type sparkJobDefinitionClientExecuteSparkJobDefinitionResponse struct {
-	sparkJobDefinitionClientExecuteSparkJobDefinitionResult
+	SparkBatchJob
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sparkJobDefinitionClientExecuteSparkJobDefinitionResult contains the result from method sparkJobDefinitionClient.ExecuteSparkJobDefinition.
-type sparkJobDefinitionClientExecuteSparkJobDefinitionResult struct {
-	SparkBatchJob
 }
 
 // sparkJobDefinitionClientGetSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.GetSparkJobDefinition.
 type sparkJobDefinitionClientGetSparkJobDefinitionResponse struct {
-	sparkJobDefinitionClientGetSparkJobDefinitionResult
+	SparkJobDefinitionResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sparkJobDefinitionClientGetSparkJobDefinitionResult contains the result from method sparkJobDefinitionClient.GetSparkJobDefinition.
-type sparkJobDefinitionClientGetSparkJobDefinitionResult struct {
-	SparkJobDefinitionResource
 }
 
 // sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse contains the response from method sparkJobDefinitionClient.GetSparkJobDefinitionsByWorkspace.
 type sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse struct {
-	sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResult
+	SparkJobDefinitionsListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResult contains the result from method sparkJobDefinitionClient.GetSparkJobDefinitionsByWorkspace.
-type sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResult struct {
-	SparkJobDefinitionsListResponse
 }
 
 // sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.RenameSparkJobDefinition.
@@ -1552,26 +1362,16 @@ type sparkJobDefinitionClientRenameSparkJobDefinitionResponse struct {
 
 // sqlPoolsClientGetResponse contains the response from method sqlPoolsClient.Get.
 type sqlPoolsClientGetResponse struct {
-	sqlPoolsClientGetResult
+	SQLPool
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sqlPoolsClientGetResult contains the result from method sqlPoolsClient.Get.
-type sqlPoolsClientGetResult struct {
-	SQLPool
 }
 
 // sqlPoolsClientListResponse contains the response from method sqlPoolsClient.List.
 type sqlPoolsClientListResponse struct {
-	sqlPoolsClientListResult
+	SQLPoolInfoListResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sqlPoolsClientListResult contains the result from method sqlPoolsClient.List.
-type sqlPoolsClientListResult struct {
-	SQLPoolInfoListResult
 }
 
 // sqlScriptClientCreateOrUpdateSQLScriptPollerResponse contains the response from method sqlScriptClient.CreateOrUpdateSQLScript.
@@ -1615,14 +1415,9 @@ func (l *sqlScriptClientCreateOrUpdateSQLScriptPollerResponse) Resume(ctx contex
 
 // sqlScriptClientCreateOrUpdateSQLScriptResponse contains the response from method sqlScriptClient.CreateOrUpdateSQLScript.
 type sqlScriptClientCreateOrUpdateSQLScriptResponse struct {
-	sqlScriptClientCreateOrUpdateSQLScriptResult
+	SQLScriptResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sqlScriptClientCreateOrUpdateSQLScriptResult contains the result from method sqlScriptClient.CreateOrUpdateSQLScript.
-type sqlScriptClientCreateOrUpdateSQLScriptResult struct {
-	SQLScriptResource
 }
 
 // sqlScriptClientDeleteSQLScriptPollerResponse contains the response from method sqlScriptClient.DeleteSQLScript.
@@ -1672,26 +1467,16 @@ type sqlScriptClientDeleteSQLScriptResponse struct {
 
 // sqlScriptClientGetSQLScriptResponse contains the response from method sqlScriptClient.GetSQLScript.
 type sqlScriptClientGetSQLScriptResponse struct {
-	sqlScriptClientGetSQLScriptResult
+	SQLScriptResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sqlScriptClientGetSQLScriptResult contains the result from method sqlScriptClient.GetSQLScript.
-type sqlScriptClientGetSQLScriptResult struct {
-	SQLScriptResource
 }
 
 // sqlScriptClientGetSQLScriptsByWorkspaceResponse contains the response from method sqlScriptClient.GetSQLScriptsByWorkspace.
 type sqlScriptClientGetSQLScriptsByWorkspaceResponse struct {
-	sqlScriptClientGetSQLScriptsByWorkspaceResult
+	SQLScriptsListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sqlScriptClientGetSQLScriptsByWorkspaceResult contains the result from method sqlScriptClient.GetSQLScriptsByWorkspace.
-type sqlScriptClientGetSQLScriptsByWorkspaceResult struct {
-	SQLScriptsListResponse
 }
 
 // sqlScriptClientRenameSQLScriptPollerResponse contains the response from method sqlScriptClient.RenameSQLScript.
@@ -1780,14 +1565,9 @@ func (l *triggerClientCreateOrUpdateTriggerPollerResponse) Resume(ctx context.Co
 
 // triggerClientCreateOrUpdateTriggerResponse contains the response from method triggerClient.CreateOrUpdateTrigger.
 type triggerClientCreateOrUpdateTriggerResponse struct {
-	triggerClientCreateOrUpdateTriggerResult
+	TriggerResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// triggerClientCreateOrUpdateTriggerResult contains the result from method triggerClient.CreateOrUpdateTrigger.
-type triggerClientCreateOrUpdateTriggerResult struct {
-	TriggerResource
 }
 
 // triggerClientDeleteTriggerPollerResponse contains the response from method triggerClient.DeleteTrigger.
@@ -1837,38 +1617,23 @@ type triggerClientDeleteTriggerResponse struct {
 
 // triggerClientGetEventSubscriptionStatusResponse contains the response from method triggerClient.GetEventSubscriptionStatus.
 type triggerClientGetEventSubscriptionStatusResponse struct {
-	triggerClientGetEventSubscriptionStatusResult
+	TriggerSubscriptionOperationStatus
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// triggerClientGetEventSubscriptionStatusResult contains the result from method triggerClient.GetEventSubscriptionStatus.
-type triggerClientGetEventSubscriptionStatusResult struct {
-	TriggerSubscriptionOperationStatus
 }
 
 // triggerClientGetTriggerResponse contains the response from method triggerClient.GetTrigger.
 type triggerClientGetTriggerResponse struct {
-	triggerClientGetTriggerResult
+	TriggerResource
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// triggerClientGetTriggerResult contains the result from method triggerClient.GetTrigger.
-type triggerClientGetTriggerResult struct {
-	TriggerResource
 }
 
 // triggerClientGetTriggersByWorkspaceResponse contains the response from method triggerClient.GetTriggersByWorkspace.
 type triggerClientGetTriggersByWorkspaceResponse struct {
-	triggerClientGetTriggersByWorkspaceResult
+	TriggerListResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// triggerClientGetTriggersByWorkspaceResult contains the result from method triggerClient.GetTriggersByWorkspace.
-type triggerClientGetTriggersByWorkspaceResult struct {
-	TriggerListResponse
 }
 
 // triggerClientStartTriggerPollerResponse contains the response from method triggerClient.StartTrigger.
@@ -2002,14 +1767,9 @@ func (l *triggerClientSubscribeTriggerToEventsPollerResponse) Resume(ctx context
 
 // triggerClientSubscribeTriggerToEventsResponse contains the response from method triggerClient.SubscribeTriggerToEvents.
 type triggerClientSubscribeTriggerToEventsResponse struct {
-	triggerClientSubscribeTriggerToEventsResult
+	TriggerSubscriptionOperationStatus
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// triggerClientSubscribeTriggerToEventsResult contains the result from method triggerClient.SubscribeTriggerToEvents.
-type triggerClientSubscribeTriggerToEventsResult struct {
-	TriggerSubscriptionOperationStatus
 }
 
 // triggerClientUnsubscribeTriggerFromEventsPollerResponse contains the response from method triggerClient.UnsubscribeTriggerFromEvents.
@@ -2053,14 +1813,9 @@ func (l *triggerClientUnsubscribeTriggerFromEventsPollerResponse) Resume(ctx con
 
 // triggerClientUnsubscribeTriggerFromEventsResponse contains the response from method triggerClient.UnsubscribeTriggerFromEvents.
 type triggerClientUnsubscribeTriggerFromEventsResponse struct {
-	triggerClientUnsubscribeTriggerFromEventsResult
+	TriggerSubscriptionOperationStatus
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// triggerClientUnsubscribeTriggerFromEventsResult contains the result from method triggerClient.UnsubscribeTriggerFromEvents.
-type triggerClientUnsubscribeTriggerFromEventsResult struct {
-	TriggerSubscriptionOperationStatus
 }
 
 // triggerRunClientCancelTriggerInstanceResponse contains the response from method triggerRunClient.CancelTriggerInstance.
@@ -2071,14 +1826,9 @@ type triggerRunClientCancelTriggerInstanceResponse struct {
 
 // triggerRunClientQueryTriggerRunsByWorkspaceResponse contains the response from method triggerRunClient.QueryTriggerRunsByWorkspace.
 type triggerRunClientQueryTriggerRunsByWorkspaceResponse struct {
-	triggerRunClientQueryTriggerRunsByWorkspaceResult
+	TriggerRunsQueryResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// triggerRunClientQueryTriggerRunsByWorkspaceResult contains the result from method triggerRunClient.QueryTriggerRunsByWorkspace.
-type triggerRunClientQueryTriggerRunsByWorkspaceResult struct {
-	TriggerRunsQueryResponse
 }
 
 // triggerRunClientRerunTriggerInstanceResponse contains the response from method triggerRunClient.RerunTriggerInstance.
@@ -2089,24 +1839,14 @@ type triggerRunClientRerunTriggerInstanceResponse struct {
 
 // workspaceClientGetResponse contains the response from method workspaceClient.Get.
 type workspaceClientGetResponse struct {
-	workspaceClientGetResult
+	Workspace
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// workspaceClientGetResult contains the result from method workspaceClient.Get.
-type workspaceClientGetResult struct {
-	Workspace
 }
 
 // workspaceGitRepoManagementClientGetGitHubAccessTokenResponse contains the response from method workspaceGitRepoManagementClient.GetGitHubAccessToken.
 type workspaceGitRepoManagementClientGetGitHubAccessTokenResponse struct {
-	workspaceGitRepoManagementClientGetGitHubAccessTokenResult
+	GitHubAccessTokenResponse
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// workspaceGitRepoManagementClientGetGitHubAccessTokenResult contains the result from method workspaceGitRepoManagementClient.GetGitHubAccessToken.
-type workspaceGitRepoManagementClientGetGitHubAccessTokenResult struct {
-	GitHubAccessTokenResponse
 }

--- a/test/synapse/2019-06-01/azspark/zz_generated_response_types.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_response_types.go
@@ -18,38 +18,23 @@ type batchClientCancelSparkBatchJobResponse struct {
 
 // batchClientCreateSparkBatchJobResponse contains the response from method batchClient.CreateSparkBatchJob.
 type batchClientCreateSparkBatchJobResponse struct {
-	batchClientCreateSparkBatchJobResult
+	BatchJob
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// batchClientCreateSparkBatchJobResult contains the result from method batchClient.CreateSparkBatchJob.
-type batchClientCreateSparkBatchJobResult struct {
-	BatchJob
 }
 
 // batchClientGetSparkBatchJobResponse contains the response from method batchClient.GetSparkBatchJob.
 type batchClientGetSparkBatchJobResponse struct {
-	batchClientGetSparkBatchJobResult
+	BatchJob
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// batchClientGetSparkBatchJobResult contains the result from method batchClient.GetSparkBatchJob.
-type batchClientGetSparkBatchJobResult struct {
-	BatchJob
 }
 
 // batchClientGetSparkBatchJobsResponse contains the response from method batchClient.GetSparkBatchJobs.
 type batchClientGetSparkBatchJobsResponse struct {
-	batchClientGetSparkBatchJobsResult
+	BatchJobCollection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// batchClientGetSparkBatchJobsResult contains the result from method batchClient.GetSparkBatchJobs.
-type batchClientGetSparkBatchJobsResult struct {
-	BatchJobCollection
 }
 
 // sessionClientCancelSparkSessionResponse contains the response from method sessionClient.CancelSparkSession.
@@ -60,86 +45,51 @@ type sessionClientCancelSparkSessionResponse struct {
 
 // sessionClientCancelSparkStatementResponse contains the response from method sessionClient.CancelSparkStatement.
 type sessionClientCancelSparkStatementResponse struct {
-	sessionClientCancelSparkStatementResult
+	StatementCancellationResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sessionClientCancelSparkStatementResult contains the result from method sessionClient.CancelSparkStatement.
-type sessionClientCancelSparkStatementResult struct {
-	StatementCancellationResult
 }
 
 // sessionClientCreateSparkSessionResponse contains the response from method sessionClient.CreateSparkSession.
 type sessionClientCreateSparkSessionResponse struct {
-	sessionClientCreateSparkSessionResult
+	Session
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sessionClientCreateSparkSessionResult contains the result from method sessionClient.CreateSparkSession.
-type sessionClientCreateSparkSessionResult struct {
-	Session
 }
 
 // sessionClientCreateSparkStatementResponse contains the response from method sessionClient.CreateSparkStatement.
 type sessionClientCreateSparkStatementResponse struct {
-	sessionClientCreateSparkStatementResult
+	Statement
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sessionClientCreateSparkStatementResult contains the result from method sessionClient.CreateSparkStatement.
-type sessionClientCreateSparkStatementResult struct {
-	Statement
 }
 
 // sessionClientGetSparkSessionResponse contains the response from method sessionClient.GetSparkSession.
 type sessionClientGetSparkSessionResponse struct {
-	sessionClientGetSparkSessionResult
+	Session
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sessionClientGetSparkSessionResult contains the result from method sessionClient.GetSparkSession.
-type sessionClientGetSparkSessionResult struct {
-	Session
 }
 
 // sessionClientGetSparkSessionsResponse contains the response from method sessionClient.GetSparkSessions.
 type sessionClientGetSparkSessionsResponse struct {
-	sessionClientGetSparkSessionsResult
+	SessionCollection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sessionClientGetSparkSessionsResult contains the result from method sessionClient.GetSparkSessions.
-type sessionClientGetSparkSessionsResult struct {
-	SessionCollection
 }
 
 // sessionClientGetSparkStatementResponse contains the response from method sessionClient.GetSparkStatement.
 type sessionClientGetSparkStatementResponse struct {
-	sessionClientGetSparkStatementResult
+	Statement
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sessionClientGetSparkStatementResult contains the result from method sessionClient.GetSparkStatement.
-type sessionClientGetSparkStatementResult struct {
-	Statement
 }
 
 // sessionClientGetSparkStatementsResponse contains the response from method sessionClient.GetSparkStatements.
 type sessionClientGetSparkStatementsResponse struct {
-	sessionClientGetSparkStatementsResult
+	StatementCollection
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-}
-
-// sessionClientGetSparkStatementsResult contains the result from method sessionClient.GetSparkStatements.
-type sessionClientGetSparkStatementsResult struct {
-	StatementCollection
 }
 
 // sessionClientResetSparkSessionTimeoutResponse contains the response from method sessionClient.ResetSparkSessionTimeout.

--- a/test/tables/2019-02-02/aztables/zz_generated_response_types.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_response_types.go
@@ -15,13 +15,6 @@ import (
 
 // ClientCreateResponse contains the response from method Client.Create.
 type ClientCreateResponse struct {
-	ClientCreateResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientCreateResult contains the result from method Client.Create.
-type ClientCreateResult struct {
 	Response
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -32,6 +25,9 @@ type ClientCreateResult struct {
 	// PreferenceApplied contains the information returned from the Preference-Applied header response.
 	PreferenceApplied *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -41,18 +37,14 @@ type ClientCreateResult struct {
 
 // ClientDeleteEntityResponse contains the response from method Client.DeleteEntity.
 type ClientDeleteEntityResponse struct {
-	ClientDeleteEntityResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientDeleteEntityResult contains the result from method Client.DeleteEntity.
-type ClientDeleteEntityResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -63,18 +55,14 @@ type ClientDeleteEntityResult struct {
 
 // ClientDeleteResponse contains the response from method Client.Delete.
 type ClientDeleteResponse struct {
-	ClientDeleteResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientDeleteResult contains the result from method Client.Delete.
-type ClientDeleteResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -85,18 +73,14 @@ type ClientDeleteResult struct {
 
 // ClientGetAccessPolicyResponse contains the response from method Client.GetAccessPolicy.
 type ClientGetAccessPolicyResponse struct {
-	ClientGetAccessPolicyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientGetAccessPolicyResult contains the result from method Client.GetAccessPolicy.
-type ClientGetAccessPolicyResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -110,13 +94,6 @@ type ClientGetAccessPolicyResult struct {
 
 // ClientInsertEntityResponse contains the response from method Client.InsertEntity.
 type ClientInsertEntityResponse struct {
-	ClientInsertEntityResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientInsertEntityResult contains the result from method Client.InsertEntity.
-type ClientInsertEntityResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -132,6 +109,9 @@ type ClientInsertEntityResult struct {
 	// PreferenceApplied contains the information returned from the Preference-Applied header response.
 	PreferenceApplied *string
 
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -144,13 +124,6 @@ type ClientInsertEntityResult struct {
 
 // ClientMergeEntityResponse contains the response from method Client.MergeEntity.
 type ClientMergeEntityResponse struct {
-	ClientMergeEntityResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientMergeEntityResult contains the result from method Client.MergeEntity.
-type ClientMergeEntityResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -159,6 +132,9 @@ type ClientMergeEntityResult struct {
 
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -169,19 +145,15 @@ type ClientMergeEntityResult struct {
 
 // ClientQueryEntitiesResponse contains the response from method Client.QueryEntities.
 type ClientQueryEntitiesResponse struct {
-	ClientQueryEntitiesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientQueryEntitiesResult contains the result from method Client.QueryEntities.
-type ClientQueryEntitiesResult struct {
 	EntityQueryResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -198,13 +170,6 @@ type ClientQueryEntitiesResult struct {
 
 // ClientQueryEntityWithPartitionAndRowKeyResponse contains the response from method Client.QueryEntityWithPartitionAndRowKey.
 type ClientQueryEntityWithPartitionAndRowKeyResponse struct {
-	ClientQueryEntityWithPartitionAndRowKeyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientQueryEntityWithPartitionAndRowKeyResult contains the result from method Client.QueryEntityWithPartitionAndRowKey.
-type ClientQueryEntityWithPartitionAndRowKeyResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -213,6 +178,9 @@ type ClientQueryEntityWithPartitionAndRowKeyResult struct {
 
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -232,19 +200,15 @@ type ClientQueryEntityWithPartitionAndRowKeyResult struct {
 
 // ClientQueryResponse contains the response from method Client.Query.
 type ClientQueryResponse struct {
-	ClientQueryResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientQueryResult contains the result from method Client.Query.
-type ClientQueryResult struct {
 	QueryResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -258,18 +222,14 @@ type ClientQueryResult struct {
 
 // ClientSetAccessPolicyResponse contains the response from method Client.SetAccessPolicy.
 type ClientSetAccessPolicyResponse struct {
-	ClientSetAccessPolicyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientSetAccessPolicyResult contains the result from method Client.SetAccessPolicy.
-type ClientSetAccessPolicyResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -280,13 +240,6 @@ type ClientSetAccessPolicyResult struct {
 
 // ClientUpdateEntityResponse contains the response from method Client.UpdateEntity.
 type ClientUpdateEntityResponse struct {
-	ClientUpdateEntityResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ClientUpdateEntityResult contains the result from method Client.UpdateEntity.
-type ClientUpdateEntityResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -295,6 +248,9 @@ type ClientUpdateEntityResult struct {
 
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -305,16 +261,12 @@ type ClientUpdateEntityResult struct {
 
 // ServiceClientGetPropertiesResponse contains the response from method ServiceClient.GetProperties.
 type ServiceClientGetPropertiesResponse struct {
-	ServiceClientGetPropertiesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ServiceClientGetPropertiesResult contains the result from method ServiceClient.GetProperties.
-type ServiceClientGetPropertiesResult struct {
 	ServiceProperties
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -325,19 +277,15 @@ type ServiceClientGetPropertiesResult struct {
 
 // ServiceClientGetStatisticsResponse contains the response from method ServiceClient.GetStatistics.
 type ServiceClientGetStatisticsResponse struct {
-	ServiceClientGetStatisticsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ServiceClientGetStatisticsResult contains the result from method ServiceClient.GetStatistics.
-type ServiceClientGetStatisticsResult struct {
 	ServiceStats
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -348,15 +296,11 @@ type ServiceClientGetStatisticsResult struct {
 
 // ServiceClientSetPropertiesResponse contains the response from method ServiceClient.SetProperties.
 type ServiceClientSetPropertiesResponse struct {
-	ServiceClientSetPropertiesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// ServiceClientSetPropertiesResult contains the result from method ServiceClient.SetProperties.
-type ServiceClientSetPropertiesResult struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string


### PR DESCRIPTION
Due to inability to anonymously embed a generic type parameter, we will
continue to generate API-specific response types.
The result types have been removed, their fields promoted to their
matching response types.