### PR TITLE
Remove *http.Response from response envelopes

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ArraySchema, DictionarySchema, ObjectSchema, Operation, Parameter, Response, Schema, SchemaResponse, SchemaType } from '@autorest/codemodel';
+import { ArraySchema, BinaryResponse, DictionarySchema, ObjectSchema, Operation, Parameter, Response, Schema, SchemaResponse, SchemaType } from '@autorest/codemodel';
 import { values } from '@azure-tools/linq';
 
 // variable to be used to determine comment length when calling comment from @azure-tools
@@ -39,6 +39,11 @@ export function isDictionarySchema(resp: Schema): resp is DictionarySchema {
 // returns SchemaResponse type predicate if the response has a schema
 export function isSchemaResponse(resp: Response): resp is SchemaResponse {
   return (resp as SchemaResponse).schema !== undefined;
+}
+
+// returns BinaryResponse type predicate if the response is a binary response
+export function isBinaryResponse(resp: Response): resp is BinaryResponse {
+  return (resp as BinaryResponse).binary !== undefined;
 }
 
 export interface PagerInfo {
@@ -159,6 +164,20 @@ export function isMultiRespOperation(op: Operation): boolean {
     }
   }
   return schemaResponses.length > 1;
+}
+
+// returns the BinaryResponse if the operation returns a binary response or undefined.
+// throws an error if called on a multi-response operation.
+export function isBinaryResponseOperation(op: Operation): BinaryResponse | undefined {
+  if (!op.responses) {
+    return undefined;
+  } else if (isMultiRespOperation(op)) {
+    throw new Error('isBinaryResponseOperation() called for multi-response operation');
+  }
+  if (isBinaryResponse(op.responses[0])) {
+    return op.responses[0];
+  }
+  return undefined;
 }
 
 // returns true if the type is implicitly passed by value (map, slice, etc)

--- a/src/generator/pollers.ts
+++ b/src/generator/pollers.ts
@@ -82,13 +82,12 @@ function finalResp(poller: PollerInfo): string {
     const resultProp = <Property>finalRespEnv.language.go!.resultProp;
     text += `\trespType := ${finalRespEnv.language.go!.name}{}\n`;
     if (resultProp) {
-      text += `\tresp, err := p.pt.FinalResponse(ctx, &respType${discriminatorFinalResponse(finalRespEnv)})\n`;
+      text += `\t_, err := p.pt.FinalResponse(ctx, &respType${discriminatorFinalResponse(finalRespEnv)})\n`;
     } else {
       // the operation doesn't return a model
-      text += `\tresp, err := p.pt.FinalResponse(ctx, nil)\n`;
+      text += `\t_, err := p.pt.FinalResponse(ctx, nil)\n`;
     }
     text += `\tif err != nil {\n\t\treturn ${finalRespEnv.language.go!.name}{}, err\n\t}\n`;
-    text += '\trespType.RawResponse = resp\n';
     text += '\treturn respType, nil\n';
   }
   text += '}\n\n';

--- a/src/generator/structs.ts
+++ b/src/generator/structs.ts
@@ -60,6 +60,9 @@ export class StructDef {
     if (this.Properties === undefined && this.Parameters?.length === 0) {
       // this is an optional params placeholder struct
       text += '\t// placeholder for future optional parameters\n';
+    } else if (this.Properties === undefined && this.Parameters === undefined) {
+      // this is an empty response envelope
+      text += '\t// placeholder for future response values\n';
     }
     // group fields by required/optional/read-only in that order
     this.Properties?.sort((lhs: Property, rhs: Property): number => {
@@ -104,9 +107,9 @@ export class StructDef {
       }
       let tag = ` \`${this.Language.marshallingFormat}:"${serialization}"${readOnly}\``;
       // if this is a response type then omit the tag IFF the marshalling format is
-      // JSON, it's a header or is the RawResponse field.  XML marshalling needs a tag.
+      // JSON, or it's a header.  XML marshalling needs a tag.
       // also omit the tag for additionalProperties
-      if ((this.Language.responseType === true && (this.Language.marshallingFormat !== 'xml' || prop.language.go!.name === 'RawResponse')) || prop.language.go!.isAdditionalProperties) {
+      if ((this.Language.responseType === true && (this.Language.marshallingFormat !== 'xml')) || prop.language.go!.isAdditionalProperties) {
         tag = '';
       }
       let pointer = '*';

--- a/test/autorest/additionalpropsgroup/zz_generated_pets_client.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets_client.go
@@ -66,7 +66,7 @@ func (client *PetsClient) createAPInPropertiesCreateRequest(ctx context.Context,
 
 // createAPInPropertiesHandleResponse handles the CreateAPInProperties response.
 func (client *PetsClient) createAPInPropertiesHandleResponse(resp *http.Response) (PetsClientCreateAPInPropertiesResponse, error) {
-	result := PetsClientCreateAPInPropertiesResponse{RawResponse: resp}
+	result := PetsClientCreateAPInPropertiesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPInProperties); err != nil {
 		return PetsClientCreateAPInPropertiesResponse{}, err
 	}
@@ -105,7 +105,7 @@ func (client *PetsClient) createAPInPropertiesWithAPStringCreateRequest(ctx cont
 
 // createAPInPropertiesWithAPStringHandleResponse handles the CreateAPInPropertiesWithAPString response.
 func (client *PetsClient) createAPInPropertiesWithAPStringHandleResponse(resp *http.Response) (PetsClientCreateAPInPropertiesWithAPStringResponse, error) {
-	result := PetsClientCreateAPInPropertiesWithAPStringResponse{RawResponse: resp}
+	result := PetsClientCreateAPInPropertiesWithAPStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPInPropertiesWithAPString); err != nil {
 		return PetsClientCreateAPInPropertiesWithAPStringResponse{}, err
 	}
@@ -143,7 +143,7 @@ func (client *PetsClient) createAPObjectCreateRequest(ctx context.Context, creat
 
 // createAPObjectHandleResponse handles the CreateAPObject response.
 func (client *PetsClient) createAPObjectHandleResponse(resp *http.Response) (PetsClientCreateAPObjectResponse, error) {
-	result := PetsClientCreateAPObjectResponse{RawResponse: resp}
+	result := PetsClientCreateAPObjectResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPObject); err != nil {
 		return PetsClientCreateAPObjectResponse{}, err
 	}
@@ -181,7 +181,7 @@ func (client *PetsClient) createAPStringCreateRequest(ctx context.Context, creat
 
 // createAPStringHandleResponse handles the CreateAPString response.
 func (client *PetsClient) createAPStringHandleResponse(resp *http.Response) (PetsClientCreateAPStringResponse, error) {
-	result := PetsClientCreateAPStringResponse{RawResponse: resp}
+	result := PetsClientCreateAPStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPString); err != nil {
 		return PetsClientCreateAPStringResponse{}, err
 	}
@@ -219,7 +219,7 @@ func (client *PetsClient) createAPTrueCreateRequest(ctx context.Context, createP
 
 // createAPTrueHandleResponse handles the CreateAPTrue response.
 func (client *PetsClient) createAPTrueHandleResponse(resp *http.Response) (PetsClientCreateAPTrueResponse, error) {
-	result := PetsClientCreateAPTrueResponse{RawResponse: resp}
+	result := PetsClientCreateAPTrueResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPTrue); err != nil {
 		return PetsClientCreateAPTrueResponse{}, err
 	}
@@ -257,7 +257,7 @@ func (client *PetsClient) createCatAPTrueCreateRequest(ctx context.Context, crea
 
 // createCatAPTrueHandleResponse handles the CreateCatAPTrue response.
 func (client *PetsClient) createCatAPTrueHandleResponse(resp *http.Response) (PetsClientCreateCatAPTrueResponse, error) {
-	result := PetsClientCreateCatAPTrueResponse{RawResponse: resp}
+	result := PetsClientCreateCatAPTrueResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CatAPTrue); err != nil {
 		return PetsClientCreateCatAPTrueResponse{}, err
 	}

--- a/test/autorest/additionalpropsgroup/zz_generated_response_types.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_response_types.go
@@ -8,46 +8,32 @@
 
 package additionalpropsgroup
 
-import "net/http"
-
 // PetsClientCreateAPInPropertiesResponse contains the response from method PetsClient.CreateAPInProperties.
 type PetsClientCreateAPInPropertiesResponse struct {
 	PetAPInProperties
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PetsClientCreateAPInPropertiesWithAPStringResponse contains the response from method PetsClient.CreateAPInPropertiesWithAPString.
 type PetsClientCreateAPInPropertiesWithAPStringResponse struct {
 	PetAPInPropertiesWithAPString
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PetsClientCreateAPObjectResponse contains the response from method PetsClient.CreateAPObject.
 type PetsClientCreateAPObjectResponse struct {
 	PetAPObject
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PetsClientCreateAPStringResponse contains the response from method PetsClient.CreateAPString.
 type PetsClientCreateAPStringResponse struct {
 	PetAPString
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PetsClientCreateAPTrueResponse contains the response from method PetsClient.CreateAPTrue.
 type PetsClientCreateAPTrueResponse struct {
 	PetAPTrue
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PetsClientCreateCatAPTrueResponse contains the response from method PetsClient.CreateCatAPTrue.
 type PetsClientCreateCatAPTrueResponse struct {
 	CatAPTrue
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -5,7 +5,6 @@ package arraygroup
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -764,8 +763,8 @@ func TestPutArrayValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -776,8 +775,8 @@ func TestPutBooleanTfft(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -792,8 +791,8 @@ func TestPutByteValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -808,8 +807,8 @@ func TestPutComplexValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -823,8 +822,8 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -838,8 +837,8 @@ func TestPutDateTimeValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -852,8 +851,8 @@ func TestPutDateValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -880,8 +879,8 @@ func TestPutDictionaryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -892,8 +891,8 @@ func TestPutDoubleValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -904,8 +903,8 @@ func TestPutDurationValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -916,8 +915,8 @@ func TestPutEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -929,8 +928,8 @@ func TestPutEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -941,8 +940,8 @@ func TestPutFloatValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -953,8 +952,8 @@ func TestPutIntegerValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -965,8 +964,8 @@ func TestPutLongValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -978,8 +977,8 @@ func TestPutStringEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -990,8 +989,8 @@ func TestPutStringValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -1002,7 +1001,7 @@ func TestPutUUIDValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/arraygroup/zz_generated_array_client.go
+++ b/test/autorest/arraygroup/zz_generated_array_client.go
@@ -66,7 +66,7 @@ func (client *ArrayClient) getArrayEmptyCreateRequest(ctx context.Context, optio
 
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *ArrayClient) getArrayEmptyHandleResponse(resp *http.Response) (ArrayClientGetArrayEmptyResponse, error) {
-	result := ArrayClientGetArrayEmptyResponse{RawResponse: resp}
+	result := ArrayClientGetArrayEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
 		return ArrayClientGetArrayEmptyResponse{}, err
 	}
@@ -104,7 +104,7 @@ func (client *ArrayClient) getArrayItemEmptyCreateRequest(ctx context.Context, o
 
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *ArrayClient) getArrayItemEmptyHandleResponse(resp *http.Response) (ArrayClientGetArrayItemEmptyResponse, error) {
-	result := ArrayClientGetArrayItemEmptyResponse{RawResponse: resp}
+	result := ArrayClientGetArrayItemEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
 		return ArrayClientGetArrayItemEmptyResponse{}, err
 	}
@@ -142,7 +142,7 @@ func (client *ArrayClient) getArrayItemNullCreateRequest(ctx context.Context, op
 
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *ArrayClient) getArrayItemNullHandleResponse(resp *http.Response) (ArrayClientGetArrayItemNullResponse, error) {
-	result := ArrayClientGetArrayItemNullResponse{RawResponse: resp}
+	result := ArrayClientGetArrayItemNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
 		return ArrayClientGetArrayItemNullResponse{}, err
 	}
@@ -180,7 +180,7 @@ func (client *ArrayClient) getArrayNullCreateRequest(ctx context.Context, option
 
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client *ArrayClient) getArrayNullHandleResponse(resp *http.Response) (ArrayClientGetArrayNullResponse, error) {
-	result := ArrayClientGetArrayNullResponse{RawResponse: resp}
+	result := ArrayClientGetArrayNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
 		return ArrayClientGetArrayNullResponse{}, err
 	}
@@ -218,7 +218,7 @@ func (client *ArrayClient) getArrayValidCreateRequest(ctx context.Context, optio
 
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client *ArrayClient) getArrayValidHandleResponse(resp *http.Response) (ArrayClientGetArrayValidResponse, error) {
-	result := ArrayClientGetArrayValidResponse{RawResponse: resp}
+	result := ArrayClientGetArrayValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
 		return ArrayClientGetArrayValidResponse{}, err
 	}
@@ -257,7 +257,7 @@ func (client *ArrayClient) getBase64URLCreateRequest(ctx context.Context, option
 
 // getBase64URLHandleResponse handles the GetBase64URL response.
 func (client *ArrayClient) getBase64URLHandleResponse(resp *http.Response) (ArrayClientGetBase64URLResponse, error) {
-	result := ArrayClientGetBase64URLResponse{RawResponse: resp}
+	result := ArrayClientGetBase64URLResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ByteArrayArray); err != nil {
 		return ArrayClientGetBase64URLResponse{}, err
 	}
@@ -296,7 +296,7 @@ func (client *ArrayClient) getBooleanInvalidNullCreateRequest(ctx context.Contex
 
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *ArrayClient) getBooleanInvalidNullHandleResponse(resp *http.Response) (ArrayClientGetBooleanInvalidNullResponse, error) {
-	result := ArrayClientGetBooleanInvalidNullResponse{RawResponse: resp}
+	result := ArrayClientGetBooleanInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BoolArray); err != nil {
 		return ArrayClientGetBooleanInvalidNullResponse{}, err
 	}
@@ -335,7 +335,7 @@ func (client *ArrayClient) getBooleanInvalidStringCreateRequest(ctx context.Cont
 
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *ArrayClient) getBooleanInvalidStringHandleResponse(resp *http.Response) (ArrayClientGetBooleanInvalidStringResponse, error) {
-	result := ArrayClientGetBooleanInvalidStringResponse{RawResponse: resp}
+	result := ArrayClientGetBooleanInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BoolArray); err != nil {
 		return ArrayClientGetBooleanInvalidStringResponse{}, err
 	}
@@ -373,7 +373,7 @@ func (client *ArrayClient) getBooleanTfftCreateRequest(ctx context.Context, opti
 
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *ArrayClient) getBooleanTfftHandleResponse(resp *http.Response) (ArrayClientGetBooleanTfftResponse, error) {
-	result := ArrayClientGetBooleanTfftResponse{RawResponse: resp}
+	result := ArrayClientGetBooleanTfftResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BoolArray); err != nil {
 		return ArrayClientGetBooleanTfftResponse{}, err
 	}
@@ -412,7 +412,7 @@ func (client *ArrayClient) getByteInvalidNullCreateRequest(ctx context.Context, 
 
 // getByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client *ArrayClient) getByteInvalidNullHandleResponse(resp *http.Response) (ArrayClientGetByteInvalidNullResponse, error) {
-	result := ArrayClientGetByteInvalidNullResponse{RawResponse: resp}
+	result := ArrayClientGetByteInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ByteArrayArray); err != nil {
 		return ArrayClientGetByteInvalidNullResponse{}, err
 	}
@@ -450,7 +450,7 @@ func (client *ArrayClient) getByteValidCreateRequest(ctx context.Context, option
 
 // getByteValidHandleResponse handles the GetByteValid response.
 func (client *ArrayClient) getByteValidHandleResponse(resp *http.Response) (ArrayClientGetByteValidResponse, error) {
-	result := ArrayClientGetByteValidResponse{RawResponse: resp}
+	result := ArrayClientGetByteValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ByteArrayArray); err != nil {
 		return ArrayClientGetByteValidResponse{}, err
 	}
@@ -488,7 +488,7 @@ func (client *ArrayClient) getComplexEmptyCreateRequest(ctx context.Context, opt
 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *ArrayClient) getComplexEmptyHandleResponse(resp *http.Response) (ArrayClientGetComplexEmptyResponse, error) {
-	result := ArrayClientGetComplexEmptyResponse{RawResponse: resp}
+	result := ArrayClientGetComplexEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
 		return ArrayClientGetComplexEmptyResponse{}, err
 	}
@@ -528,7 +528,7 @@ func (client *ArrayClient) getComplexItemEmptyCreateRequest(ctx context.Context,
 
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *ArrayClient) getComplexItemEmptyHandleResponse(resp *http.Response) (ArrayClientGetComplexItemEmptyResponse, error) {
-	result := ArrayClientGetComplexItemEmptyResponse{RawResponse: resp}
+	result := ArrayClientGetComplexItemEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
 		return ArrayClientGetComplexItemEmptyResponse{}, err
 	}
@@ -568,7 +568,7 @@ func (client *ArrayClient) getComplexItemNullCreateRequest(ctx context.Context, 
 
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *ArrayClient) getComplexItemNullHandleResponse(resp *http.Response) (ArrayClientGetComplexItemNullResponse, error) {
-	result := ArrayClientGetComplexItemNullResponse{RawResponse: resp}
+	result := ArrayClientGetComplexItemNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
 		return ArrayClientGetComplexItemNullResponse{}, err
 	}
@@ -606,7 +606,7 @@ func (client *ArrayClient) getComplexNullCreateRequest(ctx context.Context, opti
 
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client *ArrayClient) getComplexNullHandleResponse(resp *http.Response) (ArrayClientGetComplexNullResponse, error) {
-	result := ArrayClientGetComplexNullResponse{RawResponse: resp}
+	result := ArrayClientGetComplexNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
 		return ArrayClientGetComplexNullResponse{}, err
 	}
@@ -645,7 +645,7 @@ func (client *ArrayClient) getComplexValidCreateRequest(ctx context.Context, opt
 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client *ArrayClient) getComplexValidHandleResponse(resp *http.Response) (ArrayClientGetComplexValidResponse, error) {
-	result := ArrayClientGetComplexValidResponse{RawResponse: resp}
+	result := ArrayClientGetComplexValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
 		return ArrayClientGetComplexValidResponse{}, err
 	}
@@ -684,7 +684,7 @@ func (client *ArrayClient) getDateInvalidCharsCreateRequest(ctx context.Context,
 
 // getDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *ArrayClient) getDateInvalidCharsHandleResponse(resp *http.Response) (ArrayClientGetDateInvalidCharsResponse, error) {
-	result := ArrayClientGetDateInvalidCharsResponse{RawResponse: resp}
+	result := ArrayClientGetDateInvalidCharsResponse{}
 	var aux []*dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateInvalidCharsResponse{}, err
@@ -729,7 +729,7 @@ func (client *ArrayClient) getDateInvalidNullCreateRequest(ctx context.Context, 
 
 // getDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *ArrayClient) getDateInvalidNullHandleResponse(resp *http.Response) (ArrayClientGetDateInvalidNullResponse, error) {
-	result := ArrayClientGetDateInvalidNullResponse{RawResponse: resp}
+	result := ArrayClientGetDateInvalidNullResponse{}
 	var aux []*dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateInvalidNullResponse{}, err
@@ -774,7 +774,7 @@ func (client *ArrayClient) getDateTimeInvalidCharsCreateRequest(ctx context.Cont
 
 // getDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *ArrayClient) getDateTimeInvalidCharsHandleResponse(resp *http.Response) (ArrayClientGetDateTimeInvalidCharsResponse, error) {
-	result := ArrayClientGetDateTimeInvalidCharsResponse{RawResponse: resp}
+	result := ArrayClientGetDateTimeInvalidCharsResponse{}
 	var aux []*timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateTimeInvalidCharsResponse{}, err
@@ -819,7 +819,7 @@ func (client *ArrayClient) getDateTimeInvalidNullCreateRequest(ctx context.Conte
 
 // getDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *ArrayClient) getDateTimeInvalidNullHandleResponse(resp *http.Response) (ArrayClientGetDateTimeInvalidNullResponse, error) {
-	result := ArrayClientGetDateTimeInvalidNullResponse{RawResponse: resp}
+	result := ArrayClientGetDateTimeInvalidNullResponse{}
 	var aux []*timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateTimeInvalidNullResponse{}, err
@@ -865,7 +865,7 @@ func (client *ArrayClient) getDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 
 // getDateTimeRFC1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *ArrayClient) getDateTimeRFC1123ValidHandleResponse(resp *http.Response) (ArrayClientGetDateTimeRFC1123ValidResponse, error) {
-	result := ArrayClientGetDateTimeRFC1123ValidResponse{RawResponse: resp}
+	result := ArrayClientGetDateTimeRFC1123ValidResponse{}
 	var aux []*timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateTimeRFC1123ValidResponse{}, err
@@ -909,7 +909,7 @@ func (client *ArrayClient) getDateTimeValidCreateRequest(ctx context.Context, op
 
 // getDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *ArrayClient) getDateTimeValidHandleResponse(resp *http.Response) (ArrayClientGetDateTimeValidResponse, error) {
-	result := ArrayClientGetDateTimeValidResponse{RawResponse: resp}
+	result := ArrayClientGetDateTimeValidResponse{}
 	var aux []*timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateTimeValidResponse{}, err
@@ -953,7 +953,7 @@ func (client *ArrayClient) getDateValidCreateRequest(ctx context.Context, option
 
 // getDateValidHandleResponse handles the GetDateValid response.
 func (client *ArrayClient) getDateValidHandleResponse(resp *http.Response) (ArrayClientGetDateValidResponse, error) {
-	result := ArrayClientGetDateValidResponse{RawResponse: resp}
+	result := ArrayClientGetDateValidResponse{}
 	var aux []*dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return ArrayClientGetDateValidResponse{}, err
@@ -998,7 +998,7 @@ func (client *ArrayClient) getDictionaryEmptyCreateRequest(ctx context.Context, 
 
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *ArrayClient) getDictionaryEmptyHandleResponse(resp *http.Response) (ArrayClientGetDictionaryEmptyResponse, error) {
-	result := ArrayClientGetDictionaryEmptyResponse{RawResponse: resp}
+	result := ArrayClientGetDictionaryEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
 		return ArrayClientGetDictionaryEmptyResponse{}, err
 	}
@@ -1038,7 +1038,7 @@ func (client *ArrayClient) getDictionaryItemEmptyCreateRequest(ctx context.Conte
 
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *ArrayClient) getDictionaryItemEmptyHandleResponse(resp *http.Response) (ArrayClientGetDictionaryItemEmptyResponse, error) {
-	result := ArrayClientGetDictionaryItemEmptyResponse{RawResponse: resp}
+	result := ArrayClientGetDictionaryItemEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
 		return ArrayClientGetDictionaryItemEmptyResponse{}, err
 	}
@@ -1078,7 +1078,7 @@ func (client *ArrayClient) getDictionaryItemNullCreateRequest(ctx context.Contex
 
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *ArrayClient) getDictionaryItemNullHandleResponse(resp *http.Response) (ArrayClientGetDictionaryItemNullResponse, error) {
-	result := ArrayClientGetDictionaryItemNullResponse{RawResponse: resp}
+	result := ArrayClientGetDictionaryItemNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
 		return ArrayClientGetDictionaryItemNullResponse{}, err
 	}
@@ -1116,7 +1116,7 @@ func (client *ArrayClient) getDictionaryNullCreateRequest(ctx context.Context, o
 
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *ArrayClient) getDictionaryNullHandleResponse(resp *http.Response) (ArrayClientGetDictionaryNullResponse, error) {
-	result := ArrayClientGetDictionaryNullResponse{RawResponse: resp}
+	result := ArrayClientGetDictionaryNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
 		return ArrayClientGetDictionaryNullResponse{}, err
 	}
@@ -1156,7 +1156,7 @@ func (client *ArrayClient) getDictionaryValidCreateRequest(ctx context.Context, 
 
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *ArrayClient) getDictionaryValidHandleResponse(resp *http.Response) (ArrayClientGetDictionaryValidResponse, error) {
-	result := ArrayClientGetDictionaryValidResponse{RawResponse: resp}
+	result := ArrayClientGetDictionaryValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
 		return ArrayClientGetDictionaryValidResponse{}, err
 	}
@@ -1195,7 +1195,7 @@ func (client *ArrayClient) getDoubleInvalidNullCreateRequest(ctx context.Context
 
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *ArrayClient) getDoubleInvalidNullHandleResponse(resp *http.Response) (ArrayClientGetDoubleInvalidNullResponse, error) {
-	result := ArrayClientGetDoubleInvalidNullResponse{RawResponse: resp}
+	result := ArrayClientGetDoubleInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float64Array); err != nil {
 		return ArrayClientGetDoubleInvalidNullResponse{}, err
 	}
@@ -1234,7 +1234,7 @@ func (client *ArrayClient) getDoubleInvalidStringCreateRequest(ctx context.Conte
 
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *ArrayClient) getDoubleInvalidStringHandleResponse(resp *http.Response) (ArrayClientGetDoubleInvalidStringResponse, error) {
-	result := ArrayClientGetDoubleInvalidStringResponse{RawResponse: resp}
+	result := ArrayClientGetDoubleInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float64Array); err != nil {
 		return ArrayClientGetDoubleInvalidStringResponse{}, err
 	}
@@ -1272,7 +1272,7 @@ func (client *ArrayClient) getDoubleValidCreateRequest(ctx context.Context, opti
 
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *ArrayClient) getDoubleValidHandleResponse(resp *http.Response) (ArrayClientGetDoubleValidResponse, error) {
-	result := ArrayClientGetDoubleValidResponse{RawResponse: resp}
+	result := ArrayClientGetDoubleValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float64Array); err != nil {
 		return ArrayClientGetDoubleValidResponse{}, err
 	}
@@ -1310,7 +1310,7 @@ func (client *ArrayClient) getDurationValidCreateRequest(ctx context.Context, op
 
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client *ArrayClient) getDurationValidHandleResponse(resp *http.Response) (ArrayClientGetDurationValidResponse, error) {
-	result := ArrayClientGetDurationValidResponse{RawResponse: resp}
+	result := ArrayClientGetDurationValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayClientGetDurationValidResponse{}, err
 	}
@@ -1348,7 +1348,7 @@ func (client *ArrayClient) getEmptyCreateRequest(ctx context.Context, options *A
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *ArrayClient) getEmptyHandleResponse(resp *http.Response) (ArrayClientGetEmptyResponse, error) {
-	result := ArrayClientGetEmptyResponse{RawResponse: resp}
+	result := ArrayClientGetEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
 		return ArrayClientGetEmptyResponse{}, err
 	}
@@ -1386,7 +1386,7 @@ func (client *ArrayClient) getEnumValidCreateRequest(ctx context.Context, option
 
 // getEnumValidHandleResponse handles the GetEnumValid response.
 func (client *ArrayClient) getEnumValidHandleResponse(resp *http.Response) (ArrayClientGetEnumValidResponse, error) {
-	result := ArrayClientGetEnumValidResponse{RawResponse: resp}
+	result := ArrayClientGetEnumValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FooEnumArray); err != nil {
 		return ArrayClientGetEnumValidResponse{}, err
 	}
@@ -1425,7 +1425,7 @@ func (client *ArrayClient) getFloatInvalidNullCreateRequest(ctx context.Context,
 
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *ArrayClient) getFloatInvalidNullHandleResponse(resp *http.Response) (ArrayClientGetFloatInvalidNullResponse, error) {
-	result := ArrayClientGetFloatInvalidNullResponse{RawResponse: resp}
+	result := ArrayClientGetFloatInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float32Array); err != nil {
 		return ArrayClientGetFloatInvalidNullResponse{}, err
 	}
@@ -1464,7 +1464,7 @@ func (client *ArrayClient) getFloatInvalidStringCreateRequest(ctx context.Contex
 
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *ArrayClient) getFloatInvalidStringHandleResponse(resp *http.Response) (ArrayClientGetFloatInvalidStringResponse, error) {
-	result := ArrayClientGetFloatInvalidStringResponse{RawResponse: resp}
+	result := ArrayClientGetFloatInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float32Array); err != nil {
 		return ArrayClientGetFloatInvalidStringResponse{}, err
 	}
@@ -1502,7 +1502,7 @@ func (client *ArrayClient) getFloatValidCreateRequest(ctx context.Context, optio
 
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client *ArrayClient) getFloatValidHandleResponse(resp *http.Response) (ArrayClientGetFloatValidResponse, error) {
-	result := ArrayClientGetFloatValidResponse{RawResponse: resp}
+	result := ArrayClientGetFloatValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float32Array); err != nil {
 		return ArrayClientGetFloatValidResponse{}, err
 	}
@@ -1540,7 +1540,7 @@ func (client *ArrayClient) getIntInvalidNullCreateRequest(ctx context.Context, o
 
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *ArrayClient) getIntInvalidNullHandleResponse(resp *http.Response) (ArrayClientGetIntInvalidNullResponse, error) {
-	result := ArrayClientGetIntInvalidNullResponse{RawResponse: resp}
+	result := ArrayClientGetIntInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
 		return ArrayClientGetIntInvalidNullResponse{}, err
 	}
@@ -1579,7 +1579,7 @@ func (client *ArrayClient) getIntInvalidStringCreateRequest(ctx context.Context,
 
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *ArrayClient) getIntInvalidStringHandleResponse(resp *http.Response) (ArrayClientGetIntInvalidStringResponse, error) {
-	result := ArrayClientGetIntInvalidStringResponse{RawResponse: resp}
+	result := ArrayClientGetIntInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
 		return ArrayClientGetIntInvalidStringResponse{}, err
 	}
@@ -1617,7 +1617,7 @@ func (client *ArrayClient) getIntegerValidCreateRequest(ctx context.Context, opt
 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *ArrayClient) getIntegerValidHandleResponse(resp *http.Response) (ArrayClientGetIntegerValidResponse, error) {
-	result := ArrayClientGetIntegerValidResponse{RawResponse: resp}
+	result := ArrayClientGetIntegerValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
 		return ArrayClientGetIntegerValidResponse{}, err
 	}
@@ -1655,7 +1655,7 @@ func (client *ArrayClient) getInvalidCreateRequest(ctx context.Context, options 
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *ArrayClient) getInvalidHandleResponse(resp *http.Response) (ArrayClientGetInvalidResponse, error) {
-	result := ArrayClientGetInvalidResponse{RawResponse: resp}
+	result := ArrayClientGetInvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
 		return ArrayClientGetInvalidResponse{}, err
 	}
@@ -1694,7 +1694,7 @@ func (client *ArrayClient) getLongInvalidNullCreateRequest(ctx context.Context, 
 
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *ArrayClient) getLongInvalidNullHandleResponse(resp *http.Response) (ArrayClientGetLongInvalidNullResponse, error) {
-	result := ArrayClientGetLongInvalidNullResponse{RawResponse: resp}
+	result := ArrayClientGetLongInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int64Array); err != nil {
 		return ArrayClientGetLongInvalidNullResponse{}, err
 	}
@@ -1733,7 +1733,7 @@ func (client *ArrayClient) getLongInvalidStringCreateRequest(ctx context.Context
 
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *ArrayClient) getLongInvalidStringHandleResponse(resp *http.Response) (ArrayClientGetLongInvalidStringResponse, error) {
-	result := ArrayClientGetLongInvalidStringResponse{RawResponse: resp}
+	result := ArrayClientGetLongInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int64Array); err != nil {
 		return ArrayClientGetLongInvalidStringResponse{}, err
 	}
@@ -1771,7 +1771,7 @@ func (client *ArrayClient) getLongValidCreateRequest(ctx context.Context, option
 
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client *ArrayClient) getLongValidHandleResponse(resp *http.Response) (ArrayClientGetLongValidResponse, error) {
-	result := ArrayClientGetLongValidResponse{RawResponse: resp}
+	result := ArrayClientGetLongValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int64Array); err != nil {
 		return ArrayClientGetLongValidResponse{}, err
 	}
@@ -1809,7 +1809,7 @@ func (client *ArrayClient) getNullCreateRequest(ctx context.Context, options *Ar
 
 // getNullHandleResponse handles the GetNull response.
 func (client *ArrayClient) getNullHandleResponse(resp *http.Response) (ArrayClientGetNullResponse, error) {
-	result := ArrayClientGetNullResponse{RawResponse: resp}
+	result := ArrayClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
 		return ArrayClientGetNullResponse{}, err
 	}
@@ -1848,7 +1848,7 @@ func (client *ArrayClient) getStringEnumValidCreateRequest(ctx context.Context, 
 
 // getStringEnumValidHandleResponse handles the GetStringEnumValid response.
 func (client *ArrayClient) getStringEnumValidHandleResponse(resp *http.Response) (ArrayClientGetStringEnumValidResponse, error) {
-	result := ArrayClientGetStringEnumValidResponse{RawResponse: resp}
+	result := ArrayClientGetStringEnumValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Enum0Array); err != nil {
 		return ArrayClientGetStringEnumValidResponse{}, err
 	}
@@ -1886,7 +1886,7 @@ func (client *ArrayClient) getStringValidCreateRequest(ctx context.Context, opti
 
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client *ArrayClient) getStringValidHandleResponse(resp *http.Response) (ArrayClientGetStringValidResponse, error) {
-	result := ArrayClientGetStringValidResponse{RawResponse: resp}
+	result := ArrayClientGetStringValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayClientGetStringValidResponse{}, err
 	}
@@ -1925,7 +1925,7 @@ func (client *ArrayClient) getStringWithInvalidCreateRequest(ctx context.Context
 
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *ArrayClient) getStringWithInvalidHandleResponse(resp *http.Response) (ArrayClientGetStringWithInvalidResponse, error) {
-	result := ArrayClientGetStringWithInvalidResponse{RawResponse: resp}
+	result := ArrayClientGetStringWithInvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayClientGetStringWithInvalidResponse{}, err
 	}
@@ -1963,7 +1963,7 @@ func (client *ArrayClient) getStringWithNullCreateRequest(ctx context.Context, o
 
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *ArrayClient) getStringWithNullHandleResponse(resp *http.Response) (ArrayClientGetStringWithNullResponse, error) {
-	result := ArrayClientGetStringWithNullResponse{RawResponse: resp}
+	result := ArrayClientGetStringWithNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayClientGetStringWithNullResponse{}, err
 	}
@@ -2002,7 +2002,7 @@ func (client *ArrayClient) getUUIDInvalidCharsCreateRequest(ctx context.Context,
 
 // getUUIDInvalidCharsHandleResponse handles the GetUUIDInvalidChars response.
 func (client *ArrayClient) getUUIDInvalidCharsHandleResponse(resp *http.Response) (ArrayClientGetUUIDInvalidCharsResponse, error) {
-	result := ArrayClientGetUUIDInvalidCharsResponse{RawResponse: resp}
+	result := ArrayClientGetUUIDInvalidCharsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayClientGetUUIDInvalidCharsResponse{}, err
 	}
@@ -2040,7 +2040,7 @@ func (client *ArrayClient) getUUIDValidCreateRequest(ctx context.Context, option
 
 // getUUIDValidHandleResponse handles the GetUUIDValid response.
 func (client *ArrayClient) getUUIDValidHandleResponse(resp *http.Response) (ArrayClientGetUUIDValidResponse, error) {
-	result := ArrayClientGetUUIDValidResponse{RawResponse: resp}
+	result := ArrayClientGetUUIDValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayClientGetUUIDValidResponse{}, err
 	}
@@ -2062,7 +2062,7 @@ func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]*str
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutArrayValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutArrayValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutArrayValidResponse{}, nil
 }
 
 // putArrayValidCreateRequest creates the PutArrayValid request.
@@ -2091,7 +2091,7 @@ func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []*bool
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutBooleanTfftResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutBooleanTfftResponse{RawResponse: resp}, nil
+	return ArrayClientPutBooleanTfftResponse{}, nil
 }
 
 // putBooleanTfftCreateRequest creates the PutBooleanTfft request.
@@ -2121,7 +2121,7 @@ func (client *ArrayClient) PutByteValid(ctx context.Context, arrayBody [][]byte,
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutByteValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutByteValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutByteValidResponse{}, nil
 }
 
 // putByteValidCreateRequest creates the PutByteValid request.
@@ -2151,7 +2151,7 @@ func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []*Pro
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutComplexValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutComplexValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutComplexValidResponse{}, nil
 }
 
 // putComplexValidCreateRequest creates the PutComplexValid request.
@@ -2182,7 +2182,7 @@ func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBod
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutDateTimeRFC1123ValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutDateTimeRFC1123ValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutDateTimeRFC1123ValidResponse{}, nil
 }
 
 // putDateTimeRFC1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
@@ -2215,7 +2215,7 @@ func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []*ti
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutDateTimeValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutDateTimeValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutDateTimeValidResponse{}, nil
 }
 
 // putDateTimeValidCreateRequest creates the PutDateTimeValid request.
@@ -2244,7 +2244,7 @@ func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []*time.T
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutDateValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutDateValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutDateValidResponse{}, nil
 }
 
 // putDateValidCreateRequest creates the PutDateValid request.
@@ -2279,7 +2279,7 @@ func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []m
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutDictionaryValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutDictionaryValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutDictionaryValidResponse{}, nil
 }
 
 // putDictionaryValidCreateRequest creates the PutDictionaryValid request.
@@ -2308,7 +2308,7 @@ func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []*floa
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutDoubleValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutDoubleValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutDoubleValidResponse{}, nil
 }
 
 // putDoubleValidCreateRequest creates the PutDoubleValid request.
@@ -2337,7 +2337,7 @@ func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []*st
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutDurationValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutDurationValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutDurationValidResponse{}, nil
 }
 
 // putDurationValidCreateRequest creates the PutDurationValid request.
@@ -2366,7 +2366,7 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []*string, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutEmptyResponse{RawResponse: resp}, nil
+	return ArrayClientPutEmptyResponse{}, nil
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
@@ -2395,7 +2395,7 @@ func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []*FooEnu
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutEnumValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutEnumValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutEnumValidResponse{}, nil
 }
 
 // putEnumValidCreateRequest creates the PutEnumValid request.
@@ -2424,7 +2424,7 @@ func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []*float
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutFloatValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutFloatValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutFloatValidResponse{}, nil
 }
 
 // putFloatValidCreateRequest creates the PutFloatValid request.
@@ -2453,7 +2453,7 @@ func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []*int
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutIntegerValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutIntegerValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutIntegerValidResponse{}, nil
 }
 
 // putIntegerValidCreateRequest creates the PutIntegerValid request.
@@ -2482,7 +2482,7 @@ func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []*int64,
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutLongValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutLongValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutLongValidResponse{}, nil
 }
 
 // putLongValidCreateRequest creates the PutLongValid request.
@@ -2512,7 +2512,7 @@ func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []*
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutStringEnumValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutStringEnumValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutStringEnumValidResponse{}, nil
 }
 
 // putStringEnumValidCreateRequest creates the PutStringEnumValid request.
@@ -2541,7 +2541,7 @@ func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []*stri
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutStringValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutStringValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutStringValidResponse{}, nil
 }
 
 // putStringValidCreateRequest creates the PutStringValid request.
@@ -2570,7 +2570,7 @@ func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []*string
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutUUIDValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutUUIDValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutUUIDValidResponse{}, nil
 }
 
 // putUUIDValidCreateRequest creates the PutUUIDValid request.

--- a/test/autorest/arraygroup/zz_generated_response_types.go
+++ b/test/autorest/arraygroup/zz_generated_response_types.go
@@ -8,52 +8,34 @@
 
 package arraygroup
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 // ArrayClientGetArrayEmptyResponse contains the response from method ArrayClient.GetArrayEmpty.
 type ArrayClientGetArrayEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An empty array []
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetArrayItemEmptyResponse contains the response from method ArrayClient.GetArrayItemEmpty.
 type ArrayClientGetArrayItemEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetArrayItemNullResponse contains the response from method ArrayClient.GetArrayItemNull.
 type ArrayClientGetArrayItemNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetArrayNullResponse contains the response from method ArrayClient.GetArrayNull.
 type ArrayClientGetArrayNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// a null array
 	StringArrayArray [][]*string
 }
 
 // ArrayClientGetArrayValidResponse contains the response from method ArrayClient.GetArrayValid.
 type ArrayClientGetArrayValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
 	StringArrayArray [][]*string
 }
@@ -62,160 +44,106 @@ type ArrayClientGetArrayValidResponse struct {
 type ArrayClientGetBase64URLResponse struct {
 	// Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded
 	ByteArrayArray [][]byte
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetBooleanInvalidNullResponse contains the response from method ArrayClient.GetBooleanInvalidNull.
 type ArrayClientGetBooleanInvalidNullResponse struct {
 	// The array value [true, null, false]
 	BoolArray []*bool
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetBooleanInvalidStringResponse contains the response from method ArrayClient.GetBooleanInvalidString.
 type ArrayClientGetBooleanInvalidStringResponse struct {
 	// The array value [true, 'boolean', false]
 	BoolArray []*bool
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetBooleanTfftResponse contains the response from method ArrayClient.GetBooleanTfft.
 type ArrayClientGetBooleanTfftResponse struct {
 	// The array value [true, false, false, true]
 	BoolArray []*bool
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetByteInvalidNullResponse contains the response from method ArrayClient.GetByteInvalidNull.
 type ArrayClientGetByteInvalidNullResponse struct {
 	// The byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
 	ByteArrayArray [][]byte
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetByteValidResponse contains the response from method ArrayClient.GetByteValid.
 type ArrayClientGetByteValidResponse struct {
 	// The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
 	ByteArrayArray [][]byte
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexEmptyResponse contains the response from method ArrayClient.GetComplexEmpty.
 type ArrayClientGetComplexEmptyResponse struct {
 	// Empty array of complex type []
 	ProductArray []*Product
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexItemEmptyResponse contains the response from method ArrayClient.GetComplexItemEmpty.
 type ArrayClientGetComplexItemEmptyResponse struct {
 	// Array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
 	ProductArray []*Product
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexItemNullResponse contains the response from method ArrayClient.GetComplexItemNull.
 type ArrayClientGetComplexItemNullResponse struct {
 	// Array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
 	ProductArray []*Product
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexNullResponse contains the response from method ArrayClient.GetComplexNull.
 type ArrayClientGetComplexNullResponse struct {
 	// array of complex type with null value
 	ProductArray []*Product
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetComplexValidResponse contains the response from method ArrayClient.GetComplexValid.
 type ArrayClientGetComplexValidResponse struct {
 	// array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
 	ProductArray []*Product
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDateInvalidCharsResponse contains the response from method ArrayClient.GetDateInvalidChars.
 type ArrayClientGetDateInvalidCharsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['2011-03-22', 'date']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateInvalidNullResponse contains the response from method ArrayClient.GetDateInvalidNull.
 type ArrayClientGetDateInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['2012-01-01', null, '1776-07-04']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateTimeInvalidCharsResponse contains the response from method ArrayClient.GetDateTimeInvalidChars.
 type ArrayClientGetDateTimeInvalidCharsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['2000-12-01t00:00:01z', 'date-time']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateTimeInvalidNullResponse contains the response from method ArrayClient.GetDateTimeInvalidNull.
 type ArrayClientGetDateTimeInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['2000-12-01t00:00:01z', null]
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateTimeRFC1123ValidResponse contains the response from method ArrayClient.GetDateTimeRFC1123Valid.
 type ArrayClientGetDateTimeRFC1123ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateTimeValidResponse contains the response from method ArrayClient.GetDateTimeValid.
 type ArrayClientGetDateTimeValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
 	TimeArray []*time.Time
 }
 
 // ArrayClientGetDateValidResponse contains the response from method ArrayClient.GetDateValid.
 type ArrayClientGetDateValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['2000-12-01', '1980-01-02', '1492-10-12']
 	TimeArray []*time.Time
 }
@@ -224,9 +152,6 @@ type ArrayClientGetDateValidResponse struct {
 type ArrayClientGetDictionaryEmptyResponse struct {
 	// An array of Dictionaries of type <string, string> with value []
 	MapOfStringArray []map[string]*string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDictionaryItemEmptyResponse contains the response from method ArrayClient.GetDictionaryItemEmpty.
@@ -234,9 +159,6 @@ type ArrayClientGetDictionaryItemEmptyResponse struct {
 	// An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven',
 	// '8': 'eight', '9': 'nine'}]
 	MapOfStringArray []map[string]*string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDictionaryItemNullResponse contains the response from method ArrayClient.GetDictionaryItemNull.
@@ -244,18 +166,12 @@ type ArrayClientGetDictionaryItemNullResponse struct {
 	// An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven',
 	// '8': 'eight', '9': 'nine'}]
 	MapOfStringArray []map[string]*string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDictionaryNullResponse contains the response from method ArrayClient.GetDictionaryNull.
 type ArrayClientGetDictionaryNullResponse struct {
 	// An array of Dictionaries with value null
 	MapOfStringArray []map[string]*string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDictionaryValidResponse contains the response from method ArrayClient.GetDictionaryValid.
@@ -263,43 +179,28 @@ type ArrayClientGetDictionaryValidResponse struct {
 	// An array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5':
 	// 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 	MapOfStringArray []map[string]*string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDoubleInvalidNullResponse contains the response from method ArrayClient.GetDoubleInvalidNull.
 type ArrayClientGetDoubleInvalidNullResponse struct {
 	// The array value [0.0, null, -1.2e20]
 	Float64Array []*float64
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDoubleInvalidStringResponse contains the response from method ArrayClient.GetDoubleInvalidString.
 type ArrayClientGetDoubleInvalidStringResponse struct {
 	// The array value [1.0, 'number', 0.0]
 	Float64Array []*float64
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDoubleValidResponse contains the response from method ArrayClient.GetDoubleValid.
 type ArrayClientGetDoubleValidResponse struct {
 	// The array value [0, -0.01, 1.2e20]
 	Float64Array []*float64
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetDurationValidResponse contains the response from method ArrayClient.GetDurationValid.
 type ArrayClientGetDurationValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 	StringArray []*string
 }
@@ -308,277 +209,202 @@ type ArrayClientGetDurationValidResponse struct {
 type ArrayClientGetEmptyResponse struct {
 	// The empty array value []
 	Int32Array []*int32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetEnumValidResponse contains the response from method ArrayClient.GetEnumValid.
 type ArrayClientGetEnumValidResponse struct {
 	// The array value ['foo1', 'foo2', 'foo3']
 	FooEnumArray []*FooEnum
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetFloatInvalidNullResponse contains the response from method ArrayClient.GetFloatInvalidNull.
 type ArrayClientGetFloatInvalidNullResponse struct {
 	// The array value [0.0, null, -1.2e20]
 	Float32Array []*float32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetFloatInvalidStringResponse contains the response from method ArrayClient.GetFloatInvalidString.
 type ArrayClientGetFloatInvalidStringResponse struct {
 	// The array value [1.0, 'number', 0.0]
 	Float32Array []*float32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetFloatValidResponse contains the response from method ArrayClient.GetFloatValid.
 type ArrayClientGetFloatValidResponse struct {
 	// The array value [0, -0.01, 1.2e20]
 	Float32Array []*float32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetIntInvalidNullResponse contains the response from method ArrayClient.GetIntInvalidNull.
 type ArrayClientGetIntInvalidNullResponse struct {
 	// The array value [1, null, 0]
 	Int32Array []*int32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetIntInvalidStringResponse contains the response from method ArrayClient.GetIntInvalidString.
 type ArrayClientGetIntInvalidStringResponse struct {
 	// The array value [1, 'integer', 0]
 	Int32Array []*int32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetIntegerValidResponse contains the response from method ArrayClient.GetIntegerValid.
 type ArrayClientGetIntegerValidResponse struct {
 	// The array value [1, -1, 3, 300]
 	Int32Array []*int32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetInvalidResponse contains the response from method ArrayClient.GetInvalid.
 type ArrayClientGetInvalidResponse struct {
 	// The invalid Array [1, 2, 3
 	Int32Array []*int32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetLongInvalidNullResponse contains the response from method ArrayClient.GetLongInvalidNull.
 type ArrayClientGetLongInvalidNullResponse struct {
 	// The array value [1, null, 0]
 	Int64Array []*int64
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetLongInvalidStringResponse contains the response from method ArrayClient.GetLongInvalidString.
 type ArrayClientGetLongInvalidStringResponse struct {
 	// The array value [1, 'integer', 0]
 	Int64Array []*int64
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetLongValidResponse contains the response from method ArrayClient.GetLongValid.
 type ArrayClientGetLongValidResponse struct {
 	// The array value [1, -1, 3, 300]
 	Int64Array []*int64
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetNullResponse contains the response from method ArrayClient.GetNull.
 type ArrayClientGetNullResponse struct {
 	// The null Array value
 	Int32Array []*int32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetStringEnumValidResponse contains the response from method ArrayClient.GetStringEnumValid.
 type ArrayClientGetStringEnumValidResponse struct {
 	// The array value ['foo1', 'foo2', 'foo3']
 	Enum0Array []*Enum0
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetStringValidResponse contains the response from method ArrayClient.GetStringValid.
 type ArrayClientGetStringValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['foo1', 'foo2', 'foo3']
 	StringArray []*string
 }
 
 // ArrayClientGetStringWithInvalidResponse contains the response from method ArrayClient.GetStringWithInvalid.
 type ArrayClientGetStringWithInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['foo', 123, 'foo2']
 	StringArray []*string
 }
 
 // ArrayClientGetStringWithNullResponse contains the response from method ArrayClient.GetStringWithNull.
 type ArrayClientGetStringWithNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['foo', null, 'foo2']
 	StringArray []*string
 }
 
 // ArrayClientGetUUIDInvalidCharsResponse contains the response from method ArrayClient.GetUUIDInvalidChars.
 type ArrayClientGetUUIDInvalidCharsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']
 	StringArray []*string
 }
 
 // ArrayClientGetUUIDValidResponse contains the response from method ArrayClient.GetUUIDValid.
 type ArrayClientGetUUIDValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 	StringArray []*string
 }
 
 // ArrayClientPutArrayValidResponse contains the response from method ArrayClient.PutArrayValid.
 type ArrayClientPutArrayValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutBooleanTfftResponse contains the response from method ArrayClient.PutBooleanTfft.
 type ArrayClientPutBooleanTfftResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutByteValidResponse contains the response from method ArrayClient.PutByteValid.
 type ArrayClientPutByteValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutComplexValidResponse contains the response from method ArrayClient.PutComplexValid.
 type ArrayClientPutComplexValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutDateTimeRFC1123ValidResponse contains the response from method ArrayClient.PutDateTimeRFC1123Valid.
 type ArrayClientPutDateTimeRFC1123ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutDateTimeValidResponse contains the response from method ArrayClient.PutDateTimeValid.
 type ArrayClientPutDateTimeValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutDateValidResponse contains the response from method ArrayClient.PutDateValid.
 type ArrayClientPutDateValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutDictionaryValidResponse contains the response from method ArrayClient.PutDictionaryValid.
 type ArrayClientPutDictionaryValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutDoubleValidResponse contains the response from method ArrayClient.PutDoubleValid.
 type ArrayClientPutDoubleValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutDurationValidResponse contains the response from method ArrayClient.PutDurationValid.
 type ArrayClientPutDurationValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutEmptyResponse contains the response from method ArrayClient.PutEmpty.
 type ArrayClientPutEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutEnumValidResponse contains the response from method ArrayClient.PutEnumValid.
 type ArrayClientPutEnumValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutFloatValidResponse contains the response from method ArrayClient.PutFloatValid.
 type ArrayClientPutFloatValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutIntegerValidResponse contains the response from method ArrayClient.PutIntegerValid.
 type ArrayClientPutIntegerValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutLongValidResponse contains the response from method ArrayClient.PutLongValid.
 type ArrayClientPutLongValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutStringEnumValidResponse contains the response from method ArrayClient.PutStringEnumValid.
 type ArrayClientPutStringEnumValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutStringValidResponse contains the response from method ArrayClient.PutStringValid.
 type ArrayClientPutStringValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutUUIDValidResponse contains the response from method ArrayClient.PutUUIDValid.
 type ArrayClientPutUUIDValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure_client.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure_client.go
@@ -71,7 +71,7 @@ func (client *AutoRestReportServiceForAzureClient) getReportCreateRequest(ctx co
 
 // getReportHandleResponse handles the GetReport response.
 func (client *AutoRestReportServiceForAzureClient) getReportHandleResponse(resp *http.Response) (AutoRestReportServiceForAzureClientGetReportResponse, error) {
-	result := AutoRestReportServiceForAzureClientGetReportResponse{RawResponse: resp}
+	result := AutoRestReportServiceForAzureClientGetReportResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return AutoRestReportServiceForAzureClientGetReportResponse{}, err
 	}

--- a/test/autorest/azurereportgroup/zz_generated_response_types.go
+++ b/test/autorest/azurereportgroup/zz_generated_response_types.go
@@ -8,13 +8,8 @@
 
 package azurereportgroup
 
-import "net/http"
-
 // AutoRestReportServiceForAzureClientGetReportResponse contains the response from method AutoRestReportServiceForAzureClient.GetReport.
 type AutoRestReportServiceForAzureClientGetReportResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of <integer>
 	Value map[string]*int32
 }

--- a/test/autorest/azurespecialsgroup/apiversiondefault_test.go
+++ b/test/autorest/azurespecialsgroup/apiversiondefault_test.go
@@ -5,7 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -20,8 +20,8 @@ func TestGetMethodGlobalNotProvidedValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -32,8 +32,8 @@ func TestGetMethodGlobalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -44,8 +44,8 @@ func TestGetPathGlobalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -56,7 +56,7 @@ func TestGetSwaggerGlobalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/azurespecialsgroup/apiversionlocal_test.go
+++ b/test/autorest/azurespecialsgroup/apiversionlocal_test.go
@@ -5,7 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -20,8 +20,8 @@ func TestGetMethodLocalNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -32,8 +32,8 @@ func TestGetMethodLocalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -44,8 +44,8 @@ func TestGetPathLocalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -56,7 +56,7 @@ func TestGetSwaggerLocalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/azurespecialsgroup/odata_test.go
+++ b/test/autorest/azurespecialsgroup/odata_test.go
@@ -5,7 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -26,7 +26,7 @@ func TestGetWithFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/azurespecialsgroup/skipurlencoding_test.go
+++ b/test/autorest/azurespecialsgroup/skipurlencoding_test.go
@@ -5,7 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -20,8 +20,8 @@ func TestGetMethodPathValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -32,8 +32,8 @@ func TestGetMethodQueryNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -44,8 +44,8 @@ func TestGetMethodQueryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -56,8 +56,8 @@ func TestGetPathQueryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -68,8 +68,8 @@ func TestGetPathValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -80,8 +80,8 @@ func TestGetSwaggerPathValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -92,7 +92,7 @@ func TestGetSwaggerQueryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
@@ -6,6 +6,7 @@ package azurespecialsgroup
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -24,8 +25,8 @@ func TestPostMethodGlobalNotProvidedValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -43,8 +44,8 @@ func TestPostMethodGlobalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -57,8 +58,8 @@ func TestPostPathGlobalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -71,7 +72,7 @@ func TestPostSwaggerGlobalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
@@ -6,6 +6,7 @@ package azurespecialsgroup
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -29,8 +30,8 @@ func TestPostMethodLocalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -43,8 +44,8 @@ func TestPostPathLocalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -57,7 +58,7 @@ func TestPostSwaggerLocalValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
+++ b/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
@@ -6,6 +6,7 @@ package azurespecialsgroup
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -24,8 +25,8 @@ func TestGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -36,7 +37,7 @@ func TestParamGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault_client.go
@@ -50,7 +50,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValid(ctx conte
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return APIVersionDefaultClientGetMethodGlobalNotProvidedValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return APIVersionDefaultClientGetMethodGlobalNotProvidedValidResponse{RawResponse: resp}, nil
+	return APIVersionDefaultClientGetMethodGlobalNotProvidedValidResponse{}, nil
 }
 
 // getMethodGlobalNotProvidedValidCreateRequest creates the GetMethodGlobalNotProvidedValid request.
@@ -83,7 +83,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValid(ctx context.Context,
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return APIVersionDefaultClientGetMethodGlobalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return APIVersionDefaultClientGetMethodGlobalValidResponse{RawResponse: resp}, nil
+	return APIVersionDefaultClientGetMethodGlobalValidResponse{}, nil
 }
 
 // getMethodGlobalValidCreateRequest creates the GetMethodGlobalValid request.
@@ -116,7 +116,7 @@ func (client *APIVersionDefaultClient) GetPathGlobalValid(ctx context.Context, o
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return APIVersionDefaultClientGetPathGlobalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return APIVersionDefaultClientGetPathGlobalValidResponse{RawResponse: resp}, nil
+	return APIVersionDefaultClientGetPathGlobalValidResponse{}, nil
 }
 
 // getPathGlobalValidCreateRequest creates the GetPathGlobalValid request.
@@ -149,7 +149,7 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValid(ctx context.Context
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return APIVersionDefaultClientGetSwaggerGlobalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return APIVersionDefaultClientGetSwaggerGlobalValidResponse{RawResponse: resp}, nil
+	return APIVersionDefaultClientGetSwaggerGlobalValidResponse{}, nil
 }
 
 // getSwaggerGlobalValidCreateRequest creates the GetSwaggerGlobalValid request.

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal_client.go
@@ -50,7 +50,7 @@ func (client *APIVersionLocalClient) GetMethodLocalNull(ctx context.Context, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return APIVersionLocalClientGetMethodLocalNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return APIVersionLocalClientGetMethodLocalNullResponse{RawResponse: resp}, nil
+	return APIVersionLocalClientGetMethodLocalNullResponse{}, nil
 }
 
 // getMethodLocalNullCreateRequest creates the GetMethodLocalNull request.
@@ -85,7 +85,7 @@ func (client *APIVersionLocalClient) GetMethodLocalValid(ctx context.Context, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return APIVersionLocalClientGetMethodLocalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return APIVersionLocalClientGetMethodLocalValidResponse{RawResponse: resp}, nil
+	return APIVersionLocalClientGetMethodLocalValidResponse{}, nil
 }
 
 // getMethodLocalValidCreateRequest creates the GetMethodLocalValid request.
@@ -118,7 +118,7 @@ func (client *APIVersionLocalClient) GetPathLocalValid(ctx context.Context, opti
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return APIVersionLocalClientGetPathLocalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return APIVersionLocalClientGetPathLocalValidResponse{RawResponse: resp}, nil
+	return APIVersionLocalClientGetPathLocalValidResponse{}, nil
 }
 
 // getPathLocalValidCreateRequest creates the GetPathLocalValid request.
@@ -151,7 +151,7 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValid(ctx context.Context, o
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return APIVersionLocalClientGetSwaggerLocalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return APIVersionLocalClientGetSwaggerLocalValidResponse{RawResponse: resp}, nil
+	return APIVersionLocalClientGetSwaggerLocalValidResponse{}, nil
 }
 
 // getSwaggerLocalValidCreateRequest creates the GetSwaggerLocalValid request.

--- a/test/autorest/azurespecialsgroup/zz_generated_header_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header_client.go
@@ -68,7 +68,7 @@ func (client *HeaderClient) customNamedRequestIDCreateRequest(ctx context.Contex
 
 // customNamedRequestIDHandleResponse handles the CustomNamedRequestID response.
 func (client *HeaderClient) customNamedRequestIDHandleResponse(resp *http.Response) (HeaderClientCustomNamedRequestIDResponse, error) {
-	result := HeaderClientCustomNamedRequestIDResponse{RawResponse: resp}
+	result := HeaderClientCustomNamedRequestIDResponse{}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestID = &val
 	}
@@ -105,7 +105,7 @@ func (client *HeaderClient) customNamedRequestIDHeadCreateRequest(ctx context.Co
 
 // customNamedRequestIDHeadHandleResponse handles the CustomNamedRequestIDHead response.
 func (client *HeaderClient) customNamedRequestIDHeadHandleResponse(resp *http.Response) (HeaderClientCustomNamedRequestIDHeadResponse, error) {
-	result := HeaderClientCustomNamedRequestIDHeadResponse{RawResponse: resp}
+	result := HeaderClientCustomNamedRequestIDHeadResponse{}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestID = &val
 	}
@@ -149,7 +149,7 @@ func (client *HeaderClient) customNamedRequestIDParamGroupingCreateRequest(ctx c
 
 // customNamedRequestIDParamGroupingHandleResponse handles the CustomNamedRequestIDParamGrouping response.
 func (client *HeaderClient) customNamedRequestIDParamGroupingHandleResponse(resp *http.Response) (HeaderClientCustomNamedRequestIDParamGroupingResponse, error) {
-	result := HeaderClientCustomNamedRequestIDParamGroupingResponse{RawResponse: resp}
+	result := HeaderClientCustomNamedRequestIDParamGroupingResponse{}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestID = &val
 	}

--- a/test/autorest/azurespecialsgroup/zz_generated_odata_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_odata_client.go
@@ -50,7 +50,7 @@ func (client *ODataClient) GetWithFilter(ctx context.Context, options *ODataClie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ODataClientGetWithFilterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ODataClientGetWithFilterResponse{RawResponse: resp}, nil
+	return ODataClientGetWithFilterResponse{}, nil
 }
 
 // getWithFilterCreateRequest creates the GetWithFilter request.

--- a/test/autorest/azurespecialsgroup/zz_generated_response_types.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_response_types.go
@@ -8,63 +8,50 @@
 
 package azurespecialsgroup
 
-import "net/http"
-
 // APIVersionDefaultClientGetMethodGlobalNotProvidedValidResponse contains the response from method APIVersionDefaultClient.GetMethodGlobalNotProvidedValid.
 type APIVersionDefaultClientGetMethodGlobalNotProvidedValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // APIVersionDefaultClientGetMethodGlobalValidResponse contains the response from method APIVersionDefaultClient.GetMethodGlobalValid.
 type APIVersionDefaultClientGetMethodGlobalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // APIVersionDefaultClientGetPathGlobalValidResponse contains the response from method APIVersionDefaultClient.GetPathGlobalValid.
 type APIVersionDefaultClientGetPathGlobalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // APIVersionDefaultClientGetSwaggerGlobalValidResponse contains the response from method APIVersionDefaultClient.GetSwaggerGlobalValid.
 type APIVersionDefaultClientGetSwaggerGlobalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // APIVersionLocalClientGetMethodLocalNullResponse contains the response from method APIVersionLocalClient.GetMethodLocalNull.
 type APIVersionLocalClientGetMethodLocalNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // APIVersionLocalClientGetMethodLocalValidResponse contains the response from method APIVersionLocalClient.GetMethodLocalValid.
 type APIVersionLocalClientGetMethodLocalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // APIVersionLocalClientGetPathLocalValidResponse contains the response from method APIVersionLocalClient.GetPathLocalValid.
 type APIVersionLocalClientGetPathLocalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // APIVersionLocalClientGetSwaggerLocalValidResponse contains the response from method APIVersionLocalClient.GetSwaggerLocalValid.
 type APIVersionLocalClientGetSwaggerLocalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientCustomNamedRequestIDHeadResponse contains the response from method HeaderClient.CustomNamedRequestIDHead.
 type HeaderClientCustomNamedRequestIDHeadResponse struct {
 	// FooRequestID contains the information returned from the foo-request-id header response.
 	FooRequestID *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// Success indicates if the operation succeeded or failed.
 	Success bool
@@ -74,130 +61,105 @@ type HeaderClientCustomNamedRequestIDHeadResponse struct {
 type HeaderClientCustomNamedRequestIDParamGroupingResponse struct {
 	// FooRequestID contains the information returned from the foo-request-id header response.
 	FooRequestID *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HeaderClientCustomNamedRequestIDResponse contains the response from method HeaderClient.CustomNamedRequestID.
 type HeaderClientCustomNamedRequestIDResponse struct {
 	// FooRequestID contains the information returned from the foo-request-id header response.
 	FooRequestID *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ODataClientGetWithFilterResponse contains the response from method ODataClient.GetWithFilter.
 type ODataClientGetWithFilterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SkipURLEncodingClientGetMethodPathValidResponse contains the response from method SkipURLEncodingClient.GetMethodPathValid.
 type SkipURLEncodingClientGetMethodPathValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SkipURLEncodingClientGetMethodQueryNullResponse contains the response from method SkipURLEncodingClient.GetMethodQueryNull.
 type SkipURLEncodingClientGetMethodQueryNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SkipURLEncodingClientGetMethodQueryValidResponse contains the response from method SkipURLEncodingClient.GetMethodQueryValid.
 type SkipURLEncodingClientGetMethodQueryValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SkipURLEncodingClientGetPathQueryValidResponse contains the response from method SkipURLEncodingClient.GetPathQueryValid.
 type SkipURLEncodingClientGetPathQueryValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SkipURLEncodingClientGetPathValidResponse contains the response from method SkipURLEncodingClient.GetPathValid.
 type SkipURLEncodingClientGetPathValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SkipURLEncodingClientGetSwaggerPathValidResponse contains the response from method SkipURLEncodingClient.GetSwaggerPathValid.
 type SkipURLEncodingClientGetSwaggerPathValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SkipURLEncodingClientGetSwaggerQueryValidResponse contains the response from method SkipURLEncodingClient.GetSwaggerQueryValid.
 type SkipURLEncodingClientGetSwaggerQueryValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInCredentialsClientPostMethodGlobalNotProvidedValidResponse contains the response from method SubscriptionInCredentialsClient.PostMethodGlobalNotProvidedValid.
 type SubscriptionInCredentialsClientPostMethodGlobalNotProvidedValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInCredentialsClientPostMethodGlobalNullResponse contains the response from method SubscriptionInCredentialsClient.PostMethodGlobalNull.
 type SubscriptionInCredentialsClientPostMethodGlobalNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInCredentialsClientPostMethodGlobalValidResponse contains the response from method SubscriptionInCredentialsClient.PostMethodGlobalValid.
 type SubscriptionInCredentialsClientPostMethodGlobalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInCredentialsClientPostPathGlobalValidResponse contains the response from method SubscriptionInCredentialsClient.PostPathGlobalValid.
 type SubscriptionInCredentialsClientPostPathGlobalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInCredentialsClientPostSwaggerGlobalValidResponse contains the response from method SubscriptionInCredentialsClient.PostSwaggerGlobalValid.
 type SubscriptionInCredentialsClientPostSwaggerGlobalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInMethodClientPostMethodLocalNullResponse contains the response from method SubscriptionInMethodClient.PostMethodLocalNull.
 type SubscriptionInMethodClientPostMethodLocalNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInMethodClientPostMethodLocalValidResponse contains the response from method SubscriptionInMethodClient.PostMethodLocalValid.
 type SubscriptionInMethodClientPostMethodLocalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInMethodClientPostPathLocalValidResponse contains the response from method SubscriptionInMethodClient.PostPathLocalValid.
 type SubscriptionInMethodClientPostPathLocalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubscriptionInMethodClientPostSwaggerLocalValidResponse contains the response from method SubscriptionInMethodClient.PostSwaggerLocalValid.
 type SubscriptionInMethodClientPostSwaggerLocalValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMSClientRequestIDClientGetResponse contains the response from method XMSClientRequestIDClient.Get.
 type XMSClientRequestIDClientGetResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMSClientRequestIDClientParamGetResponse contains the response from method XMSClientRequestIDClient.ParamGet.
 type XMSClientRequestIDClientParamGetResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding_client.go
@@ -52,7 +52,7 @@ func (client *SkipURLEncodingClient) GetMethodPathValid(ctx context.Context, une
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SkipURLEncodingClientGetMethodPathValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SkipURLEncodingClientGetMethodPathValidResponse{RawResponse: resp}, nil
+	return SkipURLEncodingClientGetMethodPathValidResponse{}, nil
 }
 
 // getMethodPathValidCreateRequest creates the GetMethodPathValid request.
@@ -83,7 +83,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryNull(ctx context.Context, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SkipURLEncodingClientGetMethodQueryNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return SkipURLEncodingClientGetMethodQueryNullResponse{RawResponse: resp}, nil
+	return SkipURLEncodingClientGetMethodQueryNullResponse{}, nil
 }
 
 // getMethodQueryNullCreateRequest creates the GetMethodQueryNull request.
@@ -119,7 +119,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryValid(ctx context.Context, q1
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SkipURLEncodingClientGetMethodQueryValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SkipURLEncodingClientGetMethodQueryValidResponse{RawResponse: resp}, nil
+	return SkipURLEncodingClientGetMethodQueryValidResponse{}, nil
 }
 
 // getMethodQueryValidCreateRequest creates the GetMethodQueryValid request.
@@ -153,7 +153,7 @@ func (client *SkipURLEncodingClient) GetPathQueryValid(ctx context.Context, q1 s
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SkipURLEncodingClientGetPathQueryValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SkipURLEncodingClientGetPathQueryValidResponse{RawResponse: resp}, nil
+	return SkipURLEncodingClientGetPathQueryValidResponse{}, nil
 }
 
 // getPathQueryValidCreateRequest creates the GetPathQueryValid request.
@@ -187,7 +187,7 @@ func (client *SkipURLEncodingClient) GetPathValid(ctx context.Context, unencoded
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SkipURLEncodingClientGetPathValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SkipURLEncodingClientGetPathValidResponse{RawResponse: resp}, nil
+	return SkipURLEncodingClientGetPathValidResponse{}, nil
 }
 
 // getPathValidCreateRequest creates the GetPathValid request.
@@ -218,7 +218,7 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValid(ctx context.Context, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SkipURLEncodingClientGetSwaggerPathValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SkipURLEncodingClientGetSwaggerPathValidResponse{RawResponse: resp}, nil
+	return SkipURLEncodingClientGetSwaggerPathValidResponse{}, nil
 }
 
 // getSwaggerPathValidCreateRequest creates the GetSwaggerPathValid request.
@@ -249,7 +249,7 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValid(ctx context.Context, o
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SkipURLEncodingClientGetSwaggerQueryValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SkipURLEncodingClientGetSwaggerQueryValidResponse{RawResponse: resp}, nil
+	return SkipURLEncodingClientGetSwaggerQueryValidResponse{}, nil
 }
 
 // getSwaggerQueryValidCreateRequest creates the GetSwaggerQueryValid request.

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials_client.go
@@ -57,7 +57,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValid(
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInCredentialsClientPostMethodGlobalNotProvidedValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInCredentialsClientPostMethodGlobalNotProvidedValidResponse{RawResponse: resp}, nil
+	return SubscriptionInCredentialsClientPostMethodGlobalNotProvidedValidResponse{}, nil
 }
 
 // postMethodGlobalNotProvidedValidCreateRequest creates the PostMethodGlobalNotProvidedValid request.
@@ -95,7 +95,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNull(ctx context.
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInCredentialsClientPostMethodGlobalNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInCredentialsClientPostMethodGlobalNullResponse{RawResponse: resp}, nil
+	return SubscriptionInCredentialsClientPostMethodGlobalNullResponse{}, nil
 }
 
 // postMethodGlobalNullCreateRequest creates the PostMethodGlobalNull request.
@@ -130,7 +130,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValid(ctx context
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInCredentialsClientPostMethodGlobalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInCredentialsClientPostMethodGlobalValidResponse{RawResponse: resp}, nil
+	return SubscriptionInCredentialsClientPostMethodGlobalValidResponse{}, nil
 }
 
 // postMethodGlobalValidCreateRequest creates the PostMethodGlobalValid request.
@@ -165,7 +165,7 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValid(ctx context.C
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInCredentialsClientPostPathGlobalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInCredentialsClientPostPathGlobalValidResponse{RawResponse: resp}, nil
+	return SubscriptionInCredentialsClientPostPathGlobalValidResponse{}, nil
 }
 
 // postPathGlobalValidCreateRequest creates the PostPathGlobalValid request.
@@ -200,7 +200,7 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValid(ctx contex
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInCredentialsClientPostSwaggerGlobalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInCredentialsClientPostSwaggerGlobalValidResponse{RawResponse: resp}, nil
+	return SubscriptionInCredentialsClientPostSwaggerGlobalValidResponse{}, nil
 }
 
 // postSwaggerGlobalValidCreateRequest creates the PostSwaggerGlobalValid request.

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod_client.go
@@ -55,7 +55,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNull(ctx context.Contex
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInMethodClientPostMethodLocalNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInMethodClientPostMethodLocalNullResponse{RawResponse: resp}, nil
+	return SubscriptionInMethodClientPostMethodLocalNullResponse{}, nil
 }
 
 // postMethodLocalNullCreateRequest creates the PostMethodLocalNull request.
@@ -91,7 +91,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValid(ctx context.Conte
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInMethodClientPostMethodLocalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInMethodClientPostMethodLocalValidResponse{RawResponse: resp}, nil
+	return SubscriptionInMethodClientPostMethodLocalValidResponse{}, nil
 }
 
 // postMethodLocalValidCreateRequest creates the PostMethodLocalValid request.
@@ -127,7 +127,7 @@ func (client *SubscriptionInMethodClient) PostPathLocalValid(ctx context.Context
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInMethodClientPostPathLocalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInMethodClientPostPathLocalValidResponse{RawResponse: resp}, nil
+	return SubscriptionInMethodClientPostPathLocalValidResponse{}, nil
 }
 
 // postPathLocalValidCreateRequest creates the PostPathLocalValid request.
@@ -163,7 +163,7 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValid(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return SubscriptionInMethodClientPostSwaggerLocalValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return SubscriptionInMethodClientPostSwaggerLocalValidResponse{RawResponse: resp}, nil
+	return SubscriptionInMethodClientPostSwaggerLocalValidResponse{}, nil
 }
 
 // postSwaggerLocalValidCreateRequest creates the PostSwaggerLocalValid request.

--- a/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid_client.go
@@ -49,7 +49,7 @@ func (client *XMSClientRequestIDClient) Get(ctx context.Context, options *XMSCli
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return XMSClientRequestIDClientGetResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMSClientRequestIDClientGetResponse{RawResponse: resp}, nil
+	return XMSClientRequestIDClientGetResponse{}, nil
 }
 
 // getCreateRequest creates the Get request.
@@ -79,7 +79,7 @@ func (client *XMSClientRequestIDClient) ParamGet(ctx context.Context, xmsClientR
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return XMSClientRequestIDClientParamGetResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMSClientRequestIDClientParamGetResponse{RawResponse: resp}, nil
+	return XMSClientRequestIDClientParamGetResponse{}, nil
 }
 
 // paramGetCreateRequest creates the ParamGet request.

--- a/test/autorest/binarygroup/binarygroup_test.go
+++ b/test/autorest/binarygroup/binarygroup_test.go
@@ -6,7 +6,7 @@ package binarygroup
 import (
 	"bytes"
 	"context"
-	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -23,8 +23,8 @@ func TestBinary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sc := resp.RawResponse.StatusCode; sc != http.StatusOK {
-		t.Fatalf("unexpected status code %d", sc)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -35,7 +35,7 @@ func TestFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sc := resp.RawResponse.StatusCode; sc != http.StatusOK {
-		t.Fatalf("unexpected status code %d", sc)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/binarygroup/zz_generated_response_types.go
+++ b/test/autorest/binarygroup/zz_generated_response_types.go
@@ -8,16 +8,12 @@
 
 package binarygroup
 
-import "net/http"
-
 // UploadClientBinaryResponse contains the response from method UploadClient.Binary.
 type UploadClientBinaryResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // UploadClientFileResponse contains the response from method UploadClient.File.
 type UploadClientFileResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/binarygroup/zz_generated_upload_client.go
+++ b/test/autorest/binarygroup/zz_generated_upload_client.go
@@ -51,7 +51,7 @@ func (client *UploadClient) Binary(ctx context.Context, fileParam io.ReadSeekClo
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return UploadClientBinaryResponse{}, runtime.NewResponseError(resp)
 	}
-	return UploadClientBinaryResponse{RawResponse: resp}, nil
+	return UploadClientBinaryResponse{}, nil
 }
 
 // binaryCreateRequest creates the Binary request.
@@ -80,7 +80,7 @@ func (client *UploadClient) File(ctx context.Context, fileParam io.ReadSeekClose
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return UploadClientFileResponse{}, runtime.NewResponseError(resp)
 	}
-	return UploadClientFileResponse{RawResponse: resp}, nil
+	return UploadClientFileResponse{}, nil
 }
 
 // fileCreateRequest creates the File request.

--- a/test/autorest/booleangroup/booleangroup_test.go
+++ b/test/autorest/booleangroup/booleangroup_test.go
@@ -5,7 +5,6 @@ package booleangroup
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 
@@ -23,9 +22,6 @@ func TestGetTrue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTrue: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, to.BoolPtr(true)); r != "" {
 		t.Fatal(r)
 	}
@@ -37,9 +33,6 @@ func TestGetFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetFalse: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, to.BoolPtr(false)); r != "" {
 		t.Fatal(r)
 	}
@@ -50,9 +43,6 @@ func TestGetNull(t *testing.T) {
 	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(result.Value, (*bool)(nil)); r != "" {
 		t.Fatal(r)
@@ -77,8 +67,8 @@ func TestPutTrue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutTrue: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -88,7 +78,7 @@ func TestPutFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutFalse: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/booleangroup/zz_generated_bool_client.go
+++ b/test/autorest/booleangroup/zz_generated_bool_client.go
@@ -65,7 +65,7 @@ func (client *BoolClient) getFalseCreateRequest(ctx context.Context, options *Bo
 
 // getFalseHandleResponse handles the GetFalse response.
 func (client *BoolClient) getFalseHandleResponse(resp *http.Response) (BoolClientGetFalseResponse, error) {
-	result := BoolClientGetFalseResponse{RawResponse: resp}
+	result := BoolClientGetFalseResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return BoolClientGetFalseResponse{}, err
 	}
@@ -103,7 +103,7 @@ func (client *BoolClient) getInvalidCreateRequest(ctx context.Context, options *
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *BoolClient) getInvalidHandleResponse(resp *http.Response) (BoolClientGetInvalidResponse, error) {
-	result := BoolClientGetInvalidResponse{RawResponse: resp}
+	result := BoolClientGetInvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return BoolClientGetInvalidResponse{}, err
 	}
@@ -141,7 +141,7 @@ func (client *BoolClient) getNullCreateRequest(ctx context.Context, options *Boo
 
 // getNullHandleResponse handles the GetNull response.
 func (client *BoolClient) getNullHandleResponse(resp *http.Response) (BoolClientGetNullResponse, error) {
-	result := BoolClientGetNullResponse{RawResponse: resp}
+	result := BoolClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return BoolClientGetNullResponse{}, err
 	}
@@ -179,7 +179,7 @@ func (client *BoolClient) getTrueCreateRequest(ctx context.Context, options *Boo
 
 // getTrueHandleResponse handles the GetTrue response.
 func (client *BoolClient) getTrueHandleResponse(resp *http.Response) (BoolClientGetTrueResponse, error) {
-	result := BoolClientGetTrueResponse{RawResponse: resp}
+	result := BoolClientGetTrueResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return BoolClientGetTrueResponse{}, err
 	}
@@ -201,7 +201,7 @@ func (client *BoolClient) PutFalse(ctx context.Context, options *BoolClientPutFa
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return BoolClientPutFalseResponse{}, runtime.NewResponseError(resp)
 	}
-	return BoolClientPutFalseResponse{RawResponse: resp}, nil
+	return BoolClientPutFalseResponse{}, nil
 }
 
 // putFalseCreateRequest creates the PutFalse request.
@@ -230,7 +230,7 @@ func (client *BoolClient) PutTrue(ctx context.Context, options *BoolClientPutTru
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return BoolClientPutTrueResponse{}, runtime.NewResponseError(resp)
 	}
-	return BoolClientPutTrueResponse{RawResponse: resp}, nil
+	return BoolClientPutTrueResponse{}, nil
 }
 
 // putTrueCreateRequest creates the PutTrue request.

--- a/test/autorest/booleangroup/zz_generated_response_types.go
+++ b/test/autorest/booleangroup/zz_generated_response_types.go
@@ -8,48 +8,34 @@
 
 package booleangroup
 
-import "net/http"
-
 // BoolClientGetFalseResponse contains the response from method BoolClient.GetFalse.
 type BoolClientGetFalseResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple boolean
 	Value *bool
 }
 
 // BoolClientGetInvalidResponse contains the response from method BoolClient.GetInvalid.
 type BoolClientGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *bool
+	Value *bool
 }
 
 // BoolClientGetNullResponse contains the response from method BoolClient.GetNull.
 type BoolClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *bool
+	Value *bool
 }
 
 // BoolClientGetTrueResponse contains the response from method BoolClient.GetTrue.
 type BoolClientGetTrueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple boolean
 	Value *bool
 }
 
 // BoolClientPutFalseResponse contains the response from method BoolClient.PutFalse.
 type BoolClientPutFalseResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // BoolClientPutTrueResponse contains the response from method BoolClient.PutTrue.
 type BoolClientPutTrueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/bytegroup/bytegroup_test.go
+++ b/test/autorest/bytegroup/bytegroup_test.go
@@ -5,7 +5,6 @@ package bytegroup
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 
@@ -21,9 +20,6 @@ func TestGetEmpty(t *testing.T) {
 	result, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(result.Value, []byte{}); r != "" {
 		t.Fatal(r)
@@ -48,9 +44,6 @@ func TestGetNonASCII(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetNonASCII: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, []byte{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8, 0xF7, 0xF6}); r != "" {
 		t.Fatal(r)
 	}
@@ -61,9 +54,6 @@ func TestGetNull(t *testing.T) {
 	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(result.Value, ([]byte)(nil)); r != "" {
 		t.Fatal(r)
@@ -76,7 +66,7 @@ func TestPutNonASCII(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutNonASCII: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/bytegroup/zz_generated_byte_client.go
+++ b/test/autorest/bytegroup/zz_generated_byte_client.go
@@ -65,7 +65,7 @@ func (client *ByteClient) getEmptyCreateRequest(ctx context.Context, options *By
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *ByteClient) getEmptyHandleResponse(resp *http.Response) (ByteClientGetEmptyResponse, error) {
-	result := ByteClientGetEmptyResponse{RawResponse: resp}
+	result := ByteClientGetEmptyResponse{}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
 		return ByteClientGetEmptyResponse{}, err
 	}
@@ -103,7 +103,7 @@ func (client *ByteClient) getInvalidCreateRequest(ctx context.Context, options *
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *ByteClient) getInvalidHandleResponse(resp *http.Response) (ByteClientGetInvalidResponse, error) {
-	result := ByteClientGetInvalidResponse{RawResponse: resp}
+	result := ByteClientGetInvalidResponse{}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
 		return ByteClientGetInvalidResponse{}, err
 	}
@@ -141,7 +141,7 @@ func (client *ByteClient) getNonASCIICreateRequest(ctx context.Context, options 
 
 // getNonASCIIHandleResponse handles the GetNonASCII response.
 func (client *ByteClient) getNonASCIIHandleResponse(resp *http.Response) (ByteClientGetNonASCIIResponse, error) {
-	result := ByteClientGetNonASCIIResponse{RawResponse: resp}
+	result := ByteClientGetNonASCIIResponse{}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
 		return ByteClientGetNonASCIIResponse{}, err
 	}
@@ -179,7 +179,7 @@ func (client *ByteClient) getNullCreateRequest(ctx context.Context, options *Byt
 
 // getNullHandleResponse handles the GetNull response.
 func (client *ByteClient) getNullHandleResponse(resp *http.Response) (ByteClientGetNullResponse, error) {
-	result := ByteClientGetNullResponse{RawResponse: resp}
+	result := ByteClientGetNullResponse{}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
 		return ByteClientGetNullResponse{}, err
 	}
@@ -202,7 +202,7 @@ func (client *ByteClient) PutNonASCII(ctx context.Context, byteBody []byte, opti
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ByteClientPutNonASCIIResponse{}, runtime.NewResponseError(resp)
 	}
-	return ByteClientPutNonASCIIResponse{RawResponse: resp}, nil
+	return ByteClientPutNonASCIIResponse{}, nil
 }
 
 // putNonASCIICreateRequest creates the PutNonASCII request.

--- a/test/autorest/bytegroup/zz_generated_response_types.go
+++ b/test/autorest/bytegroup/zz_generated_response_types.go
@@ -8,46 +8,31 @@
 
 package bytegroup
 
-import "net/http"
-
 // ByteClientGetEmptyResponse contains the response from method ByteClient.GetEmpty.
 type ByteClientGetEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The empty byte value ''
 	Value []byte
 }
 
 // ByteClientGetInvalidResponse contains the response from method ByteClient.GetInvalid.
 type ByteClientGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The invalid byte value '::::SWAGGER::::'
 	Value []byte
 }
 
 // ByteClientGetNonASCIIResponse contains the response from method ByteClient.GetNonASCII.
 type ByteClientGetNonASCIIResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Non-ascii base-64 encoded byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
 	Value []byte
 }
 
 // ByteClientGetNullResponse contains the response from method ByteClient.GetNull.
 type ByteClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The null byte value
 	Value []byte
 }
 
 // ByteClientPutNonASCIIResponse contains the response from method ByteClient.PutNonASCII.
 type ByteClientPutNonASCIIResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -5,7 +5,7 @@ package complexgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -65,8 +65,8 @@ func TestArrayPutEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -82,7 +82,7 @@ func TestArrayPutValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/complexgroup/basic_test.go
+++ b/test/autorest/complexgroup/basic_test.go
@@ -5,7 +5,7 @@ package complexgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -37,8 +37,8 @@ func TestBasicPutValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -5,7 +5,7 @@ package complexgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -67,8 +67,8 @@ func TestDictionaryPutEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -79,7 +79,7 @@ func TestDictionaryPutValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -5,7 +5,7 @@ package complexgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -67,7 +67,7 @@ func TestInheritancePutValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -5,7 +5,7 @@ package complexgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -158,7 +158,7 @@ func TestPutValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -5,7 +5,7 @@ package complexgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -366,8 +366,8 @@ func TestPolymorphismPutComplicated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -409,8 +409,40 @@ func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	expectedSalmon := &Salmon{
+		Length: to.Float32Ptr(1),
+		Siblings: []FishClassification{
+			&Shark{
+				Fishtype: to.StringPtr("shark"),
+				Length:   to.Float32Ptr(20),
+				Species:  to.StringPtr("predator"),
+				Age:      to.Int32Ptr(6),
+				Birthday: &sharkBday,
+			},
+			&Sawshark{
+				Fishtype: to.StringPtr("sawshark"),
+				Length:   to.Float32Ptr(10),
+				Species:  to.StringPtr("dangerous"),
+				Age:      to.Int32Ptr(105),
+				Birthday: &sawBday,
+				Picture:  []byte{255, 255, 255, 255, 254},
+			},
+			&Goblinshark{
+				Fishtype: to.StringPtr("goblin"),
+				Length:   to.Float32Ptr(30),
+				Species:  to.StringPtr("scary"),
+				Age:      to.Int32Ptr(1),
+				Birthday: &goblinBday,
+				Color:    GoblinSharkColor("pinkish-gray").ToPtr(),
+				Jawsize:  to.Int32Ptr(5),
+			},
+		},
+		Species:  to.StringPtr("king"),
+		Iswild:   to.BoolPtr(true),
+		Location: to.StringPtr("alaska"),
+	}
+	if r := cmp.Diff(expectedSalmon, result.SalmonClassification); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -420,7 +452,7 @@ func TestPolymorphismPutValid(t *testing.T) {
 	goblinBday := time.Date(2015, time.August, 8, 0, 0, 0, 0, time.UTC)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
-	resp, err := client.PutValid(context.Background(), &Salmon{
+	result, err := client.PutValid(context.Background(), &Salmon{
 		Length: to.Float32Ptr(1),
 		Siblings: []FishClassification{
 			&Shark{
@@ -452,8 +484,8 @@ func TestPolymorphismPutValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -6,7 +6,7 @@ package complexgroup
 import (
 	"context"
 	"encoding/json"
-	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -37,8 +37,8 @@ func TestPrimitivePutInt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutInt: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -63,8 +63,8 @@ func TestPrimitivePutLong(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutLong: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -89,8 +89,8 @@ func TestPrimitivePutFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutFloat: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -115,8 +115,8 @@ func TestPrimitivePutDouble(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutDouble: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -152,8 +152,8 @@ func TestPrimitivePutBool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBool: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -182,8 +182,8 @@ func TestPrimitivePutByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutByte: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -209,8 +209,8 @@ func TestPrimitivePutString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutString: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -244,12 +244,12 @@ func TestPrimitivePutDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse leap year date string: %v", err)
 	}
-	resp, err := client.PutDate(context.Background(), DateWrapper{Field: &a, Leap: &b}, nil)
+	result, err := client.PutDate(context.Background(), DateWrapper{Field: &a, Leap: &b}, nil)
 	if err != nil {
 		t.Fatalf("PutDate: %v", err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -272,8 +272,8 @@ func TestPrimitivePutDuration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutDuration: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -320,8 +320,8 @@ func TestPrimitivePutDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutDateTime: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -336,8 +336,8 @@ func TestPrimitivePutDateTimeRFC1123(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutDateTimeRFC1123: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 

--- a/test/autorest/complexgroup/readonlyproperty_test.go
+++ b/test/autorest/complexgroup/readonlyproperty_test.go
@@ -5,7 +5,7 @@ package complexgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -34,7 +34,7 @@ func TestReadonlypropertyPutValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/complexgroup/zz_generated_array_client.go
+++ b/test/autorest/complexgroup/zz_generated_array_client.go
@@ -65,7 +65,7 @@ func (client *ArrayClient) getEmptyCreateRequest(ctx context.Context, options *A
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *ArrayClient) getEmptyHandleResponse(resp *http.Response) (ArrayClientGetEmptyResponse, error) {
-	result := ArrayClientGetEmptyResponse{RawResponse: resp}
+	result := ArrayClientGetEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArrayWrapper); err != nil {
 		return ArrayClientGetEmptyResponse{}, err
 	}
@@ -103,7 +103,7 @@ func (client *ArrayClient) getNotProvidedCreateRequest(ctx context.Context, opti
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *ArrayClient) getNotProvidedHandleResponse(resp *http.Response) (ArrayClientGetNotProvidedResponse, error) {
-	result := ArrayClientGetNotProvidedResponse{RawResponse: resp}
+	result := ArrayClientGetNotProvidedResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArrayWrapper); err != nil {
 		return ArrayClientGetNotProvidedResponse{}, err
 	}
@@ -141,7 +141,7 @@ func (client *ArrayClient) getValidCreateRequest(ctx context.Context, options *A
 
 // getValidHandleResponse handles the GetValid response.
 func (client *ArrayClient) getValidHandleResponse(resp *http.Response) (ArrayClientGetValidResponse, error) {
-	result := ArrayClientGetValidResponse{RawResponse: resp}
+	result := ArrayClientGetValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArrayWrapper); err != nil {
 		return ArrayClientGetValidResponse{}, err
 	}
@@ -164,7 +164,7 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, complexBody ArrayWrappe
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutEmptyResponse{RawResponse: resp}, nil
+	return ArrayClientPutEmptyResponse{}, nil
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
@@ -195,7 +195,7 @@ func (client *ArrayClient) PutValid(ctx context.Context, complexBody ArrayWrappe
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ArrayClientPutValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ArrayClientPutValidResponse{RawResponse: resp}, nil
+	return ArrayClientPutValidResponse{}, nil
 }
 
 // putValidCreateRequest creates the PutValid request.

--- a/test/autorest/complexgroup/zz_generated_basic_client.go
+++ b/test/autorest/complexgroup/zz_generated_basic_client.go
@@ -65,7 +65,7 @@ func (client *BasicClient) getEmptyCreateRequest(ctx context.Context, options *B
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *BasicClient) getEmptyHandleResponse(resp *http.Response) (BasicClientGetEmptyResponse, error) {
-	result := BasicClientGetEmptyResponse{RawResponse: resp}
+	result := BasicClientGetEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
 		return BasicClientGetEmptyResponse{}, err
 	}
@@ -103,7 +103,7 @@ func (client *BasicClient) getInvalidCreateRequest(ctx context.Context, options 
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *BasicClient) getInvalidHandleResponse(resp *http.Response) (BasicClientGetInvalidResponse, error) {
-	result := BasicClientGetInvalidResponse{RawResponse: resp}
+	result := BasicClientGetInvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
 		return BasicClientGetInvalidResponse{}, err
 	}
@@ -141,7 +141,7 @@ func (client *BasicClient) getNotProvidedCreateRequest(ctx context.Context, opti
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *BasicClient) getNotProvidedHandleResponse(resp *http.Response) (BasicClientGetNotProvidedResponse, error) {
-	result := BasicClientGetNotProvidedResponse{RawResponse: resp}
+	result := BasicClientGetNotProvidedResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
 		return BasicClientGetNotProvidedResponse{}, err
 	}
@@ -179,7 +179,7 @@ func (client *BasicClient) getNullCreateRequest(ctx context.Context, options *Ba
 
 // getNullHandleResponse handles the GetNull response.
 func (client *BasicClient) getNullHandleResponse(resp *http.Response) (BasicClientGetNullResponse, error) {
-	result := BasicClientGetNullResponse{RawResponse: resp}
+	result := BasicClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
 		return BasicClientGetNullResponse{}, err
 	}
@@ -217,7 +217,7 @@ func (client *BasicClient) getValidCreateRequest(ctx context.Context, options *B
 
 // getValidHandleResponse handles the GetValid response.
 func (client *BasicClient) getValidHandleResponse(resp *http.Response) (BasicClientGetValidResponse, error) {
-	result := BasicClientGetValidResponse{RawResponse: resp}
+	result := BasicClientGetValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
 		return BasicClientGetValidResponse{}, err
 	}
@@ -240,7 +240,7 @@ func (client *BasicClient) PutValid(ctx context.Context, complexBody Basic, opti
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return BasicClientPutValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return BasicClientPutValidResponse{RawResponse: resp}, nil
+	return BasicClientPutValidResponse{}, nil
 }
 
 // putValidCreateRequest creates the PutValid request.

--- a/test/autorest/complexgroup/zz_generated_dictionary_client.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary_client.go
@@ -65,7 +65,7 @@ func (client *DictionaryClient) getEmptyCreateRequest(ctx context.Context, optio
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *DictionaryClient) getEmptyHandleResponse(resp *http.Response) (DictionaryClientGetEmptyResponse, error) {
-	result := DictionaryClientGetEmptyResponse{RawResponse: resp}
+	result := DictionaryClientGetEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DictionaryWrapper); err != nil {
 		return DictionaryClientGetEmptyResponse{}, err
 	}
@@ -104,7 +104,7 @@ func (client *DictionaryClient) getNotProvidedCreateRequest(ctx context.Context,
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *DictionaryClient) getNotProvidedHandleResponse(resp *http.Response) (DictionaryClientGetNotProvidedResponse, error) {
-	result := DictionaryClientGetNotProvidedResponse{RawResponse: resp}
+	result := DictionaryClientGetNotProvidedResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DictionaryWrapper); err != nil {
 		return DictionaryClientGetNotProvidedResponse{}, err
 	}
@@ -142,7 +142,7 @@ func (client *DictionaryClient) getNullCreateRequest(ctx context.Context, option
 
 // getNullHandleResponse handles the GetNull response.
 func (client *DictionaryClient) getNullHandleResponse(resp *http.Response) (DictionaryClientGetNullResponse, error) {
-	result := DictionaryClientGetNullResponse{RawResponse: resp}
+	result := DictionaryClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DictionaryWrapper); err != nil {
 		return DictionaryClientGetNullResponse{}, err
 	}
@@ -180,7 +180,7 @@ func (client *DictionaryClient) getValidCreateRequest(ctx context.Context, optio
 
 // getValidHandleResponse handles the GetValid response.
 func (client *DictionaryClient) getValidHandleResponse(resp *http.Response) (DictionaryClientGetValidResponse, error) {
-	result := DictionaryClientGetValidResponse{RawResponse: resp}
+	result := DictionaryClientGetValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DictionaryWrapper); err != nil {
 		return DictionaryClientGetValidResponse{}, err
 	}
@@ -203,7 +203,7 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, complexBody Dictio
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutEmptyResponse{RawResponse: resp}, nil
+	return DictionaryClientPutEmptyResponse{}, nil
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
@@ -234,7 +234,7 @@ func (client *DictionaryClient) PutValid(ctx context.Context, complexBody Dictio
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutValidResponse{}, nil
 }
 
 // putValidCreateRequest creates the PutValid request.

--- a/test/autorest/complexgroup/zz_generated_flattencomplex_client.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex_client.go
@@ -65,7 +65,7 @@ func (client *FlattencomplexClient) getValidCreateRequest(ctx context.Context, o
 
 // getValidHandleResponse handles the GetValid response.
 func (client *FlattencomplexClient) getValidHandleResponse(resp *http.Response) (FlattencomplexClientGetValidResponse, error) {
-	result := FlattencomplexClientGetValidResponse{RawResponse: resp}
+	result := FlattencomplexClientGetValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return FlattencomplexClientGetValidResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_generated_inheritance_client.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance_client.go
@@ -65,7 +65,7 @@ func (client *InheritanceClient) getValidCreateRequest(ctx context.Context, opti
 
 // getValidHandleResponse handles the GetValid response.
 func (client *InheritanceClient) getValidHandleResponse(resp *http.Response) (InheritanceClientGetValidResponse, error) {
-	result := InheritanceClientGetValidResponse{RawResponse: resp}
+	result := InheritanceClientGetValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Siamese); err != nil {
 		return InheritanceClientGetValidResponse{}, err
 	}
@@ -90,7 +90,7 @@ func (client *InheritanceClient) PutValid(ctx context.Context, complexBody Siame
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return InheritanceClientPutValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return InheritanceClientPutValidResponse{RawResponse: resp}, nil
+	return InheritanceClientPutValidResponse{}, nil
 }
 
 // putValidCreateRequest creates the PutValid request.

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive_client.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive_client.go
@@ -66,7 +66,7 @@ func (client *PolymorphicrecursiveClient) getValidCreateRequest(ctx context.Cont
 
 // getValidHandleResponse handles the GetValid response.
 func (client *PolymorphicrecursiveClient) getValidHandleResponse(resp *http.Response) (PolymorphicrecursiveClientGetValidResponse, error) {
-	result := PolymorphicrecursiveClientGetValidResponse{RawResponse: resp}
+	result := PolymorphicrecursiveClientGetValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return PolymorphicrecursiveClientGetValidResponse{}, err
 	}
@@ -96,7 +96,7 @@ func (client *PolymorphicrecursiveClient) PutValid(ctx context.Context, complexB
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PolymorphicrecursiveClientPutValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return PolymorphicrecursiveClientPutValidResponse{RawResponse: resp}, nil
+	return PolymorphicrecursiveClientPutValidResponse{}, nil
 }
 
 // putValidCreateRequest creates the PutValid request.

--- a/test/autorest/complexgroup/zz_generated_polymorphism_client.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism_client.go
@@ -66,7 +66,7 @@ func (client *PolymorphismClient) getComplicatedCreateRequest(ctx context.Contex
 
 // getComplicatedHandleResponse handles the GetComplicated response.
 func (client *PolymorphismClient) getComplicatedHandleResponse(resp *http.Response) (PolymorphismClientGetComplicatedResponse, error) {
-	result := PolymorphismClientGetComplicatedResponse{RawResponse: resp}
+	result := PolymorphismClientGetComplicatedResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return PolymorphismClientGetComplicatedResponse{}, err
 	}
@@ -107,7 +107,7 @@ func (client *PolymorphismClient) getComposedWithDiscriminatorCreateRequest(ctx 
 
 // getComposedWithDiscriminatorHandleResponse handles the GetComposedWithDiscriminator response.
 func (client *PolymorphismClient) getComposedWithDiscriminatorHandleResponse(resp *http.Response) (PolymorphismClientGetComposedWithDiscriminatorResponse, error) {
-	result := PolymorphismClientGetComposedWithDiscriminatorResponse{RawResponse: resp}
+	result := PolymorphismClientGetComposedWithDiscriminatorResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DotFishMarket); err != nil {
 		return PolymorphismClientGetComposedWithDiscriminatorResponse{}, err
 	}
@@ -148,7 +148,7 @@ func (client *PolymorphismClient) getComposedWithoutDiscriminatorCreateRequest(c
 
 // getComposedWithoutDiscriminatorHandleResponse handles the GetComposedWithoutDiscriminator response.
 func (client *PolymorphismClient) getComposedWithoutDiscriminatorHandleResponse(resp *http.Response) (PolymorphismClientGetComposedWithoutDiscriminatorResponse, error) {
-	result := PolymorphismClientGetComposedWithoutDiscriminatorResponse{RawResponse: resp}
+	result := PolymorphismClientGetComposedWithoutDiscriminatorResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DotFishMarket); err != nil {
 		return PolymorphismClientGetComposedWithoutDiscriminatorResponse{}, err
 	}
@@ -187,7 +187,7 @@ func (client *PolymorphismClient) getDotSyntaxCreateRequest(ctx context.Context,
 
 // getDotSyntaxHandleResponse handles the GetDotSyntax response.
 func (client *PolymorphismClient) getDotSyntaxHandleResponse(resp *http.Response) (PolymorphismClientGetDotSyntaxResponse, error) {
-	result := PolymorphismClientGetDotSyntaxResponse{RawResponse: resp}
+	result := PolymorphismClientGetDotSyntaxResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return PolymorphismClientGetDotSyntaxResponse{}, err
 	}
@@ -225,7 +225,7 @@ func (client *PolymorphismClient) getValidCreateRequest(ctx context.Context, opt
 
 // getValidHandleResponse handles the GetValid response.
 func (client *PolymorphismClient) getValidHandleResponse(resp *http.Response) (PolymorphismClientGetValidResponse, error) {
-	result := PolymorphismClientGetValidResponse{RawResponse: resp}
+	result := PolymorphismClientGetValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return PolymorphismClientGetValidResponse{}, err
 	}
@@ -248,7 +248,7 @@ func (client *PolymorphismClient) PutComplicated(ctx context.Context, complexBod
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PolymorphismClientPutComplicatedResponse{}, runtime.NewResponseError(resp)
 	}
-	return PolymorphismClientPutComplicatedResponse{RawResponse: resp}, nil
+	return PolymorphismClientPutComplicatedResponse{}, nil
 }
 
 // putComplicatedCreateRequest creates the PutComplicated request.
@@ -294,7 +294,7 @@ func (client *PolymorphismClient) putMissingDiscriminatorCreateRequest(ctx conte
 
 // putMissingDiscriminatorHandleResponse handles the PutMissingDiscriminator response.
 func (client *PolymorphismClient) putMissingDiscriminatorHandleResponse(resp *http.Response) (PolymorphismClientPutMissingDiscriminatorResponse, error) {
-	result := PolymorphismClientPutMissingDiscriminatorResponse{RawResponse: resp}
+	result := PolymorphismClientPutMissingDiscriminatorResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return PolymorphismClientPutMissingDiscriminatorResponse{}, err
 	}
@@ -322,7 +322,7 @@ func (client *PolymorphismClient) PutValid(ctx context.Context, complexBody Fish
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PolymorphismClientPutValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return PolymorphismClientPutValidResponse{RawResponse: resp}, nil
+	return PolymorphismClientPutValidResponse{}, nil
 }
 
 // putValidCreateRequest creates the PutValid request.
@@ -358,7 +358,7 @@ func (client *PolymorphismClient) PutValidMissingRequired(ctx context.Context, c
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PolymorphismClientPutValidMissingRequiredResponse{}, runtime.NewResponseError(resp)
 	}
-	return PolymorphismClientPutValidMissingRequiredResponse{RawResponse: resp}, nil
+	return PolymorphismClientPutValidMissingRequiredResponse{}, nil
 }
 
 // putValidMissingRequiredCreateRequest creates the PutValidMissingRequired request.

--- a/test/autorest/complexgroup/zz_generated_primitive_client.go
+++ b/test/autorest/complexgroup/zz_generated_primitive_client.go
@@ -65,7 +65,7 @@ func (client *PrimitiveClient) getBoolCreateRequest(ctx context.Context, options
 
 // getBoolHandleResponse handles the GetBool response.
 func (client *PrimitiveClient) getBoolHandleResponse(resp *http.Response) (PrimitiveClientGetBoolResponse, error) {
-	result := PrimitiveClientGetBoolResponse{RawResponse: resp}
+	result := PrimitiveClientGetBoolResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BooleanWrapper); err != nil {
 		return PrimitiveClientGetBoolResponse{}, err
 	}
@@ -103,7 +103,7 @@ func (client *PrimitiveClient) getByteCreateRequest(ctx context.Context, options
 
 // getByteHandleResponse handles the GetByte response.
 func (client *PrimitiveClient) getByteHandleResponse(resp *http.Response) (PrimitiveClientGetByteResponse, error) {
-	result := PrimitiveClientGetByteResponse{RawResponse: resp}
+	result := PrimitiveClientGetByteResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ByteWrapper); err != nil {
 		return PrimitiveClientGetByteResponse{}, err
 	}
@@ -141,7 +141,7 @@ func (client *PrimitiveClient) getDateCreateRequest(ctx context.Context, options
 
 // getDateHandleResponse handles the GetDate response.
 func (client *PrimitiveClient) getDateHandleResponse(resp *http.Response) (PrimitiveClientGetDateResponse, error) {
-	result := PrimitiveClientGetDateResponse{RawResponse: resp}
+	result := PrimitiveClientGetDateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DateWrapper); err != nil {
 		return PrimitiveClientGetDateResponse{}, err
 	}
@@ -179,7 +179,7 @@ func (client *PrimitiveClient) getDateTimeCreateRequest(ctx context.Context, opt
 
 // getDateTimeHandleResponse handles the GetDateTime response.
 func (client *PrimitiveClient) getDateTimeHandleResponse(resp *http.Response) (PrimitiveClientGetDateTimeResponse, error) {
-	result := PrimitiveClientGetDateTimeResponse{RawResponse: resp}
+	result := PrimitiveClientGetDateTimeResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DatetimeWrapper); err != nil {
 		return PrimitiveClientGetDateTimeResponse{}, err
 	}
@@ -218,7 +218,7 @@ func (client *PrimitiveClient) getDateTimeRFC1123CreateRequest(ctx context.Conte
 
 // getDateTimeRFC1123HandleResponse handles the GetDateTimeRFC1123 response.
 func (client *PrimitiveClient) getDateTimeRFC1123HandleResponse(resp *http.Response) (PrimitiveClientGetDateTimeRFC1123Response, error) {
-	result := PrimitiveClientGetDateTimeRFC1123Response{RawResponse: resp}
+	result := PrimitiveClientGetDateTimeRFC1123Response{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Datetimerfc1123Wrapper); err != nil {
 		return PrimitiveClientGetDateTimeRFC1123Response{}, err
 	}
@@ -256,7 +256,7 @@ func (client *PrimitiveClient) getDoubleCreateRequest(ctx context.Context, optio
 
 // getDoubleHandleResponse handles the GetDouble response.
 func (client *PrimitiveClient) getDoubleHandleResponse(resp *http.Response) (PrimitiveClientGetDoubleResponse, error) {
-	result := PrimitiveClientGetDoubleResponse{RawResponse: resp}
+	result := PrimitiveClientGetDoubleResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DoubleWrapper); err != nil {
 		return PrimitiveClientGetDoubleResponse{}, err
 	}
@@ -294,7 +294,7 @@ func (client *PrimitiveClient) getDurationCreateRequest(ctx context.Context, opt
 
 // getDurationHandleResponse handles the GetDuration response.
 func (client *PrimitiveClient) getDurationHandleResponse(resp *http.Response) (PrimitiveClientGetDurationResponse, error) {
-	result := PrimitiveClientGetDurationResponse{RawResponse: resp}
+	result := PrimitiveClientGetDurationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DurationWrapper); err != nil {
 		return PrimitiveClientGetDurationResponse{}, err
 	}
@@ -332,7 +332,7 @@ func (client *PrimitiveClient) getFloatCreateRequest(ctx context.Context, option
 
 // getFloatHandleResponse handles the GetFloat response.
 func (client *PrimitiveClient) getFloatHandleResponse(resp *http.Response) (PrimitiveClientGetFloatResponse, error) {
-	result := PrimitiveClientGetFloatResponse{RawResponse: resp}
+	result := PrimitiveClientGetFloatResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FloatWrapper); err != nil {
 		return PrimitiveClientGetFloatResponse{}, err
 	}
@@ -370,7 +370,7 @@ func (client *PrimitiveClient) getIntCreateRequest(ctx context.Context, options 
 
 // getIntHandleResponse handles the GetInt response.
 func (client *PrimitiveClient) getIntHandleResponse(resp *http.Response) (PrimitiveClientGetIntResponse, error) {
-	result := PrimitiveClientGetIntResponse{RawResponse: resp}
+	result := PrimitiveClientGetIntResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IntWrapper); err != nil {
 		return PrimitiveClientGetIntResponse{}, err
 	}
@@ -408,7 +408,7 @@ func (client *PrimitiveClient) getLongCreateRequest(ctx context.Context, options
 
 // getLongHandleResponse handles the GetLong response.
 func (client *PrimitiveClient) getLongHandleResponse(resp *http.Response) (PrimitiveClientGetLongResponse, error) {
-	result := PrimitiveClientGetLongResponse{RawResponse: resp}
+	result := PrimitiveClientGetLongResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LongWrapper); err != nil {
 		return PrimitiveClientGetLongResponse{}, err
 	}
@@ -446,7 +446,7 @@ func (client *PrimitiveClient) getStringCreateRequest(ctx context.Context, optio
 
 // getStringHandleResponse handles the GetString response.
 func (client *PrimitiveClient) getStringHandleResponse(resp *http.Response) (PrimitiveClientGetStringResponse, error) {
-	result := PrimitiveClientGetStringResponse{RawResponse: resp}
+	result := PrimitiveClientGetStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringWrapper); err != nil {
 		return PrimitiveClientGetStringResponse{}, err
 	}
@@ -469,7 +469,7 @@ func (client *PrimitiveClient) PutBool(ctx context.Context, complexBody BooleanW
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutBoolResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutBoolResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutBoolResponse{}, nil
 }
 
 // putBoolCreateRequest creates the PutBool request.
@@ -499,7 +499,7 @@ func (client *PrimitiveClient) PutByte(ctx context.Context, complexBody ByteWrap
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutByteResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutByteResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutByteResponse{}, nil
 }
 
 // putByteCreateRequest creates the PutByte request.
@@ -529,7 +529,7 @@ func (client *PrimitiveClient) PutDate(ctx context.Context, complexBody DateWrap
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutDateResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutDateResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutDateResponse{}, nil
 }
 
 // putDateCreateRequest creates the PutDate request.
@@ -559,7 +559,7 @@ func (client *PrimitiveClient) PutDateTime(ctx context.Context, complexBody Date
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutDateTimeResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutDateTimeResponse{}, nil
 }
 
 // putDateTimeCreateRequest creates the PutDateTime request.
@@ -590,7 +590,7 @@ func (client *PrimitiveClient) PutDateTimeRFC1123(ctx context.Context, complexBo
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutDateTimeRFC1123Response{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutDateTimeRFC1123Response{RawResponse: resp}, nil
+	return PrimitiveClientPutDateTimeRFC1123Response{}, nil
 }
 
 // putDateTimeRFC1123CreateRequest creates the PutDateTimeRFC1123 request.
@@ -620,7 +620,7 @@ func (client *PrimitiveClient) PutDouble(ctx context.Context, complexBody Double
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutDoubleResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutDoubleResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutDoubleResponse{}, nil
 }
 
 // putDoubleCreateRequest creates the PutDouble request.
@@ -650,7 +650,7 @@ func (client *PrimitiveClient) PutDuration(ctx context.Context, complexBody Dura
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutDurationResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutDurationResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutDurationResponse{}, nil
 }
 
 // putDurationCreateRequest creates the PutDuration request.
@@ -680,7 +680,7 @@ func (client *PrimitiveClient) PutFloat(ctx context.Context, complexBody FloatWr
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutFloatResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutFloatResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutFloatResponse{}, nil
 }
 
 // putFloatCreateRequest creates the PutFloat request.
@@ -710,7 +710,7 @@ func (client *PrimitiveClient) PutInt(ctx context.Context, complexBody IntWrappe
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutIntResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutIntResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutIntResponse{}, nil
 }
 
 // putIntCreateRequest creates the PutInt request.
@@ -740,7 +740,7 @@ func (client *PrimitiveClient) PutLong(ctx context.Context, complexBody LongWrap
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutLongResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutLongResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutLongResponse{}, nil
 }
 
 // putLongCreateRequest creates the PutLong request.
@@ -770,7 +770,7 @@ func (client *PrimitiveClient) PutString(ctx context.Context, complexBody String
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PrimitiveClientPutStringResponse{}, runtime.NewResponseError(resp)
 	}
-	return PrimitiveClientPutStringResponse{RawResponse: resp}, nil
+	return PrimitiveClientPutStringResponse{}, nil
 }
 
 // putStringCreateRequest creates the PutString request.

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty_client.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty_client.go
@@ -66,7 +66,7 @@ func (client *ReadonlypropertyClient) getValidCreateRequest(ctx context.Context,
 
 // getValidHandleResponse handles the GetValid response.
 func (client *ReadonlypropertyClient) getValidHandleResponse(resp *http.Response) (ReadonlypropertyClientGetValidResponse, error) {
-	result := ReadonlypropertyClientGetValidResponse{RawResponse: resp}
+	result := ReadonlypropertyClientGetValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReadonlyObj); err != nil {
 		return ReadonlypropertyClientGetValidResponse{}, err
 	}
@@ -89,7 +89,7 @@ func (client *ReadonlypropertyClient) PutValid(ctx context.Context, complexBody 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ReadonlypropertyClientPutValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return ReadonlypropertyClientPutValidResponse{RawResponse: resp}, nil
+	return ReadonlypropertyClientPutValidResponse{}, nil
 }
 
 // putValidCreateRequest creates the PutValid request.

--- a/test/autorest/complexgroup/zz_generated_response_types.go
+++ b/test/autorest/complexgroup/zz_generated_response_types.go
@@ -8,127 +8,94 @@
 
 package complexgroup
 
-import "net/http"
-
 // ArrayClientGetEmptyResponse contains the response from method ArrayClient.GetEmpty.
 type ArrayClientGetEmptyResponse struct {
 	ArrayWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetNotProvidedResponse contains the response from method ArrayClient.GetNotProvided.
 type ArrayClientGetNotProvidedResponse struct {
 	ArrayWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientGetValidResponse contains the response from method ArrayClient.GetValid.
 type ArrayClientGetValidResponse struct {
 	ArrayWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ArrayClientPutEmptyResponse contains the response from method ArrayClient.PutEmpty.
 type ArrayClientPutEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ArrayClientPutValidResponse contains the response from method ArrayClient.PutValid.
 type ArrayClientPutValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // BasicClientGetEmptyResponse contains the response from method BasicClient.GetEmpty.
 type BasicClientGetEmptyResponse struct {
 	Basic
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BasicClientGetInvalidResponse contains the response from method BasicClient.GetInvalid.
 type BasicClientGetInvalidResponse struct {
 	Basic
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BasicClientGetNotProvidedResponse contains the response from method BasicClient.GetNotProvided.
 type BasicClientGetNotProvidedResponse struct {
 	Basic
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BasicClientGetNullResponse contains the response from method BasicClient.GetNull.
 type BasicClientGetNullResponse struct {
 	Basic
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BasicClientGetValidResponse contains the response from method BasicClient.GetValid.
 type BasicClientGetValidResponse struct {
 	Basic
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BasicClientPutValidResponse contains the response from method BasicClient.PutValid.
 type BasicClientPutValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientGetEmptyResponse contains the response from method DictionaryClient.GetEmpty.
 type DictionaryClientGetEmptyResponse struct {
 	DictionaryWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DictionaryClientGetNotProvidedResponse contains the response from method DictionaryClient.GetNotProvided.
 type DictionaryClientGetNotProvidedResponse struct {
 	DictionaryWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DictionaryClientGetNullResponse contains the response from method DictionaryClient.GetNull.
 type DictionaryClientGetNullResponse struct {
 	DictionaryWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DictionaryClientGetValidResponse contains the response from method DictionaryClient.GetValid.
 type DictionaryClientGetValidResponse struct {
 	DictionaryWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DictionaryClientPutEmptyResponse contains the response from method DictionaryClient.PutEmpty.
 type DictionaryClientPutEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutValidResponse contains the response from method DictionaryClient.PutValid.
 type DictionaryClientPutValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // FlattencomplexClientGetValidResponse contains the response from method FlattencomplexClient.GetValid.
 type FlattencomplexClientGetValidResponse struct {
 	MyBaseTypeClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type FlattencomplexClientGetValidResponse.
@@ -144,21 +111,16 @@ func (f *FlattencomplexClientGetValidResponse) UnmarshalJSON(data []byte) error 
 // InheritanceClientGetValidResponse contains the response from method InheritanceClient.GetValid.
 type InheritanceClientGetValidResponse struct {
 	Siamese
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InheritanceClientPutValidResponse contains the response from method InheritanceClient.PutValid.
 type InheritanceClientPutValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PolymorphicrecursiveClientGetValidResponse contains the response from method PolymorphicrecursiveClient.GetValid.
 type PolymorphicrecursiveClientGetValidResponse struct {
 	FishClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphicrecursiveClientGetValidResponse.
@@ -173,15 +135,12 @@ func (p *PolymorphicrecursiveClientGetValidResponse) UnmarshalJSON(data []byte) 
 
 // PolymorphicrecursiveClientPutValidResponse contains the response from method PolymorphicrecursiveClient.PutValid.
 type PolymorphicrecursiveClientPutValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PolymorphismClientGetComplicatedResponse contains the response from method PolymorphismClient.GetComplicated.
 type PolymorphismClientGetComplicatedResponse struct {
 	SalmonClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetComplicatedResponse.
@@ -197,22 +156,16 @@ func (p *PolymorphismClientGetComplicatedResponse) UnmarshalJSON(data []byte) er
 // PolymorphismClientGetComposedWithDiscriminatorResponse contains the response from method PolymorphismClient.GetComposedWithDiscriminator.
 type PolymorphismClientGetComposedWithDiscriminatorResponse struct {
 	DotFishMarket
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PolymorphismClientGetComposedWithoutDiscriminatorResponse contains the response from method PolymorphismClient.GetComposedWithoutDiscriminator.
 type PolymorphismClientGetComposedWithoutDiscriminatorResponse struct {
 	DotFishMarket
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PolymorphismClientGetDotSyntaxResponse contains the response from method PolymorphismClient.GetDotSyntax.
 type PolymorphismClientGetDotSyntaxResponse struct {
 	DotFishClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetDotSyntaxResponse.
@@ -228,8 +181,6 @@ func (p *PolymorphismClientGetDotSyntaxResponse) UnmarshalJSON(data []byte) erro
 // PolymorphismClientGetValidResponse contains the response from method PolymorphismClient.GetValid.
 type PolymorphismClientGetValidResponse struct {
 	FishClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientGetValidResponse.
@@ -244,15 +195,12 @@ func (p *PolymorphismClientGetValidResponse) UnmarshalJSON(data []byte) error {
 
 // PolymorphismClientPutComplicatedResponse contains the response from method PolymorphismClient.PutComplicated.
 type PolymorphismClientPutComplicatedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PolymorphismClientPutMissingDiscriminatorResponse contains the response from method PolymorphismClient.PutMissingDiscriminator.
 type PolymorphismClientPutMissingDiscriminatorResponse struct {
 	SalmonClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type PolymorphismClientPutMissingDiscriminatorResponse.
@@ -267,168 +215,130 @@ func (p *PolymorphismClientPutMissingDiscriminatorResponse) UnmarshalJSON(data [
 
 // PolymorphismClientPutValidMissingRequiredResponse contains the response from method PolymorphismClient.PutValidMissingRequired.
 type PolymorphismClientPutValidMissingRequiredResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PolymorphismClientPutValidResponse contains the response from method PolymorphismClient.PutValid.
 type PolymorphismClientPutValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientGetBoolResponse contains the response from method PrimitiveClient.GetBool.
 type PrimitiveClientGetBoolResponse struct {
 	BooleanWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetByteResponse contains the response from method PrimitiveClient.GetByte.
 type PrimitiveClientGetByteResponse struct {
 	ByteWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetDateResponse contains the response from method PrimitiveClient.GetDate.
 type PrimitiveClientGetDateResponse struct {
 	DateWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetDateTimeRFC1123Response contains the response from method PrimitiveClient.GetDateTimeRFC1123.
 type PrimitiveClientGetDateTimeRFC1123Response struct {
 	Datetimerfc1123Wrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetDateTimeResponse contains the response from method PrimitiveClient.GetDateTime.
 type PrimitiveClientGetDateTimeResponse struct {
 	DatetimeWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetDoubleResponse contains the response from method PrimitiveClient.GetDouble.
 type PrimitiveClientGetDoubleResponse struct {
 	DoubleWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetDurationResponse contains the response from method PrimitiveClient.GetDuration.
 type PrimitiveClientGetDurationResponse struct {
 	DurationWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetFloatResponse contains the response from method PrimitiveClient.GetFloat.
 type PrimitiveClientGetFloatResponse struct {
 	FloatWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetIntResponse contains the response from method PrimitiveClient.GetInt.
 type PrimitiveClientGetIntResponse struct {
 	IntWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetLongResponse contains the response from method PrimitiveClient.GetLong.
 type PrimitiveClientGetLongResponse struct {
 	LongWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientGetStringResponse contains the response from method PrimitiveClient.GetString.
 type PrimitiveClientGetStringResponse struct {
 	StringWrapper
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrimitiveClientPutBoolResponse contains the response from method PrimitiveClient.PutBool.
 type PrimitiveClientPutBoolResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutByteResponse contains the response from method PrimitiveClient.PutByte.
 type PrimitiveClientPutByteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutDateResponse contains the response from method PrimitiveClient.PutDate.
 type PrimitiveClientPutDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutDateTimeRFC1123Response contains the response from method PrimitiveClient.PutDateTimeRFC1123.
 type PrimitiveClientPutDateTimeRFC1123Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutDateTimeResponse contains the response from method PrimitiveClient.PutDateTime.
 type PrimitiveClientPutDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutDoubleResponse contains the response from method PrimitiveClient.PutDouble.
 type PrimitiveClientPutDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutDurationResponse contains the response from method PrimitiveClient.PutDuration.
 type PrimitiveClientPutDurationResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutFloatResponse contains the response from method PrimitiveClient.PutFloat.
 type PrimitiveClientPutFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutIntResponse contains the response from method PrimitiveClient.PutInt.
 type PrimitiveClientPutIntResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutLongResponse contains the response from method PrimitiveClient.PutLong.
 type PrimitiveClientPutLongResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrimitiveClientPutStringResponse contains the response from method PrimitiveClient.PutString.
 type PrimitiveClientPutStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ReadonlypropertyClientGetValidResponse contains the response from method ReadonlypropertyClient.GetValid.
 type ReadonlypropertyClientGetValidResponse struct {
 	ReadonlyObj
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReadonlypropertyClientPutValidResponse contains the response from method ReadonlypropertyClient.PutValid.
 type ReadonlypropertyClientPutValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodel_client.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodel_client.go
@@ -82,7 +82,7 @@ func (client *ComplexModelClient) createCreateRequest(ctx context.Context, subsc
 
 // createHandleResponse handles the Create response.
 func (client *ComplexModelClient) createHandleResponse(resp *http.Response) (ComplexModelClientCreateResponse, error) {
-	result := ComplexModelClientCreateResponse{RawResponse: resp}
+	result := ComplexModelClientCreateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CatalogDictionary); err != nil {
 		return ComplexModelClientCreateResponse{}, err
 	}
@@ -131,7 +131,7 @@ func (client *ComplexModelClient) listCreateRequest(ctx context.Context, resourc
 
 // listHandleResponse handles the List response.
 func (client *ComplexModelClient) listHandleResponse(resp *http.Response) (ComplexModelClientListResponse, error) {
-	result := ComplexModelClientListResponse{RawResponse: resp}
+	result := ComplexModelClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CatalogArray); err != nil {
 		return ComplexModelClientListResponse{}, err
 	}
@@ -183,7 +183,7 @@ func (client *ComplexModelClient) updateCreateRequest(ctx context.Context, subsc
 
 // updateHandleResponse handles the Update response.
 func (client *ComplexModelClient) updateHandleResponse(resp *http.Response) (ComplexModelClientUpdateResponse, error) {
-	result := ComplexModelClientUpdateResponse{RawResponse: resp}
+	result := ComplexModelClientUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CatalogArray); err != nil {
 		return ComplexModelClientUpdateResponse{}, err
 	}

--- a/test/autorest/complexmodelgroup/zz_generated_response_types.go
+++ b/test/autorest/complexmodelgroup/zz_generated_response_types.go
@@ -8,25 +8,17 @@
 
 package complexmodelgroup
 
-import "net/http"
-
 // ComplexModelClientCreateResponse contains the response from method ComplexModelClient.Create.
 type ComplexModelClientCreateResponse struct {
 	CatalogDictionary
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ComplexModelClientListResponse contains the response from method ComplexModelClient.List.
 type ComplexModelClientListResponse struct {
 	CatalogArray
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ComplexModelClientUpdateResponse contains the response from method ComplexModelClient.Update.
 type ComplexModelClientUpdateResponse struct {
 	CatalogArray
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
+++ b/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
@@ -5,7 +5,7 @@ package custombaseurlgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -23,7 +23,7 @@ func TestGetEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/custombaseurlgroup/zz_generated_paths_client.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_paths_client.go
@@ -62,7 +62,7 @@ func (client *PathsClient) GetEmpty(ctx context.Context, accountName string, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientGetEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientGetEmptyResponse{RawResponse: resp}, nil
+	return PathsClientGetEmptyResponse{}, nil
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.

--- a/test/autorest/custombaseurlgroup/zz_generated_response_types.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_response_types.go
@@ -8,10 +8,7 @@
 
 package custombaseurlgroup
 
-import "net/http"
-
 // PathsClientGetEmptyResponse contains the response from method PathsClient.GetEmpty.
 type PathsClientGetEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/dategroup/date_test.go
+++ b/test/autorest/dategroup/date_test.go
@@ -5,7 +5,6 @@ package dategroup
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -88,23 +87,23 @@ func TestGetUnderflowDate(t *testing.T) {
 func TestPutMaxDate(t *testing.T) {
 	client := newDateClient()
 	dt := time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
-	resp, err := client.PutMaxDate(context.Background(), dt, nil)
+	result, err := client.PutMaxDate(context.Background(), dt, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.RawResponse.StatusCode, http.StatusOK); r != "" {
-		t.Fatal(r)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
 func TestPutMinDate(t *testing.T) {
 	client := newDateClient()
 	dt := time.Date(0001, 01, 01, 0, 0, 0, 0, time.UTC)
-	resp, err := client.PutMinDate(context.Background(), dt, nil)
+	result, err := client.PutMinDate(context.Background(), dt, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.RawResponse.StatusCode, http.StatusOK); r != "" {
-		t.Fatal(r)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/dategroup/zz_generated_date_client.go
+++ b/test/autorest/dategroup/zz_generated_date_client.go
@@ -66,7 +66,7 @@ func (client *DateClient) getInvalidDateCreateRequest(ctx context.Context, optio
 
 // getInvalidDateHandleResponse handles the GetInvalidDate response.
 func (client *DateClient) getInvalidDateHandleResponse(resp *http.Response) (DateClientGetInvalidDateResponse, error) {
-	result := DateClientGetInvalidDateResponse{RawResponse: resp}
+	result := DateClientGetInvalidDateResponse{}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DateClientGetInvalidDateResponse{}, err
@@ -106,7 +106,7 @@ func (client *DateClient) getMaxDateCreateRequest(ctx context.Context, options *
 
 // getMaxDateHandleResponse handles the GetMaxDate response.
 func (client *DateClient) getMaxDateHandleResponse(resp *http.Response) (DateClientGetMaxDateResponse, error) {
-	result := DateClientGetMaxDateResponse{RawResponse: resp}
+	result := DateClientGetMaxDateResponse{}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DateClientGetMaxDateResponse{}, err
@@ -146,7 +146,7 @@ func (client *DateClient) getMinDateCreateRequest(ctx context.Context, options *
 
 // getMinDateHandleResponse handles the GetMinDate response.
 func (client *DateClient) getMinDateHandleResponse(resp *http.Response) (DateClientGetMinDateResponse, error) {
-	result := DateClientGetMinDateResponse{RawResponse: resp}
+	result := DateClientGetMinDateResponse{}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DateClientGetMinDateResponse{}, err
@@ -186,7 +186,7 @@ func (client *DateClient) getNullCreateRequest(ctx context.Context, options *Dat
 
 // getNullHandleResponse handles the GetNull response.
 func (client *DateClient) getNullHandleResponse(resp *http.Response) (DateClientGetNullResponse, error) {
-	result := DateClientGetNullResponse{RawResponse: resp}
+	result := DateClientGetNullResponse{}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DateClientGetNullResponse{}, err
@@ -226,7 +226,7 @@ func (client *DateClient) getOverflowDateCreateRequest(ctx context.Context, opti
 
 // getOverflowDateHandleResponse handles the GetOverflowDate response.
 func (client *DateClient) getOverflowDateHandleResponse(resp *http.Response) (DateClientGetOverflowDateResponse, error) {
-	result := DateClientGetOverflowDateResponse{RawResponse: resp}
+	result := DateClientGetOverflowDateResponse{}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DateClientGetOverflowDateResponse{}, err
@@ -266,7 +266,7 @@ func (client *DateClient) getUnderflowDateCreateRequest(ctx context.Context, opt
 
 // getUnderflowDateHandleResponse handles the GetUnderflowDate response.
 func (client *DateClient) getUnderflowDateHandleResponse(resp *http.Response) (DateClientGetUnderflowDateResponse, error) {
-	result := DateClientGetUnderflowDateResponse{RawResponse: resp}
+	result := DateClientGetUnderflowDateResponse{}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DateClientGetUnderflowDateResponse{}, err
@@ -291,7 +291,7 @@ func (client *DateClient) PutMaxDate(ctx context.Context, dateBody time.Time, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DateClientPutMaxDateResponse{}, runtime.NewResponseError(resp)
 	}
-	return DateClientPutMaxDateResponse{RawResponse: resp}, nil
+	return DateClientPutMaxDateResponse{}, nil
 }
 
 // putMaxDateCreateRequest creates the PutMaxDate request.
@@ -321,7 +321,7 @@ func (client *DateClient) PutMinDate(ctx context.Context, dateBody time.Time, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DateClientPutMinDateResponse{}, runtime.NewResponseError(resp)
 	}
-	return DateClientPutMinDateResponse{RawResponse: resp}, nil
+	return DateClientPutMinDateResponse{}, nil
 }
 
 // putMinDateCreateRequest creates the PutMinDate request.

--- a/test/autorest/dategroup/zz_generated_response_types.go
+++ b/test/autorest/dategroup/zz_generated_response_types.go
@@ -8,61 +8,44 @@
 
 package dategroup
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 // DateClientGetInvalidDateResponse contains the response from method DateClient.GetInvalidDate.
 type DateClientGetInvalidDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DateClientGetMaxDateResponse contains the response from method DateClient.GetMaxDate.
 type DateClientGetMaxDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DateClientGetMinDateResponse contains the response from method DateClient.GetMinDate.
 type DateClientGetMinDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DateClientGetNullResponse contains the response from method DateClient.GetNull.
 type DateClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DateClientGetOverflowDateResponse contains the response from method DateClient.GetOverflowDate.
 type DateClientGetOverflowDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DateClientGetUnderflowDateResponse contains the response from method DateClient.GetUnderflowDate.
 type DateClientGetUnderflowDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DateClientPutMaxDateResponse contains the response from method DateClient.PutMaxDate.
 type DateClientPutMaxDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DateClientPutMinDateResponse contains the response from method DateClient.PutMinDate.
 type DateClientPutMinDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/datetimegroup/datetimegroup_test.go
+++ b/test/autorest/datetimegroup/datetimegroup_test.go
@@ -5,7 +5,7 @@ package datetimegroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -227,8 +227,8 @@ func TestPutLocalNegativeOffsetMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -242,8 +242,8 @@ func TestPutLocalNegativeOffsetMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -257,8 +257,8 @@ func TestPutLocalPositiveOffsetMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -272,8 +272,8 @@ func TestPutLocalPositiveOffsetMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -287,8 +287,8 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -302,8 +302,8 @@ func TestPutUTCMaxDateTime7Digits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -317,7 +317,7 @@ func TestPutUTCMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/datetimegroup/zz_generated_datetime_client.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime_client.go
@@ -66,7 +66,7 @@ func (client *DatetimeClient) getInvalidCreateRequest(ctx context.Context, optio
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *DatetimeClient) getInvalidHandleResponse(resp *http.Response) (DatetimeClientGetInvalidResponse, error) {
-	result := DatetimeClientGetInvalidResponse{RawResponse: resp}
+	result := DatetimeClientGetInvalidResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetInvalidResponse{}, err
@@ -107,7 +107,7 @@ func (client *DatetimeClient) getLocalNegativeOffsetLowercaseMaxDateTimeCreateRe
 
 // getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetLowercaseMaxDateTime response.
 func (client *DatetimeClient) getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse, error) {
-	result := DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{}, err
@@ -148,7 +148,7 @@ func (client *DatetimeClient) getLocalNegativeOffsetMinDateTimeCreateRequest(ctx
 
 // getLocalNegativeOffsetMinDateTimeHandleResponse handles the GetLocalNegativeOffsetMinDateTime response.
 func (client *DatetimeClient) getLocalNegativeOffsetMinDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse, error) {
-	result := DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse{}, err
@@ -189,7 +189,7 @@ func (client *DatetimeClient) getLocalNegativeOffsetUppercaseMaxDateTimeCreateRe
 
 // getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetUppercaseMaxDateTime response.
 func (client *DatetimeClient) getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse, error) {
-	result := DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{}, err
@@ -230,7 +230,7 @@ func (client *DatetimeClient) getLocalNoOffsetMinDateTimeCreateRequest(ctx conte
 
 // getLocalNoOffsetMinDateTimeHandleResponse handles the GetLocalNoOffsetMinDateTime response.
 func (client *DatetimeClient) getLocalNoOffsetMinDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetLocalNoOffsetMinDateTimeResponse, error) {
-	result := DatetimeClientGetLocalNoOffsetMinDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetLocalNoOffsetMinDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetLocalNoOffsetMinDateTimeResponse{}, err
@@ -271,7 +271,7 @@ func (client *DatetimeClient) getLocalPositiveOffsetLowercaseMaxDateTimeCreateRe
 
 // getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetLowercaseMaxDateTime response.
 func (client *DatetimeClient) getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse, error) {
-	result := DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{}, err
@@ -312,7 +312,7 @@ func (client *DatetimeClient) getLocalPositiveOffsetMinDateTimeCreateRequest(ctx
 
 // getLocalPositiveOffsetMinDateTimeHandleResponse handles the GetLocalPositiveOffsetMinDateTime response.
 func (client *DatetimeClient) getLocalPositiveOffsetMinDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse, error) {
-	result := DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse{}, err
@@ -353,7 +353,7 @@ func (client *DatetimeClient) getLocalPositiveOffsetUppercaseMaxDateTimeCreateRe
 
 // getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetUppercaseMaxDateTime response.
 func (client *DatetimeClient) getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse, error) {
-	result := DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{}, err
@@ -393,7 +393,7 @@ func (client *DatetimeClient) getNullCreateRequest(ctx context.Context, options 
 
 // getNullHandleResponse handles the GetNull response.
 func (client *DatetimeClient) getNullHandleResponse(resp *http.Response) (DatetimeClientGetNullResponse, error) {
-	result := DatetimeClientGetNullResponse{RawResponse: resp}
+	result := DatetimeClientGetNullResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetNullResponse{}, err
@@ -433,7 +433,7 @@ func (client *DatetimeClient) getOverflowCreateRequest(ctx context.Context, opti
 
 // getOverflowHandleResponse handles the GetOverflow response.
 func (client *DatetimeClient) getOverflowHandleResponse(resp *http.Response) (DatetimeClientGetOverflowResponse, error) {
-	result := DatetimeClientGetOverflowResponse{RawResponse: resp}
+	result := DatetimeClientGetOverflowResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetOverflowResponse{}, err
@@ -474,7 +474,7 @@ func (client *DatetimeClient) getUTCLowercaseMaxDateTimeCreateRequest(ctx contex
 
 // getUTCLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
 func (client *DatetimeClient) getUTCLowercaseMaxDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetUTCLowercaseMaxDateTimeResponse, error) {
-	result := DatetimeClientGetUTCLowercaseMaxDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetUTCLowercaseMaxDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetUTCLowercaseMaxDateTimeResponse{}, err
@@ -515,7 +515,7 @@ func (client *DatetimeClient) getUTCMinDateTimeCreateRequest(ctx context.Context
 
 // getUTCMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
 func (client *DatetimeClient) getUTCMinDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetUTCMinDateTimeResponse, error) {
-	result := DatetimeClientGetUTCMinDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetUTCMinDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetUTCMinDateTimeResponse{}, err
@@ -556,7 +556,7 @@ func (client *DatetimeClient) getUTCUppercaseMaxDateTimeCreateRequest(ctx contex
 
 // getUTCUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
 func (client *DatetimeClient) getUTCUppercaseMaxDateTimeHandleResponse(resp *http.Response) (DatetimeClientGetUTCUppercaseMaxDateTimeResponse, error) {
-	result := DatetimeClientGetUTCUppercaseMaxDateTimeResponse{RawResponse: resp}
+	result := DatetimeClientGetUTCUppercaseMaxDateTimeResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetUTCUppercaseMaxDateTimeResponse{}, err
@@ -598,7 +598,7 @@ func (client *DatetimeClient) getUTCUppercaseMaxDateTime7DigitsCreateRequest(ctx
 
 // getUTCUppercaseMaxDateTime7DigitsHandleResponse handles the GetUTCUppercaseMaxDateTime7Digits response.
 func (client *DatetimeClient) getUTCUppercaseMaxDateTime7DigitsHandleResponse(resp *http.Response) (DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse, error) {
-	result := DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse{RawResponse: resp}
+	result := DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse{}, err
@@ -638,7 +638,7 @@ func (client *DatetimeClient) getUnderflowCreateRequest(ctx context.Context, opt
 
 // getUnderflowHandleResponse handles the GetUnderflow response.
 func (client *DatetimeClient) getUnderflowHandleResponse(resp *http.Response) (DatetimeClientGetUnderflowResponse, error) {
-	result := DatetimeClientGetUnderflowResponse{RawResponse: resp}
+	result := DatetimeClientGetUnderflowResponse{}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DatetimeClientGetUnderflowResponse{}, err
@@ -664,7 +664,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTime(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DatetimeClientPutLocalNegativeOffsetMaxDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return DatetimeClientPutLocalNegativeOffsetMaxDateTimeResponse{RawResponse: resp}, nil
+	return DatetimeClientPutLocalNegativeOffsetMaxDateTimeResponse{}, nil
 }
 
 // putLocalNegativeOffsetMaxDateTimeCreateRequest creates the PutLocalNegativeOffsetMaxDateTime request.
@@ -695,7 +695,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTime(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DatetimeClientPutLocalNegativeOffsetMinDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return DatetimeClientPutLocalNegativeOffsetMinDateTimeResponse{RawResponse: resp}, nil
+	return DatetimeClientPutLocalNegativeOffsetMinDateTimeResponse{}, nil
 }
 
 // putLocalNegativeOffsetMinDateTimeCreateRequest creates the PutLocalNegativeOffsetMinDateTime request.
@@ -726,7 +726,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTime(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DatetimeClientPutLocalPositiveOffsetMaxDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return DatetimeClientPutLocalPositiveOffsetMaxDateTimeResponse{RawResponse: resp}, nil
+	return DatetimeClientPutLocalPositiveOffsetMaxDateTimeResponse{}, nil
 }
 
 // putLocalPositiveOffsetMaxDateTimeCreateRequest creates the PutLocalPositiveOffsetMaxDateTime request.
@@ -757,7 +757,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTime(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DatetimeClientPutLocalPositiveOffsetMinDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return DatetimeClientPutLocalPositiveOffsetMinDateTimeResponse{RawResponse: resp}, nil
+	return DatetimeClientPutLocalPositiveOffsetMinDateTimeResponse{}, nil
 }
 
 // putLocalPositiveOffsetMinDateTimeCreateRequest creates the PutLocalPositiveOffsetMinDateTime request.
@@ -788,7 +788,7 @@ func (client *DatetimeClient) PutUTCMaxDateTime(ctx context.Context, datetimeBod
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DatetimeClientPutUTCMaxDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return DatetimeClientPutUTCMaxDateTimeResponse{RawResponse: resp}, nil
+	return DatetimeClientPutUTCMaxDateTimeResponse{}, nil
 }
 
 // putUTCMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
@@ -820,7 +820,7 @@ func (client *DatetimeClient) PutUTCMaxDateTime7Digits(ctx context.Context, date
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DatetimeClientPutUTCMaxDateTime7DigitsResponse{}, runtime.NewResponseError(resp)
 	}
-	return DatetimeClientPutUTCMaxDateTime7DigitsResponse{RawResponse: resp}, nil
+	return DatetimeClientPutUTCMaxDateTime7DigitsResponse{}, nil
 }
 
 // putUTCMaxDateTime7DigitsCreateRequest creates the PutUTCMaxDateTime7Digits request.
@@ -851,7 +851,7 @@ func (client *DatetimeClient) PutUTCMinDateTime(ctx context.Context, datetimeBod
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DatetimeClientPutUTCMinDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return DatetimeClientPutUTCMinDateTimeResponse{RawResponse: resp}, nil
+	return DatetimeClientPutUTCMinDateTimeResponse{}, nil
 }
 
 // putUTCMinDateTimeCreateRequest creates the PutUTCMinDateTime request.

--- a/test/autorest/datetimegroup/zz_generated_response_types.go
+++ b/test/autorest/datetimegroup/zz_generated_response_types.go
@@ -8,154 +8,114 @@
 
 package datetimegroup
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 // DatetimeClientGetInvalidResponse contains the response from method DatetimeClient.GetInvalid.
 type DatetimeClientGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetLocalNegativeOffsetLowercaseMaxDateTime.
 type DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse contains the response from method DatetimeClient.GetLocalNegativeOffsetMinDateTime.
 type DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetLocalNegativeOffsetUppercaseMaxDateTime.
 type DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetLocalNoOffsetMinDateTimeResponse contains the response from method DatetimeClient.GetLocalNoOffsetMinDateTime.
 type DatetimeClientGetLocalNoOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetLocalPositiveOffsetLowercaseMaxDateTime.
 type DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse contains the response from method DatetimeClient.GetLocalPositiveOffsetMinDateTime.
 type DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetLocalPositiveOffsetUppercaseMaxDateTime.
 type DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetNullResponse contains the response from method DatetimeClient.GetNull.
 type DatetimeClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetOverflowResponse contains the response from method DatetimeClient.GetOverflow.
 type DatetimeClientGetOverflowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetUTCLowercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetUTCLowercaseMaxDateTime.
 type DatetimeClientGetUTCLowercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetUTCMinDateTimeResponse contains the response from method DatetimeClient.GetUTCMinDateTime.
 type DatetimeClientGetUTCMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse contains the response from method DatetimeClient.GetUTCUppercaseMaxDateTime7Digits.
 type DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetUTCUppercaseMaxDateTimeResponse contains the response from method DatetimeClient.GetUTCUppercaseMaxDateTime.
 type DatetimeClientGetUTCUppercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientGetUnderflowResponse contains the response from method DatetimeClient.GetUnderflow.
 type DatetimeClientGetUnderflowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // DatetimeClientPutLocalNegativeOffsetMaxDateTimeResponse contains the response from method DatetimeClient.PutLocalNegativeOffsetMaxDateTime.
 type DatetimeClientPutLocalNegativeOffsetMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DatetimeClientPutLocalNegativeOffsetMinDateTimeResponse contains the response from method DatetimeClient.PutLocalNegativeOffsetMinDateTime.
 type DatetimeClientPutLocalNegativeOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DatetimeClientPutLocalPositiveOffsetMaxDateTimeResponse contains the response from method DatetimeClient.PutLocalPositiveOffsetMaxDateTime.
 type DatetimeClientPutLocalPositiveOffsetMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DatetimeClientPutLocalPositiveOffsetMinDateTimeResponse contains the response from method DatetimeClient.PutLocalPositiveOffsetMinDateTime.
 type DatetimeClientPutLocalPositiveOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DatetimeClientPutUTCMaxDateTime7DigitsResponse contains the response from method DatetimeClient.PutUTCMaxDateTime7Digits.
 type DatetimeClientPutUTCMaxDateTime7DigitsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DatetimeClientPutUTCMaxDateTimeResponse contains the response from method DatetimeClient.PutUTCMaxDateTime.
 type DatetimeClientPutUTCMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DatetimeClientPutUTCMinDateTimeResponse contains the response from method DatetimeClient.PutUTCMinDateTime.
 type DatetimeClientPutUTCMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
+++ b/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
@@ -5,7 +5,7 @@ package datetimerfc1123group
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -110,8 +110,8 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -126,7 +126,7 @@ func TestPutUTCMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123_client.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123_client.go
@@ -67,7 +67,7 @@ func (client *Datetimerfc1123Client) getInvalidCreateRequest(ctx context.Context
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *Datetimerfc1123Client) getInvalidHandleResponse(resp *http.Response) (Datetimerfc1123ClientGetInvalidResponse, error) {
-	result := Datetimerfc1123ClientGetInvalidResponse{RawResponse: resp}
+	result := Datetimerfc1123ClientGetInvalidResponse{}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return Datetimerfc1123ClientGetInvalidResponse{}, err
@@ -107,7 +107,7 @@ func (client *Datetimerfc1123Client) getNullCreateRequest(ctx context.Context, o
 
 // getNullHandleResponse handles the GetNull response.
 func (client *Datetimerfc1123Client) getNullHandleResponse(resp *http.Response) (Datetimerfc1123ClientGetNullResponse, error) {
-	result := Datetimerfc1123ClientGetNullResponse{RawResponse: resp}
+	result := Datetimerfc1123ClientGetNullResponse{}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return Datetimerfc1123ClientGetNullResponse{}, err
@@ -148,7 +148,7 @@ func (client *Datetimerfc1123Client) getOverflowCreateRequest(ctx context.Contex
 
 // getOverflowHandleResponse handles the GetOverflow response.
 func (client *Datetimerfc1123Client) getOverflowHandleResponse(resp *http.Response) (Datetimerfc1123ClientGetOverflowResponse, error) {
-	result := Datetimerfc1123ClientGetOverflowResponse{RawResponse: resp}
+	result := Datetimerfc1123ClientGetOverflowResponse{}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return Datetimerfc1123ClientGetOverflowResponse{}, err
@@ -189,7 +189,7 @@ func (client *Datetimerfc1123Client) getUTCLowercaseMaxDateTimeCreateRequest(ctx
 
 // getUTCLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
 func (client *Datetimerfc1123Client) getUTCLowercaseMaxDateTimeHandleResponse(resp *http.Response) (Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse, error) {
-	result := Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse{RawResponse: resp}
+	result := Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse{}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse{}, err
@@ -230,7 +230,7 @@ func (client *Datetimerfc1123Client) getUTCMinDateTimeCreateRequest(ctx context.
 
 // getUTCMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
 func (client *Datetimerfc1123Client) getUTCMinDateTimeHandleResponse(resp *http.Response) (Datetimerfc1123ClientGetUTCMinDateTimeResponse, error) {
-	result := Datetimerfc1123ClientGetUTCMinDateTimeResponse{RawResponse: resp}
+	result := Datetimerfc1123ClientGetUTCMinDateTimeResponse{}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return Datetimerfc1123ClientGetUTCMinDateTimeResponse{}, err
@@ -271,7 +271,7 @@ func (client *Datetimerfc1123Client) getUTCUppercaseMaxDateTimeCreateRequest(ctx
 
 // getUTCUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
 func (client *Datetimerfc1123Client) getUTCUppercaseMaxDateTimeHandleResponse(resp *http.Response) (Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse, error) {
-	result := Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse{RawResponse: resp}
+	result := Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse{}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse{}, err
@@ -312,7 +312,7 @@ func (client *Datetimerfc1123Client) getUnderflowCreateRequest(ctx context.Conte
 
 // getUnderflowHandleResponse handles the GetUnderflow response.
 func (client *Datetimerfc1123Client) getUnderflowHandleResponse(resp *http.Response) (Datetimerfc1123ClientGetUnderflowResponse, error) {
-	result := Datetimerfc1123ClientGetUnderflowResponse{RawResponse: resp}
+	result := Datetimerfc1123ClientGetUnderflowResponse{}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return Datetimerfc1123ClientGetUnderflowResponse{}, err
@@ -338,7 +338,7 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTime(ctx context.Context, date
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return Datetimerfc1123ClientPutUTCMaxDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return Datetimerfc1123ClientPutUTCMaxDateTimeResponse{RawResponse: resp}, nil
+	return Datetimerfc1123ClientPutUTCMaxDateTimeResponse{}, nil
 }
 
 // putUTCMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
@@ -370,7 +370,7 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTime(ctx context.Context, date
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return Datetimerfc1123ClientPutUTCMinDateTimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return Datetimerfc1123ClientPutUTCMinDateTimeResponse{RawResponse: resp}, nil
+	return Datetimerfc1123ClientPutUTCMinDateTimeResponse{}, nil
 }
 
 // putUTCMinDateTimeCreateRequest creates the PutUTCMinDateTime request.

--- a/test/autorest/datetimerfc1123group/zz_generated_response_types.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_response_types.go
@@ -8,68 +8,49 @@
 
 package datetimerfc1123group
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 // Datetimerfc1123ClientGetInvalidResponse contains the response from method Datetimerfc1123Client.GetInvalid.
 type Datetimerfc1123ClientGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // Datetimerfc1123ClientGetNullResponse contains the response from method Datetimerfc1123Client.GetNull.
 type Datetimerfc1123ClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // Datetimerfc1123ClientGetOverflowResponse contains the response from method Datetimerfc1123Client.GetOverflow.
 type Datetimerfc1123ClientGetOverflowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse contains the response from method Datetimerfc1123Client.GetUTCLowercaseMaxDateTime.
 type Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // Datetimerfc1123ClientGetUTCMinDateTimeResponse contains the response from method Datetimerfc1123Client.GetUTCMinDateTime.
 type Datetimerfc1123ClientGetUTCMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse contains the response from method Datetimerfc1123Client.GetUTCUppercaseMaxDateTime.
 type Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // Datetimerfc1123ClientGetUnderflowResponse contains the response from method Datetimerfc1123Client.GetUnderflow.
 type Datetimerfc1123ClientGetUnderflowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
+	Value *time.Time
 }
 
 // Datetimerfc1123ClientPutUTCMaxDateTimeResponse contains the response from method Datetimerfc1123Client.PutUTCMaxDateTime.
 type Datetimerfc1123ClientPutUTCMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // Datetimerfc1123ClientPutUTCMinDateTimeResponse contains the response from method Datetimerfc1123Client.PutUTCMinDateTime.
 type Datetimerfc1123ClientPutUTCMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -5,7 +5,6 @@ package dictionarygroup
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -793,8 +792,8 @@ func TestPutArrayValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -810,8 +809,8 @@ func TestPutBooleanTfft(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -826,8 +825,8 @@ func TestPutByteValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -842,8 +841,8 @@ func TestPutComplexValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -861,8 +860,8 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -880,8 +879,8 @@ func TestPutDateTimeValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -899,8 +898,8 @@ func TestPutDateValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -927,8 +926,8 @@ func TestPutDictionaryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -943,8 +942,8 @@ func TestPutDoubleValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -958,8 +957,8 @@ func TestPutDurationValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -970,8 +969,8 @@ func TestPutEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -986,8 +985,8 @@ func TestPutFloatValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -1003,8 +1002,8 @@ func TestPutIntegerValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -1020,8 +1019,8 @@ func TestPutLongValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -1036,7 +1035,7 @@ func TestPutStringValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(resp).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/dictionarygroup/zz_generated_dictionary_client.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary_client.go
@@ -67,7 +67,7 @@ func (client *DictionaryClient) getArrayEmptyCreateRequest(ctx context.Context, 
 
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *DictionaryClient) getArrayEmptyHandleResponse(resp *http.Response) (DictionaryClientGetArrayEmptyResponse, error) {
-	result := DictionaryClientGetArrayEmptyResponse{RawResponse: resp}
+	result := DictionaryClientGetArrayEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetArrayEmptyResponse{}, err
 	}
@@ -106,7 +106,7 @@ func (client *DictionaryClient) getArrayItemEmptyCreateRequest(ctx context.Conte
 
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *DictionaryClient) getArrayItemEmptyHandleResponse(resp *http.Response) (DictionaryClientGetArrayItemEmptyResponse, error) {
-	result := DictionaryClientGetArrayItemEmptyResponse{RawResponse: resp}
+	result := DictionaryClientGetArrayItemEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetArrayItemEmptyResponse{}, err
 	}
@@ -145,7 +145,7 @@ func (client *DictionaryClient) getArrayItemNullCreateRequest(ctx context.Contex
 
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *DictionaryClient) getArrayItemNullHandleResponse(resp *http.Response) (DictionaryClientGetArrayItemNullResponse, error) {
-	result := DictionaryClientGetArrayItemNullResponse{RawResponse: resp}
+	result := DictionaryClientGetArrayItemNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetArrayItemNullResponse{}, err
 	}
@@ -183,7 +183,7 @@ func (client *DictionaryClient) getArrayNullCreateRequest(ctx context.Context, o
 
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client *DictionaryClient) getArrayNullHandleResponse(resp *http.Response) (DictionaryClientGetArrayNullResponse, error) {
-	result := DictionaryClientGetArrayNullResponse{RawResponse: resp}
+	result := DictionaryClientGetArrayNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetArrayNullResponse{}, err
 	}
@@ -222,7 +222,7 @@ func (client *DictionaryClient) getArrayValidCreateRequest(ctx context.Context, 
 
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client *DictionaryClient) getArrayValidHandleResponse(resp *http.Response) (DictionaryClientGetArrayValidResponse, error) {
-	result := DictionaryClientGetArrayValidResponse{RawResponse: resp}
+	result := DictionaryClientGetArrayValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetArrayValidResponse{}, err
 	}
@@ -261,7 +261,7 @@ func (client *DictionaryClient) getBase64URLCreateRequest(ctx context.Context, o
 
 // getBase64URLHandleResponse handles the GetBase64URL response.
 func (client *DictionaryClient) getBase64URLHandleResponse(resp *http.Response) (DictionaryClientGetBase64URLResponse, error) {
-	result := DictionaryClientGetBase64URLResponse{RawResponse: resp}
+	result := DictionaryClientGetBase64URLResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetBase64URLResponse{}, err
 	}
@@ -300,7 +300,7 @@ func (client *DictionaryClient) getBooleanInvalidNullCreateRequest(ctx context.C
 
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *DictionaryClient) getBooleanInvalidNullHandleResponse(resp *http.Response) (DictionaryClientGetBooleanInvalidNullResponse, error) {
-	result := DictionaryClientGetBooleanInvalidNullResponse{RawResponse: resp}
+	result := DictionaryClientGetBooleanInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetBooleanInvalidNullResponse{}, err
 	}
@@ -339,7 +339,7 @@ func (client *DictionaryClient) getBooleanInvalidStringCreateRequest(ctx context
 
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *DictionaryClient) getBooleanInvalidStringHandleResponse(resp *http.Response) (DictionaryClientGetBooleanInvalidStringResponse, error) {
-	result := DictionaryClientGetBooleanInvalidStringResponse{RawResponse: resp}
+	result := DictionaryClientGetBooleanInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetBooleanInvalidStringResponse{}, err
 	}
@@ -378,7 +378,7 @@ func (client *DictionaryClient) getBooleanTfftCreateRequest(ctx context.Context,
 
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *DictionaryClient) getBooleanTfftHandleResponse(resp *http.Response) (DictionaryClientGetBooleanTfftResponse, error) {
-	result := DictionaryClientGetBooleanTfftResponse{RawResponse: resp}
+	result := DictionaryClientGetBooleanTfftResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetBooleanTfftResponse{}, err
 	}
@@ -417,7 +417,7 @@ func (client *DictionaryClient) getByteInvalidNullCreateRequest(ctx context.Cont
 
 // getByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client *DictionaryClient) getByteInvalidNullHandleResponse(resp *http.Response) (DictionaryClientGetByteInvalidNullResponse, error) {
-	result := DictionaryClientGetByteInvalidNullResponse{RawResponse: resp}
+	result := DictionaryClientGetByteInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetByteInvalidNullResponse{}, err
 	}
@@ -456,7 +456,7 @@ func (client *DictionaryClient) getByteValidCreateRequest(ctx context.Context, o
 
 // getByteValidHandleResponse handles the GetByteValid response.
 func (client *DictionaryClient) getByteValidHandleResponse(resp *http.Response) (DictionaryClientGetByteValidResponse, error) {
-	result := DictionaryClientGetByteValidResponse{RawResponse: resp}
+	result := DictionaryClientGetByteValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetByteValidResponse{}, err
 	}
@@ -495,7 +495,7 @@ func (client *DictionaryClient) getComplexEmptyCreateRequest(ctx context.Context
 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *DictionaryClient) getComplexEmptyHandleResponse(resp *http.Response) (DictionaryClientGetComplexEmptyResponse, error) {
-	result := DictionaryClientGetComplexEmptyResponse{RawResponse: resp}
+	result := DictionaryClientGetComplexEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetComplexEmptyResponse{}, err
 	}
@@ -535,7 +535,7 @@ func (client *DictionaryClient) getComplexItemEmptyCreateRequest(ctx context.Con
 
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *DictionaryClient) getComplexItemEmptyHandleResponse(resp *http.Response) (DictionaryClientGetComplexItemEmptyResponse, error) {
-	result := DictionaryClientGetComplexItemEmptyResponse{RawResponse: resp}
+	result := DictionaryClientGetComplexItemEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetComplexItemEmptyResponse{}, err
 	}
@@ -575,7 +575,7 @@ func (client *DictionaryClient) getComplexItemNullCreateRequest(ctx context.Cont
 
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *DictionaryClient) getComplexItemNullHandleResponse(resp *http.Response) (DictionaryClientGetComplexItemNullResponse, error) {
-	result := DictionaryClientGetComplexItemNullResponse{RawResponse: resp}
+	result := DictionaryClientGetComplexItemNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetComplexItemNullResponse{}, err
 	}
@@ -614,7 +614,7 @@ func (client *DictionaryClient) getComplexNullCreateRequest(ctx context.Context,
 
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client *DictionaryClient) getComplexNullHandleResponse(resp *http.Response) (DictionaryClientGetComplexNullResponse, error) {
-	result := DictionaryClientGetComplexNullResponse{RawResponse: resp}
+	result := DictionaryClientGetComplexNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetComplexNullResponse{}, err
 	}
@@ -654,7 +654,7 @@ func (client *DictionaryClient) getComplexValidCreateRequest(ctx context.Context
 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client *DictionaryClient) getComplexValidHandleResponse(resp *http.Response) (DictionaryClientGetComplexValidResponse, error) {
-	result := DictionaryClientGetComplexValidResponse{RawResponse: resp}
+	result := DictionaryClientGetComplexValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetComplexValidResponse{}, err
 	}
@@ -693,7 +693,7 @@ func (client *DictionaryClient) getDateInvalidCharsCreateRequest(ctx context.Con
 
 // getDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *DictionaryClient) getDateInvalidCharsHandleResponse(resp *http.Response) (DictionaryClientGetDateInvalidCharsResponse, error) {
-	result := DictionaryClientGetDateInvalidCharsResponse{RawResponse: resp}
+	result := DictionaryClientGetDateInvalidCharsResponse{}
 	aux := map[string]*dateType{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DictionaryClientGetDateInvalidCharsResponse{}, err
@@ -738,7 +738,7 @@ func (client *DictionaryClient) getDateInvalidNullCreateRequest(ctx context.Cont
 
 // getDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *DictionaryClient) getDateInvalidNullHandleResponse(resp *http.Response) (DictionaryClientGetDateInvalidNullResponse, error) {
-	result := DictionaryClientGetDateInvalidNullResponse{RawResponse: resp}
+	result := DictionaryClientGetDateInvalidNullResponse{}
 	aux := map[string]*dateType{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DictionaryClientGetDateInvalidNullResponse{}, err
@@ -783,7 +783,7 @@ func (client *DictionaryClient) getDateTimeInvalidCharsCreateRequest(ctx context
 
 // getDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *DictionaryClient) getDateTimeInvalidCharsHandleResponse(resp *http.Response) (DictionaryClientGetDateTimeInvalidCharsResponse, error) {
-	result := DictionaryClientGetDateTimeInvalidCharsResponse{RawResponse: resp}
+	result := DictionaryClientGetDateTimeInvalidCharsResponse{}
 	aux := map[string]*timeRFC3339{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DictionaryClientGetDateTimeInvalidCharsResponse{}, err
@@ -828,7 +828,7 @@ func (client *DictionaryClient) getDateTimeInvalidNullCreateRequest(ctx context.
 
 // getDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *DictionaryClient) getDateTimeInvalidNullHandleResponse(resp *http.Response) (DictionaryClientGetDateTimeInvalidNullResponse, error) {
-	result := DictionaryClientGetDateTimeInvalidNullResponse{RawResponse: resp}
+	result := DictionaryClientGetDateTimeInvalidNullResponse{}
 	aux := map[string]*timeRFC3339{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DictionaryClientGetDateTimeInvalidNullResponse{}, err
@@ -874,7 +874,7 @@ func (client *DictionaryClient) getDateTimeRFC1123ValidCreateRequest(ctx context
 
 // getDateTimeRFC1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *DictionaryClient) getDateTimeRFC1123ValidHandleResponse(resp *http.Response) (DictionaryClientGetDateTimeRFC1123ValidResponse, error) {
-	result := DictionaryClientGetDateTimeRFC1123ValidResponse{RawResponse: resp}
+	result := DictionaryClientGetDateTimeRFC1123ValidResponse{}
 	aux := map[string]*timeRFC1123{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DictionaryClientGetDateTimeRFC1123ValidResponse{}, err
@@ -920,7 +920,7 @@ func (client *DictionaryClient) getDateTimeValidCreateRequest(ctx context.Contex
 
 // getDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *DictionaryClient) getDateTimeValidHandleResponse(resp *http.Response) (DictionaryClientGetDateTimeValidResponse, error) {
-	result := DictionaryClientGetDateTimeValidResponse{RawResponse: resp}
+	result := DictionaryClientGetDateTimeValidResponse{}
 	aux := map[string]*timeRFC3339{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DictionaryClientGetDateTimeValidResponse{}, err
@@ -964,7 +964,7 @@ func (client *DictionaryClient) getDateValidCreateRequest(ctx context.Context, o
 
 // getDateValidHandleResponse handles the GetDateValid response.
 func (client *DictionaryClient) getDateValidHandleResponse(resp *http.Response) (DictionaryClientGetDateValidResponse, error) {
-	result := DictionaryClientGetDateValidResponse{RawResponse: resp}
+	result := DictionaryClientGetDateValidResponse{}
 	aux := map[string]*dateType{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return DictionaryClientGetDateValidResponse{}, err
@@ -1009,7 +1009,7 @@ func (client *DictionaryClient) getDictionaryEmptyCreateRequest(ctx context.Cont
 
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *DictionaryClient) getDictionaryEmptyHandleResponse(resp *http.Response) (DictionaryClientGetDictionaryEmptyResponse, error) {
-	result := DictionaryClientGetDictionaryEmptyResponse{RawResponse: resp}
+	result := DictionaryClientGetDictionaryEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDictionaryEmptyResponse{}, err
 	}
@@ -1049,7 +1049,7 @@ func (client *DictionaryClient) getDictionaryItemEmptyCreateRequest(ctx context.
 
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *DictionaryClient) getDictionaryItemEmptyHandleResponse(resp *http.Response) (DictionaryClientGetDictionaryItemEmptyResponse, error) {
-	result := DictionaryClientGetDictionaryItemEmptyResponse{RawResponse: resp}
+	result := DictionaryClientGetDictionaryItemEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDictionaryItemEmptyResponse{}, err
 	}
@@ -1089,7 +1089,7 @@ func (client *DictionaryClient) getDictionaryItemNullCreateRequest(ctx context.C
 
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *DictionaryClient) getDictionaryItemNullHandleResponse(resp *http.Response) (DictionaryClientGetDictionaryItemNullResponse, error) {
-	result := DictionaryClientGetDictionaryItemNullResponse{RawResponse: resp}
+	result := DictionaryClientGetDictionaryItemNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDictionaryItemNullResponse{}, err
 	}
@@ -1128,7 +1128,7 @@ func (client *DictionaryClient) getDictionaryNullCreateRequest(ctx context.Conte
 
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *DictionaryClient) getDictionaryNullHandleResponse(resp *http.Response) (DictionaryClientGetDictionaryNullResponse, error) {
-	result := DictionaryClientGetDictionaryNullResponse{RawResponse: resp}
+	result := DictionaryClientGetDictionaryNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDictionaryNullResponse{}, err
 	}
@@ -1168,7 +1168,7 @@ func (client *DictionaryClient) getDictionaryValidCreateRequest(ctx context.Cont
 
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *DictionaryClient) getDictionaryValidHandleResponse(resp *http.Response) (DictionaryClientGetDictionaryValidResponse, error) {
-	result := DictionaryClientGetDictionaryValidResponse{RawResponse: resp}
+	result := DictionaryClientGetDictionaryValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDictionaryValidResponse{}, err
 	}
@@ -1207,7 +1207,7 @@ func (client *DictionaryClient) getDoubleInvalidNullCreateRequest(ctx context.Co
 
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *DictionaryClient) getDoubleInvalidNullHandleResponse(resp *http.Response) (DictionaryClientGetDoubleInvalidNullResponse, error) {
-	result := DictionaryClientGetDoubleInvalidNullResponse{RawResponse: resp}
+	result := DictionaryClientGetDoubleInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDoubleInvalidNullResponse{}, err
 	}
@@ -1246,7 +1246,7 @@ func (client *DictionaryClient) getDoubleInvalidStringCreateRequest(ctx context.
 
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *DictionaryClient) getDoubleInvalidStringHandleResponse(resp *http.Response) (DictionaryClientGetDoubleInvalidStringResponse, error) {
-	result := DictionaryClientGetDoubleInvalidStringResponse{RawResponse: resp}
+	result := DictionaryClientGetDoubleInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDoubleInvalidStringResponse{}, err
 	}
@@ -1285,7 +1285,7 @@ func (client *DictionaryClient) getDoubleValidCreateRequest(ctx context.Context,
 
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *DictionaryClient) getDoubleValidHandleResponse(resp *http.Response) (DictionaryClientGetDoubleValidResponse, error) {
-	result := DictionaryClientGetDoubleValidResponse{RawResponse: resp}
+	result := DictionaryClientGetDoubleValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDoubleValidResponse{}, err
 	}
@@ -1324,7 +1324,7 @@ func (client *DictionaryClient) getDurationValidCreateRequest(ctx context.Contex
 
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client *DictionaryClient) getDurationValidHandleResponse(resp *http.Response) (DictionaryClientGetDurationValidResponse, error) {
-	result := DictionaryClientGetDurationValidResponse{RawResponse: resp}
+	result := DictionaryClientGetDurationValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetDurationValidResponse{}, err
 	}
@@ -1362,7 +1362,7 @@ func (client *DictionaryClient) getEmptyCreateRequest(ctx context.Context, optio
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *DictionaryClient) getEmptyHandleResponse(resp *http.Response) (DictionaryClientGetEmptyResponse, error) {
-	result := DictionaryClientGetEmptyResponse{RawResponse: resp}
+	result := DictionaryClientGetEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetEmptyResponse{}, err
 	}
@@ -1401,7 +1401,7 @@ func (client *DictionaryClient) getEmptyStringKeyCreateRequest(ctx context.Conte
 
 // getEmptyStringKeyHandleResponse handles the GetEmptyStringKey response.
 func (client *DictionaryClient) getEmptyStringKeyHandleResponse(resp *http.Response) (DictionaryClientGetEmptyStringKeyResponse, error) {
-	result := DictionaryClientGetEmptyStringKeyResponse{RawResponse: resp}
+	result := DictionaryClientGetEmptyStringKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetEmptyStringKeyResponse{}, err
 	}
@@ -1440,7 +1440,7 @@ func (client *DictionaryClient) getFloatInvalidNullCreateRequest(ctx context.Con
 
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *DictionaryClient) getFloatInvalidNullHandleResponse(resp *http.Response) (DictionaryClientGetFloatInvalidNullResponse, error) {
-	result := DictionaryClientGetFloatInvalidNullResponse{RawResponse: resp}
+	result := DictionaryClientGetFloatInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetFloatInvalidNullResponse{}, err
 	}
@@ -1479,7 +1479,7 @@ func (client *DictionaryClient) getFloatInvalidStringCreateRequest(ctx context.C
 
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *DictionaryClient) getFloatInvalidStringHandleResponse(resp *http.Response) (DictionaryClientGetFloatInvalidStringResponse, error) {
-	result := DictionaryClientGetFloatInvalidStringResponse{RawResponse: resp}
+	result := DictionaryClientGetFloatInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetFloatInvalidStringResponse{}, err
 	}
@@ -1518,7 +1518,7 @@ func (client *DictionaryClient) getFloatValidCreateRequest(ctx context.Context, 
 
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client *DictionaryClient) getFloatValidHandleResponse(resp *http.Response) (DictionaryClientGetFloatValidResponse, error) {
-	result := DictionaryClientGetFloatValidResponse{RawResponse: resp}
+	result := DictionaryClientGetFloatValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetFloatValidResponse{}, err
 	}
@@ -1557,7 +1557,7 @@ func (client *DictionaryClient) getIntInvalidNullCreateRequest(ctx context.Conte
 
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *DictionaryClient) getIntInvalidNullHandleResponse(resp *http.Response) (DictionaryClientGetIntInvalidNullResponse, error) {
-	result := DictionaryClientGetIntInvalidNullResponse{RawResponse: resp}
+	result := DictionaryClientGetIntInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetIntInvalidNullResponse{}, err
 	}
@@ -1596,7 +1596,7 @@ func (client *DictionaryClient) getIntInvalidStringCreateRequest(ctx context.Con
 
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *DictionaryClient) getIntInvalidStringHandleResponse(resp *http.Response) (DictionaryClientGetIntInvalidStringResponse, error) {
-	result := DictionaryClientGetIntInvalidStringResponse{RawResponse: resp}
+	result := DictionaryClientGetIntInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetIntInvalidStringResponse{}, err
 	}
@@ -1635,7 +1635,7 @@ func (client *DictionaryClient) getIntegerValidCreateRequest(ctx context.Context
 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *DictionaryClient) getIntegerValidHandleResponse(resp *http.Response) (DictionaryClientGetIntegerValidResponse, error) {
-	result := DictionaryClientGetIntegerValidResponse{RawResponse: resp}
+	result := DictionaryClientGetIntegerValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetIntegerValidResponse{}, err
 	}
@@ -1673,7 +1673,7 @@ func (client *DictionaryClient) getInvalidCreateRequest(ctx context.Context, opt
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *DictionaryClient) getInvalidHandleResponse(resp *http.Response) (DictionaryClientGetInvalidResponse, error) {
-	result := DictionaryClientGetInvalidResponse{RawResponse: resp}
+	result := DictionaryClientGetInvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetInvalidResponse{}, err
 	}
@@ -1712,7 +1712,7 @@ func (client *DictionaryClient) getLongInvalidNullCreateRequest(ctx context.Cont
 
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *DictionaryClient) getLongInvalidNullHandleResponse(resp *http.Response) (DictionaryClientGetLongInvalidNullResponse, error) {
-	result := DictionaryClientGetLongInvalidNullResponse{RawResponse: resp}
+	result := DictionaryClientGetLongInvalidNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetLongInvalidNullResponse{}, err
 	}
@@ -1751,7 +1751,7 @@ func (client *DictionaryClient) getLongInvalidStringCreateRequest(ctx context.Co
 
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *DictionaryClient) getLongInvalidStringHandleResponse(resp *http.Response) (DictionaryClientGetLongInvalidStringResponse, error) {
-	result := DictionaryClientGetLongInvalidStringResponse{RawResponse: resp}
+	result := DictionaryClientGetLongInvalidStringResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetLongInvalidStringResponse{}, err
 	}
@@ -1789,7 +1789,7 @@ func (client *DictionaryClient) getLongValidCreateRequest(ctx context.Context, o
 
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client *DictionaryClient) getLongValidHandleResponse(resp *http.Response) (DictionaryClientGetLongValidResponse, error) {
-	result := DictionaryClientGetLongValidResponse{RawResponse: resp}
+	result := DictionaryClientGetLongValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetLongValidResponse{}, err
 	}
@@ -1827,7 +1827,7 @@ func (client *DictionaryClient) getNullCreateRequest(ctx context.Context, option
 
 // getNullHandleResponse handles the GetNull response.
 func (client *DictionaryClient) getNullHandleResponse(resp *http.Response) (DictionaryClientGetNullResponse, error) {
-	result := DictionaryClientGetNullResponse{RawResponse: resp}
+	result := DictionaryClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetNullResponse{}, err
 	}
@@ -1865,7 +1865,7 @@ func (client *DictionaryClient) getNullKeyCreateRequest(ctx context.Context, opt
 
 // getNullKeyHandleResponse handles the GetNullKey response.
 func (client *DictionaryClient) getNullKeyHandleResponse(resp *http.Response) (DictionaryClientGetNullKeyResponse, error) {
-	result := DictionaryClientGetNullKeyResponse{RawResponse: resp}
+	result := DictionaryClientGetNullKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetNullKeyResponse{}, err
 	}
@@ -1903,7 +1903,7 @@ func (client *DictionaryClient) getNullValueCreateRequest(ctx context.Context, o
 
 // getNullValueHandleResponse handles the GetNullValue response.
 func (client *DictionaryClient) getNullValueHandleResponse(resp *http.Response) (DictionaryClientGetNullValueResponse, error) {
-	result := DictionaryClientGetNullValueResponse{RawResponse: resp}
+	result := DictionaryClientGetNullValueResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetNullValueResponse{}, err
 	}
@@ -1942,7 +1942,7 @@ func (client *DictionaryClient) getStringValidCreateRequest(ctx context.Context,
 
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client *DictionaryClient) getStringValidHandleResponse(resp *http.Response) (DictionaryClientGetStringValidResponse, error) {
-	result := DictionaryClientGetStringValidResponse{RawResponse: resp}
+	result := DictionaryClientGetStringValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetStringValidResponse{}, err
 	}
@@ -1981,7 +1981,7 @@ func (client *DictionaryClient) getStringWithInvalidCreateRequest(ctx context.Co
 
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *DictionaryClient) getStringWithInvalidHandleResponse(resp *http.Response) (DictionaryClientGetStringWithInvalidResponse, error) {
-	result := DictionaryClientGetStringWithInvalidResponse{RawResponse: resp}
+	result := DictionaryClientGetStringWithInvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetStringWithInvalidResponse{}, err
 	}
@@ -2020,7 +2020,7 @@ func (client *DictionaryClient) getStringWithNullCreateRequest(ctx context.Conte
 
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *DictionaryClient) getStringWithNullHandleResponse(resp *http.Response) (DictionaryClientGetStringWithNullResponse, error) {
-	result := DictionaryClientGetStringWithNullResponse{RawResponse: resp}
+	result := DictionaryClientGetStringWithNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DictionaryClientGetStringWithNullResponse{}, err
 	}
@@ -2043,7 +2043,7 @@ func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutArrayValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutArrayValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutArrayValidResponse{}, nil
 }
 
 // putArrayValidCreateRequest creates the PutArrayValid request.
@@ -2073,7 +2073,7 @@ func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody ma
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutBooleanTfftResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutBooleanTfftResponse{RawResponse: resp}, nil
+	return DictionaryClientPutBooleanTfftResponse{}, nil
 }
 
 // putBooleanTfftCreateRequest creates the PutBooleanTfft request.
@@ -2103,7 +2103,7 @@ func (client *DictionaryClient) PutByteValid(ctx context.Context, arrayBody map[
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutByteValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutByteValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutByteValidResponse{}, nil
 }
 
 // putByteValidCreateRequest creates the PutByteValid request.
@@ -2134,7 +2134,7 @@ func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody m
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutComplexValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutComplexValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutComplexValidResponse{}, nil
 }
 
 // putComplexValidCreateRequest creates the PutComplexValid request.
@@ -2165,7 +2165,7 @@ func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arr
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutDateTimeRFC1123ValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutDateTimeRFC1123ValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutDateTimeRFC1123ValidResponse{}, nil
 }
 
 // putDateTimeRFC1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
@@ -2199,7 +2199,7 @@ func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutDateTimeValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutDateTimeValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutDateTimeValidResponse{}, nil
 }
 
 // putDateTimeValidCreateRequest creates the PutDateTimeValid request.
@@ -2232,7 +2232,7 @@ func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutDateValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutDateValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutDateValidResponse{}, nil
 }
 
 // putDateValidCreateRequest creates the PutDateValid request.
@@ -2267,7 +2267,7 @@ func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBod
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutDictionaryValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutDictionaryValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutDictionaryValidResponse{}, nil
 }
 
 // putDictionaryValidCreateRequest creates the PutDictionaryValid request.
@@ -2297,7 +2297,7 @@ func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody ma
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutDoubleValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutDoubleValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutDoubleValidResponse{}, nil
 }
 
 // putDoubleValidCreateRequest creates the PutDoubleValid request.
@@ -2327,7 +2327,7 @@ func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutDurationValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutDurationValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutDurationValidResponse{}, nil
 }
 
 // putDurationValidCreateRequest creates the PutDurationValid request.
@@ -2356,7 +2356,7 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[stri
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutEmptyResponse{RawResponse: resp}, nil
+	return DictionaryClientPutEmptyResponse{}, nil
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
@@ -2386,7 +2386,7 @@ func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutFloatValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutFloatValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutFloatValidResponse{}, nil
 }
 
 // putFloatValidCreateRequest creates the PutFloatValid request.
@@ -2416,7 +2416,7 @@ func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody m
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutIntegerValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutIntegerValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutIntegerValidResponse{}, nil
 }
 
 // putIntegerValidCreateRequest creates the PutIntegerValid request.
@@ -2445,7 +2445,7 @@ func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutLongValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutLongValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutLongValidResponse{}, nil
 }
 
 // putLongValidCreateRequest creates the PutLongValid request.
@@ -2475,7 +2475,7 @@ func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody ma
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DictionaryClientPutStringValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return DictionaryClientPutStringValidResponse{RawResponse: resp}, nil
+	return DictionaryClientPutStringValidResponse{}, nil
 }
 
 // putStringValidCreateRequest creates the PutStringValid request.

--- a/test/autorest/dictionarygroup/zz_generated_response_types.go
+++ b/test/autorest/dictionarygroup/zz_generated_response_types.go
@@ -8,106 +8,70 @@
 
 package dictionarygroup
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 // DictionaryClientGetArrayEmptyResponse contains the response from method DictionaryClient.GetArrayEmpty.
 type DictionaryClientGetArrayEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An empty dictionary {}
 	Value map[string][]*string
 }
 
 // DictionaryClientGetArrayItemEmptyResponse contains the response from method DictionaryClient.GetArrayItemEmpty.
 type DictionaryClientGetArrayItemEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An array of array of strings {"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
 	Value map[string][]*string
 }
 
 // DictionaryClientGetArrayItemNullResponse contains the response from method DictionaryClient.GetArrayItemNull.
 type DictionaryClientGetArrayItemNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An array of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
 	Value map[string][]*string
 }
 
 // DictionaryClientGetArrayNullResponse contains the response from method DictionaryClient.GetArrayNull.
 type DictionaryClientGetArrayNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// a null array
 	Value map[string][]*string
 }
 
 // DictionaryClientGetArrayValidResponse contains the response from method DictionaryClient.GetArrayValid.
 type DictionaryClientGetArrayValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
 	Value map[string][]*string
 }
 
 // DictionaryClientGetBase64URLResponse contains the response from method DictionaryClient.GetBase64URL.
 type DictionaryClientGetBase64URLResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}
 	Value map[string][]byte
 }
 
 // DictionaryClientGetBooleanInvalidNullResponse contains the response from method DictionaryClient.GetBooleanInvalidNull.
 type DictionaryClientGetBooleanInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": true, "1": null, "2": false }
 	Value map[string]*bool
 }
 
 // DictionaryClientGetBooleanInvalidStringResponse contains the response from method DictionaryClient.GetBooleanInvalidString.
 type DictionaryClientGetBooleanInvalidStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value [true, 'boolean', false]
 	Value map[string]*bool
 }
 
 // DictionaryClientGetBooleanTfftResponse contains the response from method DictionaryClient.GetBooleanTfft.
 type DictionaryClientGetBooleanTfftResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": true, "1": false, "2": false, "3": true }
 	Value map[string]*bool
 }
 
 // DictionaryClientGetByteInvalidNullResponse contains the response from method DictionaryClient.GetByteInvalidNull.
 type DictionaryClientGetByteInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
 	Value map[string][]byte
 }
 
 // DictionaryClientGetByteValidResponse contains the response from method DictionaryClient.GetByteValid.
 type DictionaryClientGetByteValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base
 	// 64
 	Value map[string][]byte
@@ -115,45 +79,30 @@ type DictionaryClientGetByteValidResponse struct {
 
 // DictionaryClientGetComplexEmptyResponse contains the response from method DictionaryClient.GetComplexEmpty.
 type DictionaryClientGetComplexEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Empty dictionary of complex type {}
 	Value map[string]*Widget
 }
 
 // DictionaryClientGetComplexItemEmptyResponse contains the response from method DictionaryClient.GetComplexItemEmpty.
 type DictionaryClientGetComplexItemEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
 	Value map[string]*Widget
 }
 
 // DictionaryClientGetComplexItemNullResponse contains the response from method DictionaryClient.GetComplexItemNull.
 type DictionaryClientGetComplexItemNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
 	Value map[string]*Widget
 }
 
 // DictionaryClientGetComplexNullResponse contains the response from method DictionaryClient.GetComplexNull.
 type DictionaryClientGetComplexNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of complex type with null value
 	Value map[string]*Widget
 }
 
 // DictionaryClientGetComplexValidResponse contains the response from method DictionaryClient.GetComplexValid.
 type DictionaryClientGetComplexValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string':
 	// '6'}]
 	Value map[string]*Widget
@@ -161,45 +110,30 @@ type DictionaryClientGetComplexValidResponse struct {
 
 // DictionaryClientGetDateInvalidCharsResponse contains the response from method DictionaryClient.GetDateInvalidChars.
 type DictionaryClientGetDateInvalidCharsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "2011-03-22", "1": "date"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateInvalidNullResponse contains the response from method DictionaryClient.GetDateInvalidNull.
 type DictionaryClientGetDateInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateTimeInvalidCharsResponse contains the response from method DictionaryClient.GetDateTimeInvalidChars.
 type DictionaryClientGetDateTimeInvalidCharsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateTimeInvalidNullResponse contains the response from method DictionaryClient.GetDateTimeInvalidNull.
 type DictionaryClientGetDateTimeInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateTimeRFC1123ValidResponse contains the response from method DictionaryClient.GetDateTimeRFC1123Valid.
 type DictionaryClientGetDateTimeRFC1123ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492
 	// 10:15:01 GMT"}
 	Value map[string]*time.Time
@@ -207,36 +141,24 @@ type DictionaryClientGetDateTimeRFC1123ValidResponse struct {
 
 // DictionaryClientGetDateTimeValidResponse contains the response from method DictionaryClient.GetDateTimeValid.
 type DictionaryClientGetDateTimeValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDateValidResponse contains the response from method DictionaryClient.GetDateValid.
 type DictionaryClientGetDateValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
 	Value map[string]*time.Time
 }
 
 // DictionaryClientGetDictionaryEmptyResponse contains the response from method DictionaryClient.GetDictionaryEmpty.
 type DictionaryClientGetDictionaryEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An dictionaries of dictionaries of type <string, string> with value {}
 	Value map[string]map[string]*string
 }
 
 // DictionaryClientGetDictionaryItemEmptyResponse contains the response from method DictionaryClient.GetDictionaryItemEmpty.
 type DictionaryClientGetDictionaryItemEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
 	// {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 	Value map[string]map[string]*string
@@ -244,9 +166,6 @@ type DictionaryClientGetDictionaryItemEmptyResponse struct {
 
 // DictionaryClientGetDictionaryItemNullResponse contains the response from method DictionaryClient.GetDictionaryItemNull.
 type DictionaryClientGetDictionaryItemNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
 	// null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 	Value map[string]map[string]*string
@@ -254,18 +173,12 @@ type DictionaryClientGetDictionaryItemNullResponse struct {
 
 // DictionaryClientGetDictionaryNullResponse contains the response from method DictionaryClient.GetDictionaryNull.
 type DictionaryClientGetDictionaryNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An dictionaries of dictionaries with value null
 	Value map[string]map[string]*string
 }
 
 // DictionaryClientGetDictionaryValidResponse contains the response from method DictionaryClient.GetDictionaryValid.
 type DictionaryClientGetDictionaryValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// An dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
 	// {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 	Value map[string]map[string]*string
@@ -273,288 +186,207 @@ type DictionaryClientGetDictionaryValidResponse struct {
 
 // DictionaryClientGetDoubleInvalidNullResponse contains the response from method DictionaryClient.GetDoubleInvalidNull.
 type DictionaryClientGetDoubleInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 	Value map[string]*float64
 }
 
 // DictionaryClientGetDoubleInvalidStringResponse contains the response from method DictionaryClient.GetDoubleInvalidString.
 type DictionaryClientGetDoubleInvalidStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 	Value map[string]*float64
 }
 
 // DictionaryClientGetDoubleValidResponse contains the response from method DictionaryClient.GetDoubleValid.
 type DictionaryClientGetDoubleValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 	Value map[string]*float64
 }
 
 // DictionaryClientGetDurationValidResponse contains the response from method DictionaryClient.GetDurationValid.
 type DictionaryClientGetDurationValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
 	Value map[string]*string
 }
 
 // DictionaryClientGetEmptyResponse contains the response from method DictionaryClient.GetEmpty.
 type DictionaryClientGetEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The empty dictionary value {}
 	Value map[string]*int32
 }
 
 // DictionaryClientGetEmptyStringKeyResponse contains the response from method DictionaryClient.GetEmptyStringKey.
 type DictionaryClientGetEmptyStringKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of <string>
 	Value map[string]*string
 }
 
 // DictionaryClientGetFloatInvalidNullResponse contains the response from method DictionaryClient.GetFloatInvalidNull.
 type DictionaryClientGetFloatInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 	Value map[string]*float32
 }
 
 // DictionaryClientGetFloatInvalidStringResponse contains the response from method DictionaryClient.GetFloatInvalidString.
 type DictionaryClientGetFloatInvalidStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 	Value map[string]*float32
 }
 
 // DictionaryClientGetFloatValidResponse contains the response from method DictionaryClient.GetFloatValid.
 type DictionaryClientGetFloatValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 	Value map[string]*float32
 }
 
 // DictionaryClientGetIntInvalidNullResponse contains the response from method DictionaryClient.GetIntInvalidNull.
 type DictionaryClientGetIntInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 1, "1": null, "2": 0}
 	Value map[string]*int32
 }
 
 // DictionaryClientGetIntInvalidStringResponse contains the response from method DictionaryClient.GetIntInvalidString.
 type DictionaryClientGetIntInvalidStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 1, "1": "integer", "2": 0}
 	Value map[string]*int32
 }
 
 // DictionaryClientGetIntegerValidResponse contains the response from method DictionaryClient.GetIntegerValid.
 type DictionaryClientGetIntegerValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 	Value map[string]*int32
 }
 
 // DictionaryClientGetInvalidResponse contains the response from method DictionaryClient.GetInvalid.
 type DictionaryClientGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of <string>
 	Value map[string]*string
 }
 
 // DictionaryClientGetLongInvalidNullResponse contains the response from method DictionaryClient.GetLongInvalidNull.
 type DictionaryClientGetLongInvalidNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 1, "1": null, "2": 0}
 	Value map[string]*int64
 }
 
 // DictionaryClientGetLongInvalidStringResponse contains the response from method DictionaryClient.GetLongInvalidString.
 type DictionaryClientGetLongInvalidStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 1, "1": "integer", "2": 0}
 	Value map[string]*int64
 }
 
 // DictionaryClientGetLongValidResponse contains the response from method DictionaryClient.GetLongValid.
 type DictionaryClientGetLongValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 	Value map[string]*int64
 }
 
 // DictionaryClientGetNullKeyResponse contains the response from method DictionaryClient.GetNullKey.
 type DictionaryClientGetNullKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of <string>
 	Value map[string]*string
 }
 
 // DictionaryClientGetNullResponse contains the response from method DictionaryClient.GetNull.
 type DictionaryClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The null dictionary value
 	Value map[string]*int32
 }
 
 // DictionaryClientGetNullValueResponse contains the response from method DictionaryClient.GetNullValue.
 type DictionaryClientGetNullValueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of <string>
 	Value map[string]*string
 }
 
 // DictionaryClientGetStringValidResponse contains the response from method DictionaryClient.GetStringValid.
 type DictionaryClientGetStringValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
 	Value map[string]*string
 }
 
 // DictionaryClientGetStringWithInvalidResponse contains the response from method DictionaryClient.GetStringWithInvalid.
 type DictionaryClientGetStringWithInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "foo", "1": 123, "2": "foo2"}
 	Value map[string]*string
 }
 
 // DictionaryClientGetStringWithNullResponse contains the response from method DictionaryClient.GetStringWithNull.
 type DictionaryClientGetStringWithNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// The dictionary value {"0": "foo", "1": null, "2": "foo2"}
 	Value map[string]*string
 }
 
 // DictionaryClientPutArrayValidResponse contains the response from method DictionaryClient.PutArrayValid.
 type DictionaryClientPutArrayValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutBooleanTfftResponse contains the response from method DictionaryClient.PutBooleanTfft.
 type DictionaryClientPutBooleanTfftResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutByteValidResponse contains the response from method DictionaryClient.PutByteValid.
 type DictionaryClientPutByteValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutComplexValidResponse contains the response from method DictionaryClient.PutComplexValid.
 type DictionaryClientPutComplexValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutDateTimeRFC1123ValidResponse contains the response from method DictionaryClient.PutDateTimeRFC1123Valid.
 type DictionaryClientPutDateTimeRFC1123ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutDateTimeValidResponse contains the response from method DictionaryClient.PutDateTimeValid.
 type DictionaryClientPutDateTimeValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutDateValidResponse contains the response from method DictionaryClient.PutDateValid.
 type DictionaryClientPutDateValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutDictionaryValidResponse contains the response from method DictionaryClient.PutDictionaryValid.
 type DictionaryClientPutDictionaryValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutDoubleValidResponse contains the response from method DictionaryClient.PutDoubleValid.
 type DictionaryClientPutDoubleValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutDurationValidResponse contains the response from method DictionaryClient.PutDurationValid.
 type DictionaryClientPutDurationValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutEmptyResponse contains the response from method DictionaryClient.PutEmpty.
 type DictionaryClientPutEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutFloatValidResponse contains the response from method DictionaryClient.PutFloatValid.
 type DictionaryClientPutFloatValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutIntegerValidResponse contains the response from method DictionaryClient.PutIntegerValid.
 type DictionaryClientPutIntegerValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutLongValidResponse contains the response from method DictionaryClient.PutLongValid.
 type DictionaryClientPutLongValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DictionaryClientPutStringValidResponse contains the response from method DictionaryClient.PutStringValid.
 type DictionaryClientPutStringValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/durationgroup/durationgroup_test.go
+++ b/test/autorest/durationgroup/durationgroup_test.go
@@ -5,7 +5,7 @@ package durationgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -54,7 +54,7 @@ func TestPutPositiveDuration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/durationgroup/zz_generated_duration_client.go
+++ b/test/autorest/durationgroup/zz_generated_duration_client.go
@@ -65,7 +65,7 @@ func (client *DurationClient) getInvalidCreateRequest(ctx context.Context, optio
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *DurationClient) getInvalidHandleResponse(resp *http.Response) (DurationClientGetInvalidResponse, error) {
-	result := DurationClientGetInvalidResponse{RawResponse: resp}
+	result := DurationClientGetInvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DurationClientGetInvalidResponse{}, err
 	}
@@ -103,7 +103,7 @@ func (client *DurationClient) getNullCreateRequest(ctx context.Context, options 
 
 // getNullHandleResponse handles the GetNull response.
 func (client *DurationClient) getNullHandleResponse(resp *http.Response) (DurationClientGetNullResponse, error) {
-	result := DurationClientGetNullResponse{RawResponse: resp}
+	result := DurationClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DurationClientGetNullResponse{}, err
 	}
@@ -142,7 +142,7 @@ func (client *DurationClient) getPositiveDurationCreateRequest(ctx context.Conte
 
 // getPositiveDurationHandleResponse handles the GetPositiveDuration response.
 func (client *DurationClient) getPositiveDurationHandleResponse(resp *http.Response) (DurationClientGetPositiveDurationResponse, error) {
-	result := DurationClientGetPositiveDurationResponse{RawResponse: resp}
+	result := DurationClientGetPositiveDurationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return DurationClientGetPositiveDurationResponse{}, err
 	}
@@ -166,7 +166,7 @@ func (client *DurationClient) PutPositiveDuration(ctx context.Context, durationB
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return DurationClientPutPositiveDurationResponse{}, runtime.NewResponseError(resp)
 	}
-	return DurationClientPutPositiveDurationResponse{RawResponse: resp}, nil
+	return DurationClientPutPositiveDurationResponse{}, nil
 }
 
 // putPositiveDurationCreateRequest creates the PutPositiveDuration request.

--- a/test/autorest/durationgroup/zz_generated_response_types.go
+++ b/test/autorest/durationgroup/zz_generated_response_types.go
@@ -8,31 +8,22 @@
 
 package durationgroup
 
-import "net/http"
-
 // DurationClientGetInvalidResponse contains the response from method DurationClient.GetInvalid.
 type DurationClientGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // DurationClientGetNullResponse contains the response from method DurationClient.GetNull.
 type DurationClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // DurationClientGetPositiveDurationResponse contains the response from method DurationClient.GetPositiveDuration.
 type DurationClientGetPositiveDurationResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // DurationClientPutPositiveDurationResponse contains the response from method DurationClient.PutPositiveDuration.
 type DurationClientPutPositiveDurationResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/errorsgroup/errorsgroup_test.go
+++ b/test/autorest/errorsgroup/errorsgroup_test.go
@@ -6,7 +6,6 @@ package errorsgroup
 import (
 	"context"
 	"errors"
-	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -139,8 +138,8 @@ func TestGetPetByIDSuccess2(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusAccepted {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 

--- a/test/autorest/errorsgroup/zz_generated_pet_client.go
+++ b/test/autorest/errorsgroup/zz_generated_pet_client.go
@@ -73,7 +73,7 @@ func (client *PetClient) doSomethingCreateRequest(ctx context.Context, whatActio
 
 // doSomethingHandleResponse handles the DoSomething response.
 func (client *PetClient) doSomethingHandleResponse(resp *http.Response) (PetClientDoSomethingResponse, error) {
-	result := PetClientDoSomethingResponse{RawResponse: resp}
+	result := PetClientDoSomethingResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAction); err != nil {
 		return PetClientDoSomethingResponse{}, err
 	}
@@ -116,7 +116,7 @@ func (client *PetClient) getPetByIDCreateRequest(ctx context.Context, petID stri
 
 // getPetByIDHandleResponse handles the GetPetByID response.
 func (client *PetClient) getPetByIDHandleResponse(resp *http.Response) (PetClientGetPetByIDResponse, error) {
-	result := PetClientGetPetByIDResponse{RawResponse: resp}
+	result := PetClientGetPetByIDResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Pet); err != nil {
 		return PetClientGetPetByIDResponse{}, err
 	}
@@ -139,7 +139,7 @@ func (client *PetClient) HasModelsParam(ctx context.Context, options *PetClientH
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PetClientHasModelsParamResponse{}, runtime.NewResponseError(resp)
 	}
-	return PetClientHasModelsParamResponse{RawResponse: resp}, nil
+	return PetClientHasModelsParamResponse{}, nil
 }
 
 // hasModelsParamCreateRequest creates the HasModelsParam request.

--- a/test/autorest/errorsgroup/zz_generated_response_types.go
+++ b/test/autorest/errorsgroup/zz_generated_response_types.go
@@ -8,24 +8,17 @@
 
 package errorsgroup
 
-import "net/http"
-
 // PetClientDoSomethingResponse contains the response from method PetClient.DoSomething.
 type PetClientDoSomethingResponse struct {
 	PetAction
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PetClientGetPetByIDResponse contains the response from method PetClient.GetPetByID.
 type PetClientGetPetByIDResponse struct {
 	Pet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PetClientHasModelsParamResponse contains the response from method PetClient.HasModelsParam.
 type PetClientHasModelsParamResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/extenumsgroup/zz_generated_pet_client.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet_client.go
@@ -71,7 +71,7 @@ func (client *PetClient) addPetCreateRequest(ctx context.Context, options *PetCl
 
 // addPetHandleResponse handles the AddPet response.
 func (client *PetClient) addPetHandleResponse(resp *http.Response) (PetClientAddPetResponse, error) {
-	result := PetClientAddPetResponse{RawResponse: resp}
+	result := PetClientAddPetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Pet); err != nil {
 		return PetClientAddPetResponse{}, err
 	}
@@ -114,7 +114,7 @@ func (client *PetClient) getByPetIDCreateRequest(ctx context.Context, petID stri
 
 // getByPetIDHandleResponse handles the GetByPetID response.
 func (client *PetClient) getByPetIDHandleResponse(resp *http.Response) (PetClientGetByPetIDResponse, error) {
-	result := PetClientGetByPetIDResponse{RawResponse: resp}
+	result := PetClientGetByPetIDResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Pet); err != nil {
 		return PetClientGetByPetIDResponse{}, err
 	}

--- a/test/autorest/extenumsgroup/zz_generated_response_types.go
+++ b/test/autorest/extenumsgroup/zz_generated_response_types.go
@@ -8,18 +8,12 @@
 
 package extenumsgroup
 
-import "net/http"
-
 // PetClientAddPetResponse contains the response from method PetClient.AddPet.
 type PetClientAddPetResponse struct {
 	Pet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PetClientGetByPetIDResponse contains the response from method PetClient.GetByPetID.
 type PetClientGetByPetIDResponse struct {
 	Pet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/filegroup/filegroup_test.go
+++ b/test/autorest/filegroup/filegroup_test.go
@@ -6,7 +6,6 @@ package filegroup
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 	"testing"
 )
 
@@ -20,16 +19,10 @@ func TestGetEmptyFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
-	if result.RawResponse.Body == nil {
+	if result.Body == nil {
 		t.Fatal("unexpected nil response body")
 	}
-	if result.RawResponse.ContentLength != 0 {
-		t.Fatalf("expected zero ContentLength, got %d", result.RawResponse.ContentLength)
-	}
-	result.RawResponse.Body.Close()
+	result.Body.Close()
 }
 
 func TestGetFile(t *testing.T) {
@@ -38,17 +31,14 @@ func TestGetFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
-	if result.RawResponse.Body == nil {
+	if result.Body == nil {
 		t.Fatal("unexpected nil response body")
 	}
-	b, err := ioutil.ReadAll(result.RawResponse.Body)
+	b, err := ioutil.ReadAll(result.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	result.RawResponse.Body.Close()
+	result.Body.Close()
 	if l := len(b); l != 8725 {
 		t.Fatalf("unexpected byte count: want 8725, got %d", l)
 	}
@@ -61,17 +51,14 @@ func TestGetFileLarge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
-	if result.RawResponse.Body == nil {
+	if result.Body == nil {
 		t.Fatal("unexpected nil response body")
 	}
-	b, err := ioutil.ReadAll(result.RawResponse.Body)
+	b, err := ioutil.ReadAll(result.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	result.RawResponse.Body.Close()
+	result.Body.Close()
 	const size = 3000 * 1024 * 1024
 	if l := len(b); l != size {
 		t.Fatalf("unexpected byte count: want %d, got %d", size, l)

--- a/test/autorest/filegroup/zz_generated_files_client.go
+++ b/test/autorest/filegroup/zz_generated_files_client.go
@@ -49,7 +49,7 @@ func (client *FilesClient) GetEmptyFile(ctx context.Context, options *FilesClien
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return FilesClientGetEmptyFileResponse{}, runtime.NewResponseError(resp)
 	}
-	return FilesClientGetEmptyFileResponse{RawResponse: resp}, nil
+	return FilesClientGetEmptyFileResponse{Body: resp.Body}, nil
 }
 
 // getEmptyFileCreateRequest creates the GetEmptyFile request.
@@ -79,7 +79,7 @@ func (client *FilesClient) GetFile(ctx context.Context, options *FilesClientGetF
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return FilesClientGetFileResponse{}, runtime.NewResponseError(resp)
 	}
-	return FilesClientGetFileResponse{RawResponse: resp}, nil
+	return FilesClientGetFileResponse{Body: resp.Body}, nil
 }
 
 // getFileCreateRequest creates the GetFile request.
@@ -109,7 +109,7 @@ func (client *FilesClient) GetFileLarge(ctx context.Context, options *FilesClien
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return FilesClientGetFileLargeResponse{}, runtime.NewResponseError(resp)
 	}
-	return FilesClientGetFileLargeResponse{RawResponse: resp}, nil
+	return FilesClientGetFileLargeResponse{Body: resp.Body}, nil
 }
 
 // getFileLargeCreateRequest creates the GetFileLarge request.

--- a/test/autorest/filegroup/zz_generated_response_types.go
+++ b/test/autorest/filegroup/zz_generated_response_types.go
@@ -8,22 +8,22 @@
 
 package filegroup
 
-import "net/http"
+import "io"
 
 // FilesClientGetEmptyFileResponse contains the response from method FilesClient.GetEmptyFile.
 type FilesClientGetEmptyFileResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// Body contains the streaming response.
+	Body io.ReadCloser
 }
 
 // FilesClientGetFileLargeResponse contains the response from method FilesClient.GetFileLarge.
 type FilesClientGetFileLargeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// Body contains the streaming response.
+	Body io.ReadCloser
 }
 
 // FilesClientGetFileResponse contains the response from method FilesClient.GetFile.
 type FilesClientGetFileResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// Body contains the streaming response.
+	Body io.ReadCloser
 }

--- a/test/autorest/formdatagroup/formgroup_test.go
+++ b/test/autorest/formdatagroup/formgroup_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -25,10 +24,7 @@ func TestUploadFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.RawResponse.StatusCode != http.StatusOK {
-		t.Fatal("unexpected status code")
-	}
-	b, err := ioutil.ReadAll(resp.RawResponse.Body)
+	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,10 +40,7 @@ func TestUploadFileViaBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.RawResponse.StatusCode != http.StatusOK {
-		t.Fatal("unexpected status code")
-	}
-	b, err := ioutil.ReadAll(resp.RawResponse.Body)
+	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,8 +61,11 @@ func TestUploadFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.RawResponse.StatusCode != http.StatusOK {
-		t.Fatal("unexpected status code")
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
 	}
-	// TODO: verify response body
+	if string(b) != "the data" {
+		t.Fatalf("unexpected result %s", string(b))
+	}
 }

--- a/test/autorest/formdatagroup/zz_generated_formdata_client.go
+++ b/test/autorest/formdatagroup/zz_generated_formdata_client.go
@@ -52,7 +52,7 @@ func (client *FormdataClient) UploadFile(ctx context.Context, fileContent io.Rea
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return FormdataClientUploadFileResponse{}, runtime.NewResponseError(resp)
 	}
-	return FormdataClientUploadFileResponse{RawResponse: resp}, nil
+	return FormdataClientUploadFileResponse{Body: resp.Body}, nil
 }
 
 // uploadFileCreateRequest creates the UploadFile request.
@@ -90,7 +90,7 @@ func (client *FormdataClient) UploadFileViaBody(ctx context.Context, fileContent
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return FormdataClientUploadFileViaBodyResponse{}, runtime.NewResponseError(resp)
 	}
-	return FormdataClientUploadFileViaBodyResponse{RawResponse: resp}, nil
+	return FormdataClientUploadFileViaBodyResponse{Body: resp.Body}, nil
 }
 
 // uploadFileViaBodyCreateRequest creates the UploadFileViaBody request.
@@ -121,7 +121,7 @@ func (client *FormdataClient) UploadFiles(ctx context.Context, fileContent []io.
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return FormdataClientUploadFilesResponse{}, runtime.NewResponseError(resp)
 	}
-	return FormdataClientUploadFilesResponse{RawResponse: resp}, nil
+	return FormdataClientUploadFilesResponse{Body: resp.Body}, nil
 }
 
 // uploadFilesCreateRequest creates the UploadFiles request.

--- a/test/autorest/formdatagroup/zz_generated_response_types.go
+++ b/test/autorest/formdatagroup/zz_generated_response_types.go
@@ -8,22 +8,22 @@
 
 package formdatagroup
 
-import "net/http"
+import "io"
 
 // FormdataClientUploadFileResponse contains the response from method FormdataClient.UploadFile.
 type FormdataClientUploadFileResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// Body contains the streaming response.
+	Body io.ReadCloser
 }
 
 // FormdataClientUploadFileViaBodyResponse contains the response from method FormdataClient.UploadFileViaBody.
 type FormdataClientUploadFileViaBodyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// Body contains the streaming response.
+	Body io.ReadCloser
 }
 
 // FormdataClientUploadFilesResponse contains the response from method FormdataClient.UploadFiles.
 type FormdataClientUploadFilesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// Body contains the streaming response.
+	Body io.ReadCloser
 }

--- a/test/autorest/headergroup/headergroup_test.go
+++ b/test/autorest/headergroup/headergroup_test.go
@@ -6,6 +6,7 @@ package headergroup
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -26,8 +27,8 @@ func TestHeaderCustomRequestID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CustomRequestID: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -37,16 +38,16 @@ func TestHeaderParamBool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamBool: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 	result, err = client.ParamBool(context.Background(), "false", false, nil)
 	if err != nil {
 		t.Fatalf("ParamBool: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -56,8 +57,8 @@ func TestHeaderParamByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamByte: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -71,8 +72,8 @@ func TestHeaderParamDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDate: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -86,8 +87,8 @@ func TestHeaderParamDatetime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDatetime: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -101,8 +102,8 @@ func TestHeaderParamDatetimeRFC1123(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDatetimeRFC1123: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -112,16 +113,16 @@ func TestHeaderParamDouble(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDouble: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 	result, err = client.ParamDouble(context.Background(), "negative", -3.0, nil)
 	if err != nil {
 		t.Fatalf("ParamDouble: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -131,8 +132,8 @@ func TestHeaderParamDuration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDuration: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -143,16 +144,16 @@ func TestHeaderParamEnum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamEnum: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 	result, err = client.ParamEnum(context.Background(), "null", nil)
 	if err != nil {
 		t.Fatalf("ParamEnum: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -162,8 +163,8 @@ func TestHeaderParamEnum(t *testing.T) {
 // 	if err != nil {
 // 		t.Fatalf("ParamExistingKey: %v", err)
 // 	}
-// 	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-//		t.Fatalf("unexpected status code %d", s)
+// 	if !reflect.ValueOf(result).IsZero() {
+//		t.Fatal("expected zero-value result")
 //	}
 // }
 
@@ -173,16 +174,16 @@ func TestHeaderParamFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamFloat: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 	result, err = client.ParamFloat(context.Background(), "negative", -3.0, nil)
 	if err != nil {
 		t.Fatalf("ParamFloat: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -192,16 +193,16 @@ func TestHeaderParamInteger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamInteger: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 	result, err = client.ParamInteger(context.Background(), "negative", -2, nil)
 	if err != nil {
 		t.Fatalf("ParamInteger: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -211,16 +212,16 @@ func TestHeaderParamLong(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamLong: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 	result, err = client.ParamLong(context.Background(), "negative", -2, nil)
 	if err != nil {
 		t.Fatalf("ParamLong: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -230,8 +231,8 @@ func TestHeaderParamProtectedKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamProtectedKey: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -242,16 +243,16 @@ func TestHeaderParamString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamString: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 	result, err = client.ParamString(context.Background(), "null", nil)
 	if err != nil {
 		t.Fatalf("ParamString: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 	val = ""
@@ -259,8 +260,8 @@ func TestHeaderParamString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamString: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -270,9 +271,6 @@ func TestHeaderResponseBool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseBool: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	val := true
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
@@ -280,9 +278,6 @@ func TestHeaderResponseBool(t *testing.T) {
 	result, err = client.ResponseBool(context.Background(), "false", nil)
 	if err != nil {
 		t.Fatalf("ResponseBool: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	val = false
 	if r := cmp.Diff(result.Value, &val); r != "" {
@@ -296,9 +291,6 @@ func TestHeaderResponseByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseByte: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	val := []byte("啊齄丂狛狜隣郎隣兀﨩")
 	if r := cmp.Diff(result.Value, val); r != "" {
 		t.Fatal(r)
@@ -311,9 +303,6 @@ func TestHeaderResponseDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseDate: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	val, err := time.Parse("2006-01-02", "2010-01-01")
 	if err != nil {
 		t.Fatalf("Unable to parse time: %v", err)
@@ -324,9 +313,6 @@ func TestHeaderResponseDate(t *testing.T) {
 	result, err = client.ResponseDate(context.Background(), "min", nil)
 	if err != nil {
 		t.Fatalf("ResponseDate: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	val, err = time.Parse("2006-01-02", "0001-01-01")
 	if err != nil {
@@ -343,9 +329,6 @@ func TestHeaderResponseDatetime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseDatetime: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	val, err := time.Parse(time.RFC3339, "2010-01-01T12:34:56Z")
 	if err != nil {
 		t.Fatalf("Unable to parse time: %v", err)
@@ -356,9 +339,6 @@ func TestHeaderResponseDatetime(t *testing.T) {
 	result, err = client.ResponseDatetime(context.Background(), "min", nil)
 	if err != nil {
 		t.Fatalf("ResponseDatetime: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	val, err = time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
 	if err != nil {
@@ -375,9 +355,6 @@ func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseDatetimeRFC1123: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	val, err := time.Parse(time.RFC1123, "Wed, 01 Jan 2010 12:34:56 GMT")
 	if err != nil {
 		t.Fatalf("Unable to parse time: %v", err)
@@ -388,9 +365,6 @@ func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
 	result, err = client.ResponseDatetimeRFC1123(context.Background(), "min", nil)
 	if err != nil {
 		t.Fatalf("ResponseDatetimeRFC1123: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	val, err = time.Parse(time.RFC1123, "Mon, 01 Jan 0001 00:00:00 GMT")
 	if err != nil {
@@ -407,16 +381,16 @@ func TestHeaderResponseDouble(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseDouble: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != 7e120 {
+		t.Fatalf("unexpected value %f", *result.Value)
 	}
 
 	result, err = client.ResponseDouble(context.Background(), "negative", nil)
 	if err != nil {
 		t.Fatalf("ResponseDouble: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != -3 {
+		t.Fatalf("unexpected value %f", *result.Value)
 	}
 }
 
@@ -437,9 +411,6 @@ func TestHeaderResponseEnum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseEnum: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	val := GreyscaleColors("GREY")
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
@@ -448,8 +419,8 @@ func TestHeaderResponseEnum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseEnum: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -459,8 +430,8 @@ func TestHeaderResponseExistingKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseExistingKey: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.UserAgent != "overwrite" {
+		t.Fatalf("unexpected value %s", *result.UserAgent)
 	}
 }
 
@@ -470,16 +441,16 @@ func TestHeaderResponseFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseFloat: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != 0.07 {
+		t.Fatalf("unexpected value %f", *result.Value)
 	}
 
 	result, err = client.ResponseFloat(context.Background(), "negative", nil)
 	if err != nil {
 		t.Fatalf("ResponseFloat: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != -3 {
+		t.Fatalf("unexpected value %f", *result.Value)
 	}
 }
 
@@ -489,16 +460,16 @@ func TestHeaderResponseInteger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseInteger: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != 1 {
+		t.Fatalf("unexpected value %d", *result.Value)
 	}
 
 	result, err = client.ResponseInteger(context.Background(), "negative", nil)
 	if err != nil {
 		t.Fatalf("ResponseInteger: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != -2 {
+		t.Fatalf("unexpected value %d", *result.Value)
 	}
 }
 
@@ -508,16 +479,16 @@ func TestHeaderResponseLong(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseLong: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != 105 {
+		t.Fatalf("unexpected value %d", *result.Value)
 	}
 
 	result, err = client.ResponseLong(context.Background(), "negative", nil)
 	if err != nil {
 		t.Fatalf("ResponseLong: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != -2 {
+		t.Fatalf("unexpected value %d", *result.Value)
 	}
 }
 
@@ -527,8 +498,8 @@ func TestHeaderResponseProtectedKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseProtectedKey: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.ContentType != "text/html; charset=utf-8" {
+		t.Fatalf("unexpected value %s", *result.ContentType)
 	}
 }
 
@@ -538,23 +509,23 @@ func TestHeaderResponseString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResponseString: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != "The quick brown fox jumps over the lazy dog" {
+		t.Fatalf("unexpected value %s", *result.Value)
 	}
 
 	result, err = client.ResponseString(context.Background(), "null", nil)
 	if err != nil {
 		t.Fatalf("ResponseString: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != "null" {
+		t.Fatalf("unexpected value %s", *result.Value)
 	}
 
 	result, err = client.ResponseString(context.Background(), "empty", nil)
 	if err != nil {
 		t.Fatalf("ResponseString: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if result.Value != nil {
+		t.Fatal("expected nil value")
 	}
 }

--- a/test/autorest/headergroup/zz_generated_header_client.go
+++ b/test/autorest/headergroup/zz_generated_header_client.go
@@ -52,7 +52,7 @@ func (client *HeaderClient) CustomRequestID(ctx context.Context, options *Header
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientCustomRequestIDResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientCustomRequestIDResponse{RawResponse: resp}, nil
+	return HeaderClientCustomRequestIDResponse{}, nil
 }
 
 // customRequestIDCreateRequest creates the CustomRequestID request.
@@ -83,7 +83,7 @@ func (client *HeaderClient) ParamBool(ctx context.Context, scenario string, valu
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamBoolResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamBoolResponse{RawResponse: resp}, nil
+	return HeaderClientParamBoolResponse{}, nil
 }
 
 // paramBoolCreateRequest creates the ParamBool request.
@@ -116,7 +116,7 @@ func (client *HeaderClient) ParamByte(ctx context.Context, scenario string, valu
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamByteResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamByteResponse{RawResponse: resp}, nil
+	return HeaderClientParamByteResponse{}, nil
 }
 
 // paramByteCreateRequest creates the ParamByte request.
@@ -150,7 +150,7 @@ func (client *HeaderClient) ParamDate(ctx context.Context, scenario string, valu
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamDateResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamDateResponse{RawResponse: resp}, nil
+	return HeaderClientParamDateResponse{}, nil
 }
 
 // paramDateCreateRequest creates the ParamDate request.
@@ -184,7 +184,7 @@ func (client *HeaderClient) ParamDatetime(ctx context.Context, scenario string, 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamDatetimeResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamDatetimeResponse{RawResponse: resp}, nil
+	return HeaderClientParamDatetimeResponse{}, nil
 }
 
 // paramDatetimeCreateRequest creates the ParamDatetime request.
@@ -218,7 +218,7 @@ func (client *HeaderClient) ParamDatetimeRFC1123(ctx context.Context, scenario s
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamDatetimeRFC1123Response{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamDatetimeRFC1123Response{RawResponse: resp}, nil
+	return HeaderClientParamDatetimeRFC1123Response{}, nil
 }
 
 // paramDatetimeRFC1123CreateRequest creates the ParamDatetimeRFC1123 request.
@@ -254,7 +254,7 @@ func (client *HeaderClient) ParamDouble(ctx context.Context, scenario string, va
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamDoubleResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamDoubleResponse{RawResponse: resp}, nil
+	return HeaderClientParamDoubleResponse{}, nil
 }
 
 // paramDoubleCreateRequest creates the ParamDouble request.
@@ -287,7 +287,7 @@ func (client *HeaderClient) ParamDuration(ctx context.Context, scenario string, 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamDurationResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamDurationResponse{RawResponse: resp}, nil
+	return HeaderClientParamDurationResponse{}, nil
 }
 
 // paramDurationCreateRequest creates the ParamDuration request.
@@ -320,7 +320,7 @@ func (client *HeaderClient) ParamEnum(ctx context.Context, scenario string, opti
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamEnumResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamEnumResponse{RawResponse: resp}, nil
+	return HeaderClientParamEnumResponse{}, nil
 }
 
 // paramEnumCreateRequest creates the ParamEnum request.
@@ -354,7 +354,7 @@ func (client *HeaderClient) ParamExistingKey(ctx context.Context, userAgent stri
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamExistingKeyResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamExistingKeyResponse{RawResponse: resp}, nil
+	return HeaderClientParamExistingKeyResponse{}, nil
 }
 
 // paramExistingKeyCreateRequest creates the ParamExistingKey request.
@@ -387,7 +387,7 @@ func (client *HeaderClient) ParamFloat(ctx context.Context, scenario string, val
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamFloatResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamFloatResponse{RawResponse: resp}, nil
+	return HeaderClientParamFloatResponse{}, nil
 }
 
 // paramFloatCreateRequest creates the ParamFloat request.
@@ -421,7 +421,7 @@ func (client *HeaderClient) ParamInteger(ctx context.Context, scenario string, v
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamIntegerResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamIntegerResponse{RawResponse: resp}, nil
+	return HeaderClientParamIntegerResponse{}, nil
 }
 
 // paramIntegerCreateRequest creates the ParamInteger request.
@@ -455,7 +455,7 @@ func (client *HeaderClient) ParamLong(ctx context.Context, scenario string, valu
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamLongResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamLongResponse{RawResponse: resp}, nil
+	return HeaderClientParamLongResponse{}, nil
 }
 
 // paramLongCreateRequest creates the ParamLong request.
@@ -488,7 +488,7 @@ func (client *HeaderClient) ParamProtectedKey(ctx context.Context, contentType s
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamProtectedKeyResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamProtectedKeyResponse{RawResponse: resp}, nil
+	return HeaderClientParamProtectedKeyResponse{}, nil
 }
 
 // paramProtectedKeyCreateRequest creates the ParamProtectedKey request.
@@ -520,7 +520,7 @@ func (client *HeaderClient) ParamString(ctx context.Context, scenario string, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HeaderClientParamStringResponse{}, runtime.NewResponseError(resp)
 	}
-	return HeaderClientParamStringResponse{RawResponse: resp}, nil
+	return HeaderClientParamStringResponse{}, nil
 }
 
 // paramStringCreateRequest creates the ParamString request.
@@ -571,7 +571,7 @@ func (client *HeaderClient) responseBoolCreateRequest(ctx context.Context, scena
 
 // responseBoolHandleResponse handles the ResponseBool response.
 func (client *HeaderClient) responseBoolHandleResponse(resp *http.Response) (HeaderClientResponseBoolResponse, error) {
-	result := HeaderClientResponseBoolResponse{RawResponse: resp}
+	result := HeaderClientResponseBoolResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := strconv.ParseBool(val)
 		if err != nil {
@@ -615,7 +615,7 @@ func (client *HeaderClient) responseByteCreateRequest(ctx context.Context, scena
 
 // responseByteHandleResponse handles the ResponseByte response.
 func (client *HeaderClient) responseByteHandleResponse(resp *http.Response) (HeaderClientResponseByteResponse, error) {
-	result := HeaderClientResponseByteResponse{RawResponse: resp}
+	result := HeaderClientResponseByteResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
@@ -659,7 +659,7 @@ func (client *HeaderClient) responseDateCreateRequest(ctx context.Context, scena
 
 // responseDateHandleResponse handles the ResponseDate response.
 func (client *HeaderClient) responseDateHandleResponse(resp *http.Response) (HeaderClientResponseDateResponse, error) {
-	result := HeaderClientResponseDateResponse{RawResponse: resp}
+	result := HeaderClientResponseDateResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := time.Parse("2006-01-02", val)
 		if err != nil {
@@ -703,7 +703,7 @@ func (client *HeaderClient) responseDatetimeCreateRequest(ctx context.Context, s
 
 // responseDatetimeHandleResponse handles the ResponseDatetime response.
 func (client *HeaderClient) responseDatetimeHandleResponse(resp *http.Response) (HeaderClientResponseDatetimeResponse, error) {
-	result := HeaderClientResponseDatetimeResponse{RawResponse: resp}
+	result := HeaderClientResponseDatetimeResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := time.Parse(time.RFC3339Nano, val)
 		if err != nil {
@@ -749,7 +749,7 @@ func (client *HeaderClient) responseDatetimeRFC1123CreateRequest(ctx context.Con
 
 // responseDatetimeRFC1123HandleResponse handles the ResponseDatetimeRFC1123 response.
 func (client *HeaderClient) responseDatetimeRFC1123HandleResponse(resp *http.Response) (HeaderClientResponseDatetimeRFC1123Response, error) {
-	result := HeaderClientResponseDatetimeRFC1123Response{RawResponse: resp}
+	result := HeaderClientResponseDatetimeRFC1123Response{}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -793,7 +793,7 @@ func (client *HeaderClient) responseDoubleCreateRequest(ctx context.Context, sce
 
 // responseDoubleHandleResponse handles the ResponseDouble response.
 func (client *HeaderClient) responseDoubleHandleResponse(resp *http.Response) (HeaderClientResponseDoubleResponse, error) {
-	result := HeaderClientResponseDoubleResponse{RawResponse: resp}
+	result := HeaderClientResponseDoubleResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := strconv.ParseFloat(val, 64)
 		if err != nil {
@@ -837,7 +837,7 @@ func (client *HeaderClient) responseDurationCreateRequest(ctx context.Context, s
 
 // responseDurationHandleResponse handles the ResponseDuration response.
 func (client *HeaderClient) responseDurationHandleResponse(resp *http.Response) (HeaderClientResponseDurationResponse, error) {
-	result := HeaderClientResponseDurationResponse{RawResponse: resp}
+	result := HeaderClientResponseDurationResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		result.Value = &val
 	}
@@ -877,7 +877,7 @@ func (client *HeaderClient) responseEnumCreateRequest(ctx context.Context, scena
 
 // responseEnumHandleResponse handles the ResponseEnum response.
 func (client *HeaderClient) responseEnumHandleResponse(resp *http.Response) (HeaderClientResponseEnumResponse, error) {
-	result := HeaderClientResponseEnumResponse{RawResponse: resp}
+	result := HeaderClientResponseEnumResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		result.Value = (*GreyscaleColors)(&val)
 	}
@@ -916,7 +916,7 @@ func (client *HeaderClient) responseExistingKeyCreateRequest(ctx context.Context
 
 // responseExistingKeyHandleResponse handles the ResponseExistingKey response.
 func (client *HeaderClient) responseExistingKeyHandleResponse(resp *http.Response) (HeaderClientResponseExistingKeyResponse, error) {
-	result := HeaderClientResponseExistingKeyResponse{RawResponse: resp}
+	result := HeaderClientResponseExistingKeyResponse{}
 	if val := resp.Header.Get("User-Agent"); val != "" {
 		result.UserAgent = &val
 	}
@@ -956,7 +956,7 @@ func (client *HeaderClient) responseFloatCreateRequest(ctx context.Context, scen
 
 // responseFloatHandleResponse handles the ResponseFloat response.
 func (client *HeaderClient) responseFloatHandleResponse(resp *http.Response) (HeaderClientResponseFloatResponse, error) {
-	result := HeaderClientResponseFloatResponse{RawResponse: resp}
+	result := HeaderClientResponseFloatResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		value32, err := strconv.ParseFloat(val, 32)
 		value := float32(value32)
@@ -1001,7 +1001,7 @@ func (client *HeaderClient) responseIntegerCreateRequest(ctx context.Context, sc
 
 // responseIntegerHandleResponse handles the ResponseInteger response.
 func (client *HeaderClient) responseIntegerHandleResponse(resp *http.Response) (HeaderClientResponseIntegerResponse, error) {
-	result := HeaderClientResponseIntegerResponse{RawResponse: resp}
+	result := HeaderClientResponseIntegerResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		value32, err := strconv.ParseInt(val, 10, 32)
 		value := int32(value32)
@@ -1046,7 +1046,7 @@ func (client *HeaderClient) responseLongCreateRequest(ctx context.Context, scena
 
 // responseLongHandleResponse handles the ResponseLong response.
 func (client *HeaderClient) responseLongHandleResponse(resp *http.Response) (HeaderClientResponseLongResponse, error) {
-	result := HeaderClientResponseLongResponse{RawResponse: resp}
+	result := HeaderClientResponseLongResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
@@ -1089,7 +1089,7 @@ func (client *HeaderClient) responseProtectedKeyCreateRequest(ctx context.Contex
 
 // responseProtectedKeyHandleResponse handles the ResponseProtectedKey response.
 func (client *HeaderClient) responseProtectedKeyHandleResponse(resp *http.Response) (HeaderClientResponseProtectedKeyResponse, error) {
-	result := HeaderClientResponseProtectedKeyResponse{RawResponse: resp}
+	result := HeaderClientResponseProtectedKeyResponse{}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}
@@ -1129,7 +1129,7 @@ func (client *HeaderClient) responseStringCreateRequest(ctx context.Context, sce
 
 // responseStringHandleResponse handles the ResponseString response.
 func (client *HeaderClient) responseStringHandleResponse(resp *http.Response) (HeaderClientResponseStringResponse, error) {
-	result := HeaderClientResponseStringResponse{RawResponse: resp}
+	result := HeaderClientResponseStringResponse{}
 	if val := resp.Header.Get("value"); val != "" {
 		result.Value = &val
 	}

--- a/test/autorest/headergroup/zz_generated_response_types.go
+++ b/test/autorest/headergroup/zz_generated_response_types.go
@@ -8,205 +8,151 @@
 
 package headergroup
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 // HeaderClientCustomRequestIDResponse contains the response from method HeaderClient.CustomRequestID.
 type HeaderClientCustomRequestIDResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamBoolResponse contains the response from method HeaderClient.ParamBool.
 type HeaderClientParamBoolResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamByteResponse contains the response from method HeaderClient.ParamByte.
 type HeaderClientParamByteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamDateResponse contains the response from method HeaderClient.ParamDate.
 type HeaderClientParamDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamDatetimeRFC1123Response contains the response from method HeaderClient.ParamDatetimeRFC1123.
 type HeaderClientParamDatetimeRFC1123Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamDatetimeResponse contains the response from method HeaderClient.ParamDatetime.
 type HeaderClientParamDatetimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamDoubleResponse contains the response from method HeaderClient.ParamDouble.
 type HeaderClientParamDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamDurationResponse contains the response from method HeaderClient.ParamDuration.
 type HeaderClientParamDurationResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamEnumResponse contains the response from method HeaderClient.ParamEnum.
 type HeaderClientParamEnumResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamExistingKeyResponse contains the response from method HeaderClient.ParamExistingKey.
 type HeaderClientParamExistingKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamFloatResponse contains the response from method HeaderClient.ParamFloat.
 type HeaderClientParamFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamIntegerResponse contains the response from method HeaderClient.ParamInteger.
 type HeaderClientParamIntegerResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamLongResponse contains the response from method HeaderClient.ParamLong.
 type HeaderClientParamLongResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamProtectedKeyResponse contains the response from method HeaderClient.ParamProtectedKey.
 type HeaderClientParamProtectedKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientParamStringResponse contains the response from method HeaderClient.ParamString.
 type HeaderClientParamStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HeaderClientResponseBoolResponse contains the response from method HeaderClient.ResponseBool.
 type HeaderClientResponseBoolResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *bool
 }
 
 // HeaderClientResponseByteResponse contains the response from method HeaderClient.ResponseByte.
 type HeaderClientResponseByteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value []byte
 }
 
 // HeaderClientResponseDateResponse contains the response from method HeaderClient.ResponseDate.
 type HeaderClientResponseDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
 // HeaderClientResponseDatetimeRFC1123Response contains the response from method HeaderClient.ResponseDatetimeRFC1123.
 type HeaderClientResponseDatetimeRFC1123Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
 // HeaderClientResponseDatetimeResponse contains the response from method HeaderClient.ResponseDatetime.
 type HeaderClientResponseDatetimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
 // HeaderClientResponseDoubleResponse contains the response from method HeaderClient.ResponseDouble.
 type HeaderClientResponseDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *float64
 }
 
 // HeaderClientResponseDurationResponse contains the response from method HeaderClient.ResponseDuration.
 type HeaderClientResponseDurationResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *string
 }
 
 // HeaderClientResponseEnumResponse contains the response from method HeaderClient.ResponseEnum.
 type HeaderClientResponseEnumResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *GreyscaleColors
 }
 
 // HeaderClientResponseExistingKeyResponse contains the response from method HeaderClient.ResponseExistingKey.
 type HeaderClientResponseExistingKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// UserAgent contains the information returned from the User-Agent header response.
 	UserAgent *string
 }
 
 // HeaderClientResponseFloatResponse contains the response from method HeaderClient.ResponseFloat.
 type HeaderClientResponseFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *float32
 }
 
 // HeaderClientResponseIntegerResponse contains the response from method HeaderClient.ResponseInteger.
 type HeaderClientResponseIntegerResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *int32
 }
 
 // HeaderClientResponseLongResponse contains the response from method HeaderClient.ResponseLong.
 type HeaderClientResponseLongResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *int64
 }
@@ -215,16 +161,10 @@ type HeaderClientResponseLongResponse struct {
 type HeaderClientResponseProtectedKeyResponse struct {
 	// ContentType contains the information returned from the Content-Type header response.
 	ContentType *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HeaderClientResponseStringResponse contains the response from method HeaderClient.ResponseString.
 type HeaderClientResponseStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Value contains the information returned from the value header response.
 	Value *string
 }

--- a/test/autorest/headgroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/headgroup/zz_generated_httpsuccess_client.go
@@ -45,7 +45,7 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead200Response{}, err
 	}
-	result := HTTPSuccessClientHead200Response{RawResponse: resp}
+	result := HTTPSuccessClientHead200Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -73,7 +73,7 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead204Response{}, err
 	}
-	result := HTTPSuccessClientHead204Response{RawResponse: resp}
+	result := HTTPSuccessClientHead204Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -101,7 +101,7 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead404Response{}, err
 	}
-	result := HTTPSuccessClientHead404Response{RawResponse: resp}
+	result := HTTPSuccessClientHead404Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}

--- a/test/autorest/headgroup/zz_generated_response_types.go
+++ b/test/autorest/headgroup/zz_generated_response_types.go
@@ -8,31 +8,20 @@
 
 package headgroup
 
-import "net/http"
-
 // HTTPSuccessClientHead200Response contains the response from method HTTPSuccessClient.Head200.
 type HTTPSuccessClientHead200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientHead204Response contains the response from method HTTPSuccessClient.Head204.
 type HTTPSuccessClientHead204Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientHead404Response contains the response from method HTTPSuccessClient.Head404.
 type HTTPSuccessClientHead404Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -6,7 +6,6 @@ package httpinfrastructuregroup
 import (
 	"context"
 	"errors"
-	"net/http"
 	"reflect"
 	"testing"
 
@@ -33,8 +32,8 @@ func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
 			t.Fatal(r)
 		}
 	case B:
-		if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-			t.Fatalf("unexpected status code %d", s)
+		if !reflect.ValueOf(result).IsZero() {
+			t.Fatal("expected zero-value result")
 		}
 	default:
 		t.Fatalf("unhandled response type %T", x)
@@ -158,8 +157,8 @@ func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 	if !reflect.ValueOf(result.MyException).IsZero() {
 		t.Fatal("expected zero-value MyException")
@@ -355,8 +354,8 @@ func TestGet202None204NoneDefaultError202None(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusAccepted {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -367,8 +366,8 @@ func TestGet202None204NoneDefaultError204None(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -391,8 +390,8 @@ func TestGet202None204NoneDefaultNone202Invalid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusAccepted {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -403,8 +402,8 @@ func TestGet202None204NoneDefaultNone204None(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -494,8 +493,8 @@ func TestGetDefaultNone200None(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 

--- a/test/autorest/httpinfrastructuregroup/httpredirects_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpredirects_test.go
@@ -5,7 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -19,8 +19,8 @@ func TestHTTPRedirectsDelete307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -31,8 +31,8 @@ func TestHTTPRedirectsGet300(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("expected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -42,8 +42,8 @@ func TestHTTPRedirectsGet301(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -53,8 +53,8 @@ func TestHTTPRedirectsGet302(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -64,8 +64,8 @@ func TestHTTPRedirectsGet307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -76,8 +76,8 @@ func TestHTTPRedirectsHead300(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -87,8 +87,8 @@ func TestHTTPRedirectsHead301(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !result.Success {
+		t.Fatal("expected Success")
 	}
 }
 
@@ -121,8 +121,8 @@ func TestHTTPRedirectsOptions307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -133,8 +133,8 @@ func TestHTTPRedirectsPatch302(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -144,8 +144,8 @@ func TestHTTPRedirectsPatch307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -155,8 +155,8 @@ func TestHTTPRedirectsPost303(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -166,8 +166,8 @@ func TestHTTPRedirectsPost307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -178,8 +178,8 @@ func TestHTTPRedirectsPut301(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -189,7 +189,7 @@ func TestHTTPRedirectsPut307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/httpinfrastructuregroup/httpretry_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpretry_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/cookiejar"
+	"reflect"
 	"testing"
 	"time"
 
@@ -36,8 +37,8 @@ func TestHTTPRetryDelete503(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -47,8 +48,8 @@ func TestHTTPRetryGet502(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -70,8 +71,8 @@ func TestHTTPRetryOptions502(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -81,8 +82,8 @@ func TestHTTPRetryPatch500(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -92,8 +93,8 @@ func TestHTTPRetryPatch504(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -103,8 +104,8 @@ func TestHTTPRetryPost503(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -114,8 +115,8 @@ func TestHTTPRetryPut500(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -125,7 +126,7 @@ func TestHTTPRetryPut504(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
@@ -5,7 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -19,8 +19,8 @@ func TestHTTPSuccessDelete200(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -30,8 +30,8 @@ func TestHTTPSuccessDelete202(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusAccepted {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -41,8 +41,8 @@ func TestHTTPSuccessDelete204(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -52,8 +52,8 @@ func TestHTTPSuccessGet200(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !*result.Value {
+		t.Fatal("expected Success")
 	}
 }
 
@@ -97,8 +97,8 @@ func TestHTTPSuccessOptions200(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -108,8 +108,8 @@ func TestHTTPSuccessPatch200(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -119,8 +119,8 @@ func TestHTTPSuccessPatch202(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusAccepted {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -130,8 +130,8 @@ func TestHTTPSuccessPatch204(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -141,8 +141,8 @@ func TestHTTPSuccessPost200(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -152,8 +152,8 @@ func TestHTTPSuccessPost201(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -163,8 +163,8 @@ func TestHTTPSuccessPost202(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusAccepted {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -174,8 +174,8 @@ func TestHTTPSuccessPost204(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -185,8 +185,8 @@ func TestHTTPSuccessPut200(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -196,8 +196,8 @@ func TestHTTPSuccessPut201(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -207,8 +207,8 @@ func TestHTTPSuccessPut202(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusAccepted {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -218,7 +218,7 @@ func TestHTTPSuccessPut204(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure_client.go
@@ -50,7 +50,7 @@ func (client *HTTPClientFailureClient) Delete400(ctx context.Context, options *H
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientDelete400Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientDelete400Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientDelete400Response{}, nil
 }
 
 // delete400CreateRequest creates the Delete400 request.
@@ -80,7 +80,7 @@ func (client *HTTPClientFailureClient) Delete407(ctx context.Context, options *H
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientDelete407Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientDelete407Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientDelete407Response{}, nil
 }
 
 // delete407CreateRequest creates the Delete407 request.
@@ -110,7 +110,7 @@ func (client *HTTPClientFailureClient) Delete417(ctx context.Context, options *H
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientDelete417Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientDelete417Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientDelete417Response{}, nil
 }
 
 // delete417CreateRequest creates the Delete417 request.
@@ -140,7 +140,7 @@ func (client *HTTPClientFailureClient) Get400(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientGet400Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientGet400Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientGet400Response{}, nil
 }
 
 // get400CreateRequest creates the Get400 request.
@@ -170,7 +170,7 @@ func (client *HTTPClientFailureClient) Get402(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientGet402Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientGet402Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientGet402Response{}, nil
 }
 
 // get402CreateRequest creates the Get402 request.
@@ -200,7 +200,7 @@ func (client *HTTPClientFailureClient) Get403(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientGet403Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientGet403Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientGet403Response{}, nil
 }
 
 // get403CreateRequest creates the Get403 request.
@@ -230,7 +230,7 @@ func (client *HTTPClientFailureClient) Get411(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientGet411Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientGet411Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientGet411Response{}, nil
 }
 
 // get411CreateRequest creates the Get411 request.
@@ -260,7 +260,7 @@ func (client *HTTPClientFailureClient) Get412(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientGet412Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientGet412Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientGet412Response{}, nil
 }
 
 // get412CreateRequest creates the Get412 request.
@@ -290,7 +290,7 @@ func (client *HTTPClientFailureClient) Get416(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientGet416Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientGet416Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientGet416Response{}, nil
 }
 
 // get416CreateRequest creates the Get416 request.
@@ -316,7 +316,7 @@ func (client *HTTPClientFailureClient) Head400(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead400Response{}, err
 	}
-	result := HTTPClientFailureClientHead400Response{RawResponse: resp}
+	result := HTTPClientFailureClientHead400Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -346,7 +346,7 @@ func (client *HTTPClientFailureClient) Head401(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead401Response{}, err
 	}
-	result := HTTPClientFailureClientHead401Response{RawResponse: resp}
+	result := HTTPClientFailureClientHead401Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -376,7 +376,7 @@ func (client *HTTPClientFailureClient) Head410(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead410Response{}, err
 	}
-	result := HTTPClientFailureClientHead410Response{RawResponse: resp}
+	result := HTTPClientFailureClientHead410Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -406,7 +406,7 @@ func (client *HTTPClientFailureClient) Head429(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead429Response{}, err
 	}
-	result := HTTPClientFailureClientHead429Response{RawResponse: resp}
+	result := HTTPClientFailureClientHead429Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -440,7 +440,7 @@ func (client *HTTPClientFailureClient) Options400(ctx context.Context, options *
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientOptions400Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientOptions400Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientOptions400Response{}, nil
 }
 
 // options400CreateRequest creates the Options400 request.
@@ -470,7 +470,7 @@ func (client *HTTPClientFailureClient) Options403(ctx context.Context, options *
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientOptions403Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientOptions403Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientOptions403Response{}, nil
 }
 
 // options403CreateRequest creates the Options403 request.
@@ -500,7 +500,7 @@ func (client *HTTPClientFailureClient) Options412(ctx context.Context, options *
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientOptions412Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientOptions412Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientOptions412Response{}, nil
 }
 
 // options412CreateRequest creates the Options412 request.
@@ -530,7 +530,7 @@ func (client *HTTPClientFailureClient) Patch400(ctx context.Context, options *HT
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPatch400Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPatch400Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPatch400Response{}, nil
 }
 
 // patch400CreateRequest creates the Patch400 request.
@@ -560,7 +560,7 @@ func (client *HTTPClientFailureClient) Patch405(ctx context.Context, options *HT
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPatch405Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPatch405Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPatch405Response{}, nil
 }
 
 // patch405CreateRequest creates the Patch405 request.
@@ -590,7 +590,7 @@ func (client *HTTPClientFailureClient) Patch414(ctx context.Context, options *HT
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPatch414Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPatch414Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPatch414Response{}, nil
 }
 
 // patch414CreateRequest creates the Patch414 request.
@@ -620,7 +620,7 @@ func (client *HTTPClientFailureClient) Post400(ctx context.Context, options *HTT
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPost400Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPost400Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPost400Response{}, nil
 }
 
 // post400CreateRequest creates the Post400 request.
@@ -650,7 +650,7 @@ func (client *HTTPClientFailureClient) Post406(ctx context.Context, options *HTT
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPost406Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPost406Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPost406Response{}, nil
 }
 
 // post406CreateRequest creates the Post406 request.
@@ -680,7 +680,7 @@ func (client *HTTPClientFailureClient) Post415(ctx context.Context, options *HTT
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPost415Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPost415Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPost415Response{}, nil
 }
 
 // post415CreateRequest creates the Post415 request.
@@ -710,7 +710,7 @@ func (client *HTTPClientFailureClient) Put400(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPut400Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPut400Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPut400Response{}, nil
 }
 
 // put400CreateRequest creates the Put400 request.
@@ -740,7 +740,7 @@ func (client *HTTPClientFailureClient) Put404(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPut404Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPut404Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPut404Response{}, nil
 }
 
 // put404CreateRequest creates the Put404 request.
@@ -770,7 +770,7 @@ func (client *HTTPClientFailureClient) Put409(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPut409Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPut409Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPut409Response{}, nil
 }
 
 // put409CreateRequest creates the Put409 request.
@@ -800,7 +800,7 @@ func (client *HTTPClientFailureClient) Put413(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPClientFailureClientPut413Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPClientFailureClientPut413Response{RawResponse: resp}, nil
+	return HTTPClientFailureClientPut413Response{}, nil
 }
 
 // put413CreateRequest creates the Put413 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure_client.go
@@ -66,7 +66,7 @@ func (client *HTTPFailureClient) getEmptyErrorCreateRequest(ctx context.Context,
 
 // getEmptyErrorHandleResponse handles the GetEmptyError response.
 func (client *HTTPFailureClient) getEmptyErrorHandleResponse(resp *http.Response) (HTTPFailureClientGetEmptyErrorResponse, error) {
-	result := HTTPFailureClientGetEmptyErrorResponse{RawResponse: resp}
+	result := HTTPFailureClientGetEmptyErrorResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return HTTPFailureClientGetEmptyErrorResponse{}, err
 	}
@@ -105,7 +105,7 @@ func (client *HTTPFailureClient) getNoModelEmptyCreateRequest(ctx context.Contex
 
 // getNoModelEmptyHandleResponse handles the GetNoModelEmpty response.
 func (client *HTTPFailureClient) getNoModelEmptyHandleResponse(resp *http.Response) (HTTPFailureClientGetNoModelEmptyResponse, error) {
-	result := HTTPFailureClientGetNoModelEmptyResponse{RawResponse: resp}
+	result := HTTPFailureClientGetNoModelEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return HTTPFailureClientGetNoModelEmptyResponse{}, err
 	}
@@ -144,7 +144,7 @@ func (client *HTTPFailureClient) getNoModelErrorCreateRequest(ctx context.Contex
 
 // getNoModelErrorHandleResponse handles the GetNoModelError response.
 func (client *HTTPFailureClient) getNoModelErrorHandleResponse(resp *http.Response) (HTTPFailureClientGetNoModelErrorResponse, error) {
-	result := HTTPFailureClientGetNoModelErrorResponse{RawResponse: resp}
+	result := HTTPFailureClientGetNoModelErrorResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return HTTPFailureClientGetNoModelErrorResponse{}, err
 	}

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
@@ -49,7 +49,7 @@ func (client *HTTPRedirectsClient) Delete307(ctx context.Context, options *HTTPR
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRedirectsClientDelete307Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRedirectsClientDelete307Response{RawResponse: resp}, nil
+	return HTTPRedirectsClientDelete307Response{}, nil
 }
 
 // delete307CreateRequest creates the Delete307 request.
@@ -94,7 +94,7 @@ func (client *HTTPRedirectsClient) get300CreateRequest(ctx context.Context, opti
 
 // get300HandleResponse handles the Get300 response.
 func (client *HTTPRedirectsClient) get300HandleResponse(resp *http.Response) (HTTPRedirectsClientGet300Response, error) {
-	result := HTTPRedirectsClientGet300Response{RawResponse: resp}
+	result := HTTPRedirectsClientGet300Response{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
@@ -119,7 +119,7 @@ func (client *HTTPRedirectsClient) Get301(ctx context.Context, options *HTTPRedi
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRedirectsClientGet301Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRedirectsClientGet301Response{RawResponse: resp}, nil
+	return HTTPRedirectsClientGet301Response{}, nil
 }
 
 // get301CreateRequest creates the Get301 request.
@@ -148,7 +148,7 @@ func (client *HTTPRedirectsClient) Get302(ctx context.Context, options *HTTPRedi
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRedirectsClientGet302Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRedirectsClientGet302Response{RawResponse: resp}, nil
+	return HTTPRedirectsClientGet302Response{}, nil
 }
 
 // get302CreateRequest creates the Get302 request.
@@ -177,7 +177,7 @@ func (client *HTTPRedirectsClient) Get307(ctx context.Context, options *HTTPRedi
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRedirectsClientGet307Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRedirectsClientGet307Response{RawResponse: resp}, nil
+	return HTTPRedirectsClientGet307Response{}, nil
 }
 
 // get307CreateRequest creates the Get307 request.
@@ -218,7 +218,7 @@ func (client *HTTPRedirectsClient) head300CreateRequest(ctx context.Context, opt
 
 // head300HandleResponse handles the Head300 response.
 func (client *HTTPRedirectsClient) head300HandleResponse(resp *http.Response) (HTTPRedirectsClientHead300Response, error) {
-	result := HTTPRedirectsClientHead300Response{RawResponse: resp}
+	result := HTTPRedirectsClientHead300Response{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
@@ -239,7 +239,7 @@ func (client *HTTPRedirectsClient) Head301(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead301Response{}, err
 	}
-	result := HTTPRedirectsClientHead301Response{RawResponse: resp}
+	result := HTTPRedirectsClientHead301Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -268,7 +268,7 @@ func (client *HTTPRedirectsClient) Head302(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead302Response{}, err
 	}
-	result := HTTPRedirectsClientHead302Response{RawResponse: resp}
+	result := HTTPRedirectsClientHead302Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -297,7 +297,7 @@ func (client *HTTPRedirectsClient) Head307(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead307Response{}, err
 	}
-	result := HTTPRedirectsClientHead307Response{RawResponse: resp}
+	result := HTTPRedirectsClientHead307Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -331,7 +331,7 @@ func (client *HTTPRedirectsClient) Options307(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRedirectsClientOptions307Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRedirectsClientOptions307Response{RawResponse: resp}, nil
+	return HTTPRedirectsClientOptions307Response{}, nil
 }
 
 // options307CreateRequest creates the Options307 request.
@@ -377,7 +377,7 @@ func (client *HTTPRedirectsClient) patch302CreateRequest(ctx context.Context, op
 
 // patch302HandleResponse handles the Patch302 response.
 func (client *HTTPRedirectsClient) patch302HandleResponse(resp *http.Response) (HTTPRedirectsClientPatch302Response, error) {
-	result := HTTPRedirectsClientPatch302Response{RawResponse: resp}
+	result := HTTPRedirectsClientPatch302Response{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
@@ -399,7 +399,7 @@ func (client *HTTPRedirectsClient) Patch307(ctx context.Context, options *HTTPRe
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRedirectsClientPatch307Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRedirectsClientPatch307Response{RawResponse: resp}, nil
+	return HTTPRedirectsClientPatch307Response{}, nil
 }
 
 // patch307CreateRequest creates the Patch307 request.
@@ -445,7 +445,7 @@ func (client *HTTPRedirectsClient) post303CreateRequest(ctx context.Context, opt
 
 // post303HandleResponse handles the Post303 response.
 func (client *HTTPRedirectsClient) post303HandleResponse(resp *http.Response) (HTTPRedirectsClientPost303Response, error) {
-	result := HTTPRedirectsClientPost303Response{RawResponse: resp}
+	result := HTTPRedirectsClientPost303Response{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
@@ -467,7 +467,7 @@ func (client *HTTPRedirectsClient) Post307(ctx context.Context, options *HTTPRed
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRedirectsClientPost307Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRedirectsClientPost307Response{RawResponse: resp}, nil
+	return HTTPRedirectsClientPost307Response{}, nil
 }
 
 // post307CreateRequest creates the Post307 request.
@@ -513,7 +513,7 @@ func (client *HTTPRedirectsClient) put301CreateRequest(ctx context.Context, opti
 
 // put301HandleResponse handles the Put301 response.
 func (client *HTTPRedirectsClient) put301HandleResponse(resp *http.Response) (HTTPRedirectsClientPut301Response, error) {
-	result := HTTPRedirectsClientPut301Response{RawResponse: resp}
+	result := HTTPRedirectsClientPut301Response{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
@@ -535,7 +535,7 @@ func (client *HTTPRedirectsClient) Put307(ctx context.Context, options *HTTPRedi
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRedirectsClientPut307Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRedirectsClientPut307Response{RawResponse: resp}, nil
+	return HTTPRedirectsClientPut307Response{}, nil
 }
 
 // put307CreateRequest creates the Put307 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
@@ -49,7 +49,7 @@ func (client *HTTPRetryClient) Delete503(ctx context.Context, options *HTTPRetry
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRetryClientDelete503Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRetryClientDelete503Response{RawResponse: resp}, nil
+	return HTTPRetryClientDelete503Response{}, nil
 }
 
 // delete503CreateRequest creates the Delete503 request.
@@ -78,7 +78,7 @@ func (client *HTTPRetryClient) Get502(ctx context.Context, options *HTTPRetryCli
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRetryClientGet502Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRetryClientGet502Response{RawResponse: resp}, nil
+	return HTTPRetryClientGet502Response{}, nil
 }
 
 // get502CreateRequest creates the Get502 request.
@@ -103,7 +103,7 @@ func (client *HTTPRetryClient) Head408(ctx context.Context, options *HTTPRetryCl
 	if err != nil {
 		return HTTPRetryClientHead408Response{}, err
 	}
-	result := HTTPRetryClientHead408Response{RawResponse: resp}
+	result := HTTPRetryClientHead408Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -152,7 +152,7 @@ func (client *HTTPRetryClient) options502CreateRequest(ctx context.Context, opti
 
 // options502HandleResponse handles the Options502 response.
 func (client *HTTPRetryClient) options502HandleResponse(resp *http.Response) (HTTPRetryClientOptions502Response, error) {
-	result := HTTPRetryClientOptions502Response{RawResponse: resp}
+	result := HTTPRetryClientOptions502Response{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return HTTPRetryClientOptions502Response{}, err
 	}
@@ -174,7 +174,7 @@ func (client *HTTPRetryClient) Patch500(ctx context.Context, options *HTTPRetryC
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRetryClientPatch500Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRetryClientPatch500Response{RawResponse: resp}, nil
+	return HTTPRetryClientPatch500Response{}, nil
 }
 
 // patch500CreateRequest creates the Patch500 request.
@@ -203,7 +203,7 @@ func (client *HTTPRetryClient) Patch504(ctx context.Context, options *HTTPRetryC
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRetryClientPatch504Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRetryClientPatch504Response{RawResponse: resp}, nil
+	return HTTPRetryClientPatch504Response{}, nil
 }
 
 // patch504CreateRequest creates the Patch504 request.
@@ -232,7 +232,7 @@ func (client *HTTPRetryClient) Post503(ctx context.Context, options *HTTPRetryCl
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRetryClientPost503Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRetryClientPost503Response{RawResponse: resp}, nil
+	return HTTPRetryClientPost503Response{}, nil
 }
 
 // post503CreateRequest creates the Post503 request.
@@ -261,7 +261,7 @@ func (client *HTTPRetryClient) Put500(ctx context.Context, options *HTTPRetryCli
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRetryClientPut500Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRetryClientPut500Response{RawResponse: resp}, nil
+	return HTTPRetryClientPut500Response{}, nil
 }
 
 // put500CreateRequest creates the Put500 request.
@@ -290,7 +290,7 @@ func (client *HTTPRetryClient) Put504(ctx context.Context, options *HTTPRetryCli
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPRetryClientPut504Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPRetryClientPut504Response{RawResponse: resp}, nil
+	return HTTPRetryClientPut504Response{}, nil
 }
 
 // put504CreateRequest creates the Put504 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure_client.go
@@ -50,7 +50,7 @@ func (client *HTTPServerFailureClient) Delete505(ctx context.Context, options *H
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPServerFailureClientDelete505Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPServerFailureClientDelete505Response{RawResponse: resp}, nil
+	return HTTPServerFailureClientDelete505Response{}, nil
 }
 
 // delete505CreateRequest creates the Delete505 request.
@@ -80,7 +80,7 @@ func (client *HTTPServerFailureClient) Get501(ctx context.Context, options *HTTP
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPServerFailureClientGet501Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPServerFailureClientGet501Response{RawResponse: resp}, nil
+	return HTTPServerFailureClientGet501Response{}, nil
 }
 
 // get501CreateRequest creates the Get501 request.
@@ -106,7 +106,7 @@ func (client *HTTPServerFailureClient) Head501(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPServerFailureClientHead501Response{}, err
 	}
-	result := HTTPServerFailureClientHead501Response{RawResponse: resp}
+	result := HTTPServerFailureClientHead501Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -140,7 +140,7 @@ func (client *HTTPServerFailureClient) Post505(ctx context.Context, options *HTT
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return HTTPServerFailureClientPost505Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPServerFailureClientPost505Response{RawResponse: resp}, nil
+	return HTTPServerFailureClientPost505Response{}, nil
 }
 
 // post505CreateRequest creates the Post505 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
@@ -49,7 +49,7 @@ func (client *HTTPSuccessClient) Delete200(ctx context.Context, options *HTTPSuc
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPSuccessClientDelete200Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientDelete200Response{RawResponse: resp}, nil
+	return HTTPSuccessClientDelete200Response{}, nil
 }
 
 // delete200CreateRequest creates the Delete200 request.
@@ -78,7 +78,7 @@ func (client *HTTPSuccessClient) Delete202(ctx context.Context, options *HTTPSuc
 	if !runtime.HasStatusCode(resp, http.StatusAccepted) {
 		return HTTPSuccessClientDelete202Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientDelete202Response{RawResponse: resp}, nil
+	return HTTPSuccessClientDelete202Response{}, nil
 }
 
 // delete202CreateRequest creates the Delete202 request.
@@ -107,7 +107,7 @@ func (client *HTTPSuccessClient) Delete204(ctx context.Context, options *HTTPSuc
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return HTTPSuccessClientDelete204Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientDelete204Response{RawResponse: resp}, nil
+	return HTTPSuccessClientDelete204Response{}, nil
 }
 
 // delete204CreateRequest creates the Delete204 request.
@@ -152,7 +152,7 @@ func (client *HTTPSuccessClient) get200CreateRequest(ctx context.Context, option
 
 // get200HandleResponse handles the Get200 response.
 func (client *HTTPSuccessClient) get200HandleResponse(resp *http.Response) (HTTPSuccessClientGet200Response, error) {
-	result := HTTPSuccessClientGet200Response{RawResponse: resp}
+	result := HTTPSuccessClientGet200Response{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return HTTPSuccessClientGet200Response{}, err
 	}
@@ -170,7 +170,7 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead200Response{}, err
 	}
-	result := HTTPSuccessClientHead200Response{RawResponse: resp}
+	result := HTTPSuccessClientHead200Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -199,7 +199,7 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead204Response{}, err
 	}
-	result := HTTPSuccessClientHead204Response{RawResponse: resp}
+	result := HTTPSuccessClientHead204Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -228,7 +228,7 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead404Response{}, err
 	}
-	result := HTTPSuccessClientHead404Response{RawResponse: resp}
+	result := HTTPSuccessClientHead404Response{}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true
 	}
@@ -277,7 +277,7 @@ func (client *HTTPSuccessClient) options200CreateRequest(ctx context.Context, op
 
 // options200HandleResponse handles the Options200 response.
 func (client *HTTPSuccessClient) options200HandleResponse(resp *http.Response) (HTTPSuccessClientOptions200Response, error) {
-	result := HTTPSuccessClientOptions200Response{RawResponse: resp}
+	result := HTTPSuccessClientOptions200Response{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return HTTPSuccessClientOptions200Response{}, err
 	}
@@ -299,7 +299,7 @@ func (client *HTTPSuccessClient) Patch200(ctx context.Context, options *HTTPSucc
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPSuccessClientPatch200Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPatch200Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPatch200Response{}, nil
 }
 
 // patch200CreateRequest creates the Patch200 request.
@@ -328,7 +328,7 @@ func (client *HTTPSuccessClient) Patch202(ctx context.Context, options *HTTPSucc
 	if !runtime.HasStatusCode(resp, http.StatusAccepted) {
 		return HTTPSuccessClientPatch202Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPatch202Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPatch202Response{}, nil
 }
 
 // patch202CreateRequest creates the Patch202 request.
@@ -357,7 +357,7 @@ func (client *HTTPSuccessClient) Patch204(ctx context.Context, options *HTTPSucc
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return HTTPSuccessClientPatch204Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPatch204Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPatch204Response{}, nil
 }
 
 // patch204CreateRequest creates the Patch204 request.
@@ -386,7 +386,7 @@ func (client *HTTPSuccessClient) Post200(ctx context.Context, options *HTTPSucce
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPSuccessClientPost200Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPost200Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPost200Response{}, nil
 }
 
 // post200CreateRequest creates the Post200 request.
@@ -415,7 +415,7 @@ func (client *HTTPSuccessClient) Post201(ctx context.Context, options *HTTPSucce
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return HTTPSuccessClientPost201Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPost201Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPost201Response{}, nil
 }
 
 // post201CreateRequest creates the Post201 request.
@@ -444,7 +444,7 @@ func (client *HTTPSuccessClient) Post202(ctx context.Context, options *HTTPSucce
 	if !runtime.HasStatusCode(resp, http.StatusAccepted) {
 		return HTTPSuccessClientPost202Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPost202Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPost202Response{}, nil
 }
 
 // post202CreateRequest creates the Post202 request.
@@ -473,7 +473,7 @@ func (client *HTTPSuccessClient) Post204(ctx context.Context, options *HTTPSucce
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return HTTPSuccessClientPost204Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPost204Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPost204Response{}, nil
 }
 
 // post204CreateRequest creates the Post204 request.
@@ -502,7 +502,7 @@ func (client *HTTPSuccessClient) Put200(ctx context.Context, options *HTTPSucces
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return HTTPSuccessClientPut200Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPut200Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPut200Response{}, nil
 }
 
 // put200CreateRequest creates the Put200 request.
@@ -531,7 +531,7 @@ func (client *HTTPSuccessClient) Put201(ctx context.Context, options *HTTPSucces
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return HTTPSuccessClientPut201Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPut201Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPut201Response{}, nil
 }
 
 // put201CreateRequest creates the Put201 request.
@@ -560,7 +560,7 @@ func (client *HTTPSuccessClient) Put202(ctx context.Context, options *HTTPSucces
 	if !runtime.HasStatusCode(resp, http.StatusAccepted) {
 		return HTTPSuccessClientPut202Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPut202Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPut202Response{}, nil
 }
 
 // put202CreateRequest creates the Put202 request.
@@ -589,7 +589,7 @@ func (client *HTTPSuccessClient) Put204(ctx context.Context, options *HTTPSucces
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return HTTPSuccessClientPut204Response{}, runtime.NewResponseError(resp)
 	}
-	return HTTPSuccessClientPut204Response{RawResponse: resp}, nil
+	return HTTPSuccessClientPut204Response{}, nil
 }
 
 // put204CreateRequest creates the Put204 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses_client.go
@@ -67,7 +67,7 @@ func (client *MultipleResponsesClient) get200Model201ModelDefaultError200ValidCr
 
 // get200Model201ModelDefaultError200ValidHandleResponse handles the Get200Model201ModelDefaultError200Valid response.
 func (client *MultipleResponsesClient) get200Model201ModelDefaultError200ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200Model201ModelDefaultError200ValidResponse, error) {
-	result := MultipleResponsesClientGet200Model201ModelDefaultError200ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200Model201ModelDefaultError200ValidResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var val MyException
@@ -120,7 +120,7 @@ func (client *MultipleResponsesClient) get200Model201ModelDefaultError201ValidCr
 
 // get200Model201ModelDefaultError201ValidHandleResponse handles the Get200Model201ModelDefaultError201Valid response.
 func (client *MultipleResponsesClient) get200Model201ModelDefaultError201ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200Model201ModelDefaultError201ValidResponse, error) {
-	result := MultipleResponsesClientGet200Model201ModelDefaultError201ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200Model201ModelDefaultError201ValidResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var val MyException
@@ -172,7 +172,7 @@ func (client *MultipleResponsesClient) get200Model201ModelDefaultError400ValidCr
 
 // get200Model201ModelDefaultError400ValidHandleResponse handles the Get200Model201ModelDefaultError400Valid response.
 func (client *MultipleResponsesClient) get200Model201ModelDefaultError400ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse, error) {
-	result := MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var val MyException
@@ -224,7 +224,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError200Valid
 
 // get200Model204NoModelDefaultError200ValidHandleResponse handles the Get200Model204NoModelDefaultError200Valid response.
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError200ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse, error) {
-	result := MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse{}, err
 	}
@@ -263,7 +263,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError201Inval
 
 // get200Model204NoModelDefaultError201InvalidHandleResponse handles the Get200Model204NoModelDefaultError201Invalid response.
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError201InvalidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse, error) {
-	result := MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse{}, err
 	}
@@ -302,7 +302,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError202NoneC
 
 // get200Model204NoModelDefaultError202NoneHandleResponse handles the Get200Model204NoModelDefaultError202None response.
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError202NoneHandleResponse(resp *http.Response) (MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse, error) {
-	result := MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse{}, err
 	}
@@ -341,7 +341,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError204Valid
 
 // get200Model204NoModelDefaultError204ValidHandleResponse handles the Get200Model204NoModelDefaultError204Valid response.
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError204ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse, error) {
-	result := MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse{}, err
 	}
@@ -381,7 +381,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError400Valid
 
 // get200Model204NoModelDefaultError400ValidHandleResponse handles the Get200Model204NoModelDefaultError400Valid response.
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError400ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse, error) {
-	result := MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse{}, err
 	}
@@ -420,7 +420,7 @@ func (client *MultipleResponsesClient) get200ModelA200InvalidCreateRequest(ctx c
 
 // get200ModelA200InvalidHandleResponse handles the Get200ModelA200Invalid response.
 func (client *MultipleResponsesClient) get200ModelA200InvalidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA200InvalidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA200InvalidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA200InvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200ModelA200InvalidResponse{}, err
 	}
@@ -460,7 +460,7 @@ func (client *MultipleResponsesClient) get200ModelA200NoneCreateRequest(ctx cont
 
 // get200ModelA200NoneHandleResponse handles the Get200ModelA200None response.
 func (client *MultipleResponsesClient) get200ModelA200NoneHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA200NoneResponse, error) {
-	result := MultipleResponsesClientGet200ModelA200NoneResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA200NoneResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200ModelA200NoneResponse{}, err
 	}
@@ -499,7 +499,7 @@ func (client *MultipleResponsesClient) get200ModelA200ValidCreateRequest(ctx con
 
 // get200ModelA200ValidHandleResponse handles the Get200ModelA200Valid response.
 func (client *MultipleResponsesClient) get200ModelA200ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA200ValidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA200ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA200ValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200ModelA200ValidResponse{}, err
 	}
@@ -538,7 +538,7 @@ func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultErro
 
 // get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError200Valid response.
 func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError200ValidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var val MyException
@@ -596,7 +596,7 @@ func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultErro
 
 // get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError201Valid response.
 func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError201ValidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var val MyException
@@ -655,7 +655,7 @@ func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultErro
 
 // get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError400Valid response.
 func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError400ValidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var val MyException
@@ -713,7 +713,7 @@ func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultErro
 
 // get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError404Valid response.
 func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var val MyException
@@ -771,7 +771,7 @@ func (client *MultipleResponsesClient) get200ModelA202ValidCreateRequest(ctx con
 
 // get200ModelA202ValidHandleResponse handles the Get200ModelA202Valid response.
 func (client *MultipleResponsesClient) get200ModelA202ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA202ValidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA202ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA202ValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200ModelA202ValidResponse{}, err
 	}
@@ -810,7 +810,7 @@ func (client *MultipleResponsesClient) get200ModelA400InvalidCreateRequest(ctx c
 
 // get200ModelA400InvalidHandleResponse handles the Get200ModelA400Invalid response.
 func (client *MultipleResponsesClient) get200ModelA400InvalidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA400InvalidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA400InvalidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA400InvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200ModelA400InvalidResponse{}, err
 	}
@@ -849,7 +849,7 @@ func (client *MultipleResponsesClient) get200ModelA400NoneCreateRequest(ctx cont
 
 // get200ModelA400NoneHandleResponse handles the Get200ModelA400None response.
 func (client *MultipleResponsesClient) get200ModelA400NoneHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA400NoneResponse, error) {
-	result := MultipleResponsesClientGet200ModelA400NoneResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA400NoneResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200ModelA400NoneResponse{}, err
 	}
@@ -888,7 +888,7 @@ func (client *MultipleResponsesClient) get200ModelA400ValidCreateRequest(ctx con
 
 // get200ModelA400ValidHandleResponse handles the Get200ModelA400Valid response.
 func (client *MultipleResponsesClient) get200ModelA400ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGet200ModelA400ValidResponse, error) {
-	result := MultipleResponsesClientGet200ModelA400ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGet200ModelA400ValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGet200ModelA400ValidResponse{}, err
 	}
@@ -911,7 +911,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202None(ctx 
 	if !runtime.HasStatusCode(resp, http.StatusAccepted, http.StatusNoContent) {
 		return MultipleResponsesClientGet202None204NoneDefaultError202NoneResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGet202None204NoneDefaultError202NoneResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGet202None204NoneDefaultError202NoneResponse{}, nil
 }
 
 // get202None204NoneDefaultError202NoneCreateRequest creates the Get202None204NoneDefaultError202None request.
@@ -941,7 +941,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204None(ctx 
 	if !runtime.HasStatusCode(resp, http.StatusAccepted, http.StatusNoContent) {
 		return MultipleResponsesClientGet202None204NoneDefaultError204NoneResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGet202None204NoneDefaultError204NoneResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGet202None204NoneDefaultError204NoneResponse{}, nil
 }
 
 // get202None204NoneDefaultError204NoneCreateRequest creates the Get202None204NoneDefaultError204None request.
@@ -971,7 +971,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400Valid(ctx
 	if !runtime.HasStatusCode(resp, http.StatusAccepted, http.StatusNoContent) {
 		return MultipleResponsesClientGet202None204NoneDefaultError400ValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGet202None204NoneDefaultError400ValidResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGet202None204NoneDefaultError400ValidResponse{}, nil
 }
 
 // get202None204NoneDefaultError400ValidCreateRequest creates the Get202None204NoneDefaultError400Valid request.
@@ -1001,7 +1001,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202Invalid(ct
 	if !runtime.HasStatusCode(resp, http.StatusAccepted, http.StatusNoContent) {
 		return MultipleResponsesClientGet202None204NoneDefaultNone202InvalidResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGet202None204NoneDefaultNone202InvalidResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGet202None204NoneDefaultNone202InvalidResponse{}, nil
 }
 
 // get202None204NoneDefaultNone202InvalidCreateRequest creates the Get202None204NoneDefaultNone202Invalid request.
@@ -1030,7 +1030,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204None(ctx c
 	if !runtime.HasStatusCode(resp, http.StatusAccepted, http.StatusNoContent) {
 		return MultipleResponsesClientGet202None204NoneDefaultNone204NoneResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGet202None204NoneDefaultNone204NoneResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGet202None204NoneDefaultNone204NoneResponse{}, nil
 }
 
 // get202None204NoneDefaultNone204NoneCreateRequest creates the Get202None204NoneDefaultNone204None request.
@@ -1059,7 +1059,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400Invalid(ct
 	if !runtime.HasStatusCode(resp, http.StatusAccepted, http.StatusNoContent) {
 		return MultipleResponsesClientGet202None204NoneDefaultNone400InvalidResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGet202None204NoneDefaultNone400InvalidResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGet202None204NoneDefaultNone400InvalidResponse{}, nil
 }
 
 // get202None204NoneDefaultNone400InvalidCreateRequest creates the Get202None204NoneDefaultNone400Invalid request.
@@ -1088,7 +1088,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400None(ctx c
 	if !runtime.HasStatusCode(resp, http.StatusAccepted, http.StatusNoContent) {
 		return MultipleResponsesClientGet202None204NoneDefaultNone400NoneResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGet202None204NoneDefaultNone400NoneResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGet202None204NoneDefaultNone400NoneResponse{}, nil
 }
 
 // get202None204NoneDefaultNone400NoneCreateRequest creates the Get202None204NoneDefaultNone400None request.
@@ -1133,7 +1133,7 @@ func (client *MultipleResponsesClient) getDefaultModelA200NoneCreateRequest(ctx 
 
 // getDefaultModelA200NoneHandleResponse handles the GetDefaultModelA200None response.
 func (client *MultipleResponsesClient) getDefaultModelA200NoneHandleResponse(resp *http.Response) (MultipleResponsesClientGetDefaultModelA200NoneResponse, error) {
-	result := MultipleResponsesClientGetDefaultModelA200NoneResponse{RawResponse: resp}
+	result := MultipleResponsesClientGetDefaultModelA200NoneResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGetDefaultModelA200NoneResponse{}, err
 	}
@@ -1172,7 +1172,7 @@ func (client *MultipleResponsesClient) getDefaultModelA200ValidCreateRequest(ctx
 
 // getDefaultModelA200ValidHandleResponse handles the GetDefaultModelA200Valid response.
 func (client *MultipleResponsesClient) getDefaultModelA200ValidHandleResponse(resp *http.Response) (MultipleResponsesClientGetDefaultModelA200ValidResponse, error) {
-	result := MultipleResponsesClientGetDefaultModelA200ValidResponse{RawResponse: resp}
+	result := MultipleResponsesClientGetDefaultModelA200ValidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
 		return MultipleResponsesClientGetDefaultModelA200ValidResponse{}, err
 	}
@@ -1195,7 +1195,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400None(ctx context.Conte
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return MultipleResponsesClientGetDefaultModelA400NoneResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGetDefaultModelA400NoneResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGetDefaultModelA400NoneResponse{}, nil
 }
 
 // getDefaultModelA400NoneCreateRequest creates the GetDefaultModelA400None request.
@@ -1225,7 +1225,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400Valid(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return MultipleResponsesClientGetDefaultModelA400ValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGetDefaultModelA400ValidResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGetDefaultModelA400ValidResponse{}, nil
 }
 
 // getDefaultModelA400ValidCreateRequest creates the GetDefaultModelA400Valid request.
@@ -1255,7 +1255,7 @@ func (client *MultipleResponsesClient) GetDefaultNone200Invalid(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return MultipleResponsesClientGetDefaultNone200InvalidResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGetDefaultNone200InvalidResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGetDefaultNone200InvalidResponse{}, nil
 }
 
 // getDefaultNone200InvalidCreateRequest creates the GetDefaultNone200Invalid request.
@@ -1284,7 +1284,7 @@ func (client *MultipleResponsesClient) GetDefaultNone200None(ctx context.Context
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return MultipleResponsesClientGetDefaultNone200NoneResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGetDefaultNone200NoneResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGetDefaultNone200NoneResponse{}, nil
 }
 
 // getDefaultNone200NoneCreateRequest creates the GetDefaultNone200None request.
@@ -1313,7 +1313,7 @@ func (client *MultipleResponsesClient) GetDefaultNone400Invalid(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return MultipleResponsesClientGetDefaultNone400InvalidResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGetDefaultNone400InvalidResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGetDefaultNone400InvalidResponse{}, nil
 }
 
 // getDefaultNone400InvalidCreateRequest creates the GetDefaultNone400Invalid request.
@@ -1342,7 +1342,7 @@ func (client *MultipleResponsesClient) GetDefaultNone400None(ctx context.Context
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return MultipleResponsesClientGetDefaultNone400NoneResponse{}, runtime.NewResponseError(resp)
 	}
-	return MultipleResponsesClientGetDefaultNone400NoneResponse{RawResponse: resp}, nil
+	return MultipleResponsesClientGetDefaultNone400NoneResponse{}, nil
 }
 
 // getDefaultNone400NoneCreateRequest creates the GetDefaultNone400None request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_response_types.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_response_types.go
@@ -8,207 +8,161 @@
 
 package httpinfrastructuregroup
 
-import "net/http"
-
 // HTTPClientFailureClientDelete400Response contains the response from method HTTPClientFailureClient.Delete400.
 type HTTPClientFailureClientDelete400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientDelete407Response contains the response from method HTTPClientFailureClient.Delete407.
 type HTTPClientFailureClientDelete407Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientDelete417Response contains the response from method HTTPClientFailureClient.Delete417.
 type HTTPClientFailureClientDelete417Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientGet400Response contains the response from method HTTPClientFailureClient.Get400.
 type HTTPClientFailureClientGet400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientGet402Response contains the response from method HTTPClientFailureClient.Get402.
 type HTTPClientFailureClientGet402Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientGet403Response contains the response from method HTTPClientFailureClient.Get403.
 type HTTPClientFailureClientGet403Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientGet411Response contains the response from method HTTPClientFailureClient.Get411.
 type HTTPClientFailureClientGet411Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientGet412Response contains the response from method HTTPClientFailureClient.Get412.
 type HTTPClientFailureClientGet412Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientGet416Response contains the response from method HTTPClientFailureClient.Get416.
 type HTTPClientFailureClientGet416Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientHead400Response contains the response from method HTTPClientFailureClient.Head400.
 type HTTPClientFailureClientHead400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPClientFailureClientHead401Response contains the response from method HTTPClientFailureClient.Head401.
 type HTTPClientFailureClientHead401Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPClientFailureClientHead410Response contains the response from method HTTPClientFailureClient.Head410.
 type HTTPClientFailureClientHead410Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPClientFailureClientHead429Response contains the response from method HTTPClientFailureClient.Head429.
 type HTTPClientFailureClientHead429Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPClientFailureClientOptions400Response contains the response from method HTTPClientFailureClient.Options400.
 type HTTPClientFailureClientOptions400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientOptions403Response contains the response from method HTTPClientFailureClient.Options403.
 type HTTPClientFailureClientOptions403Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientOptions412Response contains the response from method HTTPClientFailureClient.Options412.
 type HTTPClientFailureClientOptions412Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPatch400Response contains the response from method HTTPClientFailureClient.Patch400.
 type HTTPClientFailureClientPatch400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPatch405Response contains the response from method HTTPClientFailureClient.Patch405.
 type HTTPClientFailureClientPatch405Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPatch414Response contains the response from method HTTPClientFailureClient.Patch414.
 type HTTPClientFailureClientPatch414Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPost400Response contains the response from method HTTPClientFailureClient.Post400.
 type HTTPClientFailureClientPost400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPost406Response contains the response from method HTTPClientFailureClient.Post406.
 type HTTPClientFailureClientPost406Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPost415Response contains the response from method HTTPClientFailureClient.Post415.
 type HTTPClientFailureClientPost415Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPut400Response contains the response from method HTTPClientFailureClient.Put400.
 type HTTPClientFailureClientPut400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPut404Response contains the response from method HTTPClientFailureClient.Put404.
 type HTTPClientFailureClientPut404Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPut409Response contains the response from method HTTPClientFailureClient.Put409.
 type HTTPClientFailureClientPut409Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPClientFailureClientPut413Response contains the response from method HTTPClientFailureClient.Put413.
 type HTTPClientFailureClientPut413Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPFailureClientGetEmptyErrorResponse contains the response from method HTTPFailureClient.GetEmptyError.
 type HTTPFailureClientGetEmptyErrorResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple boolean
 	Value *bool
 }
 
 // HTTPFailureClientGetNoModelEmptyResponse contains the response from method HTTPFailureClient.GetNoModelEmpty.
 type HTTPFailureClientGetNoModelEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple boolean
 	Value *bool
 }
 
 // HTTPFailureClientGetNoModelErrorResponse contains the response from method HTTPFailureClient.GetNoModelError.
 type HTTPFailureClientGetNoModelErrorResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple boolean
 	Value *bool
 }
 
 // HTTPRedirectsClientDelete307Response contains the response from method HTTPRedirectsClient.Delete307.
 type HTTPRedirectsClientDelete307Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRedirectsClientGet300Response contains the response from method HTTPRedirectsClient.Get300.
@@ -216,29 +170,23 @@ type HTTPRedirectsClientGet300Response struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// A list of location options for the request ['/http/success/get/200']
 	StringArray []*string
 }
 
 // HTTPRedirectsClientGet301Response contains the response from method HTTPRedirectsClient.Get301.
 type HTTPRedirectsClientGet301Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRedirectsClientGet302Response contains the response from method HTTPRedirectsClient.Get302.
 type HTTPRedirectsClientGet302Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRedirectsClientGet307Response contains the response from method HTTPRedirectsClient.Get307.
 type HTTPRedirectsClientGet307Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRedirectsClientHead300Response contains the response from method HTTPRedirectsClient.Head300.
@@ -246,330 +194,248 @@ type HTTPRedirectsClientHead300Response struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPRedirectsClientHead301Response contains the response from method HTTPRedirectsClient.Head301.
 type HTTPRedirectsClientHead301Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPRedirectsClientHead302Response contains the response from method HTTPRedirectsClient.Head302.
 type HTTPRedirectsClientHead302Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPRedirectsClientHead307Response contains the response from method HTTPRedirectsClient.Head307.
 type HTTPRedirectsClientHead307Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPRedirectsClientOptions307Response contains the response from method HTTPRedirectsClient.Options307.
 type HTTPRedirectsClientOptions307Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRedirectsClientPatch302Response contains the response from method HTTPRedirectsClient.Patch302.
 type HTTPRedirectsClientPatch302Response struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HTTPRedirectsClientPatch307Response contains the response from method HTTPRedirectsClient.Patch307.
 type HTTPRedirectsClientPatch307Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRedirectsClientPost303Response contains the response from method HTTPRedirectsClient.Post303.
 type HTTPRedirectsClientPost303Response struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HTTPRedirectsClientPost307Response contains the response from method HTTPRedirectsClient.Post307.
 type HTTPRedirectsClientPost307Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRedirectsClientPut301Response contains the response from method HTTPRedirectsClient.Put301.
 type HTTPRedirectsClientPut301Response struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HTTPRedirectsClientPut307Response contains the response from method HTTPRedirectsClient.Put307.
 type HTTPRedirectsClientPut307Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRetryClientDelete503Response contains the response from method HTTPRetryClient.Delete503.
 type HTTPRetryClientDelete503Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRetryClientGet502Response contains the response from method HTTPRetryClient.Get502.
 type HTTPRetryClientGet502Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRetryClientHead408Response contains the response from method HTTPRetryClient.Head408.
 type HTTPRetryClientHead408Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPRetryClientOptions502Response contains the response from method HTTPRetryClient.Options502.
 type HTTPRetryClientOptions502Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple boolean
 	Value *bool
 }
 
 // HTTPRetryClientPatch500Response contains the response from method HTTPRetryClient.Patch500.
 type HTTPRetryClientPatch500Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRetryClientPatch504Response contains the response from method HTTPRetryClient.Patch504.
 type HTTPRetryClientPatch504Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRetryClientPost503Response contains the response from method HTTPRetryClient.Post503.
 type HTTPRetryClientPost503Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRetryClientPut500Response contains the response from method HTTPRetryClient.Put500.
 type HTTPRetryClientPut500Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPRetryClientPut504Response contains the response from method HTTPRetryClient.Put504.
 type HTTPRetryClientPut504Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPServerFailureClientDelete505Response contains the response from method HTTPServerFailureClient.Delete505.
 type HTTPServerFailureClientDelete505Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPServerFailureClientGet501Response contains the response from method HTTPServerFailureClient.Get501.
 type HTTPServerFailureClientGet501Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPServerFailureClientHead501Response contains the response from method HTTPServerFailureClient.Head501.
 type HTTPServerFailureClientHead501Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPServerFailureClientPost505Response contains the response from method HTTPServerFailureClient.Post505.
 type HTTPServerFailureClientPost505Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientDelete200Response contains the response from method HTTPSuccessClient.Delete200.
 type HTTPSuccessClientDelete200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientDelete202Response contains the response from method HTTPSuccessClient.Delete202.
 type HTTPSuccessClientDelete202Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientDelete204Response contains the response from method HTTPSuccessClient.Delete204.
 type HTTPSuccessClientDelete204Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientGet200Response contains the response from method HTTPSuccessClient.Get200.
 type HTTPSuccessClientGet200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple boolean
 	Value *bool
 }
 
 // HTTPSuccessClientHead200Response contains the response from method HTTPSuccessClient.Head200.
 type HTTPSuccessClientHead200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientHead204Response contains the response from method HTTPSuccessClient.Head204.
 type HTTPSuccessClientHead204Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientHead404Response contains the response from method HTTPSuccessClient.Head404.
 type HTTPSuccessClientHead404Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
 // HTTPSuccessClientOptions200Response contains the response from method HTTPSuccessClient.Options200.
 type HTTPSuccessClientOptions200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple boolean
 	Value *bool
 }
 
 // HTTPSuccessClientPatch200Response contains the response from method HTTPSuccessClient.Patch200.
 type HTTPSuccessClientPatch200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPatch202Response contains the response from method HTTPSuccessClient.Patch202.
 type HTTPSuccessClientPatch202Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPatch204Response contains the response from method HTTPSuccessClient.Patch204.
 type HTTPSuccessClientPatch204Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPost200Response contains the response from method HTTPSuccessClient.Post200.
 type HTTPSuccessClientPost200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPost201Response contains the response from method HTTPSuccessClient.Post201.
 type HTTPSuccessClientPost201Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPost202Response contains the response from method HTTPSuccessClient.Post202.
 type HTTPSuccessClientPost202Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPost204Response contains the response from method HTTPSuccessClient.Post204.
 type HTTPSuccessClientPost204Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPut200Response contains the response from method HTTPSuccessClient.Put200.
 type HTTPSuccessClientPut200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPut201Response contains the response from method HTTPSuccessClient.Put201.
 type HTTPSuccessClientPut201Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPut202Response contains the response from method HTTPSuccessClient.Put202.
 type HTTPSuccessClientPut202Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // HTTPSuccessClientPut204Response contains the response from method HTTPSuccessClient.Put204.
 type HTTPSuccessClientPut204Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGet200Model201ModelDefaultError200ValidResponse contains the response from method MultipleResponsesClient.Get200Model201ModelDefaultError200Valid.
 type MultipleResponsesClientGet200Model201ModelDefaultError200ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// // Possible types are MyException, B
 	Value interface{}
 }
 
 // MultipleResponsesClientGet200Model201ModelDefaultError201ValidResponse contains the response from method MultipleResponsesClient.Get200Model201ModelDefaultError201Valid.
 type MultipleResponsesClientGet200Model201ModelDefaultError201ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// // Possible types are MyException, B
 	Value interface{}
 }
 
 // MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse contains the response from method MultipleResponsesClient.Get200Model201ModelDefaultError400Valid.
 type MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// // Possible types are MyException, B
 	Value interface{}
 }
@@ -577,91 +443,63 @@ type MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse stru
 // MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError200Valid.
 type MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError201Invalid.
 type MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError202None.
 type MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError204Valid.
 type MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse contains the response from method MultipleResponsesClient.Get200Model204NoModelDefaultError400Valid.
 type MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200ModelA200InvalidResponse contains the response from method MultipleResponsesClient.Get200ModelA200Invalid.
 type MultipleResponsesClientGet200ModelA200InvalidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200ModelA200NoneResponse contains the response from method MultipleResponsesClient.Get200ModelA200None.
 type MultipleResponsesClientGet200ModelA200NoneResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200ModelA200ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA200Valid.
 type MultipleResponsesClientGet200ModelA200ValidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError200ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA201ModelC404ModelDDefaultError200Valid.
 type MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError200ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// // Possible types are MyException, C, D
 	Value interface{}
 }
 
 // MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError201ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA201ModelC404ModelDDefaultError201Valid.
 type MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError201ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// // Possible types are MyException, C, D
 	Value interface{}
 }
 
 // MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError400ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA201ModelC404ModelDDefaultError400Valid.
 type MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError400ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// // Possible types are MyException, C, D
 	Value interface{}
 }
 
 // MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA201ModelC404ModelDDefaultError404Valid.
 type MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// // Possible types are MyException, C, D
 	Value interface{}
 }
@@ -669,119 +507,94 @@ type MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidRe
 // MultipleResponsesClientGet200ModelA202ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA202Valid.
 type MultipleResponsesClientGet200ModelA202ValidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200ModelA400InvalidResponse contains the response from method MultipleResponsesClient.Get200ModelA400Invalid.
 type MultipleResponsesClientGet200ModelA400InvalidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200ModelA400NoneResponse contains the response from method MultipleResponsesClient.Get200ModelA400None.
 type MultipleResponsesClientGet200ModelA400NoneResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet200ModelA400ValidResponse contains the response from method MultipleResponsesClient.Get200ModelA400Valid.
 type MultipleResponsesClientGet200ModelA400ValidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGet202None204NoneDefaultError202NoneResponse contains the response from method MultipleResponsesClient.Get202None204NoneDefaultError202None.
 type MultipleResponsesClientGet202None204NoneDefaultError202NoneResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGet202None204NoneDefaultError204NoneResponse contains the response from method MultipleResponsesClient.Get202None204NoneDefaultError204None.
 type MultipleResponsesClientGet202None204NoneDefaultError204NoneResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGet202None204NoneDefaultError400ValidResponse contains the response from method MultipleResponsesClient.Get202None204NoneDefaultError400Valid.
 type MultipleResponsesClientGet202None204NoneDefaultError400ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGet202None204NoneDefaultNone202InvalidResponse contains the response from method MultipleResponsesClient.Get202None204NoneDefaultNone202Invalid.
 type MultipleResponsesClientGet202None204NoneDefaultNone202InvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGet202None204NoneDefaultNone204NoneResponse contains the response from method MultipleResponsesClient.Get202None204NoneDefaultNone204None.
 type MultipleResponsesClientGet202None204NoneDefaultNone204NoneResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGet202None204NoneDefaultNone400InvalidResponse contains the response from method MultipleResponsesClient.Get202None204NoneDefaultNone400Invalid.
 type MultipleResponsesClientGet202None204NoneDefaultNone400InvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGet202None204NoneDefaultNone400NoneResponse contains the response from method MultipleResponsesClient.Get202None204NoneDefaultNone400None.
 type MultipleResponsesClientGet202None204NoneDefaultNone400NoneResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGetDefaultModelA200NoneResponse contains the response from method MultipleResponsesClient.GetDefaultModelA200None.
 type MultipleResponsesClientGetDefaultModelA200NoneResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGetDefaultModelA200ValidResponse contains the response from method MultipleResponsesClient.GetDefaultModelA200Valid.
 type MultipleResponsesClientGetDefaultModelA200ValidResponse struct {
 	MyException
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleResponsesClientGetDefaultModelA400NoneResponse contains the response from method MultipleResponsesClient.GetDefaultModelA400None.
 type MultipleResponsesClientGetDefaultModelA400NoneResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGetDefaultModelA400ValidResponse contains the response from method MultipleResponsesClient.GetDefaultModelA400Valid.
 type MultipleResponsesClientGetDefaultModelA400ValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGetDefaultNone200InvalidResponse contains the response from method MultipleResponsesClient.GetDefaultNone200Invalid.
 type MultipleResponsesClientGetDefaultNone200InvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGetDefaultNone200NoneResponse contains the response from method MultipleResponsesClient.GetDefaultNone200None.
 type MultipleResponsesClientGetDefaultNone200NoneResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGetDefaultNone400InvalidResponse contains the response from method MultipleResponsesClient.GetDefaultNone400Invalid.
 type MultipleResponsesClientGetDefaultNone400InvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MultipleResponsesClientGetDefaultNone400NoneResponse contains the response from method MultipleResponsesClient.GetDefaultNone400None.
 type MultipleResponsesClientGetDefaultNone400NoneResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/integergroup/integergroup_test.go
+++ b/test/autorest/integergroup/integergroup_test.go
@@ -6,7 +6,6 @@ package integergroup
 import (
 	"context"
 	"math"
-	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -46,9 +45,6 @@ func TestIntGetNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, (*int32)(nil)); r != "" {
 		t.Fatal(r)
 	}
@@ -59,9 +55,6 @@ func TestIntGetNullUnixTime(t *testing.T) {
 	result, err := client.GetNullUnixTime(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNullUnixTime: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if result.Value != nil {
 		t.Fatal("expected nil value")
@@ -119,9 +112,6 @@ func TestIntGetUnixTime(t *testing.T) {
 		t.Fatalf("GetUnixTime: %v", err)
 	}
 	t1 := time.Unix(1460505600, 0)
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &t1); r != "" {
 		t.Fatal(r)
 	}
@@ -133,8 +123,8 @@ func TestIntPutMax32(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutMax32: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -144,8 +134,8 @@ func TestIntPutMax64(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutMax64: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -155,8 +145,8 @@ func TestIntPutMin32(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutMin32: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -166,8 +156,8 @@ func TestIntPutMin64(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutMin64: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -178,7 +168,7 @@ func TestIntPutUnixTimeDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutUnixTimeDate: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/integergroup/zz_generated_int_client.go
+++ b/test/autorest/integergroup/zz_generated_int_client.go
@@ -66,7 +66,7 @@ func (client *IntClient) getInvalidCreateRequest(ctx context.Context, options *I
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *IntClient) getInvalidHandleResponse(resp *http.Response) (IntClientGetInvalidResponse, error) {
-	result := IntClientGetInvalidResponse{RawResponse: resp}
+	result := IntClientGetInvalidResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return IntClientGetInvalidResponse{}, err
 	}
@@ -104,7 +104,7 @@ func (client *IntClient) getInvalidUnixTimeCreateRequest(ctx context.Context, op
 
 // getInvalidUnixTimeHandleResponse handles the GetInvalidUnixTime response.
 func (client *IntClient) getInvalidUnixTimeHandleResponse(resp *http.Response) (IntClientGetInvalidUnixTimeResponse, error) {
-	result := IntClientGetInvalidUnixTimeResponse{RawResponse: resp}
+	result := IntClientGetInvalidUnixTimeResponse{}
 	var aux *timeUnix
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return IntClientGetInvalidUnixTimeResponse{}, err
@@ -144,7 +144,7 @@ func (client *IntClient) getNullCreateRequest(ctx context.Context, options *IntC
 
 // getNullHandleResponse handles the GetNull response.
 func (client *IntClient) getNullHandleResponse(resp *http.Response) (IntClientGetNullResponse, error) {
-	result := IntClientGetNullResponse{RawResponse: resp}
+	result := IntClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return IntClientGetNullResponse{}, err
 	}
@@ -182,7 +182,7 @@ func (client *IntClient) getNullUnixTimeCreateRequest(ctx context.Context, optio
 
 // getNullUnixTimeHandleResponse handles the GetNullUnixTime response.
 func (client *IntClient) getNullUnixTimeHandleResponse(resp *http.Response) (IntClientGetNullUnixTimeResponse, error) {
-	result := IntClientGetNullUnixTimeResponse{RawResponse: resp}
+	result := IntClientGetNullUnixTimeResponse{}
 	var aux *timeUnix
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return IntClientGetNullUnixTimeResponse{}, err
@@ -222,7 +222,7 @@ func (client *IntClient) getOverflowInt32CreateRequest(ctx context.Context, opti
 
 // getOverflowInt32HandleResponse handles the GetOverflowInt32 response.
 func (client *IntClient) getOverflowInt32HandleResponse(resp *http.Response) (IntClientGetOverflowInt32Response, error) {
-	result := IntClientGetOverflowInt32Response{RawResponse: resp}
+	result := IntClientGetOverflowInt32Response{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return IntClientGetOverflowInt32Response{}, err
 	}
@@ -260,7 +260,7 @@ func (client *IntClient) getOverflowInt64CreateRequest(ctx context.Context, opti
 
 // getOverflowInt64HandleResponse handles the GetOverflowInt64 response.
 func (client *IntClient) getOverflowInt64HandleResponse(resp *http.Response) (IntClientGetOverflowInt64Response, error) {
-	result := IntClientGetOverflowInt64Response{RawResponse: resp}
+	result := IntClientGetOverflowInt64Response{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return IntClientGetOverflowInt64Response{}, err
 	}
@@ -298,7 +298,7 @@ func (client *IntClient) getUnderflowInt32CreateRequest(ctx context.Context, opt
 
 // getUnderflowInt32HandleResponse handles the GetUnderflowInt32 response.
 func (client *IntClient) getUnderflowInt32HandleResponse(resp *http.Response) (IntClientGetUnderflowInt32Response, error) {
-	result := IntClientGetUnderflowInt32Response{RawResponse: resp}
+	result := IntClientGetUnderflowInt32Response{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return IntClientGetUnderflowInt32Response{}, err
 	}
@@ -336,7 +336,7 @@ func (client *IntClient) getUnderflowInt64CreateRequest(ctx context.Context, opt
 
 // getUnderflowInt64HandleResponse handles the GetUnderflowInt64 response.
 func (client *IntClient) getUnderflowInt64HandleResponse(resp *http.Response) (IntClientGetUnderflowInt64Response, error) {
-	result := IntClientGetUnderflowInt64Response{RawResponse: resp}
+	result := IntClientGetUnderflowInt64Response{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return IntClientGetUnderflowInt64Response{}, err
 	}
@@ -374,7 +374,7 @@ func (client *IntClient) getUnixTimeCreateRequest(ctx context.Context, options *
 
 // getUnixTimeHandleResponse handles the GetUnixTime response.
 func (client *IntClient) getUnixTimeHandleResponse(resp *http.Response) (IntClientGetUnixTimeResponse, error) {
-	result := IntClientGetUnixTimeResponse{RawResponse: resp}
+	result := IntClientGetUnixTimeResponse{}
 	var aux *timeUnix
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
 		return IntClientGetUnixTimeResponse{}, err
@@ -399,7 +399,7 @@ func (client *IntClient) PutMax32(ctx context.Context, intBody int32, options *I
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return IntClientPutMax32Response{}, runtime.NewResponseError(resp)
 	}
-	return IntClientPutMax32Response{RawResponse: resp}, nil
+	return IntClientPutMax32Response{}, nil
 }
 
 // putMax32CreateRequest creates the PutMax32 request.
@@ -429,7 +429,7 @@ func (client *IntClient) PutMax64(ctx context.Context, intBody int64, options *I
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return IntClientPutMax64Response{}, runtime.NewResponseError(resp)
 	}
-	return IntClientPutMax64Response{RawResponse: resp}, nil
+	return IntClientPutMax64Response{}, nil
 }
 
 // putMax64CreateRequest creates the PutMax64 request.
@@ -459,7 +459,7 @@ func (client *IntClient) PutMin32(ctx context.Context, intBody int32, options *I
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return IntClientPutMin32Response{}, runtime.NewResponseError(resp)
 	}
-	return IntClientPutMin32Response{RawResponse: resp}, nil
+	return IntClientPutMin32Response{}, nil
 }
 
 // putMin32CreateRequest creates the PutMin32 request.
@@ -489,7 +489,7 @@ func (client *IntClient) PutMin64(ctx context.Context, intBody int64, options *I
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return IntClientPutMin64Response{}, runtime.NewResponseError(resp)
 	}
-	return IntClientPutMin64Response{RawResponse: resp}, nil
+	return IntClientPutMin64Response{}, nil
 }
 
 // putMin64CreateRequest creates the PutMin64 request.
@@ -519,7 +519,7 @@ func (client *IntClient) PutUnixTimeDate(ctx context.Context, intBody time.Time,
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return IntClientPutUnixTimeDateResponse{}, runtime.NewResponseError(resp)
 	}
-	return IntClientPutUnixTimeDateResponse{RawResponse: resp}, nil
+	return IntClientPutUnixTimeDateResponse{}, nil
 }
 
 // putUnixTimeDateCreateRequest creates the PutUnixTimeDate request.

--- a/test/autorest/integergroup/zz_generated_response_types.go
+++ b/test/autorest/integergroup/zz_generated_response_types.go
@@ -8,106 +8,77 @@
 
 package integergroup
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 // IntClientGetInvalidResponse contains the response from method IntClient.GetInvalid.
 type IntClientGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *int32
+	Value *int32
 }
 
 // IntClientGetInvalidUnixTimeResponse contains the response from method IntClient.GetInvalidUnixTime.
 type IntClientGetInvalidUnixTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// date in seconds since 1970-01-01T00:00:00Z.
 	Value *time.Time
 }
 
 // IntClientGetNullResponse contains the response from method IntClient.GetNull.
 type IntClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *int32
+	Value *int32
 }
 
 // IntClientGetNullUnixTimeResponse contains the response from method IntClient.GetNullUnixTime.
 type IntClientGetNullUnixTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// date in seconds since 1970-01-01T00:00:00Z.
 	Value *time.Time
 }
 
 // IntClientGetOverflowInt32Response contains the response from method IntClient.GetOverflowInt32.
 type IntClientGetOverflowInt32Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *int32
+	Value *int32
 }
 
 // IntClientGetOverflowInt64Response contains the response from method IntClient.GetOverflowInt64.
 type IntClientGetOverflowInt64Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *int64
+	Value *int64
 }
 
 // IntClientGetUnderflowInt32Response contains the response from method IntClient.GetUnderflowInt32.
 type IntClientGetUnderflowInt32Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *int32
+	Value *int32
 }
 
 // IntClientGetUnderflowInt64Response contains the response from method IntClient.GetUnderflowInt64.
 type IntClientGetUnderflowInt64Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *int64
+	Value *int64
 }
 
 // IntClientGetUnixTimeResponse contains the response from method IntClient.GetUnixTime.
 type IntClientGetUnixTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// date in seconds since 1970-01-01T00:00:00Z.
 	Value *time.Time
 }
 
 // IntClientPutMax32Response contains the response from method IntClient.PutMax32.
 type IntClientPutMax32Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // IntClientPutMax64Response contains the response from method IntClient.PutMax64.
 type IntClientPutMax64Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // IntClientPutMin32Response contains the response from method IntClient.PutMin32.
 type IntClientPutMin32Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // IntClientPutMin64Response contains the response from method IntClient.PutMin64.
 type IntClientPutMin64Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // IntClientPutUnixTimeDateResponse contains the response from method IntClient.PutUnixTimeDate.
 type IntClientPutUnixTimeDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -5,7 +5,7 @@ package lrogroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -36,12 +36,12 @@ func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	result, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -60,12 +60,9 @@ func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -87,9 +84,6 @@ func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	res, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(res.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -117,12 +111,9 @@ func TestLRORetrysBeginPost202Retry200(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -141,12 +132,9 @@ func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -168,9 +156,6 @@ func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
 	res, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(res.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -201,9 +186,6 @@ func TestLRORetrysBeginPutAsyncRelativeRetrySucceeded(t *testing.T) {
 	res, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(res.Product, Product{
 		ID:   to.StringPtr("100"),

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -66,12 +66,9 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -90,12 +87,9 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -110,12 +104,9 @@ func TestLROBeginDelete204Succeeded(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -134,12 +125,9 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -158,12 +146,9 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -212,12 +197,9 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -266,12 +248,9 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -290,12 +269,9 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -350,9 +326,6 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.SKU, SKU{
 		ID:   to.StringPtr("1"),
 		Name: to.StringPtr("product"),
@@ -380,9 +353,6 @@ func TestLROBeginPost202List(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.ProductArray, []*Product{
 		{
 			ID:   to.StringPtr("100"),
@@ -408,12 +378,9 @@ func TestLROBeginPost202NoRetry204(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -432,12 +399,9 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 	if err = resp.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := res.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -459,9 +423,6 @@ func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -523,9 +484,6 @@ func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("foo"),
@@ -586,9 +544,6 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID: to.StringPtr("100"),
 	}); r != "" {
@@ -614,9 +569,6 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -644,9 +596,6 @@ func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -693,9 +642,6 @@ func TestLROBeginPut200Succeeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("foo"),
@@ -721,9 +667,6 @@ func TestLROBeginPut200SucceededNoState(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -752,9 +695,6 @@ func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -808,9 +748,6 @@ func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("foo"),
@@ -841,9 +778,6 @@ func TestLROBeginPut202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("foo"),
@@ -870,9 +804,6 @@ func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -903,9 +834,6 @@ func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -967,9 +895,6 @@ func TestLROBeginPutAsyncNonResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.SKU, SKU{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("sku"),
@@ -1027,9 +952,6 @@ func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("foo"),
@@ -1059,9 +981,6 @@ func TestLROBeginPutAsyncSubResource(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.SubProduct, SubProduct{
 		ID: to.StringPtr("100"),
@@ -1093,9 +1012,6 @@ func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID: to.StringPtr("100"),
 		Properties: &ProductProperties{
@@ -1126,9 +1042,6 @@ func TestLROBeginPutNonResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(pollResp.SKU, SKU{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("sku"),
@@ -1156,9 +1069,6 @@ func TestLROBeginPutSubResource(t *testing.T) {
 	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pollResp.SubProduct, SubProduct{
 		ID: to.StringPtr("100"),

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -5,7 +5,6 @@ package lrogroup
 
 import (
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
@@ -57,12 +56,9 @@ func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
 	if rt != "" {
 		t.Fatal("expected an empty resume token")
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	_, err = resp.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pollResp.RawResponse.StatusCode; s != http.StatusNoContent {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -52,12 +52,9 @@ func TestBeginPost202Retry200(t *testing.T) {
 			break
 		}
 	}
-	resp, err := env.Poller.FinalResponse(context.Background())
+	_, err = env.Poller.FinalResponse(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
-	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -85,12 +82,9 @@ func TestBeginPostAsyncRetrySucceeded(t *testing.T) {
 			break
 		}
 	}
-	resp, err := env.Poller.FinalResponse(context.Background())
+	_, err = env.Poller.FinalResponse(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
-	}
-	if s := resp.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 }
 
@@ -121,9 +115,6 @@ func TestBeginPut201CreatingSucceeded200(t *testing.T) {
 	pr, err := env.Poller.FinalResponse(ctxWithHTTPHeader())
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pr.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pr.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -163,9 +154,6 @@ func TestBeginPutAsyncRetrySucceeded(t *testing.T) {
 	pr, err := env.Poller.FinalResponse(ctxWithHTTPHeader())
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := pr.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(pr.Product, Product{
 		ID:   to.StringPtr("100"),

--- a/test/autorest/lrogroup/zz_generated_lroretrys_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys_client.go
@@ -45,9 +45,7 @@ func (client *LRORetrysClient) BeginDelete202Retry200(ctx context.Context, optio
 	if err != nil {
 		return LRORetrysClientDelete202Retry200PollerResponse{}, err
 	}
-	result := LRORetrysClientDelete202Retry200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LRORetrysClientDelete202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.Delete202Retry200", "", resp, client.pl)
 	if err != nil {
 		return LRORetrysClientDelete202Retry200PollerResponse{}, err
@@ -97,9 +95,7 @@ func (client *LRORetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx contex
 	if err != nil {
 		return LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse{}, err
 	}
-	result := LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.DeleteAsyncRelativeRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse{}, err
@@ -151,9 +147,7 @@ func (client *LRORetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ct
 	if err != nil {
 		return LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse{}, err
 	}
-	result := LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.DeleteProvisioning202Accepted200Succeeded", "", resp, client.pl)
 	if err != nil {
 		return LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse{}, err
@@ -205,9 +199,7 @@ func (client *LRORetrysClient) BeginPost202Retry200(ctx context.Context, options
 	if err != nil {
 		return LRORetrysClientPost202Retry200PollerResponse{}, err
 	}
-	result := LRORetrysClientPost202Retry200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LRORetrysClientPost202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.Post202Retry200", "", resp, client.pl)
 	if err != nil {
 		return LRORetrysClientPost202Retry200PollerResponse{}, err
@@ -261,9 +253,7 @@ func (client *LRORetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.
 	if err != nil {
 		return LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse{}, err
 	}
-	result := LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.PostAsyncRelativeRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse{}, err
@@ -318,9 +308,7 @@ func (client *LRORetrysClient) BeginPut201CreatingSucceeded200(ctx context.Conte
 	if err != nil {
 		return LRORetrysClientPut201CreatingSucceeded200PollerResponse{}, err
 	}
-	result := LRORetrysClientPut201CreatingSucceeded200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LRORetrysClientPut201CreatingSucceeded200PollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.Put201CreatingSucceeded200", "", resp, client.pl)
 	if err != nil {
 		return LRORetrysClientPut201CreatingSucceeded200PollerResponse{}, err
@@ -375,9 +363,7 @@ func (client *LRORetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.C
 	if err != nil {
 		return LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse{}, err
 	}
-	result := LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.PutAsyncRelativeRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse{}, err

--- a/test/autorest/lrogroup/zz_generated_lros_client.go
+++ b/test/autorest/lrogroup/zz_generated_lros_client.go
@@ -45,9 +45,7 @@ func (client *LROsClient) BeginDelete202NoRetry204(ctx context.Context, options 
 	if err != nil {
 		return LROsClientDelete202NoRetry204PollerResponse{}, err
 	}
-	result := LROsClientDelete202NoRetry204PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDelete202NoRetry204PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Delete202NoRetry204", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDelete202NoRetry204PollerResponse{}, err
@@ -97,9 +95,7 @@ func (client *LROsClient) BeginDelete202Retry200(ctx context.Context, options *L
 	if err != nil {
 		return LROsClientDelete202Retry200PollerResponse{}, err
 	}
-	result := LROsClientDelete202Retry200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDelete202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Delete202Retry200", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDelete202Retry200PollerResponse{}, err
@@ -148,9 +144,7 @@ func (client *LROsClient) BeginDelete204Succeeded(ctx context.Context, options *
 	if err != nil {
 		return LROsClientDelete204SucceededPollerResponse{}, err
 	}
-	result := LROsClientDelete204SucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDelete204SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Delete204Succeeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDelete204SucceededPollerResponse{}, err
@@ -199,9 +193,7 @@ func (client *LROsClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context, o
 	if err != nil {
 		return LROsClientDeleteAsyncNoHeaderInRetryPollerResponse{}, err
 	}
-	result := LROsClientDeleteAsyncNoHeaderInRetryPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteAsyncNoHeaderInRetryPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncNoHeaderInRetry", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteAsyncNoHeaderInRetryPollerResponse{}, err
@@ -251,9 +243,7 @@ func (client *LROsClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context, 
 	if err != nil {
 		return LROsClientDeleteAsyncNoRetrySucceededPollerResponse{}, err
 	}
-	result := LROsClientDeleteAsyncNoRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteAsyncNoRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncNoRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteAsyncNoRetrySucceededPollerResponse{}, err
@@ -303,9 +293,7 @@ func (client *LROsClient) BeginDeleteAsyncRetryFailed(ctx context.Context, optio
 	if err != nil {
 		return LROsClientDeleteAsyncRetryFailedPollerResponse{}, err
 	}
-	result := LROsClientDeleteAsyncRetryFailedPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteAsyncRetryFailedPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncRetryFailed", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteAsyncRetryFailedPollerResponse{}, err
@@ -355,9 +343,7 @@ func (client *LROsClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context, op
 	if err != nil {
 		return LROsClientDeleteAsyncRetrySucceededPollerResponse{}, err
 	}
-	result := LROsClientDeleteAsyncRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteAsyncRetrySucceededPollerResponse{}, err
@@ -407,9 +393,7 @@ func (client *LROsClient) BeginDeleteAsyncRetrycanceled(ctx context.Context, opt
 	if err != nil {
 		return LROsClientDeleteAsyncRetrycanceledPollerResponse{}, err
 	}
-	result := LROsClientDeleteAsyncRetrycanceledPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteAsyncRetrycanceledPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncRetrycanceled", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteAsyncRetrycanceledPollerResponse{}, err
@@ -459,9 +443,7 @@ func (client *LROsClient) BeginDeleteNoHeaderInRetry(ctx context.Context, option
 	if err != nil {
 		return LROsClientDeleteNoHeaderInRetryPollerResponse{}, err
 	}
-	result := LROsClientDeleteNoHeaderInRetryPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteNoHeaderInRetryPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteNoHeaderInRetry", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteNoHeaderInRetryPollerResponse{}, err
@@ -513,9 +495,7 @@ func (client *LROsClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx con
 	if err != nil {
 		return LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse{}, err
 	}
-	result := LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteProvisioning202Accepted200Succeeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse{}, err
@@ -569,9 +549,7 @@ func (client *LROsClient) BeginDeleteProvisioning202DeletingFailed200(ctx contex
 	if err != nil {
 		return LROsClientDeleteProvisioning202DeletingFailed200PollerResponse{}, err
 	}
-	result := LROsClientDeleteProvisioning202DeletingFailed200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteProvisioning202DeletingFailed200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteProvisioning202DeletingFailed200", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteProvisioning202DeletingFailed200PollerResponse{}, err
@@ -624,9 +602,7 @@ func (client *LROsClient) BeginDeleteProvisioning202Deletingcanceled200(ctx cont
 	if err != nil {
 		return LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse{}, err
 	}
-	result := LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteProvisioning202Deletingcanceled200", "", resp, client.pl)
 	if err != nil {
 		return LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse{}, err
@@ -677,9 +653,7 @@ func (client *LROsClient) BeginPatch200SucceededIgnoreHeaders(ctx context.Contex
 	if err != nil {
 		return LROsClientPatch200SucceededIgnoreHeadersPollerResponse{}, err
 	}
-	result := LROsClientPatch200SucceededIgnoreHeadersPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPatch200SucceededIgnoreHeadersPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Patch200SucceededIgnoreHeaders", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPatch200SucceededIgnoreHeadersPollerResponse{}, err
@@ -732,9 +706,7 @@ func (client *LROsClient) BeginPost200WithPayload(ctx context.Context, options *
 	if err != nil {
 		return LROsClientPost200WithPayloadPollerResponse{}, err
 	}
-	result := LROsClientPost200WithPayloadPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPost200WithPayloadPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Post200WithPayload", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPost200WithPayloadPollerResponse{}, err
@@ -783,9 +755,7 @@ func (client *LROsClient) BeginPost202List(ctx context.Context, options *LROsCli
 	if err != nil {
 		return LROsClientPost202ListPollerResponse{}, err
 	}
-	result := LROsClientPost202ListPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPost202ListPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Post202List", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPost202ListPollerResponse{}, err
@@ -835,9 +805,7 @@ func (client *LROsClient) BeginPost202NoRetry204(ctx context.Context, options *L
 	if err != nil {
 		return LROsClientPost202NoRetry204PollerResponse{}, err
 	}
-	result := LROsClientPost202NoRetry204PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPost202NoRetry204PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Post202NoRetry204", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPost202NoRetry204PollerResponse{}, err
@@ -890,9 +858,7 @@ func (client *LROsClient) BeginPost202Retry200(ctx context.Context, options *LRO
 	if err != nil {
 		return LROsClientPost202Retry200PollerResponse{}, err
 	}
-	result := LROsClientPost202Retry200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPost202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Post202Retry200", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPost202Retry200PollerResponse{}, err
@@ -946,9 +912,7 @@ func (client *LROsClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, op
 	if err != nil {
 		return LROsClientPostAsyncNoRetrySucceededPollerResponse{}, err
 	}
-	result := LROsClientPostAsyncNoRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPostAsyncNoRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostAsyncNoRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPostAsyncNoRetrySucceededPollerResponse{}, err
@@ -1003,9 +967,7 @@ func (client *LROsClient) BeginPostAsyncRetryFailed(ctx context.Context, options
 	if err != nil {
 		return LROsClientPostAsyncRetryFailedPollerResponse{}, err
 	}
-	result := LROsClientPostAsyncRetryFailedPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPostAsyncRetryFailedPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostAsyncRetryFailed", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPostAsyncRetryFailedPollerResponse{}, err
@@ -1060,9 +1022,7 @@ func (client *LROsClient) BeginPostAsyncRetrySucceeded(ctx context.Context, opti
 	if err != nil {
 		return LROsClientPostAsyncRetrySucceededPollerResponse{}, err
 	}
-	result := LROsClientPostAsyncRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPostAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPostAsyncRetrySucceededPollerResponse{}, err
@@ -1117,9 +1077,7 @@ func (client *LROsClient) BeginPostAsyncRetrycanceled(ctx context.Context, optio
 	if err != nil {
 		return LROsClientPostAsyncRetrycanceledPollerResponse{}, err
 	}
-	result := LROsClientPostAsyncRetrycanceledPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPostAsyncRetrycanceledPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostAsyncRetrycanceled", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPostAsyncRetrycanceledPollerResponse{}, err
@@ -1173,9 +1131,7 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse{}, err
 	}
-	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostDoubleHeadersFinalAzureHeaderGet", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse{}, err
@@ -1227,9 +1183,7 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx c
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse{}, err
 	}
-	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse{}, err
@@ -1280,9 +1234,7 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Con
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalLocationGetPollerResponse{}, err
 	}
-	result := LROsClientPostDoubleHeadersFinalLocationGetPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPostDoubleHeadersFinalLocationGetPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostDoubleHeadersFinalLocationGet", "location", resp, client.pl)
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalLocationGetPollerResponse{}, err
@@ -1333,9 +1285,7 @@ func (client *LROsClient) BeginPut200Acceptedcanceled200(ctx context.Context, op
 	if err != nil {
 		return LROsClientPut200Acceptedcanceled200PollerResponse{}, err
 	}
-	result := LROsClientPut200Acceptedcanceled200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPut200Acceptedcanceled200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put200Acceptedcanceled200", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPut200Acceptedcanceled200PollerResponse{}, err
@@ -1389,9 +1339,7 @@ func (client *LROsClient) BeginPut200Succeeded(ctx context.Context, options *LRO
 	if err != nil {
 		return LROsClientPut200SucceededPollerResponse{}, err
 	}
-	result := LROsClientPut200SucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPut200SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put200Succeeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPut200SucceededPollerResponse{}, err
@@ -1444,9 +1392,7 @@ func (client *LROsClient) BeginPut200SucceededNoState(ctx context.Context, optio
 	if err != nil {
 		return LROsClientPut200SucceededNoStatePollerResponse{}, err
 	}
-	result := LROsClientPut200SucceededNoStatePollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPut200SucceededNoStatePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put200SucceededNoState", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPut200SucceededNoStatePollerResponse{}, err
@@ -1500,9 +1446,7 @@ func (client *LROsClient) BeginPut200UpdatingSucceeded204(ctx context.Context, o
 	if err != nil {
 		return LROsClientPut200UpdatingSucceeded204PollerResponse{}, err
 	}
-	result := LROsClientPut200UpdatingSucceeded204PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPut200UpdatingSucceeded204PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put200UpdatingSucceeded204", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPut200UpdatingSucceeded204PollerResponse{}, err
@@ -1557,9 +1501,7 @@ func (client *LROsClient) BeginPut201CreatingFailed200(ctx context.Context, opti
 	if err != nil {
 		return LROsClientPut201CreatingFailed200PollerResponse{}, err
 	}
-	result := LROsClientPut201CreatingFailed200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPut201CreatingFailed200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put201CreatingFailed200", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPut201CreatingFailed200PollerResponse{}, err
@@ -1614,9 +1556,7 @@ func (client *LROsClient) BeginPut201CreatingSucceeded200(ctx context.Context, o
 	if err != nil {
 		return LROsClientPut201CreatingSucceeded200PollerResponse{}, err
 	}
-	result := LROsClientPut201CreatingSucceeded200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPut201CreatingSucceeded200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put201CreatingSucceeded200", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPut201CreatingSucceeded200PollerResponse{}, err
@@ -1670,9 +1610,7 @@ func (client *LROsClient) BeginPut201Succeeded(ctx context.Context, options *LRO
 	if err != nil {
 		return LROsClientPut201SucceededPollerResponse{}, err
 	}
-	result := LROsClientPut201SucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPut201SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put201Succeeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPut201SucceededPollerResponse{}, err
@@ -1725,9 +1663,7 @@ func (client *LROsClient) BeginPut202Retry200(ctx context.Context, options *LROs
 	if err != nil {
 		return LROsClientPut202Retry200PollerResponse{}, err
 	}
-	result := LROsClientPut202Retry200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPut202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put202Retry200", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPut202Retry200PollerResponse{}, err
@@ -1780,9 +1716,7 @@ func (client *LROsClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, opti
 	if err != nil {
 		return LROsClientPutAsyncNoHeaderInRetryPollerResponse{}, err
 	}
-	result := LROsClientPutAsyncNoHeaderInRetryPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutAsyncNoHeaderInRetryPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncNoHeaderInRetry", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutAsyncNoHeaderInRetryPollerResponse{}, err
@@ -1836,9 +1770,7 @@ func (client *LROsClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, opt
 	if err != nil {
 		return LROsClientPutAsyncNoRetrySucceededPollerResponse{}, err
 	}
-	result := LROsClientPutAsyncNoRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutAsyncNoRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncNoRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutAsyncNoRetrySucceededPollerResponse{}, err
@@ -1893,9 +1825,7 @@ func (client *LROsClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, opti
 	if err != nil {
 		return LROsClientPutAsyncNoRetrycanceledPollerResponse{}, err
 	}
-	result := LROsClientPutAsyncNoRetrycanceledPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutAsyncNoRetrycanceledPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncNoRetrycanceled", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutAsyncNoRetrycanceledPollerResponse{}, err
@@ -1948,9 +1878,7 @@ func (client *LROsClient) BeginPutAsyncNonResource(ctx context.Context, options 
 	if err != nil {
 		return LROsClientPutAsyncNonResourcePollerResponse{}, err
 	}
-	result := LROsClientPutAsyncNonResourcePollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutAsyncNonResourcePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncNonResource", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutAsyncNonResourcePollerResponse{}, err
@@ -2003,9 +1931,7 @@ func (client *LROsClient) BeginPutAsyncRetryFailed(ctx context.Context, options 
 	if err != nil {
 		return LROsClientPutAsyncRetryFailedPollerResponse{}, err
 	}
-	result := LROsClientPutAsyncRetryFailedPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutAsyncRetryFailedPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncRetryFailed", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutAsyncRetryFailedPollerResponse{}, err
@@ -2060,9 +1986,7 @@ func (client *LROsClient) BeginPutAsyncRetrySucceeded(ctx context.Context, optio
 	if err != nil {
 		return LROsClientPutAsyncRetrySucceededPollerResponse{}, err
 	}
-	result := LROsClientPutAsyncRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutAsyncRetrySucceededPollerResponse{}, err
@@ -2115,9 +2039,7 @@ func (client *LROsClient) BeginPutAsyncSubResource(ctx context.Context, options 
 	if err != nil {
 		return LROsClientPutAsyncSubResourcePollerResponse{}, err
 	}
-	result := LROsClientPutAsyncSubResourcePollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutAsyncSubResourcePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncSubResource", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutAsyncSubResourcePollerResponse{}, err
@@ -2169,9 +2091,7 @@ func (client *LROsClient) BeginPutNoHeaderInRetry(ctx context.Context, options *
 	if err != nil {
 		return LROsClientPutNoHeaderInRetryPollerResponse{}, err
 	}
-	result := LROsClientPutNoHeaderInRetryPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutNoHeaderInRetryPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutNoHeaderInRetry", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutNoHeaderInRetryPollerResponse{}, err
@@ -2223,9 +2143,7 @@ func (client *LROsClient) BeginPutNonResource(ctx context.Context, options *LROs
 	if err != nil {
 		return LROsClientPutNonResourcePollerResponse{}, err
 	}
-	result := LROsClientPutNonResourcePollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutNonResourcePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutNonResource", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutNonResourcePollerResponse{}, err
@@ -2276,9 +2194,7 @@ func (client *LROsClient) BeginPutSubResource(ctx context.Context, options *LROs
 	if err != nil {
 		return LROsClientPutSubResourcePollerResponse{}, err
 	}
-	result := LROsClientPutSubResourcePollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsClientPutSubResourcePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutSubResource", "", resp, client.pl)
 	if err != nil {
 		return LROsClientPutSubResourcePollerResponse{}, err

--- a/test/autorest/lrogroup/zz_generated_lrosads_client.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads_client.go
@@ -44,9 +44,7 @@ func (client *LROSADsClient) BeginDelete202NonRetry400(ctx context.Context, opti
 	if err != nil {
 		return LROSADsClientDelete202NonRetry400PollerResponse{}, err
 	}
-	result := LROSADsClientDelete202NonRetry400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientDelete202NonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Delete202NonRetry400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientDelete202NonRetry400PollerResponse{}, err
@@ -95,9 +93,7 @@ func (client *LROSADsClient) BeginDelete202RetryInvalidHeader(ctx context.Contex
 	if err != nil {
 		return LROSADsClientDelete202RetryInvalidHeaderPollerResponse{}, err
 	}
-	result := LROSADsClientDelete202RetryInvalidHeaderPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientDelete202RetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Delete202RetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientDelete202RetryInvalidHeaderPollerResponse{}, err
@@ -146,9 +142,7 @@ func (client *LROSADsClient) BeginDelete204Succeeded(ctx context.Context, option
 	if err != nil {
 		return LROSADsClientDelete204SucceededPollerResponse{}, err
 	}
-	result := LROSADsClientDelete204SucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientDelete204SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Delete204Succeeded", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientDelete204SucceededPollerResponse{}, err
@@ -197,9 +191,7 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Contex
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetry400PollerResponse{}, err
 	}
-	result := LROSADsClientDeleteAsyncRelativeRetry400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientDeleteAsyncRelativeRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteAsyncRelativeRetry400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetry400PollerResponse{}, err
@@ -249,9 +241,7 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx cont
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
 	}
-	result := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
@@ -301,9 +291,7 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
 	}
-	result := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
@@ -353,9 +341,7 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.C
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse{}, err
 	}
-	result := LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteAsyncRelativeRetryNoStatus", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse{}, err
@@ -404,9 +390,7 @@ func (client *LROSADsClient) BeginDeleteNonRetry400(ctx context.Context, options
 	if err != nil {
 		return LROSADsClientDeleteNonRetry400PollerResponse{}, err
 	}
-	result := LROSADsClientDeleteNonRetry400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientDeleteNonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteNonRetry400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientDeleteNonRetry400PollerResponse{}, err
@@ -454,9 +438,7 @@ func (client *LROSADsClient) BeginPost202NoLocation(ctx context.Context, options
 	if err != nil {
 		return LROSADsClientPost202NoLocationPollerResponse{}, err
 	}
-	result := LROSADsClientPost202NoLocationPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPost202NoLocationPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Post202NoLocation", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPost202NoLocationPollerResponse{}, err
@@ -507,9 +489,7 @@ func (client *LROSADsClient) BeginPost202NonRetry400(ctx context.Context, option
 	if err != nil {
 		return LROSADsClientPost202NonRetry400PollerResponse{}, err
 	}
-	result := LROSADsClientPost202NonRetry400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPost202NonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Post202NonRetry400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPost202NonRetry400PollerResponse{}, err
@@ -561,9 +541,7 @@ func (client *LROSADsClient) BeginPost202RetryInvalidHeader(ctx context.Context,
 	if err != nil {
 		return LROSADsClientPost202RetryInvalidHeaderPollerResponse{}, err
 	}
-	result := LROSADsClientPost202RetryInvalidHeaderPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPost202RetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Post202RetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPost202RetryInvalidHeaderPollerResponse{}, err
@@ -616,9 +594,7 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetry400(ctx context.Context,
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetry400PollerResponse{}, err
 	}
-	result := LROSADsClientPostAsyncRelativeRetry400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPostAsyncRelativeRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostAsyncRelativeRetry400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetry400PollerResponse{}, err
@@ -672,9 +648,7 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx contex
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
 	}
-	result := LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostAsyncRelativeRetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
@@ -730,9 +704,7 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx c
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
 	}
-	result := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
@@ -787,9 +759,7 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Co
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse{}, err
 	}
-	result := LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostAsyncRelativeRetryNoPayload", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse{}, err
@@ -842,9 +812,7 @@ func (client *LROSADsClient) BeginPostNonRetry400(ctx context.Context, options *
 	if err != nil {
 		return LROSADsClientPostNonRetry400PollerResponse{}, err
 	}
-	result := LROSADsClientPostNonRetry400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPostNonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostNonRetry400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPostNonRetry400PollerResponse{}, err
@@ -896,9 +864,7 @@ func (client *LROSADsClient) BeginPut200InvalidJSON(ctx context.Context, options
 	if err != nil {
 		return LROSADsClientPut200InvalidJSONPollerResponse{}, err
 	}
-	result := LROSADsClientPut200InvalidJSONPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPut200InvalidJSONPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Put200InvalidJSON", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPut200InvalidJSONPollerResponse{}, err
@@ -951,9 +917,7 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, 
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetry400PollerResponse{}, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetry400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutAsyncRelativeRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetry400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetry400PollerResponse{}, err
@@ -1006,9 +970,7 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
@@ -1063,9 +1025,7 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx co
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
@@ -1120,9 +1080,7 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Cont
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse{}, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetryNoStatus", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse{}, err
@@ -1177,9 +1135,7 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx conte
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse{}, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetryNoStatusPayload", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse{}, err
@@ -1233,9 +1189,7 @@ func (client *LROSADsClient) BeginPutError201NoProvisioningStatePayload(ctx cont
 	if err != nil {
 		return LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse{}, err
 	}
-	result := LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutError201NoProvisioningStatePayload", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse{}, err
@@ -1288,9 +1242,7 @@ func (client *LROSADsClient) BeginPutNonRetry201Creating400(ctx context.Context,
 	if err != nil {
 		return LROSADsClientPutNonRetry201Creating400PollerResponse{}, err
 	}
-	result := LROSADsClientPutNonRetry201Creating400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutNonRetry201Creating400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutNonRetry201Creating400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutNonRetry201Creating400PollerResponse{}, err
@@ -1343,9 +1295,7 @@ func (client *LROSADsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx conte
 	if err != nil {
 		return LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse{}, err
 	}
-	result := LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutNonRetry201Creating400InvalidJSON", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse{}, err
@@ -1397,9 +1347,7 @@ func (client *LROSADsClient) BeginPutNonRetry400(ctx context.Context, options *L
 	if err != nil {
 		return LROSADsClientPutNonRetry400PollerResponse{}, err
 	}
-	result := LROSADsClientPutNonRetry400PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROSADsClientPutNonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutNonRetry400", "", resp, client.pl)
 	if err != nil {
 		return LROSADsClientPutNonRetry400PollerResponse{}, err

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
@@ -46,9 +46,7 @@ func (client *LROsCustomHeaderClient) BeginPost202Retry200(ctx context.Context, 
 	if err != nil {
 		return LROsCustomHeaderClientPost202Retry200PollerResponse{}, err
 	}
-	result := LROsCustomHeaderClientPost202Retry200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsCustomHeaderClientPost202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsCustomHeaderClient.Post202Retry200", "", resp, client.pl)
 	if err != nil {
 		return LROsCustomHeaderClientPost202Retry200PollerResponse{}, err
@@ -103,9 +101,7 @@ func (client *LROsCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.C
 	if err != nil {
 		return LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse{}, err
 	}
-	result := LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsCustomHeaderClient.PostAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse{}, err
@@ -160,9 +156,7 @@ func (client *LROsCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx contex
 	if err != nil {
 		return LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse{}, err
 	}
-	result := LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsCustomHeaderClient.Put201CreatingSucceeded200", "", resp, client.pl)
 	if err != nil {
 		return LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse{}, err
@@ -217,9 +211,7 @@ func (client *LROsCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Co
 	if err != nil {
 		return LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse{}, err
 	}
-	result := LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse{
-		RawResponse: resp,
-	}
+	result := LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsCustomHeaderClient.PutAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
 		return LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse{}, err

--- a/test/autorest/lrogroup/zz_generated_pollers.go
+++ b/test/autorest/lrogroup/zz_generated_pollers.go
@@ -43,11 +43,10 @@ func (p *LRORetrysClientDelete202Retry200Poller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final LRORetrysClientDelete202Retry200Response will be returned.
 func (p *LRORetrysClientDelete202Retry200Poller) FinalResponse(ctx context.Context) (LRORetrysClientDelete202Retry200Response, error) {
 	respType := LRORetrysClientDelete202Retry200Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LRORetrysClientDelete202Retry200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -86,11 +85,10 @@ func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Poll(ctx contex
 // If the final GET succeeded then the final LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse will be returned.
 func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) FinalResponse(ctx context.Context) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
 	respType := LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -129,11 +127,10 @@ func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ct
 // If the final GET succeeded then the final LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse will be returned.
 func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) FinalResponse(ctx context.Context) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
 	respType := LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -172,11 +169,10 @@ func (p *LRORetrysClientPost202Retry200Poller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final LRORetrysClientPost202Retry200Response will be returned.
 func (p *LRORetrysClientPost202Retry200Poller) FinalResponse(ctx context.Context) (LRORetrysClientPost202Retry200Response, error) {
 	respType := LRORetrysClientPost202Retry200Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LRORetrysClientPost202Retry200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -215,11 +211,10 @@ func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Poll(ctx context.
 // If the final GET succeeded then the final LRORetrysClientPostAsyncRelativeRetrySucceededResponse will be returned.
 func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) FinalResponse(ctx context.Context) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
 	respType := LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -258,11 +253,10 @@ func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Poll(ctx context.Conte
 // If the final GET succeeded then the final LRORetrysClientPut201CreatingSucceeded200Response will be returned.
 func (p *LRORetrysClientPut201CreatingSucceeded200Poller) FinalResponse(ctx context.Context) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
 	respType := LRORetrysClientPut201CreatingSucceeded200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LRORetrysClientPut201CreatingSucceeded200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -301,11 +295,10 @@ func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Poll(ctx context.C
 // If the final GET succeeded then the final LRORetrysClientPutAsyncRelativeRetrySucceededResponse will be returned.
 func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) FinalResponse(ctx context.Context) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
 	respType := LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -344,11 +337,10 @@ func (p *LROSADsClientDelete202NonRetry400Poller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final LROSADsClientDelete202NonRetry400Response will be returned.
 func (p *LROSADsClientDelete202NonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientDelete202NonRetry400Response, error) {
 	respType := LROSADsClientDelete202NonRetry400Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientDelete202NonRetry400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -387,11 +379,10 @@ func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final LROSADsClientDelete202RetryInvalidHeaderResponse will be returned.
 func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientDelete202RetryInvalidHeaderResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientDelete202RetryInvalidHeaderResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -430,11 +421,10 @@ func (p *LROSADsClientDelete204SucceededPoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final LROSADsClientDelete204SucceededResponse will be returned.
 func (p *LROSADsClientDelete204SucceededPoller) FinalResponse(ctx context.Context) (LROSADsClientDelete204SucceededResponse, error) {
 	respType := LROSADsClientDelete204SucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientDelete204SucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -473,11 +463,10 @@ func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Poll(ctx context.Contex
 // If the final GET succeeded then the final LROSADsClientDeleteAsyncRelativeRetry400Response will be returned.
 func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
 	respType := LROSADsClientDeleteAsyncRelativeRetry400Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetry400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -516,11 +505,10 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx cont
 // If the final GET succeeded then the final LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse will be returned.
 func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -559,11 +547,10 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx
 // If the final GET succeeded then the final LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse will be returned.
 func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) FinalResponse(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
 	respType := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -602,11 +589,10 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Poll(ctx context.C
 // If the final GET succeeded then the final LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse will be returned.
 func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) FinalResponse(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
 	respType := LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -645,11 +631,10 @@ func (p *LROSADsClientDeleteNonRetry400Poller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final LROSADsClientDeleteNonRetry400Response will be returned.
 func (p *LROSADsClientDeleteNonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientDeleteNonRetry400Response, error) {
 	respType := LROSADsClientDeleteNonRetry400Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientDeleteNonRetry400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -688,11 +673,10 @@ func (p *LROSADsClientPost202NoLocationPoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final LROSADsClientPost202NoLocationResponse will be returned.
 func (p *LROSADsClientPost202NoLocationPoller) FinalResponse(ctx context.Context) (LROSADsClientPost202NoLocationResponse, error) {
 	respType := LROSADsClientPost202NoLocationResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientPost202NoLocationResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -731,11 +715,10 @@ func (p *LROSADsClientPost202NonRetry400Poller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final LROSADsClientPost202NonRetry400Response will be returned.
 func (p *LROSADsClientPost202NonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPost202NonRetry400Response, error) {
 	respType := LROSADsClientPost202NonRetry400Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientPost202NonRetry400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -774,11 +757,10 @@ func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final LROSADsClientPost202RetryInvalidHeaderResponse will be returned.
 func (p *LROSADsClientPost202RetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientPost202RetryInvalidHeaderResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientPost202RetryInvalidHeaderResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -817,11 +799,10 @@ func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Poll(ctx context.Context)
 // If the final GET succeeded then the final LROSADsClientPostAsyncRelativeRetry400Response will be returned.
 func (p *LROSADsClientPostAsyncRelativeRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
 	respType := LROSADsClientPostAsyncRelativeRetry400Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetry400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -860,11 +841,10 @@ func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx contex
 // If the final GET succeeded then the final LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse will be returned.
 func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -903,11 +883,10 @@ func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx c
 // If the final GET succeeded then the final LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse will be returned.
 func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) FinalResponse(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
 	respType := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -946,11 +925,10 @@ func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Poll(ctx context.Co
 // If the final GET succeeded then the final LROSADsClientPostAsyncRelativeRetryNoPayloadResponse will be returned.
 func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) FinalResponse(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
 	respType := LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -989,11 +967,10 @@ func (p *LROSADsClientPostNonRetry400Poller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final LROSADsClientPostNonRetry400Response will be returned.
 func (p *LROSADsClientPostNonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPostNonRetry400Response, error) {
 	respType := LROSADsClientPostNonRetry400Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROSADsClientPostNonRetry400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1032,11 +1009,10 @@ func (p *LROSADsClientPut200InvalidJSONPoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final LROSADsClientPut200InvalidJSONResponse will be returned.
 func (p *LROSADsClientPut200InvalidJSONPoller) FinalResponse(ctx context.Context) (LROSADsClientPut200InvalidJSONResponse, error) {
 	respType := LROSADsClientPut200InvalidJSONResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPut200InvalidJSONResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1075,11 +1051,10 @@ func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetry400Response will be returned.
 func (p *LROSADsClientPutAsyncRelativeRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
 	respType := LROSADsClientPutAsyncRelativeRetry400Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetry400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1118,11 +1093,10 @@ func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context
 // If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse will be returned.
 func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1161,11 +1135,10 @@ func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx co
 // If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse will be returned.
 func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
 	respType := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1204,11 +1177,10 @@ func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Poll(ctx conte
 // If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse will be returned.
 func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
 	respType := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1247,11 +1219,10 @@ func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Cont
 // If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetryNoStatusResponse will be returned.
 func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
 	respType := LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1290,11 +1261,10 @@ func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Poll(ctx cont
 // If the final GET succeeded then the final LROSADsClientPutError201NoProvisioningStatePayloadResponse will be returned.
 func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) FinalResponse(ctx context.Context) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
 	respType := LROSADsClientPutError201NoProvisioningStatePayloadResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutError201NoProvisioningStatePayloadResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1333,11 +1303,10 @@ func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Poll(ctx conte
 // If the final GET succeeded then the final LROSADsClientPutNonRetry201Creating400InvalidJSONResponse will be returned.
 func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) FinalResponse(ctx context.Context) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
 	respType := LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1376,11 +1345,10 @@ func (p *LROSADsClientPutNonRetry201Creating400Poller) Poll(ctx context.Context)
 // If the final GET succeeded then the final LROSADsClientPutNonRetry201Creating400Response will be returned.
 func (p *LROSADsClientPutNonRetry201Creating400Poller) FinalResponse(ctx context.Context) (LROSADsClientPutNonRetry201Creating400Response, error) {
 	respType := LROSADsClientPutNonRetry201Creating400Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutNonRetry201Creating400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1419,11 +1387,10 @@ func (p *LROSADsClientPutNonRetry400Poller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final LROSADsClientPutNonRetry400Response will be returned.
 func (p *LROSADsClientPutNonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPutNonRetry400Response, error) {
 	respType := LROSADsClientPutNonRetry400Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROSADsClientPutNonRetry400Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1462,11 +1429,10 @@ func (p *LROsClientDelete202NoRetry204Poller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final LROsClientDelete202NoRetry204Response will be returned.
 func (p *LROsClientDelete202NoRetry204Poller) FinalResponse(ctx context.Context) (LROsClientDelete202NoRetry204Response, error) {
 	respType := LROsClientDelete202NoRetry204Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientDelete202NoRetry204Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1505,11 +1471,10 @@ func (p *LROsClientDelete202Retry200Poller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final LROsClientDelete202Retry200Response will be returned.
 func (p *LROsClientDelete202Retry200Poller) FinalResponse(ctx context.Context) (LROsClientDelete202Retry200Response, error) {
 	respType := LROsClientDelete202Retry200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientDelete202Retry200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1548,11 +1513,10 @@ func (p *LROsClientDelete204SucceededPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final LROsClientDelete204SucceededResponse will be returned.
 func (p *LROsClientDelete204SucceededPoller) FinalResponse(ctx context.Context) (LROsClientDelete204SucceededResponse, error) {
 	respType := LROsClientDelete204SucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientDelete204SucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1591,11 +1555,10 @@ func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final LROsClientDeleteAsyncNoHeaderInRetryResponse will be returned.
 func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
 	respType := LROsClientDeleteAsyncNoHeaderInRetryResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientDeleteAsyncNoHeaderInRetryResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1634,11 +1597,10 @@ func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final LROsClientDeleteAsyncNoRetrySucceededResponse will be returned.
 func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
 	respType := LROsClientDeleteAsyncNoRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientDeleteAsyncNoRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1677,11 +1639,10 @@ func (p *LROsClientDeleteAsyncRetryFailedPoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final LROsClientDeleteAsyncRetryFailedResponse will be returned.
 func (p *LROsClientDeleteAsyncRetryFailedPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncRetryFailedResponse, error) {
 	respType := LROsClientDeleteAsyncRetryFailedResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientDeleteAsyncRetryFailedResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1720,11 +1681,10 @@ func (p *LROsClientDeleteAsyncRetrySucceededPoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final LROsClientDeleteAsyncRetrySucceededResponse will be returned.
 func (p *LROsClientDeleteAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
 	respType := LROsClientDeleteAsyncRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientDeleteAsyncRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1763,11 +1723,10 @@ func (p *LROsClientDeleteAsyncRetrycanceledPoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final LROsClientDeleteAsyncRetrycanceledResponse will be returned.
 func (p *LROsClientDeleteAsyncRetrycanceledPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
 	respType := LROsClientDeleteAsyncRetrycanceledResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientDeleteAsyncRetrycanceledResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1806,11 +1765,10 @@ func (p *LROsClientDeleteNoHeaderInRetryPoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final LROsClientDeleteNoHeaderInRetryResponse will be returned.
 func (p *LROsClientDeleteNoHeaderInRetryPoller) FinalResponse(ctx context.Context) (LROsClientDeleteNoHeaderInRetryResponse, error) {
 	respType := LROsClientDeleteNoHeaderInRetryResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientDeleteNoHeaderInRetryResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1849,11 +1807,10 @@ func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx con
 // If the final GET succeeded then the final LROsClientDeleteProvisioning202Accepted200SucceededResponse will be returned.
 func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) FinalResponse(ctx context.Context) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
 	respType := LROsClientDeleteProvisioning202Accepted200SucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientDeleteProvisioning202Accepted200SucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1892,11 +1849,10 @@ func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Poll(ctx contex
 // If the final GET succeeded then the final LROsClientDeleteProvisioning202DeletingFailed200Response will be returned.
 func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) FinalResponse(ctx context.Context) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
 	respType := LROsClientDeleteProvisioning202DeletingFailed200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientDeleteProvisioning202DeletingFailed200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1935,11 +1891,10 @@ func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Poll(ctx cont
 // If the final GET succeeded then the final LROsClientDeleteProvisioning202Deletingcanceled200Response will be returned.
 func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) FinalResponse(ctx context.Context) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
 	respType := LROsClientDeleteProvisioning202Deletingcanceled200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientDeleteProvisioning202Deletingcanceled200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1978,11 +1933,10 @@ func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final LROsClientPatch200SucceededIgnoreHeadersResponse will be returned.
 func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) FinalResponse(ctx context.Context) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
 	respType := LROsClientPatch200SucceededIgnoreHeadersResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPatch200SucceededIgnoreHeadersResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2021,11 +1975,10 @@ func (p *LROsClientPost200WithPayloadPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final LROsClientPost200WithPayloadResponse will be returned.
 func (p *LROsClientPost200WithPayloadPoller) FinalResponse(ctx context.Context) (LROsClientPost200WithPayloadResponse, error) {
 	respType := LROsClientPost200WithPayloadResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SKU)
+	_, err := p.pt.FinalResponse(ctx, &respType.SKU)
 	if err != nil {
 		return LROsClientPost200WithPayloadResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2064,11 +2017,10 @@ func (p *LROsClientPost202ListPoller) Poll(ctx context.Context) (*http.Response,
 // If the final GET succeeded then the final LROsClientPost202ListResponse will be returned.
 func (p *LROsClientPost202ListPoller) FinalResponse(ctx context.Context) (LROsClientPost202ListResponse, error) {
 	respType := LROsClientPost202ListResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ProductArray)
+	_, err := p.pt.FinalResponse(ctx, &respType.ProductArray)
 	if err != nil {
 		return LROsClientPost202ListResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2107,11 +2059,10 @@ func (p *LROsClientPost202NoRetry204Poller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final LROsClientPost202NoRetry204Response will be returned.
 func (p *LROsClientPost202NoRetry204Poller) FinalResponse(ctx context.Context) (LROsClientPost202NoRetry204Response, error) {
 	respType := LROsClientPost202NoRetry204Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPost202NoRetry204Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2150,11 +2101,10 @@ func (p *LROsClientPost202Retry200Poller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final LROsClientPost202Retry200Response will be returned.
 func (p *LROsClientPost202Retry200Poller) FinalResponse(ctx context.Context) (LROsClientPost202Retry200Response, error) {
 	respType := LROsClientPost202Retry200Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientPost202Retry200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2193,11 +2143,10 @@ func (p *LROsClientPostAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final LROsClientPostAsyncNoRetrySucceededResponse will be returned.
 func (p *LROsClientPostAsyncNoRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
 	respType := LROsClientPostAsyncNoRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPostAsyncNoRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2236,11 +2185,10 @@ func (p *LROsClientPostAsyncRetryFailedPoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final LROsClientPostAsyncRetryFailedResponse will be returned.
 func (p *LROsClientPostAsyncRetryFailedPoller) FinalResponse(ctx context.Context) (LROsClientPostAsyncRetryFailedResponse, error) {
 	respType := LROsClientPostAsyncRetryFailedResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientPostAsyncRetryFailedResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2279,11 +2227,10 @@ func (p *LROsClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final LROsClientPostAsyncRetrySucceededResponse will be returned.
 func (p *LROsClientPostAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientPostAsyncRetrySucceededResponse, error) {
 	respType := LROsClientPostAsyncRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPostAsyncRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2322,11 +2269,10 @@ func (p *LROsClientPostAsyncRetrycanceledPoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final LROsClientPostAsyncRetrycanceledResponse will be returned.
 func (p *LROsClientPostAsyncRetrycanceledPoller) FinalResponse(ctx context.Context) (LROsClientPostAsyncRetrycanceledResponse, error) {
 	respType := LROsClientPostAsyncRetrycanceledResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsClientPostAsyncRetrycanceledResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2365,11 +2311,10 @@ func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Poll(ctx c
 // If the final GET succeeded then the final LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse will be returned.
 func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) FinalResponse(ctx context.Context) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
 	respType := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2408,11 +2353,10 @@ func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Poll(ctx context.
 // If the final GET succeeded then the final LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse will be returned.
 func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) FinalResponse(ctx context.Context) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
 	respType := LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2451,11 +2395,10 @@ func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Poll(ctx context.Con
 // If the final GET succeeded then the final LROsClientPostDoubleHeadersFinalLocationGetResponse will be returned.
 func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) FinalResponse(ctx context.Context) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
 	respType := LROsClientPostDoubleHeadersFinalLocationGetResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPostDoubleHeadersFinalLocationGetResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2494,11 +2437,10 @@ func (p *LROsClientPut200Acceptedcanceled200Poller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final LROsClientPut200Acceptedcanceled200Response will be returned.
 func (p *LROsClientPut200Acceptedcanceled200Poller) FinalResponse(ctx context.Context) (LROsClientPut200Acceptedcanceled200Response, error) {
 	respType := LROsClientPut200Acceptedcanceled200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPut200Acceptedcanceled200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2537,11 +2479,10 @@ func (p *LROsClientPut200SucceededNoStatePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final LROsClientPut200SucceededNoStateResponse will be returned.
 func (p *LROsClientPut200SucceededNoStatePoller) FinalResponse(ctx context.Context) (LROsClientPut200SucceededNoStateResponse, error) {
 	respType := LROsClientPut200SucceededNoStateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPut200SucceededNoStateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2580,11 +2521,10 @@ func (p *LROsClientPut200SucceededPoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final LROsClientPut200SucceededResponse will be returned.
 func (p *LROsClientPut200SucceededPoller) FinalResponse(ctx context.Context) (LROsClientPut200SucceededResponse, error) {
 	respType := LROsClientPut200SucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPut200SucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2623,11 +2563,10 @@ func (p *LROsClientPut200UpdatingSucceeded204Poller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final LROsClientPut200UpdatingSucceeded204Response will be returned.
 func (p *LROsClientPut200UpdatingSucceeded204Poller) FinalResponse(ctx context.Context) (LROsClientPut200UpdatingSucceeded204Response, error) {
 	respType := LROsClientPut200UpdatingSucceeded204Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPut200UpdatingSucceeded204Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2666,11 +2605,10 @@ func (p *LROsClientPut201CreatingFailed200Poller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final LROsClientPut201CreatingFailed200Response will be returned.
 func (p *LROsClientPut201CreatingFailed200Poller) FinalResponse(ctx context.Context) (LROsClientPut201CreatingFailed200Response, error) {
 	respType := LROsClientPut201CreatingFailed200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPut201CreatingFailed200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2709,11 +2647,10 @@ func (p *LROsClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final LROsClientPut201CreatingSucceeded200Response will be returned.
 func (p *LROsClientPut201CreatingSucceeded200Poller) FinalResponse(ctx context.Context) (LROsClientPut201CreatingSucceeded200Response, error) {
 	respType := LROsClientPut201CreatingSucceeded200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPut201CreatingSucceeded200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2752,11 +2689,10 @@ func (p *LROsClientPut201SucceededPoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final LROsClientPut201SucceededResponse will be returned.
 func (p *LROsClientPut201SucceededPoller) FinalResponse(ctx context.Context) (LROsClientPut201SucceededResponse, error) {
 	respType := LROsClientPut201SucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPut201SucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2795,11 +2731,10 @@ func (p *LROsClientPut202Retry200Poller) Poll(ctx context.Context) (*http.Respon
 // If the final GET succeeded then the final LROsClientPut202Retry200Response will be returned.
 func (p *LROsClientPut202Retry200Poller) FinalResponse(ctx context.Context) (LROsClientPut202Retry200Response, error) {
 	respType := LROsClientPut202Retry200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPut202Retry200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2838,11 +2773,10 @@ func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final LROsClientPutAsyncNoHeaderInRetryResponse will be returned.
 func (p *LROsClientPutAsyncNoHeaderInRetryPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
 	respType := LROsClientPutAsyncNoHeaderInRetryResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPutAsyncNoHeaderInRetryResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2881,11 +2815,10 @@ func (p *LROsClientPutAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final LROsClientPutAsyncNoRetrySucceededResponse will be returned.
 func (p *LROsClientPutAsyncNoRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
 	respType := LROsClientPutAsyncNoRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPutAsyncNoRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2924,11 +2857,10 @@ func (p *LROsClientPutAsyncNoRetrycanceledPoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final LROsClientPutAsyncNoRetrycanceledResponse will be returned.
 func (p *LROsClientPutAsyncNoRetrycanceledPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
 	respType := LROsClientPutAsyncNoRetrycanceledResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPutAsyncNoRetrycanceledResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2967,11 +2899,10 @@ func (p *LROsClientPutAsyncNonResourcePoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final LROsClientPutAsyncNonResourceResponse will be returned.
 func (p *LROsClientPutAsyncNonResourcePoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncNonResourceResponse, error) {
 	respType := LROsClientPutAsyncNonResourceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SKU)
+	_, err := p.pt.FinalResponse(ctx, &respType.SKU)
 	if err != nil {
 		return LROsClientPutAsyncNonResourceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3010,11 +2941,10 @@ func (p *LROsClientPutAsyncRetryFailedPoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final LROsClientPutAsyncRetryFailedResponse will be returned.
 func (p *LROsClientPutAsyncRetryFailedPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncRetryFailedResponse, error) {
 	respType := LROsClientPutAsyncRetryFailedResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPutAsyncRetryFailedResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3053,11 +2983,10 @@ func (p *LROsClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final LROsClientPutAsyncRetrySucceededResponse will be returned.
 func (p *LROsClientPutAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncRetrySucceededResponse, error) {
 	respType := LROsClientPutAsyncRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPutAsyncRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3096,11 +3025,10 @@ func (p *LROsClientPutAsyncSubResourcePoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final LROsClientPutAsyncSubResourceResponse will be returned.
 func (p *LROsClientPutAsyncSubResourcePoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncSubResourceResponse, error) {
 	respType := LROsClientPutAsyncSubResourceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SubProduct)
+	_, err := p.pt.FinalResponse(ctx, &respType.SubProduct)
 	if err != nil {
 		return LROsClientPutAsyncSubResourceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3139,11 +3067,10 @@ func (p *LROsClientPutNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final LROsClientPutNoHeaderInRetryResponse will be returned.
 func (p *LROsClientPutNoHeaderInRetryPoller) FinalResponse(ctx context.Context) (LROsClientPutNoHeaderInRetryResponse, error) {
 	respType := LROsClientPutNoHeaderInRetryResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsClientPutNoHeaderInRetryResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3182,11 +3109,10 @@ func (p *LROsClientPutNonResourcePoller) Poll(ctx context.Context) (*http.Respon
 // If the final GET succeeded then the final LROsClientPutNonResourceResponse will be returned.
 func (p *LROsClientPutNonResourcePoller) FinalResponse(ctx context.Context) (LROsClientPutNonResourceResponse, error) {
 	respType := LROsClientPutNonResourceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SKU)
+	_, err := p.pt.FinalResponse(ctx, &respType.SKU)
 	if err != nil {
 		return LROsClientPutNonResourceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3225,11 +3151,10 @@ func (p *LROsClientPutSubResourcePoller) Poll(ctx context.Context) (*http.Respon
 // If the final GET succeeded then the final LROsClientPutSubResourceResponse will be returned.
 func (p *LROsClientPutSubResourcePoller) FinalResponse(ctx context.Context) (LROsClientPutSubResourceResponse, error) {
 	respType := LROsClientPutSubResourceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SubProduct)
+	_, err := p.pt.FinalResponse(ctx, &respType.SubProduct)
 	if err != nil {
 		return LROsClientPutSubResourceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3268,11 +3193,10 @@ func (p *LROsCustomHeaderClientPost202Retry200Poller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final LROsCustomHeaderClientPost202Retry200Response will be returned.
 func (p *LROsCustomHeaderClientPost202Retry200Poller) FinalResponse(ctx context.Context) (LROsCustomHeaderClientPost202Retry200Response, error) {
 	respType := LROsCustomHeaderClientPost202Retry200Response{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsCustomHeaderClientPost202Retry200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3311,11 +3235,10 @@ func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Poll(ctx context.C
 // If the final GET succeeded then the final LROsCustomHeaderClientPostAsyncRetrySucceededResponse will be returned.
 func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
 	respType := LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3354,11 +3277,10 @@ func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Poll(ctx contex
 // If the final GET succeeded then the final LROsCustomHeaderClientPut201CreatingSucceeded200Response will be returned.
 func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) FinalResponse(ctx context.Context) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
 	respType := LROsCustomHeaderClientPut201CreatingSucceeded200Response{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsCustomHeaderClientPut201CreatingSucceeded200Response{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3397,11 +3319,10 @@ func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Poll(ctx context.Co
 // If the final GET succeeded then the final LROsCustomHeaderClientPutAsyncRetrySucceededResponse will be returned.
 func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
 	respType := LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Product)
+	_, err := p.pt.FinalResponse(ctx, &respType.Product)
 	if err != nil {
 		return LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 

--- a/test/autorest/lrogroup/zz_generated_response_types.go
+++ b/test/autorest/lrogroup/zz_generated_response_types.go
@@ -11,7 +11,6 @@ package lrogroup
 import (
 	"context"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"net/http"
 	"time"
 )
 
@@ -19,20 +18,16 @@ import (
 type LRORetrysClientDelete202Retry200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LRORetrysClientDelete202Retry200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LRORetrysClientDelete202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDelete202Retry200Response, error) {
 	respType := LRORetrysClientDelete202Retry200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -45,39 +40,33 @@ func (l *LRORetrysClientDelete202Retry200PollerResponse) Resume(ctx context.Cont
 	poller := &LRORetrysClientDelete202Retry200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LRORetrysClientDelete202Retry200Response contains the response from method LRORetrysClient.Delete202Retry200.
 type LRORetrysClientDelete202Retry200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse contains the response from method LRORetrysClient.DeleteAsyncRelativeRetrySucceeded.
 type LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
 	respType := LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -91,39 +80,33 @@ func (l *LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse) Resume(
 	poller := &LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse contains the response from method LRORetrysClient.DeleteAsyncRelativeRetrySucceeded.
 type LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse contains the response from method LRORetrysClient.DeleteProvisioning202Accepted200Succeeded.
 type LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
 	respType := LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -137,40 +120,33 @@ func (l *LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse)
 	poller := &LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse contains the response from method LRORetrysClient.DeleteProvisioning202Accepted200Succeeded.
 type LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LRORetrysClientPost202Retry200PollerResponse contains the response from method LRORetrysClient.Post202Retry200.
 type LRORetrysClientPost202Retry200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LRORetrysClientPost202Retry200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LRORetrysClientPost202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPost202Retry200Response, error) {
 	respType := LRORetrysClientPost202Retry200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -183,39 +159,33 @@ func (l *LRORetrysClientPost202Retry200PollerResponse) Resume(ctx context.Contex
 	poller := &LRORetrysClientPost202Retry200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LRORetrysClientPost202Retry200Response contains the response from method LRORetrysClient.Post202Retry200.
 type LRORetrysClientPost202Retry200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse contains the response from method LRORetrysClient.PostAsyncRelativeRetrySucceeded.
 type LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LRORetrysClientPostAsyncRelativeRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
 	respType := LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -228,39 +198,33 @@ func (l *LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse) Resume(ct
 	poller := &LRORetrysClientPostAsyncRelativeRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LRORetrysClientPostAsyncRelativeRetrySucceededResponse contains the response from method LRORetrysClient.PostAsyncRelativeRetrySucceeded.
 type LRORetrysClientPostAsyncRelativeRetrySucceededResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LRORetrysClientPut201CreatingSucceeded200PollerResponse contains the response from method LRORetrysClient.Put201CreatingSucceeded200.
 type LRORetrysClientPut201CreatingSucceeded200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LRORetrysClientPut201CreatingSucceeded200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LRORetrysClientPut201CreatingSucceeded200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
 	respType := LRORetrysClientPut201CreatingSucceeded200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -273,40 +237,33 @@ func (l *LRORetrysClientPut201CreatingSucceeded200PollerResponse) Resume(ctx con
 	poller := &LRORetrysClientPut201CreatingSucceeded200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LRORetrysClientPut201CreatingSucceeded200Response contains the response from method LRORetrysClient.Put201CreatingSucceeded200.
 type LRORetrysClientPut201CreatingSucceeded200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse contains the response from method LRORetrysClient.PutAsyncRelativeRetrySucceeded.
 type LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LRORetrysClientPutAsyncRelativeRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
 	respType := LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -319,40 +276,33 @@ func (l *LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse) Resume(ctx
 	poller := &LRORetrysClientPutAsyncRelativeRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LRORetrysClientPutAsyncRelativeRetrySucceededResponse contains the response from method LRORetrysClient.PutAsyncRelativeRetrySucceeded.
 type LRORetrysClientPutAsyncRelativeRetrySucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientDelete202NonRetry400PollerResponse contains the response from method LROSADsClient.Delete202NonRetry400.
 type LROSADsClientDelete202NonRetry400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientDelete202NonRetry400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientDelete202NonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete202NonRetry400Response, error) {
 	respType := LROSADsClientDelete202NonRetry400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -365,39 +315,33 @@ func (l *LROSADsClientDelete202NonRetry400PollerResponse) Resume(ctx context.Con
 	poller := &LROSADsClientDelete202NonRetry400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientDelete202NonRetry400Response contains the response from method LROSADsClient.Delete202NonRetry400.
 type LROSADsClientDelete202NonRetry400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientDelete202RetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.Delete202RetryInvalidHeader.
 type LROSADsClientDelete202RetryInvalidHeaderPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientDelete202RetryInvalidHeaderPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientDelete202RetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientDelete202RetryInvalidHeaderResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -410,39 +354,33 @@ func (l *LROSADsClientDelete202RetryInvalidHeaderPollerResponse) Resume(ctx cont
 	poller := &LROSADsClientDelete202RetryInvalidHeaderPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientDelete202RetryInvalidHeaderResponse contains the response from method LROSADsClient.Delete202RetryInvalidHeader.
 type LROSADsClientDelete202RetryInvalidHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientDelete204SucceededPollerResponse contains the response from method LROSADsClient.Delete204Succeeded.
 type LROSADsClientDelete204SucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientDelete204SucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientDelete204SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete204SucceededResponse, error) {
 	respType := LROSADsClientDelete204SucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -455,39 +393,33 @@ func (l *LROSADsClientDelete204SucceededPollerResponse) Resume(ctx context.Conte
 	poller := &LROSADsClientDelete204SucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientDelete204SucceededResponse contains the response from method LROSADsClient.Delete204Succeeded.
 type LROSADsClientDelete204SucceededResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientDeleteAsyncRelativeRetry400PollerResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetry400.
 type LROSADsClientDeleteAsyncRelativeRetry400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientDeleteAsyncRelativeRetry400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientDeleteAsyncRelativeRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
 	respType := LROSADsClientDeleteAsyncRelativeRetry400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -500,39 +432,33 @@ func (l *LROSADsClientDeleteAsyncRelativeRetry400PollerResponse) Resume(ctx cont
 	poller := &LROSADsClientDeleteAsyncRelativeRetry400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientDeleteAsyncRelativeRetry400Response contains the response from method LROSADsClient.DeleteAsyncRelativeRetry400.
 type LROSADsClientDeleteAsyncRelativeRetry400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader.
 type LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -546,39 +472,33 @@ func (l *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse) Resum
 	poller := &LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader.
 type LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
 	respType := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -592,39 +512,33 @@ func (l *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse) 
 	poller := &LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryNoStatus.
 type LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
 	respType := LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -637,39 +551,33 @@ func (l *LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse) Resume(ctx
 	poller := &LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryNoStatus.
 type LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientDeleteNonRetry400PollerResponse contains the response from method LROSADsClient.DeleteNonRetry400.
 type LROSADsClientDeleteNonRetry400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientDeleteNonRetry400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientDeleteNonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteNonRetry400Response, error) {
 	respType := LROSADsClientDeleteNonRetry400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -682,39 +590,33 @@ func (l *LROSADsClientDeleteNonRetry400PollerResponse) Resume(ctx context.Contex
 	poller := &LROSADsClientDeleteNonRetry400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientDeleteNonRetry400Response contains the response from method LROSADsClient.DeleteNonRetry400.
 type LROSADsClientDeleteNonRetry400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPost202NoLocationPollerResponse contains the response from method LROSADsClient.Post202NoLocation.
 type LROSADsClientPost202NoLocationPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPost202NoLocationPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPost202NoLocationPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202NoLocationResponse, error) {
 	respType := LROSADsClientPost202NoLocationResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -727,39 +629,33 @@ func (l *LROSADsClientPost202NoLocationPollerResponse) Resume(ctx context.Contex
 	poller := &LROSADsClientPost202NoLocationPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPost202NoLocationResponse contains the response from method LROSADsClient.Post202NoLocation.
 type LROSADsClientPost202NoLocationResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPost202NonRetry400PollerResponse contains the response from method LROSADsClient.Post202NonRetry400.
 type LROSADsClientPost202NonRetry400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPost202NonRetry400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPost202NonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202NonRetry400Response, error) {
 	respType := LROSADsClientPost202NonRetry400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -772,39 +668,33 @@ func (l *LROSADsClientPost202NonRetry400PollerResponse) Resume(ctx context.Conte
 	poller := &LROSADsClientPost202NonRetry400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPost202NonRetry400Response contains the response from method LROSADsClient.Post202NonRetry400.
 type LROSADsClientPost202NonRetry400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPost202RetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.Post202RetryInvalidHeader.
 type LROSADsClientPost202RetryInvalidHeaderPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPost202RetryInvalidHeaderPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPost202RetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientPost202RetryInvalidHeaderResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -817,39 +707,33 @@ func (l *LROSADsClientPost202RetryInvalidHeaderPollerResponse) Resume(ctx contex
 	poller := &LROSADsClientPost202RetryInvalidHeaderPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPost202RetryInvalidHeaderResponse contains the response from method LROSADsClient.Post202RetryInvalidHeader.
 type LROSADsClientPost202RetryInvalidHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPostAsyncRelativeRetry400PollerResponse contains the response from method LROSADsClient.PostAsyncRelativeRetry400.
 type LROSADsClientPostAsyncRelativeRetry400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPostAsyncRelativeRetry400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPostAsyncRelativeRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
 	respType := LROSADsClientPostAsyncRelativeRetry400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -862,39 +746,33 @@ func (l *LROSADsClientPostAsyncRelativeRetry400PollerResponse) Resume(ctx contex
 	poller := &LROSADsClientPostAsyncRelativeRetry400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPostAsyncRelativeRetry400Response contains the response from method LROSADsClient.PostAsyncRelativeRetry400.
 type LROSADsClientPostAsyncRelativeRetry400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryInvalidHeader.
 type LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -908,39 +786,33 @@ func (l *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse) Resume(
 	poller := &LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryInvalidHeader.
 type LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
 	respType := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -954,39 +826,33 @@ func (l *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse) Re
 	poller := &LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryNoPayload.
 type LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
 	respType := LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -999,39 +865,33 @@ func (l *LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse) Resume(ctx 
 	poller := &LROSADsClientPostAsyncRelativeRetryNoPayloadPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPostAsyncRelativeRetryNoPayloadResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryNoPayload.
 type LROSADsClientPostAsyncRelativeRetryNoPayloadResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPostNonRetry400PollerResponse contains the response from method LROSADsClient.PostNonRetry400.
 type LROSADsClientPostNonRetry400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPostNonRetry400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPostNonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostNonRetry400Response, error) {
 	respType := LROSADsClientPostNonRetry400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1044,39 +904,33 @@ func (l *LROSADsClientPostNonRetry400PollerResponse) Resume(ctx context.Context,
 	poller := &LROSADsClientPostNonRetry400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPostNonRetry400Response contains the response from method LROSADsClient.PostNonRetry400.
 type LROSADsClientPostNonRetry400Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROSADsClientPut200InvalidJSONPollerResponse contains the response from method LROSADsClient.Put200InvalidJSON.
 type LROSADsClientPut200InvalidJSONPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPut200InvalidJSONPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPut200InvalidJSONPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPut200InvalidJSONResponse, error) {
 	respType := LROSADsClientPut200InvalidJSONResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1089,40 +943,33 @@ func (l *LROSADsClientPut200InvalidJSONPollerResponse) Resume(ctx context.Contex
 	poller := &LROSADsClientPut200InvalidJSONPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPut200InvalidJSONResponse contains the response from method LROSADsClient.Put200InvalidJSON.
 type LROSADsClientPut200InvalidJSONResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutAsyncRelativeRetry400PollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetry400.
 type LROSADsClientPutAsyncRelativeRetry400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutAsyncRelativeRetry400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutAsyncRelativeRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
 	respType := LROSADsClientPutAsyncRelativeRetry400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1135,40 +982,33 @@ func (l *LROSADsClientPutAsyncRelativeRetry400PollerResponse) Resume(ctx context
 	poller := &LROSADsClientPutAsyncRelativeRetry400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutAsyncRelativeRetry400Response contains the response from method LROSADsClient.PutAsyncRelativeRetry400.
 type LROSADsClientPutAsyncRelativeRetry400Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidHeader.
 type LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
 	respType := LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1181,40 +1021,33 @@ func (l *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse) Resume(c
 	poller := &LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidHeader.
 type LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
 	respType := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1228,40 +1061,33 @@ func (l *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse) Res
 	poller := &LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatusPayload.
 type LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
 	respType := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1275,40 +1101,33 @@ func (l *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse) Resume
 	poller := &LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatusPayload.
 type LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatus.
 type LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutAsyncRelativeRetryNoStatusPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
 	respType := LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1321,40 +1140,33 @@ func (l *LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse) Resume(ctx co
 	poller := &LROSADsClientPutAsyncRelativeRetryNoStatusPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatus.
 type LROSADsClientPutAsyncRelativeRetryNoStatusResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse contains the response from method LROSADsClient.PutError201NoProvisioningStatePayload.
 type LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutError201NoProvisioningStatePayloadPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
 	respType := LROSADsClientPutError201NoProvisioningStatePayloadResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1368,40 +1180,33 @@ func (l *LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse) Resum
 	poller := &LROSADsClientPutError201NoProvisioningStatePayloadPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutError201NoProvisioningStatePayloadResponse contains the response from method LROSADsClient.PutError201NoProvisioningStatePayload.
 type LROSADsClientPutError201NoProvisioningStatePayloadResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse contains the response from method LROSADsClient.PutNonRetry201Creating400InvalidJSON.
 type LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
 	respType := LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1415,40 +1220,33 @@ func (l *LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse) Resume
 	poller := &LROSADsClientPutNonRetry201Creating400InvalidJSONPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutNonRetry201Creating400InvalidJSONResponse contains the response from method LROSADsClient.PutNonRetry201Creating400InvalidJSON.
 type LROSADsClientPutNonRetry201Creating400InvalidJSONResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutNonRetry201Creating400PollerResponse contains the response from method LROSADsClient.PutNonRetry201Creating400.
 type LROSADsClientPutNonRetry201Creating400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutNonRetry201Creating400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutNonRetry201Creating400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry201Creating400Response, error) {
 	respType := LROSADsClientPutNonRetry201Creating400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1461,40 +1259,33 @@ func (l *LROSADsClientPutNonRetry201Creating400PollerResponse) Resume(ctx contex
 	poller := &LROSADsClientPutNonRetry201Creating400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutNonRetry201Creating400Response contains the response from method LROSADsClient.PutNonRetry201Creating400.
 type LROSADsClientPutNonRetry201Creating400Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROSADsClientPutNonRetry400PollerResponse contains the response from method LROSADsClient.PutNonRetry400.
 type LROSADsClientPutNonRetry400PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROSADsClientPutNonRetry400Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROSADsClientPutNonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry400Response, error) {
 	respType := LROSADsClientPutNonRetry400Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1507,40 +1298,33 @@ func (l *LROSADsClientPutNonRetry400PollerResponse) Resume(ctx context.Context, 
 	poller := &LROSADsClientPutNonRetry400Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROSADsClientPutNonRetry400Response contains the response from method LROSADsClient.PutNonRetry400.
 type LROSADsClientPutNonRetry400Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientDelete202NoRetry204PollerResponse contains the response from method LROsClient.Delete202NoRetry204.
 type LROsClientDelete202NoRetry204PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDelete202NoRetry204Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDelete202NoRetry204PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete202NoRetry204Response, error) {
 	respType := LROsClientDelete202NoRetry204Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1553,40 +1337,33 @@ func (l *LROsClientDelete202NoRetry204PollerResponse) Resume(ctx context.Context
 	poller := &LROsClientDelete202NoRetry204Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDelete202NoRetry204Response contains the response from method LROsClient.Delete202NoRetry204.
 type LROsClientDelete202NoRetry204Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientDelete202Retry200PollerResponse contains the response from method LROsClient.Delete202Retry200.
 type LROsClientDelete202Retry200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDelete202Retry200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDelete202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete202Retry200Response, error) {
 	respType := LROsClientDelete202Retry200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1599,40 +1376,33 @@ func (l *LROsClientDelete202Retry200PollerResponse) Resume(ctx context.Context, 
 	poller := &LROsClientDelete202Retry200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDelete202Retry200Response contains the response from method LROsClient.Delete202Retry200.
 type LROsClientDelete202Retry200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientDelete204SucceededPollerResponse contains the response from method LROsClient.Delete204Succeeded.
 type LROsClientDelete204SucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDelete204SucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDelete204SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete204SucceededResponse, error) {
 	respType := LROsClientDelete204SucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1645,39 +1415,33 @@ func (l *LROsClientDelete204SucceededPollerResponse) Resume(ctx context.Context,
 	poller := &LROsClientDelete204SucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDelete204SucceededResponse contains the response from method LROsClient.Delete204Succeeded.
 type LROsClientDelete204SucceededResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientDeleteAsyncNoHeaderInRetryPollerResponse contains the response from method LROsClient.DeleteAsyncNoHeaderInRetry.
 type LROsClientDeleteAsyncNoHeaderInRetryPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteAsyncNoHeaderInRetryPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteAsyncNoHeaderInRetryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
 	respType := LROsClientDeleteAsyncNoHeaderInRetryResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1690,39 +1454,33 @@ func (l *LROsClientDeleteAsyncNoHeaderInRetryPollerResponse) Resume(ctx context.
 	poller := &LROsClientDeleteAsyncNoHeaderInRetryPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteAsyncNoHeaderInRetryResponse contains the response from method LROsClient.DeleteAsyncNoHeaderInRetry.
 type LROsClientDeleteAsyncNoHeaderInRetryResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientDeleteAsyncNoRetrySucceededPollerResponse contains the response from method LROsClient.DeleteAsyncNoRetrySucceeded.
 type LROsClientDeleteAsyncNoRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteAsyncNoRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteAsyncNoRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
 	respType := LROsClientDeleteAsyncNoRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1735,39 +1493,33 @@ func (l *LROsClientDeleteAsyncNoRetrySucceededPollerResponse) Resume(ctx context
 	poller := &LROsClientDeleteAsyncNoRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteAsyncNoRetrySucceededResponse contains the response from method LROsClient.DeleteAsyncNoRetrySucceeded.
 type LROsClientDeleteAsyncNoRetrySucceededResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientDeleteAsyncRetryFailedPollerResponse contains the response from method LROsClient.DeleteAsyncRetryFailed.
 type LROsClientDeleteAsyncRetryFailedPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteAsyncRetryFailedPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteAsyncRetryFailedPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetryFailedResponse, error) {
 	respType := LROsClientDeleteAsyncRetryFailedResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1780,39 +1532,33 @@ func (l *LROsClientDeleteAsyncRetryFailedPollerResponse) Resume(ctx context.Cont
 	poller := &LROsClientDeleteAsyncRetryFailedPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteAsyncRetryFailedResponse contains the response from method LROsClient.DeleteAsyncRetryFailed.
 type LROsClientDeleteAsyncRetryFailedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientDeleteAsyncRetrySucceededPollerResponse contains the response from method LROsClient.DeleteAsyncRetrySucceeded.
 type LROsClientDeleteAsyncRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteAsyncRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
 	respType := LROsClientDeleteAsyncRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1825,39 +1571,33 @@ func (l *LROsClientDeleteAsyncRetrySucceededPollerResponse) Resume(ctx context.C
 	poller := &LROsClientDeleteAsyncRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteAsyncRetrySucceededResponse contains the response from method LROsClient.DeleteAsyncRetrySucceeded.
 type LROsClientDeleteAsyncRetrySucceededResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientDeleteAsyncRetrycanceledPollerResponse contains the response from method LROsClient.DeleteAsyncRetrycanceled.
 type LROsClientDeleteAsyncRetrycanceledPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteAsyncRetrycanceledPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteAsyncRetrycanceledPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
 	respType := LROsClientDeleteAsyncRetrycanceledResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1870,39 +1610,33 @@ func (l *LROsClientDeleteAsyncRetrycanceledPollerResponse) Resume(ctx context.Co
 	poller := &LROsClientDeleteAsyncRetrycanceledPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteAsyncRetrycanceledResponse contains the response from method LROsClient.DeleteAsyncRetrycanceled.
 type LROsClientDeleteAsyncRetrycanceledResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientDeleteNoHeaderInRetryPollerResponse contains the response from method LROsClient.DeleteNoHeaderInRetry.
 type LROsClientDeleteNoHeaderInRetryPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteNoHeaderInRetryPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteNoHeaderInRetryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteNoHeaderInRetryResponse, error) {
 	respType := LROsClientDeleteNoHeaderInRetryResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1915,39 +1649,33 @@ func (l *LROsClientDeleteNoHeaderInRetryPollerResponse) Resume(ctx context.Conte
 	poller := &LROsClientDeleteNoHeaderInRetryPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteNoHeaderInRetryResponse contains the response from method LROsClient.DeleteNoHeaderInRetry.
 type LROsClientDeleteNoHeaderInRetryResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse contains the response from method LROsClient.DeleteProvisioning202Accepted200Succeeded.
 type LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteProvisioning202Accepted200SucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
 	respType := LROsClientDeleteProvisioning202Accepted200SucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1961,40 +1689,33 @@ func (l *LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse) Resu
 	poller := &LROsClientDeleteProvisioning202Accepted200SucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteProvisioning202Accepted200SucceededResponse contains the response from method LROsClient.DeleteProvisioning202Accepted200Succeeded.
 type LROsClientDeleteProvisioning202Accepted200SucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientDeleteProvisioning202DeletingFailed200PollerResponse contains the response from method LROsClient.DeleteProvisioning202DeletingFailed200.
 type LROsClientDeleteProvisioning202DeletingFailed200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteProvisioning202DeletingFailed200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteProvisioning202DeletingFailed200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
 	respType := LROsClientDeleteProvisioning202DeletingFailed200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2008,40 +1729,33 @@ func (l *LROsClientDeleteProvisioning202DeletingFailed200PollerResponse) Resume(
 	poller := &LROsClientDeleteProvisioning202DeletingFailed200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteProvisioning202DeletingFailed200Response contains the response from method LROsClient.DeleteProvisioning202DeletingFailed200.
 type LROsClientDeleteProvisioning202DeletingFailed200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse contains the response from method LROsClient.DeleteProvisioning202Deletingcanceled200.
 type LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientDeleteProvisioning202Deletingcanceled200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
 	respType := LROsClientDeleteProvisioning202Deletingcanceled200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2055,40 +1769,33 @@ func (l *LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse) Resum
 	poller := &LROsClientDeleteProvisioning202Deletingcanceled200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientDeleteProvisioning202Deletingcanceled200Response contains the response from method LROsClient.DeleteProvisioning202Deletingcanceled200.
 type LROsClientDeleteProvisioning202Deletingcanceled200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPatch200SucceededIgnoreHeadersPollerResponse contains the response from method LROsClient.Patch200SucceededIgnoreHeaders.
 type LROsClientPatch200SucceededIgnoreHeadersPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPatch200SucceededIgnoreHeadersPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPatch200SucceededIgnoreHeadersPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
 	respType := LROsClientPatch200SucceededIgnoreHeadersResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2101,40 +1808,33 @@ func (l *LROsClientPatch200SucceededIgnoreHeadersPollerResponse) Resume(ctx cont
 	poller := &LROsClientPatch200SucceededIgnoreHeadersPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPatch200SucceededIgnoreHeadersResponse contains the response from method LROsClient.Patch200SucceededIgnoreHeaders.
 type LROsClientPatch200SucceededIgnoreHeadersResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPost200WithPayloadPollerResponse contains the response from method LROsClient.Post200WithPayload.
 type LROsClientPost200WithPayloadPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPost200WithPayloadPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPost200WithPayloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost200WithPayloadResponse, error) {
 	respType := LROsClientPost200WithPayloadResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2147,40 +1847,33 @@ func (l *LROsClientPost200WithPayloadPollerResponse) Resume(ctx context.Context,
 	poller := &LROsClientPost200WithPayloadPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPost200WithPayloadResponse contains the response from method LROsClient.Post200WithPayload.
 type LROsClientPost200WithPayloadResponse struct {
 	SKU
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPost202ListPollerResponse contains the response from method LROsClient.Post202List.
 type LROsClientPost202ListPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPost202ListPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPost202ListPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202ListResponse, error) {
 	respType := LROsClientPost202ListResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ProductArray)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ProductArray)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2193,12 +1886,11 @@ func (l *LROsClientPost202ListPollerResponse) Resume(ctx context.Context, client
 	poller := &LROsClientPost202ListPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
@@ -2206,29 +1898,22 @@ func (l *LROsClientPost202ListPollerResponse) Resume(ctx context.Context, client
 type LROsClientPost202ListResponse struct {
 	// Array of Product
 	ProductArray []*Product
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPost202NoRetry204PollerResponse contains the response from method LROsClient.Post202NoRetry204.
 type LROsClientPost202NoRetry204PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPost202NoRetry204Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPost202NoRetry204PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202NoRetry204Response, error) {
 	respType := LROsClientPost202NoRetry204Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2241,40 +1926,33 @@ func (l *LROsClientPost202NoRetry204PollerResponse) Resume(ctx context.Context, 
 	poller := &LROsClientPost202NoRetry204Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPost202NoRetry204Response contains the response from method LROsClient.Post202NoRetry204.
 type LROsClientPost202NoRetry204Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPost202Retry200PollerResponse contains the response from method LROsClient.Post202Retry200.
 type LROsClientPost202Retry200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPost202Retry200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPost202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202Retry200Response, error) {
 	respType := LROsClientPost202Retry200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2287,39 +1965,33 @@ func (l *LROsClientPost202Retry200PollerResponse) Resume(ctx context.Context, cl
 	poller := &LROsClientPost202Retry200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPost202Retry200Response contains the response from method LROsClient.Post202Retry200.
 type LROsClientPost202Retry200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientPostAsyncNoRetrySucceededPollerResponse contains the response from method LROsClient.PostAsyncNoRetrySucceeded.
 type LROsClientPostAsyncNoRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPostAsyncNoRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPostAsyncNoRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
 	respType := LROsClientPostAsyncNoRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2332,40 +2004,33 @@ func (l *LROsClientPostAsyncNoRetrySucceededPollerResponse) Resume(ctx context.C
 	poller := &LROsClientPostAsyncNoRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPostAsyncNoRetrySucceededResponse contains the response from method LROsClient.PostAsyncNoRetrySucceeded.
 type LROsClientPostAsyncNoRetrySucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPostAsyncRetryFailedPollerResponse contains the response from method LROsClient.PostAsyncRetryFailed.
 type LROsClientPostAsyncRetryFailedPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPostAsyncRetryFailedPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPostAsyncRetryFailedPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetryFailedResponse, error) {
 	respType := LROsClientPostAsyncRetryFailedResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2378,39 +2043,33 @@ func (l *LROsClientPostAsyncRetryFailedPollerResponse) Resume(ctx context.Contex
 	poller := &LROsClientPostAsyncRetryFailedPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPostAsyncRetryFailedResponse contains the response from method LROsClient.PostAsyncRetryFailed.
 type LROsClientPostAsyncRetryFailedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientPostAsyncRetrySucceededPollerResponse contains the response from method LROsClient.PostAsyncRetrySucceeded.
 type LROsClientPostAsyncRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPostAsyncRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPostAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetrySucceededResponse, error) {
 	respType := LROsClientPostAsyncRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2423,40 +2082,33 @@ func (l *LROsClientPostAsyncRetrySucceededPollerResponse) Resume(ctx context.Con
 	poller := &LROsClientPostAsyncRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPostAsyncRetrySucceededResponse contains the response from method LROsClient.PostAsyncRetrySucceeded.
 type LROsClientPostAsyncRetrySucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPostAsyncRetrycanceledPollerResponse contains the response from method LROsClient.PostAsyncRetrycanceled.
 type LROsClientPostAsyncRetrycanceledPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPostAsyncRetrycanceledPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPostAsyncRetrycanceledPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetrycanceledResponse, error) {
 	respType := LROsClientPostAsyncRetrycanceledResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2469,39 +2121,33 @@ func (l *LROsClientPostAsyncRetrycanceledPollerResponse) Resume(ctx context.Cont
 	poller := &LROsClientPostAsyncRetrycanceledPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPostAsyncRetrycanceledResponse contains the response from method LROsClient.PostAsyncRetrycanceled.
 type LROsClientPostAsyncRetrycanceledResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault.
 type LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
 	respType := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2515,40 +2161,33 @@ func (l *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse) Re
 	poller := &LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault.
 type LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGet.
 type LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
 	respType := LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2561,40 +2200,33 @@ func (l *LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse) Resume(ct
 	poller := &LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGet.
 type LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPostDoubleHeadersFinalLocationGetPollerResponse contains the response from method LROsClient.PostDoubleHeadersFinalLocationGet.
 type LROsClientPostDoubleHeadersFinalLocationGetPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPostDoubleHeadersFinalLocationGetPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPostDoubleHeadersFinalLocationGetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
 	respType := LROsClientPostDoubleHeadersFinalLocationGetResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2607,40 +2239,33 @@ func (l *LROsClientPostDoubleHeadersFinalLocationGetPollerResponse) Resume(ctx c
 	poller := &LROsClientPostDoubleHeadersFinalLocationGetPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPostDoubleHeadersFinalLocationGetResponse contains the response from method LROsClient.PostDoubleHeadersFinalLocationGet.
 type LROsClientPostDoubleHeadersFinalLocationGetResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPut200Acceptedcanceled200PollerResponse contains the response from method LROsClient.Put200Acceptedcanceled200.
 type LROsClientPut200Acceptedcanceled200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPut200Acceptedcanceled200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPut200Acceptedcanceled200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200Acceptedcanceled200Response, error) {
 	respType := LROsClientPut200Acceptedcanceled200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2653,40 +2278,33 @@ func (l *LROsClientPut200Acceptedcanceled200PollerResponse) Resume(ctx context.C
 	poller := &LROsClientPut200Acceptedcanceled200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPut200Acceptedcanceled200Response contains the response from method LROsClient.Put200Acceptedcanceled200.
 type LROsClientPut200Acceptedcanceled200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPut200SucceededNoStatePollerResponse contains the response from method LROsClient.Put200SucceededNoState.
 type LROsClientPut200SucceededNoStatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPut200SucceededNoStatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPut200SucceededNoStatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200SucceededNoStateResponse, error) {
 	respType := LROsClientPut200SucceededNoStateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2699,40 +2317,33 @@ func (l *LROsClientPut200SucceededNoStatePollerResponse) Resume(ctx context.Cont
 	poller := &LROsClientPut200SucceededNoStatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPut200SucceededNoStateResponse contains the response from method LROsClient.Put200SucceededNoState.
 type LROsClientPut200SucceededNoStateResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPut200SucceededPollerResponse contains the response from method LROsClient.Put200Succeeded.
 type LROsClientPut200SucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPut200SucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPut200SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200SucceededResponse, error) {
 	respType := LROsClientPut200SucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2745,40 +2356,33 @@ func (l *LROsClientPut200SucceededPollerResponse) Resume(ctx context.Context, cl
 	poller := &LROsClientPut200SucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPut200SucceededResponse contains the response from method LROsClient.Put200Succeeded.
 type LROsClientPut200SucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPut200UpdatingSucceeded204PollerResponse contains the response from method LROsClient.Put200UpdatingSucceeded204.
 type LROsClientPut200UpdatingSucceeded204PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPut200UpdatingSucceeded204Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPut200UpdatingSucceeded204PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200UpdatingSucceeded204Response, error) {
 	respType := LROsClientPut200UpdatingSucceeded204Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2791,40 +2395,33 @@ func (l *LROsClientPut200UpdatingSucceeded204PollerResponse) Resume(ctx context.
 	poller := &LROsClientPut200UpdatingSucceeded204Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPut200UpdatingSucceeded204Response contains the response from method LROsClient.Put200UpdatingSucceeded204.
 type LROsClientPut200UpdatingSucceeded204Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPut201CreatingFailed200PollerResponse contains the response from method LROsClient.Put201CreatingFailed200.
 type LROsClientPut201CreatingFailed200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPut201CreatingFailed200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPut201CreatingFailed200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201CreatingFailed200Response, error) {
 	respType := LROsClientPut201CreatingFailed200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2837,40 +2434,33 @@ func (l *LROsClientPut201CreatingFailed200PollerResponse) Resume(ctx context.Con
 	poller := &LROsClientPut201CreatingFailed200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPut201CreatingFailed200Response contains the response from method LROsClient.Put201CreatingFailed200.
 type LROsClientPut201CreatingFailed200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPut201CreatingSucceeded200PollerResponse contains the response from method LROsClient.Put201CreatingSucceeded200.
 type LROsClientPut201CreatingSucceeded200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPut201CreatingSucceeded200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPut201CreatingSucceeded200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201CreatingSucceeded200Response, error) {
 	respType := LROsClientPut201CreatingSucceeded200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2883,40 +2473,33 @@ func (l *LROsClientPut201CreatingSucceeded200PollerResponse) Resume(ctx context.
 	poller := &LROsClientPut201CreatingSucceeded200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPut201CreatingSucceeded200Response contains the response from method LROsClient.Put201CreatingSucceeded200.
 type LROsClientPut201CreatingSucceeded200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPut201SucceededPollerResponse contains the response from method LROsClient.Put201Succeeded.
 type LROsClientPut201SucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPut201SucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPut201SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201SucceededResponse, error) {
 	respType := LROsClientPut201SucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2929,40 +2512,33 @@ func (l *LROsClientPut201SucceededPollerResponse) Resume(ctx context.Context, cl
 	poller := &LROsClientPut201SucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPut201SucceededResponse contains the response from method LROsClient.Put201Succeeded.
 type LROsClientPut201SucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPut202Retry200PollerResponse contains the response from method LROsClient.Put202Retry200.
 type LROsClientPut202Retry200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPut202Retry200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPut202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut202Retry200Response, error) {
 	respType := LROsClientPut202Retry200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2975,40 +2551,33 @@ func (l *LROsClientPut202Retry200PollerResponse) Resume(ctx context.Context, cli
 	poller := &LROsClientPut202Retry200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPut202Retry200Response contains the response from method LROsClient.Put202Retry200.
 type LROsClientPut202Retry200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutAsyncNoHeaderInRetryPollerResponse contains the response from method LROsClient.PutAsyncNoHeaderInRetry.
 type LROsClientPutAsyncNoHeaderInRetryPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutAsyncNoHeaderInRetryPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutAsyncNoHeaderInRetryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
 	respType := LROsClientPutAsyncNoHeaderInRetryResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3021,40 +2590,33 @@ func (l *LROsClientPutAsyncNoHeaderInRetryPollerResponse) Resume(ctx context.Con
 	poller := &LROsClientPutAsyncNoHeaderInRetryPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutAsyncNoHeaderInRetryResponse contains the response from method LROsClient.PutAsyncNoHeaderInRetry.
 type LROsClientPutAsyncNoHeaderInRetryResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutAsyncNoRetrySucceededPollerResponse contains the response from method LROsClient.PutAsyncNoRetrySucceeded.
 type LROsClientPutAsyncNoRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutAsyncNoRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutAsyncNoRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
 	respType := LROsClientPutAsyncNoRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3067,40 +2629,33 @@ func (l *LROsClientPutAsyncNoRetrySucceededPollerResponse) Resume(ctx context.Co
 	poller := &LROsClientPutAsyncNoRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutAsyncNoRetrySucceededResponse contains the response from method LROsClient.PutAsyncNoRetrySucceeded.
 type LROsClientPutAsyncNoRetrySucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutAsyncNoRetrycanceledPollerResponse contains the response from method LROsClient.PutAsyncNoRetrycanceled.
 type LROsClientPutAsyncNoRetrycanceledPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutAsyncNoRetrycanceledPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutAsyncNoRetrycanceledPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
 	respType := LROsClientPutAsyncNoRetrycanceledResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3113,40 +2668,33 @@ func (l *LROsClientPutAsyncNoRetrycanceledPollerResponse) Resume(ctx context.Con
 	poller := &LROsClientPutAsyncNoRetrycanceledPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutAsyncNoRetrycanceledResponse contains the response from method LROsClient.PutAsyncNoRetrycanceled.
 type LROsClientPutAsyncNoRetrycanceledResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutAsyncNonResourcePollerResponse contains the response from method LROsClient.PutAsyncNonResource.
 type LROsClientPutAsyncNonResourcePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutAsyncNonResourcePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutAsyncNonResourcePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNonResourceResponse, error) {
 	respType := LROsClientPutAsyncNonResourceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3159,40 +2707,33 @@ func (l *LROsClientPutAsyncNonResourcePollerResponse) Resume(ctx context.Context
 	poller := &LROsClientPutAsyncNonResourcePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutAsyncNonResourceResponse contains the response from method LROsClient.PutAsyncNonResource.
 type LROsClientPutAsyncNonResourceResponse struct {
 	SKU
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutAsyncRetryFailedPollerResponse contains the response from method LROsClient.PutAsyncRetryFailed.
 type LROsClientPutAsyncRetryFailedPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutAsyncRetryFailedPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutAsyncRetryFailedPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncRetryFailedResponse, error) {
 	respType := LROsClientPutAsyncRetryFailedResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3205,40 +2746,33 @@ func (l *LROsClientPutAsyncRetryFailedPollerResponse) Resume(ctx context.Context
 	poller := &LROsClientPutAsyncRetryFailedPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutAsyncRetryFailedResponse contains the response from method LROsClient.PutAsyncRetryFailed.
 type LROsClientPutAsyncRetryFailedResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutAsyncRetrySucceededPollerResponse contains the response from method LROsClient.PutAsyncRetrySucceeded.
 type LROsClientPutAsyncRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutAsyncRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncRetrySucceededResponse, error) {
 	respType := LROsClientPutAsyncRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3251,40 +2785,33 @@ func (l *LROsClientPutAsyncRetrySucceededPollerResponse) Resume(ctx context.Cont
 	poller := &LROsClientPutAsyncRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutAsyncRetrySucceededResponse contains the response from method LROsClient.PutAsyncRetrySucceeded.
 type LROsClientPutAsyncRetrySucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutAsyncSubResourcePollerResponse contains the response from method LROsClient.PutAsyncSubResource.
 type LROsClientPutAsyncSubResourcePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutAsyncSubResourcePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutAsyncSubResourcePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncSubResourceResponse, error) {
 	respType := LROsClientPutAsyncSubResourceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SubProduct)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SubProduct)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3297,40 +2824,33 @@ func (l *LROsClientPutAsyncSubResourcePollerResponse) Resume(ctx context.Context
 	poller := &LROsClientPutAsyncSubResourcePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutAsyncSubResourceResponse contains the response from method LROsClient.PutAsyncSubResource.
 type LROsClientPutAsyncSubResourceResponse struct {
 	SubProduct
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutNoHeaderInRetryPollerResponse contains the response from method LROsClient.PutNoHeaderInRetry.
 type LROsClientPutNoHeaderInRetryPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutNoHeaderInRetryPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutNoHeaderInRetryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutNoHeaderInRetryResponse, error) {
 	respType := LROsClientPutNoHeaderInRetryResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3343,40 +2863,33 @@ func (l *LROsClientPutNoHeaderInRetryPollerResponse) Resume(ctx context.Context,
 	poller := &LROsClientPutNoHeaderInRetryPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutNoHeaderInRetryResponse contains the response from method LROsClient.PutNoHeaderInRetry.
 type LROsClientPutNoHeaderInRetryResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutNonResourcePollerResponse contains the response from method LROsClient.PutNonResource.
 type LROsClientPutNonResourcePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutNonResourcePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutNonResourcePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutNonResourceResponse, error) {
 	respType := LROsClientPutNonResourceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3389,40 +2902,33 @@ func (l *LROsClientPutNonResourcePollerResponse) Resume(ctx context.Context, cli
 	poller := &LROsClientPutNonResourcePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutNonResourceResponse contains the response from method LROsClient.PutNonResource.
 type LROsClientPutNonResourceResponse struct {
 	SKU
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsClientPutSubResourcePollerResponse contains the response from method LROsClient.PutSubResource.
 type LROsClientPutSubResourcePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsClientPutSubResourcePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsClientPutSubResourcePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutSubResourceResponse, error) {
 	respType := LROsClientPutSubResourceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SubProduct)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SubProduct)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3435,40 +2941,33 @@ func (l *LROsClientPutSubResourcePollerResponse) Resume(ctx context.Context, cli
 	poller := &LROsClientPutSubResourcePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsClientPutSubResourceResponse contains the response from method LROsClient.PutSubResource.
 type LROsClientPutSubResourceResponse struct {
 	SubProduct
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsCustomHeaderClientPost202Retry200PollerResponse contains the response from method LROsCustomHeaderClient.Post202Retry200.
 type LROsCustomHeaderClientPost202Retry200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsCustomHeaderClientPost202Retry200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsCustomHeaderClientPost202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPost202Retry200Response, error) {
 	respType := LROsCustomHeaderClientPost202Retry200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3481,39 +2980,33 @@ func (l *LROsCustomHeaderClientPost202Retry200PollerResponse) Resume(ctx context
 	poller := &LROsCustomHeaderClientPost202Retry200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsCustomHeaderClientPost202Retry200Response contains the response from method LROsCustomHeaderClient.Post202Retry200.
 type LROsCustomHeaderClientPost202Retry200Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse contains the response from method LROsCustomHeaderClient.PostAsyncRetrySucceeded.
 type LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsCustomHeaderClientPostAsyncRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
 	respType := LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3526,39 +3019,33 @@ func (l *LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse) Resume(ctx
 	poller := &LROsCustomHeaderClientPostAsyncRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsCustomHeaderClientPostAsyncRetrySucceededResponse contains the response from method LROsCustomHeaderClient.PostAsyncRetrySucceeded.
 type LROsCustomHeaderClientPostAsyncRetrySucceededResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse contains the response from method LROsCustomHeaderClient.Put201CreatingSucceeded200.
 type LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsCustomHeaderClientPut201CreatingSucceeded200Poller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
 	respType := LROsCustomHeaderClientPut201CreatingSucceeded200Response{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3572,40 +3059,33 @@ func (l *LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse) Resume(
 	poller := &LROsCustomHeaderClientPut201CreatingSucceeded200Poller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsCustomHeaderClientPut201CreatingSucceeded200Response contains the response from method LROsCustomHeaderClient.Put201CreatingSucceeded200.
 type LROsCustomHeaderClientPut201CreatingSucceeded200Response struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse contains the response from method LROsCustomHeaderClient.PutAsyncRetrySucceeded.
 type LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LROsCustomHeaderClientPutAsyncRetrySucceededPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
 	respType := LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3618,18 +3098,15 @@ func (l *LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse) Resume(ctx 
 	poller := &LROsCustomHeaderClientPutAsyncRetrySucceededPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LROsCustomHeaderClientPutAsyncRetrySucceededResponse contains the response from method LROsCustomHeaderClient.PutAsyncRetrySucceeded.
 type LROsCustomHeaderClientPutAsyncRetrySucceededResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/mediatypesgroup/mediatypesgroup_test.go
+++ b/test/autorest/mediatypesgroup/mediatypesgroup_test.go
@@ -6,7 +6,6 @@ package mediatypesgroup
 import (
 	"bytes"
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -26,8 +25,8 @@ func TestAnalyzeBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AnalyzeBody: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != "Nice job with PDF" {
+		t.Fatalf("unexpected result %s", *result.Value)
 	}
 }
 
@@ -40,8 +39,8 @@ func TestAnalyzeBodyWithJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AnalyzeBodyWithSourcePath: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != "Nice job with JSON" {
+		t.Fatalf("unexpected result %s", *result.Value)
 	}
 }
 
@@ -53,8 +52,8 @@ func TestContentTypeWithEncoding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ContentTypeWithEncoding: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != "Nice job sending content type with encoding" {
+		t.Fatalf("unexpected result %s", *result.Value)
 	}
 }
 

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypes_client.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypes_client.go
@@ -73,7 +73,7 @@ func (client *MediaTypesClient) analyzeBodyCreateRequest(ctx context.Context, co
 
 // analyzeBodyHandleResponse handles the AnalyzeBody response.
 func (client *MediaTypesClient) analyzeBodyHandleResponse(resp *http.Response) (MediaTypesClientAnalyzeBodyResponse, error) {
-	result := MediaTypesClientAnalyzeBodyResponse{RawResponse: resp}
+	result := MediaTypesClientAnalyzeBodyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return MediaTypesClientAnalyzeBodyResponse{}, err
 	}
@@ -98,7 +98,7 @@ func (client *MediaTypesClient) AnalyzeBodyNoAcceptHeader(ctx context.Context, c
 	if !runtime.HasStatusCode(resp, http.StatusAccepted) {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse{}, runtime.NewResponseError(resp)
 	}
-	return MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse{RawResponse: resp}, nil
+	return MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse{}, nil
 }
 
 // analyzeBodyNoAcceptHeaderCreateRequest creates the AnalyzeBodyNoAcceptHeader request.
@@ -132,7 +132,7 @@ func (client *MediaTypesClient) AnalyzeBodyNoAcceptHeaderWithJSON(ctx context.Co
 	if !runtime.HasStatusCode(resp, http.StatusAccepted) {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{}, runtime.NewResponseError(resp)
 	}
-	return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{RawResponse: resp}, nil
+	return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{}, nil
 }
 
 // analyzeBodyNoAcceptHeaderWithJSONCreateRequest creates the AnalyzeBodyNoAcceptHeaderWithJSON request.
@@ -183,7 +183,7 @@ func (client *MediaTypesClient) analyzeBodyWithJSONCreateRequest(ctx context.Con
 
 // analyzeBodyWithJSONHandleResponse handles the AnalyzeBodyWithJSON response.
 func (client *MediaTypesClient) analyzeBodyWithJSONHandleResponse(resp *http.Response) (MediaTypesClientAnalyzeBodyWithJSONResponse, error) {
-	result := MediaTypesClientAnalyzeBodyWithJSONResponse{RawResponse: resp}
+	result := MediaTypesClientAnalyzeBodyWithJSONResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return MediaTypesClientAnalyzeBodyWithJSONResponse{}, err
 	}
@@ -227,7 +227,7 @@ func (client *MediaTypesClient) binaryBodyWithThreeContentTypesCreateRequest(ctx
 
 // binaryBodyWithThreeContentTypesHandleResponse handles the BinaryBodyWithThreeContentTypes response.
 func (client *MediaTypesClient) binaryBodyWithThreeContentTypesHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithThreeContentTypesResponse, error) {
-	result := MediaTypesClientBinaryBodyWithThreeContentTypesResponse{RawResponse: resp}
+	result := MediaTypesClientBinaryBodyWithThreeContentTypesResponse{}
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithThreeContentTypesResponse{}, err
@@ -273,7 +273,7 @@ func (client *MediaTypesClient) binaryBodyWithThreeContentTypesWithTextCreateReq
 
 // binaryBodyWithThreeContentTypesWithTextHandleResponse handles the BinaryBodyWithThreeContentTypesWithText response.
 func (client *MediaTypesClient) binaryBodyWithThreeContentTypesWithTextHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse, error) {
-	result := MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{RawResponse: resp}
+	result := MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{}
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{}, err
@@ -319,7 +319,7 @@ func (client *MediaTypesClient) binaryBodyWithTwoContentTypesCreateRequest(ctx c
 
 // binaryBodyWithTwoContentTypesHandleResponse handles the BinaryBodyWithTwoContentTypes response.
 func (client *MediaTypesClient) binaryBodyWithTwoContentTypesHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithTwoContentTypesResponse, error) {
-	result := MediaTypesClientBinaryBodyWithTwoContentTypesResponse{RawResponse: resp}
+	result := MediaTypesClientBinaryBodyWithTwoContentTypesResponse{}
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithTwoContentTypesResponse{}, err
@@ -365,7 +365,7 @@ func (client *MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context
 
 // contentTypeWithEncodingHandleResponse handles the ContentTypeWithEncoding response.
 func (client *MediaTypesClient) contentTypeWithEncodingHandleResponse(resp *http.Response) (MediaTypesClientContentTypeWithEncodingResponse, error) {
-	result := MediaTypesClientContentTypeWithEncodingResponse{RawResponse: resp}
+	result := MediaTypesClientContentTypeWithEncodingResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return MediaTypesClientContentTypeWithEncodingResponse{}, err
 	}
@@ -405,7 +405,7 @@ func (client *MediaTypesClient) putTextAndJSONBodyWithJSONCreateRequest(ctx cont
 
 // putTextAndJSONBodyWithJSONHandleResponse handles the PutTextAndJSONBodyWithJSON response.
 func (client *MediaTypesClient) putTextAndJSONBodyWithJSONHandleResponse(resp *http.Response) (MediaTypesClientPutTextAndJSONBodyWithJSONResponse, error) {
-	result := MediaTypesClientPutTextAndJSONBodyWithJSONResponse{RawResponse: resp}
+	result := MediaTypesClientPutTextAndJSONBodyWithJSONResponse{}
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return MediaTypesClientPutTextAndJSONBodyWithJSONResponse{}, err
@@ -449,7 +449,7 @@ func (client *MediaTypesClient) putTextAndJSONBodyWithTextCreateRequest(ctx cont
 
 // putTextAndJSONBodyWithTextHandleResponse handles the PutTextAndJSONBodyWithText response.
 func (client *MediaTypesClient) putTextAndJSONBodyWithTextHandleResponse(resp *http.Response) (MediaTypesClientPutTextAndJSONBodyWithTextResponse, error) {
-	result := MediaTypesClientPutTextAndJSONBodyWithTextResponse{RawResponse: resp}
+	result := MediaTypesClientPutTextAndJSONBodyWithTextResponse{}
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return MediaTypesClientPutTextAndJSONBodyWithTextResponse{}, err

--- a/test/autorest/mediatypesgroup/zz_generated_response_types.go
+++ b/test/autorest/mediatypesgroup/zz_generated_response_types.go
@@ -8,72 +8,52 @@
 
 package mediatypesgroup
 
-import "net/http"
-
 // MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse contains the response from method MediaTypesClient.AnalyzeBodyNoAcceptHeader.
 type MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse contains the response from method MediaTypesClient.AnalyzeBodyNoAcceptHeaderWithJSON.
 type MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MediaTypesClientAnalyzeBodyResponse contains the response from method MediaTypesClient.AnalyzeBody.
 type MediaTypesClientAnalyzeBodyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MediaTypesClientAnalyzeBodyWithJSONResponse contains the response from method MediaTypesClient.AnalyzeBodyWithJSON.
 type MediaTypesClientAnalyzeBodyWithJSONResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MediaTypesClientBinaryBodyWithThreeContentTypesResponse contains the response from method MediaTypesClient.BinaryBodyWithThreeContentTypes.
 type MediaTypesClientBinaryBodyWithThreeContentTypesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse contains the response from method MediaTypesClient.BinaryBodyWithThreeContentTypesWithText.
 type MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MediaTypesClientBinaryBodyWithTwoContentTypesResponse contains the response from method MediaTypesClient.BinaryBodyWithTwoContentTypes.
 type MediaTypesClientBinaryBodyWithTwoContentTypesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MediaTypesClientContentTypeWithEncodingResponse contains the response from method MediaTypesClient.ContentTypeWithEncoding.
 type MediaTypesClientContentTypeWithEncodingResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MediaTypesClientPutTextAndJSONBodyWithJSONResponse contains the response from method MediaTypesClient.PutTextAndJSONBodyWithJSON.
 type MediaTypesClientPutTextAndJSONBodyWithJSONResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MediaTypesClientPutTextAndJSONBodyWithTextResponse contains the response from method MediaTypesClient.PutTextAndJSONBodyWithText.
 type MediaTypesClientPutTextAndJSONBodyWithTextResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }

--- a/test/autorest/migroup/zz_generated_multipleinheritanceservice_client.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceservice_client.go
@@ -66,7 +66,7 @@ func (client *MultipleInheritanceServiceClient) getCatCreateRequest(ctx context.
 
 // getCatHandleResponse handles the GetCat response.
 func (client *MultipleInheritanceServiceClient) getCatHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetCatResponse, error) {
-	result := MultipleInheritanceServiceClientGetCatResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientGetCatResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Cat); err != nil {
 		return MultipleInheritanceServiceClientGetCatResponse{}, err
 	}
@@ -105,7 +105,7 @@ func (client *MultipleInheritanceServiceClient) getFelineCreateRequest(ctx conte
 
 // getFelineHandleResponse handles the GetFeline response.
 func (client *MultipleInheritanceServiceClient) getFelineHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetFelineResponse, error) {
-	result := MultipleInheritanceServiceClientGetFelineResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientGetFelineResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Feline); err != nil {
 		return MultipleInheritanceServiceClientGetFelineResponse{}, err
 	}
@@ -144,7 +144,7 @@ func (client *MultipleInheritanceServiceClient) getHorseCreateRequest(ctx contex
 
 // getHorseHandleResponse handles the GetHorse response.
 func (client *MultipleInheritanceServiceClient) getHorseHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetHorseResponse, error) {
-	result := MultipleInheritanceServiceClientGetHorseResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientGetHorseResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Horse); err != nil {
 		return MultipleInheritanceServiceClientGetHorseResponse{}, err
 	}
@@ -183,7 +183,7 @@ func (client *MultipleInheritanceServiceClient) getKittenCreateRequest(ctx conte
 
 // getKittenHandleResponse handles the GetKitten response.
 func (client *MultipleInheritanceServiceClient) getKittenHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetKittenResponse, error) {
-	result := MultipleInheritanceServiceClientGetKittenResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientGetKittenResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Kitten); err != nil {
 		return MultipleInheritanceServiceClientGetKittenResponse{}, err
 	}
@@ -222,7 +222,7 @@ func (client *MultipleInheritanceServiceClient) getPetCreateRequest(ctx context.
 
 // getPetHandleResponse handles the GetPet response.
 func (client *MultipleInheritanceServiceClient) getPetHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetPetResponse, error) {
-	result := MultipleInheritanceServiceClientGetPetResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientGetPetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Pet); err != nil {
 		return MultipleInheritanceServiceClientGetPetResponse{}, err
 	}
@@ -262,7 +262,7 @@ func (client *MultipleInheritanceServiceClient) putCatCreateRequest(ctx context.
 
 // putCatHandleResponse handles the PutCat response.
 func (client *MultipleInheritanceServiceClient) putCatHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutCatResponse, error) {
-	result := MultipleInheritanceServiceClientPutCatResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientPutCatResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return MultipleInheritanceServiceClientPutCatResponse{}, err
 	}
@@ -302,7 +302,7 @@ func (client *MultipleInheritanceServiceClient) putFelineCreateRequest(ctx conte
 
 // putFelineHandleResponse handles the PutFeline response.
 func (client *MultipleInheritanceServiceClient) putFelineHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutFelineResponse, error) {
-	result := MultipleInheritanceServiceClientPutFelineResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientPutFelineResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return MultipleInheritanceServiceClientPutFelineResponse{}, err
 	}
@@ -342,7 +342,7 @@ func (client *MultipleInheritanceServiceClient) putHorseCreateRequest(ctx contex
 
 // putHorseHandleResponse handles the PutHorse response.
 func (client *MultipleInheritanceServiceClient) putHorseHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutHorseResponse, error) {
-	result := MultipleInheritanceServiceClientPutHorseResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientPutHorseResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return MultipleInheritanceServiceClientPutHorseResponse{}, err
 	}
@@ -382,7 +382,7 @@ func (client *MultipleInheritanceServiceClient) putKittenCreateRequest(ctx conte
 
 // putKittenHandleResponse handles the PutKitten response.
 func (client *MultipleInheritanceServiceClient) putKittenHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutKittenResponse, error) {
-	result := MultipleInheritanceServiceClientPutKittenResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientPutKittenResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return MultipleInheritanceServiceClientPutKittenResponse{}, err
 	}
@@ -422,7 +422,7 @@ func (client *MultipleInheritanceServiceClient) putPetCreateRequest(ctx context.
 
 // putPetHandleResponse handles the PutPet response.
 func (client *MultipleInheritanceServiceClient) putPetHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutPetResponse, error) {
-	result := MultipleInheritanceServiceClientPutPetResponse{RawResponse: resp}
+	result := MultipleInheritanceServiceClientPutPetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return MultipleInheritanceServiceClientPutPetResponse{}, err
 	}

--- a/test/autorest/migroup/zz_generated_response_types.go
+++ b/test/autorest/migroup/zz_generated_response_types.go
@@ -8,74 +8,52 @@
 
 package migroup
 
-import "net/http"
-
 // MultipleInheritanceServiceClientGetCatResponse contains the response from method MultipleInheritanceServiceClient.GetCat.
 type MultipleInheritanceServiceClientGetCatResponse struct {
 	Cat
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleInheritanceServiceClientGetFelineResponse contains the response from method MultipleInheritanceServiceClient.GetFeline.
 type MultipleInheritanceServiceClientGetFelineResponse struct {
 	Feline
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleInheritanceServiceClientGetHorseResponse contains the response from method MultipleInheritanceServiceClient.GetHorse.
 type MultipleInheritanceServiceClientGetHorseResponse struct {
 	Horse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleInheritanceServiceClientGetKittenResponse contains the response from method MultipleInheritanceServiceClient.GetKitten.
 type MultipleInheritanceServiceClientGetKittenResponse struct {
 	Kitten
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleInheritanceServiceClientGetPetResponse contains the response from method MultipleInheritanceServiceClient.GetPet.
 type MultipleInheritanceServiceClientGetPetResponse struct {
 	Pet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MultipleInheritanceServiceClientPutCatResponse contains the response from method MultipleInheritanceServiceClient.PutCat.
 type MultipleInheritanceServiceClientPutCatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MultipleInheritanceServiceClientPutFelineResponse contains the response from method MultipleInheritanceServiceClient.PutFeline.
 type MultipleInheritanceServiceClientPutFelineResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MultipleInheritanceServiceClientPutHorseResponse contains the response from method MultipleInheritanceServiceClient.PutHorse.
 type MultipleInheritanceServiceClientPutHorseResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MultipleInheritanceServiceClientPutKittenResponse contains the response from method MultipleInheritanceServiceClient.PutKitten.
 type MultipleInheritanceServiceClientPutKittenResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // MultipleInheritanceServiceClientPutPetResponse contains the response from method MultipleInheritanceServiceClient.PutPet.
 type MultipleInheritanceServiceClientPutPetResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }

--- a/test/autorest/morecustombaseurigroup/paths_test.go
+++ b/test/autorest/morecustombaseurigroup/paths_test.go
@@ -5,7 +5,7 @@ package morecustombaseurigroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -27,7 +27,7 @@ func TestGetEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/morecustombaseurigroup/zz_generated_paths_client.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_paths_client.go
@@ -69,7 +69,7 @@ func (client *PathsClient) GetEmpty(ctx context.Context, vault string, secret st
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientGetEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientGetEmptyResponse{RawResponse: resp}, nil
+	return PathsClientGetEmptyResponse{}, nil
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.

--- a/test/autorest/morecustombaseurigroup/zz_generated_response_types.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_response_types.go
@@ -8,10 +8,7 @@
 
 package morecustombaseurigroup
 
-import "net/http"
-
 // PathsClientGetEmptyResponse contains the response from method PathsClient.GetEmpty.
 type PathsClientGetEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/nonstringenumgroup/float_test.go
+++ b/test/autorest/nonstringenumgroup/float_test.go
@@ -5,7 +5,6 @@ package nonstringenumgroup
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,7 +35,7 @@ func TestFloatPut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != "Nice job posting a float enum" {
+		t.Fatalf("unexpected value %s", *result.Value)
 	}
 }

--- a/test/autorest/nonstringenumgroup/int_test.go
+++ b/test/autorest/nonstringenumgroup/int_test.go
@@ -5,7 +5,6 @@ package nonstringenumgroup
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,7 +35,7 @@ func TestIntPut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if *result.Value != "Nice job posting an int enum" {
+		t.Fatalf("unexpected value %s", *result.Value)
 	}
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_float_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float_client.go
@@ -65,7 +65,7 @@ func (client *FloatClient) getCreateRequest(ctx context.Context, options *FloatC
 
 // getHandleResponse handles the Get response.
 func (client *FloatClient) getHandleResponse(resp *http.Response) (FloatClientGetResponse, error) {
-	result := FloatClientGetResponse{RawResponse: resp}
+	result := FloatClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return FloatClientGetResponse{}, err
 	}
@@ -106,7 +106,7 @@ func (client *FloatClient) putCreateRequest(ctx context.Context, options *FloatC
 
 // putHandleResponse handles the Put response.
 func (client *FloatClient) putHandleResponse(resp *http.Response) (FloatClientPutResponse, error) {
-	result := FloatClientPutResponse{RawResponse: resp}
+	result := FloatClientPutResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return FloatClientPutResponse{}, err
 	}

--- a/test/autorest/nonstringenumgroup/zz_generated_int_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int_client.go
@@ -65,7 +65,7 @@ func (client *IntClient) getCreateRequest(ctx context.Context, options *IntClien
 
 // getHandleResponse handles the Get response.
 func (client *IntClient) getHandleResponse(resp *http.Response) (IntClientGetResponse, error) {
-	result := IntClientGetResponse{RawResponse: resp}
+	result := IntClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return IntClientGetResponse{}, err
 	}
@@ -106,7 +106,7 @@ func (client *IntClient) putCreateRequest(ctx context.Context, options *IntClien
 
 // putHandleResponse handles the Put response.
 func (client *IntClient) putHandleResponse(resp *http.Response) (IntClientPutResponse, error) {
-	result := IntClientPutResponse{RawResponse: resp}
+	result := IntClientPutResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return IntClientPutResponse{}, err
 	}

--- a/test/autorest/nonstringenumgroup/zz_generated_response_types.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_response_types.go
@@ -8,36 +8,24 @@
 
 package nonstringenumgroup
 
-import "net/http"
-
 // FloatClientGetResponse contains the response from method FloatClient.Get.
 type FloatClientGetResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// List of float enums
 	Value *FloatEnum
 }
 
 // FloatClientPutResponse contains the response from method FloatClient.Put.
 type FloatClientPutResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // IntClientGetResponse contains the response from method IntClient.Get.
 type IntClientGetResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// List of integer enums
 	Value *IntEnum
 }
 
 // IntClientPutResponse contains the response from method IntClient.Put.
 type IntClientPutResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }

--- a/test/autorest/numbergroup/numbergroup_test.go
+++ b/test/autorest/numbergroup/numbergroup_test.go
@@ -5,7 +5,6 @@ package numbergroup
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 
@@ -23,9 +22,6 @@ func TestNumberGetBigDecimal(t *testing.T) {
 		t.Fatalf("GetBigDecimal: %v", err)
 	}
 	val := 2.5976931e+101
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -38,9 +34,6 @@ func TestNumberGetBigDecimalNegativeDecimal(t *testing.T) {
 		t.Fatalf("GetBigDecimalNegativeDecimal: %v", err)
 	}
 	val := -99999999.99
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -53,9 +46,6 @@ func TestNumberGetBigDecimalPositiveDecimal(t *testing.T) {
 		t.Fatalf("GetBigDecimalPositiveDecimal: %v", err)
 	}
 	val := 99999999.99
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -68,9 +58,6 @@ func TestNumberGetBigDouble(t *testing.T) {
 		t.Fatalf("GetBigDouble: %v", err)
 	}
 	val := 2.5976931e+101
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -83,9 +70,6 @@ func TestNumberGetBigDoubleNegativeDecimal(t *testing.T) {
 		t.Fatalf("GetBigDoubleNegativeDecimal: %v", err)
 	}
 	val := -99999999.99
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -98,9 +82,6 @@ func TestNumberGetBigDoublePositiveDecimal(t *testing.T) {
 		t.Fatalf("GetBigDoublePositiveDecimal: %v", err)
 	}
 	val := 99999999.99
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -113,9 +94,6 @@ func TestNumberGetBigFloat(t *testing.T) {
 		t.Fatalf("GetBigFloat: %v", err)
 	}
 	val := float32(3.402823e+20)
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -160,9 +138,6 @@ func TestNumberGetNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, (*float32)(nil)); r != "" {
 		t.Fatal(r)
 	}
@@ -175,9 +150,6 @@ func TestNumberGetSmallDecimal(t *testing.T) {
 		t.Fatalf("GetSmallDecimal: %v", err)
 	}
 	val := 2.5976931e-101
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -190,9 +162,6 @@ func TestNumberGetSmallDouble(t *testing.T) {
 		t.Fatalf("GetSmallDouble: %v", err)
 	}
 	val := 2.5976931e-101
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -205,9 +174,6 @@ func TestNumberGetSmallFloat(t *testing.T) {
 		t.Fatalf("GetSmallFloat: %v", err)
 	}
 	val := 3.402823e-20
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -219,8 +185,8 @@ func TestNumberPutBigDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDecimal: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -230,8 +196,8 @@ func TestNumberPutBigDecimalNegativeDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDecimalNegativeDecimal: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -241,8 +207,8 @@ func TestNumberPutBigDecimalPositiveDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDecimalPositiveDecimal: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -252,8 +218,8 @@ func TestNumberPutBigDouble(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDouble: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -263,8 +229,8 @@ func TestNumberPutBigDoubleNegativeDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDoubleNegativeDecimal: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -274,8 +240,8 @@ func TestNumberPutBigDoublePositiveDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDeoublePositiveDecimal: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -285,8 +251,8 @@ func TestNumberPutBigFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigFloat: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -296,8 +262,8 @@ func TestNumberPutSmallDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutSmallDecimal: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -307,8 +273,8 @@ func TestNumberPutSmallDouble(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutSmallDouble: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -318,7 +284,7 @@ func TestNumberPutSmallFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutSmallFloat: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/numbergroup/zz_generated_number_client.go
+++ b/test/autorest/numbergroup/zz_generated_number_client.go
@@ -65,7 +65,7 @@ func (client *NumberClient) getBigDecimalCreateRequest(ctx context.Context, opti
 
 // getBigDecimalHandleResponse handles the GetBigDecimal response.
 func (client *NumberClient) getBigDecimalHandleResponse(resp *http.Response) (NumberClientGetBigDecimalResponse, error) {
-	result := NumberClientGetBigDecimalResponse{RawResponse: resp}
+	result := NumberClientGetBigDecimalResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetBigDecimalResponse{}, err
 	}
@@ -104,7 +104,7 @@ func (client *NumberClient) getBigDecimalNegativeDecimalCreateRequest(ctx contex
 
 // getBigDecimalNegativeDecimalHandleResponse handles the GetBigDecimalNegativeDecimal response.
 func (client *NumberClient) getBigDecimalNegativeDecimalHandleResponse(resp *http.Response) (NumberClientGetBigDecimalNegativeDecimalResponse, error) {
-	result := NumberClientGetBigDecimalNegativeDecimalResponse{RawResponse: resp}
+	result := NumberClientGetBigDecimalNegativeDecimalResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetBigDecimalNegativeDecimalResponse{}, err
 	}
@@ -143,7 +143,7 @@ func (client *NumberClient) getBigDecimalPositiveDecimalCreateRequest(ctx contex
 
 // getBigDecimalPositiveDecimalHandleResponse handles the GetBigDecimalPositiveDecimal response.
 func (client *NumberClient) getBigDecimalPositiveDecimalHandleResponse(resp *http.Response) (NumberClientGetBigDecimalPositiveDecimalResponse, error) {
-	result := NumberClientGetBigDecimalPositiveDecimalResponse{RawResponse: resp}
+	result := NumberClientGetBigDecimalPositiveDecimalResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetBigDecimalPositiveDecimalResponse{}, err
 	}
@@ -181,7 +181,7 @@ func (client *NumberClient) getBigDoubleCreateRequest(ctx context.Context, optio
 
 // getBigDoubleHandleResponse handles the GetBigDouble response.
 func (client *NumberClient) getBigDoubleHandleResponse(resp *http.Response) (NumberClientGetBigDoubleResponse, error) {
-	result := NumberClientGetBigDoubleResponse{RawResponse: resp}
+	result := NumberClientGetBigDoubleResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetBigDoubleResponse{}, err
 	}
@@ -220,7 +220,7 @@ func (client *NumberClient) getBigDoubleNegativeDecimalCreateRequest(ctx context
 
 // getBigDoubleNegativeDecimalHandleResponse handles the GetBigDoubleNegativeDecimal response.
 func (client *NumberClient) getBigDoubleNegativeDecimalHandleResponse(resp *http.Response) (NumberClientGetBigDoubleNegativeDecimalResponse, error) {
-	result := NumberClientGetBigDoubleNegativeDecimalResponse{RawResponse: resp}
+	result := NumberClientGetBigDoubleNegativeDecimalResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetBigDoubleNegativeDecimalResponse{}, err
 	}
@@ -259,7 +259,7 @@ func (client *NumberClient) getBigDoublePositiveDecimalCreateRequest(ctx context
 
 // getBigDoublePositiveDecimalHandleResponse handles the GetBigDoublePositiveDecimal response.
 func (client *NumberClient) getBigDoublePositiveDecimalHandleResponse(resp *http.Response) (NumberClientGetBigDoublePositiveDecimalResponse, error) {
-	result := NumberClientGetBigDoublePositiveDecimalResponse{RawResponse: resp}
+	result := NumberClientGetBigDoublePositiveDecimalResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetBigDoublePositiveDecimalResponse{}, err
 	}
@@ -297,7 +297,7 @@ func (client *NumberClient) getBigFloatCreateRequest(ctx context.Context, option
 
 // getBigFloatHandleResponse handles the GetBigFloat response.
 func (client *NumberClient) getBigFloatHandleResponse(resp *http.Response) (NumberClientGetBigFloatResponse, error) {
-	result := NumberClientGetBigFloatResponse{RawResponse: resp}
+	result := NumberClientGetBigFloatResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetBigFloatResponse{}, err
 	}
@@ -336,7 +336,7 @@ func (client *NumberClient) getInvalidDecimalCreateRequest(ctx context.Context, 
 
 // getInvalidDecimalHandleResponse handles the GetInvalidDecimal response.
 func (client *NumberClient) getInvalidDecimalHandleResponse(resp *http.Response) (NumberClientGetInvalidDecimalResponse, error) {
-	result := NumberClientGetInvalidDecimalResponse{RawResponse: resp}
+	result := NumberClientGetInvalidDecimalResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetInvalidDecimalResponse{}, err
 	}
@@ -374,7 +374,7 @@ func (client *NumberClient) getInvalidDoubleCreateRequest(ctx context.Context, o
 
 // getInvalidDoubleHandleResponse handles the GetInvalidDouble response.
 func (client *NumberClient) getInvalidDoubleHandleResponse(resp *http.Response) (NumberClientGetInvalidDoubleResponse, error) {
-	result := NumberClientGetInvalidDoubleResponse{RawResponse: resp}
+	result := NumberClientGetInvalidDoubleResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetInvalidDoubleResponse{}, err
 	}
@@ -412,7 +412,7 @@ func (client *NumberClient) getInvalidFloatCreateRequest(ctx context.Context, op
 
 // getInvalidFloatHandleResponse handles the GetInvalidFloat response.
 func (client *NumberClient) getInvalidFloatHandleResponse(resp *http.Response) (NumberClientGetInvalidFloatResponse, error) {
-	result := NumberClientGetInvalidFloatResponse{RawResponse: resp}
+	result := NumberClientGetInvalidFloatResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetInvalidFloatResponse{}, err
 	}
@@ -450,7 +450,7 @@ func (client *NumberClient) getNullCreateRequest(ctx context.Context, options *N
 
 // getNullHandleResponse handles the GetNull response.
 func (client *NumberClient) getNullHandleResponse(resp *http.Response) (NumberClientGetNullResponse, error) {
-	result := NumberClientGetNullResponse{RawResponse: resp}
+	result := NumberClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetNullResponse{}, err
 	}
@@ -488,7 +488,7 @@ func (client *NumberClient) getSmallDecimalCreateRequest(ctx context.Context, op
 
 // getSmallDecimalHandleResponse handles the GetSmallDecimal response.
 func (client *NumberClient) getSmallDecimalHandleResponse(resp *http.Response) (NumberClientGetSmallDecimalResponse, error) {
-	result := NumberClientGetSmallDecimalResponse{RawResponse: resp}
+	result := NumberClientGetSmallDecimalResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetSmallDecimalResponse{}, err
 	}
@@ -526,7 +526,7 @@ func (client *NumberClient) getSmallDoubleCreateRequest(ctx context.Context, opt
 
 // getSmallDoubleHandleResponse handles the GetSmallDouble response.
 func (client *NumberClient) getSmallDoubleHandleResponse(resp *http.Response) (NumberClientGetSmallDoubleResponse, error) {
-	result := NumberClientGetSmallDoubleResponse{RawResponse: resp}
+	result := NumberClientGetSmallDoubleResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetSmallDoubleResponse{}, err
 	}
@@ -564,7 +564,7 @@ func (client *NumberClient) getSmallFloatCreateRequest(ctx context.Context, opti
 
 // getSmallFloatHandleResponse handles the GetSmallFloat response.
 func (client *NumberClient) getSmallFloatHandleResponse(resp *http.Response) (NumberClientGetSmallFloatResponse, error) {
-	result := NumberClientGetSmallFloatResponse{RawResponse: resp}
+	result := NumberClientGetSmallFloatResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return NumberClientGetSmallFloatResponse{}, err
 	}
@@ -587,7 +587,7 @@ func (client *NumberClient) PutBigDecimal(ctx context.Context, numberBody float6
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutBigDecimalResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutBigDecimalResponse{RawResponse: resp}, nil
+	return NumberClientPutBigDecimalResponse{}, nil
 }
 
 // putBigDecimalCreateRequest creates the PutBigDecimal request.
@@ -617,7 +617,7 @@ func (client *NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutBigDecimalNegativeDecimalResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutBigDecimalNegativeDecimalResponse{RawResponse: resp}, nil
+	return NumberClientPutBigDecimalNegativeDecimalResponse{}, nil
 }
 
 // putBigDecimalNegativeDecimalCreateRequest creates the PutBigDecimalNegativeDecimal request.
@@ -647,7 +647,7 @@ func (client *NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutBigDecimalPositiveDecimalResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutBigDecimalPositiveDecimalResponse{RawResponse: resp}, nil
+	return NumberClientPutBigDecimalPositiveDecimalResponse{}, nil
 }
 
 // putBigDecimalPositiveDecimalCreateRequest creates the PutBigDecimalPositiveDecimal request.
@@ -677,7 +677,7 @@ func (client *NumberClient) PutBigDouble(ctx context.Context, numberBody float64
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutBigDoubleResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutBigDoubleResponse{RawResponse: resp}, nil
+	return NumberClientPutBigDoubleResponse{}, nil
 }
 
 // putBigDoubleCreateRequest creates the PutBigDouble request.
@@ -707,7 +707,7 @@ func (client *NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutBigDoubleNegativeDecimalResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutBigDoubleNegativeDecimalResponse{RawResponse: resp}, nil
+	return NumberClientPutBigDoubleNegativeDecimalResponse{}, nil
 }
 
 // putBigDoubleNegativeDecimalCreateRequest creates the PutBigDoubleNegativeDecimal request.
@@ -737,7 +737,7 @@ func (client *NumberClient) PutBigDoublePositiveDecimal(ctx context.Context, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutBigDoublePositiveDecimalResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutBigDoublePositiveDecimalResponse{RawResponse: resp}, nil
+	return NumberClientPutBigDoublePositiveDecimalResponse{}, nil
 }
 
 // putBigDoublePositiveDecimalCreateRequest creates the PutBigDoublePositiveDecimal request.
@@ -767,7 +767,7 @@ func (client *NumberClient) PutBigFloat(ctx context.Context, numberBody float32,
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutBigFloatResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutBigFloatResponse{RawResponse: resp}, nil
+	return NumberClientPutBigFloatResponse{}, nil
 }
 
 // putBigFloatCreateRequest creates the PutBigFloat request.
@@ -797,7 +797,7 @@ func (client *NumberClient) PutSmallDecimal(ctx context.Context, numberBody floa
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutSmallDecimalResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutSmallDecimalResponse{RawResponse: resp}, nil
+	return NumberClientPutSmallDecimalResponse{}, nil
 }
 
 // putSmallDecimalCreateRequest creates the PutSmallDecimal request.
@@ -827,7 +827,7 @@ func (client *NumberClient) PutSmallDouble(ctx context.Context, numberBody float
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutSmallDoubleResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutSmallDoubleResponse{RawResponse: resp}, nil
+	return NumberClientPutSmallDoubleResponse{}, nil
 }
 
 // putSmallDoubleCreateRequest creates the PutSmallDouble request.
@@ -857,7 +857,7 @@ func (client *NumberClient) PutSmallFloat(ctx context.Context, numberBody float3
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return NumberClientPutSmallFloatResponse{}, runtime.NewResponseError(resp)
 	}
-	return NumberClientPutSmallFloatResponse{RawResponse: resp}, nil
+	return NumberClientPutSmallFloatResponse{}, nil
 }
 
 // putSmallFloatCreateRequest creates the PutSmallFloat request.

--- a/test/autorest/numbergroup/zz_generated_response_types.go
+++ b/test/autorest/numbergroup/zz_generated_response_types.go
@@ -8,162 +8,122 @@
 
 package numbergroup
 
-import "net/http"
-
 // NumberClientGetBigDecimalNegativeDecimalResponse contains the response from method NumberClient.GetBigDecimalNegativeDecimal.
 type NumberClientGetBigDecimalNegativeDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetBigDecimalPositiveDecimalResponse contains the response from method NumberClient.GetBigDecimalPositiveDecimal.
 type NumberClientGetBigDecimalPositiveDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetBigDecimalResponse contains the response from method NumberClient.GetBigDecimal.
 type NumberClientGetBigDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetBigDoubleNegativeDecimalResponse contains the response from method NumberClient.GetBigDoubleNegativeDecimal.
 type NumberClientGetBigDoubleNegativeDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetBigDoublePositiveDecimalResponse contains the response from method NumberClient.GetBigDoublePositiveDecimal.
 type NumberClientGetBigDoublePositiveDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetBigDoubleResponse contains the response from method NumberClient.GetBigDouble.
 type NumberClientGetBigDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetBigFloatResponse contains the response from method NumberClient.GetBigFloat.
 type NumberClientGetBigFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float32
+	Value *float32
 }
 
 // NumberClientGetInvalidDecimalResponse contains the response from method NumberClient.GetInvalidDecimal.
 type NumberClientGetInvalidDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetInvalidDoubleResponse contains the response from method NumberClient.GetInvalidDouble.
 type NumberClientGetInvalidDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetInvalidFloatResponse contains the response from method NumberClient.GetInvalidFloat.
 type NumberClientGetInvalidFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float32
+	Value *float32
 }
 
 // NumberClientGetNullResponse contains the response from method NumberClient.GetNull.
 type NumberClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float32
+	Value *float32
 }
 
 // NumberClientGetSmallDecimalResponse contains the response from method NumberClient.GetSmallDecimal.
 type NumberClientGetSmallDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetSmallDoubleResponse contains the response from method NumberClient.GetSmallDouble.
 type NumberClientGetSmallDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientGetSmallFloatResponse contains the response from method NumberClient.GetSmallFloat.
 type NumberClientGetSmallFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
+	Value *float64
 }
 
 // NumberClientPutBigDecimalNegativeDecimalResponse contains the response from method NumberClient.PutBigDecimalNegativeDecimal.
 type NumberClientPutBigDecimalNegativeDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutBigDecimalPositiveDecimalResponse contains the response from method NumberClient.PutBigDecimalPositiveDecimal.
 type NumberClientPutBigDecimalPositiveDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutBigDecimalResponse contains the response from method NumberClient.PutBigDecimal.
 type NumberClientPutBigDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutBigDoubleNegativeDecimalResponse contains the response from method NumberClient.PutBigDoubleNegativeDecimal.
 type NumberClientPutBigDoubleNegativeDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutBigDoublePositiveDecimalResponse contains the response from method NumberClient.PutBigDoublePositiveDecimal.
 type NumberClientPutBigDoublePositiveDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutBigDoubleResponse contains the response from method NumberClient.PutBigDouble.
 type NumberClientPutBigDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutBigFloatResponse contains the response from method NumberClient.PutBigFloat.
 type NumberClientPutBigFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutSmallDecimalResponse contains the response from method NumberClient.PutSmallDecimal.
 type NumberClientPutSmallDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutSmallDoubleResponse contains the response from method NumberClient.PutSmallDouble.
 type NumberClientPutSmallDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NumberClientPutSmallFloatResponse contains the response from method NumberClient.PutSmallFloat.
 type NumberClientPutSmallFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/objectgroup/objectgroup_test.go
+++ b/test/autorest/objectgroup/objectgroup_test.go
@@ -5,7 +5,7 @@ package objectgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,13 +30,13 @@ func TestGet(t *testing.T) {
 
 func TestPut(t *testing.T) {
 	client := newObjectTypeClient()
-	resp, err := client.Put(context.Background(), map[string]interface{}{
+	result, err := client.Put(context.Background(), map[string]interface{}{
 		"foo": "bar",
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.RawResponse.StatusCode != http.StatusOK {
-		t.Fatal("unexpected status code")
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/objectgroup/zz_generated_objecttype_client.go
+++ b/test/autorest/objectgroup/zz_generated_objecttype_client.go
@@ -65,7 +65,7 @@ func (client *ObjectTypeClient) getCreateRequest(ctx context.Context, options *O
 
 // getHandleResponse handles the Get response.
 func (client *ObjectTypeClient) getHandleResponse(resp *http.Response) (ObjectTypeClientGetResponse, error) {
-	result := ObjectTypeClientGetResponse{RawResponse: resp}
+	result := ObjectTypeClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
 		return ObjectTypeClientGetResponse{}, err
 	}
@@ -88,7 +88,7 @@ func (client *ObjectTypeClient) Put(ctx context.Context, putObject interface{}, 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ObjectTypeClientPutResponse{}, runtime.NewResponseError(resp)
 	}
-	return ObjectTypeClientPutResponse{RawResponse: resp}, nil
+	return ObjectTypeClientPutResponse{}, nil
 }
 
 // putCreateRequest creates the Put request.

--- a/test/autorest/objectgroup/zz_generated_response_types.go
+++ b/test/autorest/objectgroup/zz_generated_response_types.go
@@ -8,19 +8,13 @@
 
 package objectgroup
 
-import "net/http"
-
 // ObjectTypeClientGetResponse contains the response from method ObjectTypeClient.Get.
 type ObjectTypeClientGetResponse struct {
 	// Anything
 	Interface interface{}
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ObjectTypeClientPutResponse contains the response from method ObjectTypeClient.Put.
 type ObjectTypeClientPutResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/optionalgroup/explicit_test.go
+++ b/test/autorest/optionalgroup/explicit_test.go
@@ -5,7 +5,6 @@ package optionalgroup
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 )
@@ -20,8 +19,8 @@ func TestExplicitPostOptionalArrayHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalArrayHeader: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -31,8 +30,8 @@ func TestExplicitPostOptionalArrayParameter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalArrayParameter: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -42,8 +41,8 @@ func TestExplicitPostOptionalArrayProperty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalArrayProperty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -53,8 +52,8 @@ func TestExplicitPostOptionalClassParameter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalClassParameter: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -64,8 +63,8 @@ func TestExplicitPostOptionalClassProperty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalClassProperty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -75,8 +74,8 @@ func TestExplicitPostOptionalIntegerHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalIntegerHeader: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -86,8 +85,8 @@ func TestExplicitPostOptionalIntegerParameter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalIntegerParameter: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -97,8 +96,8 @@ func TestExplicitPostOptionalIntegerProperty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalIntegerProperty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -108,8 +107,8 @@ func TestExplicitPostOptionalStringHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalStringHeader: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -119,8 +118,8 @@ func TestExplicitPostOptionalStringParameter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalStringParameter: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -130,8 +129,8 @@ func TestExplicitPostOptionalStringProperty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostOptionalStringProperty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 

--- a/test/autorest/optionalgroup/implicit_test.go
+++ b/test/autorest/optionalgroup/implicit_test.go
@@ -5,7 +5,7 @@ package optionalgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -19,8 +19,8 @@ func TestImplicitGetOptionalGlobalQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetOptionalGlobalQuery: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -31,8 +31,8 @@ func TestImplicitGetRequiredGlobalPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRequiredGlobalPath: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -43,8 +43,8 @@ func TestImplicitGetRequiredGlobalQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRequiredGlobalQuery: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -55,8 +55,8 @@ func TestImplicitGetRequiredPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRequiredPath: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -66,8 +66,8 @@ func TestImplicitPutOptionalBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutOptionalBody: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -77,8 +77,8 @@ func TestImplicitPutOptionalHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutOptionalHeader: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -88,7 +88,7 @@ func TestImplicitPutOptionalQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutOptionalQuery: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/optionalgroup/zz_generated_explicit_client.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit_client.go
@@ -53,7 +53,7 @@ func (client *ExplicitClient) PostOptionalArrayHeader(ctx context.Context, optio
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalArrayHeaderResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalArrayHeaderResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalArrayHeaderResponse{}, nil
 }
 
 // postOptionalArrayHeaderCreateRequest creates the PostOptionalArrayHeader request.
@@ -86,7 +86,7 @@ func (client *ExplicitClient) PostOptionalArrayParameter(ctx context.Context, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalArrayParameterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalArrayParameterResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalArrayParameterResponse{}, nil
 }
 
 // postOptionalArrayParameterCreateRequest creates the PostOptionalArrayParameter request.
@@ -119,7 +119,7 @@ func (client *ExplicitClient) PostOptionalArrayProperty(ctx context.Context, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalArrayPropertyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalArrayPropertyResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalArrayPropertyResponse{}, nil
 }
 
 // postOptionalArrayPropertyCreateRequest creates the PostOptionalArrayProperty request.
@@ -152,7 +152,7 @@ func (client *ExplicitClient) PostOptionalClassParameter(ctx context.Context, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalClassParameterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalClassParameterResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalClassParameterResponse{}, nil
 }
 
 // postOptionalClassParameterCreateRequest creates the PostOptionalClassParameter request.
@@ -185,7 +185,7 @@ func (client *ExplicitClient) PostOptionalClassProperty(ctx context.Context, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalClassPropertyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalClassPropertyResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalClassPropertyResponse{}, nil
 }
 
 // postOptionalClassPropertyCreateRequest creates the PostOptionalClassProperty request.
@@ -218,7 +218,7 @@ func (client *ExplicitClient) PostOptionalIntegerHeader(ctx context.Context, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalIntegerHeaderResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalIntegerHeaderResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalIntegerHeaderResponse{}, nil
 }
 
 // postOptionalIntegerHeaderCreateRequest creates the PostOptionalIntegerHeader request.
@@ -251,7 +251,7 @@ func (client *ExplicitClient) PostOptionalIntegerParameter(ctx context.Context, 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalIntegerParameterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalIntegerParameterResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalIntegerParameterResponse{}, nil
 }
 
 // postOptionalIntegerParameterCreateRequest creates the PostOptionalIntegerParameter request.
@@ -284,7 +284,7 @@ func (client *ExplicitClient) PostOptionalIntegerProperty(ctx context.Context, o
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalIntegerPropertyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalIntegerPropertyResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalIntegerPropertyResponse{}, nil
 }
 
 // postOptionalIntegerPropertyCreateRequest creates the PostOptionalIntegerProperty request.
@@ -317,7 +317,7 @@ func (client *ExplicitClient) PostOptionalStringHeader(ctx context.Context, opti
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalStringHeaderResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalStringHeaderResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalStringHeaderResponse{}, nil
 }
 
 // postOptionalStringHeaderCreateRequest creates the PostOptionalStringHeader request.
@@ -350,7 +350,7 @@ func (client *ExplicitClient) PostOptionalStringParameter(ctx context.Context, o
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalStringParameterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalStringParameterResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalStringParameterResponse{}, nil
 }
 
 // postOptionalStringParameterCreateRequest creates the PostOptionalStringParameter request.
@@ -383,7 +383,7 @@ func (client *ExplicitClient) PostOptionalStringProperty(ctx context.Context, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostOptionalStringPropertyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostOptionalStringPropertyResponse{RawResponse: resp}, nil
+	return ExplicitClientPostOptionalStringPropertyResponse{}, nil
 }
 
 // postOptionalStringPropertyCreateRequest creates the PostOptionalStringProperty request.
@@ -417,7 +417,7 @@ func (client *ExplicitClient) PostRequiredArrayHeader(ctx context.Context, heade
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredArrayHeaderResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredArrayHeaderResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredArrayHeaderResponse{}, nil
 }
 
 // postRequiredArrayHeaderCreateRequest creates the PostRequiredArrayHeader request.
@@ -449,7 +449,7 @@ func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bo
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredArrayParameterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredArrayParameterResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredArrayParameterResponse{}, nil
 }
 
 // postRequiredArrayParameterCreateRequest creates the PostRequiredArrayParameter request.
@@ -480,7 +480,7 @@ func (client *ExplicitClient) PostRequiredArrayProperty(ctx context.Context, bod
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredArrayPropertyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredArrayPropertyResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredArrayPropertyResponse{}, nil
 }
 
 // postRequiredArrayPropertyCreateRequest creates the PostRequiredArrayProperty request.
@@ -511,7 +511,7 @@ func (client *ExplicitClient) PostRequiredClassParameter(ctx context.Context, bo
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredClassParameterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredClassParameterResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredClassParameterResponse{}, nil
 }
 
 // postRequiredClassParameterCreateRequest creates the PostRequiredClassParameter request.
@@ -542,7 +542,7 @@ func (client *ExplicitClient) PostRequiredClassProperty(ctx context.Context, bod
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredClassPropertyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredClassPropertyResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredClassPropertyResponse{}, nil
 }
 
 // postRequiredClassPropertyCreateRequest creates the PostRequiredClassProperty request.
@@ -573,7 +573,7 @@ func (client *ExplicitClient) PostRequiredIntegerHeader(ctx context.Context, hea
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredIntegerHeaderResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredIntegerHeaderResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredIntegerHeaderResponse{}, nil
 }
 
 // postRequiredIntegerHeaderCreateRequest creates the PostRequiredIntegerHeader request.
@@ -605,7 +605,7 @@ func (client *ExplicitClient) PostRequiredIntegerParameter(ctx context.Context, 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredIntegerParameterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredIntegerParameterResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredIntegerParameterResponse{}, nil
 }
 
 // postRequiredIntegerParameterCreateRequest creates the PostRequiredIntegerParameter request.
@@ -636,7 +636,7 @@ func (client *ExplicitClient) PostRequiredIntegerProperty(ctx context.Context, b
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredIntegerPropertyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredIntegerPropertyResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredIntegerPropertyResponse{}, nil
 }
 
 // postRequiredIntegerPropertyCreateRequest creates the PostRequiredIntegerProperty request.
@@ -667,7 +667,7 @@ func (client *ExplicitClient) PostRequiredStringHeader(ctx context.Context, head
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredStringHeaderResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredStringHeaderResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredStringHeaderResponse{}, nil
 }
 
 // postRequiredStringHeaderCreateRequest creates the PostRequiredStringHeader request.
@@ -699,7 +699,7 @@ func (client *ExplicitClient) PostRequiredStringParameter(ctx context.Context, b
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredStringParameterResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredStringParameterResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredStringParameterResponse{}, nil
 }
 
 // postRequiredStringParameterCreateRequest creates the PostRequiredStringParameter request.
@@ -730,7 +730,7 @@ func (client *ExplicitClient) PostRequiredStringProperty(ctx context.Context, bo
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPostRequiredStringPropertyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPostRequiredStringPropertyResponse{RawResponse: resp}, nil
+	return ExplicitClientPostRequiredStringPropertyResponse{}, nil
 }
 
 // postRequiredStringPropertyCreateRequest creates the PostRequiredStringProperty request.
@@ -760,7 +760,7 @@ func (client *ExplicitClient) PutOptionalBinaryBody(ctx context.Context, options
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPutOptionalBinaryBodyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPutOptionalBinaryBodyResponse{RawResponse: resp}, nil
+	return ExplicitClientPutOptionalBinaryBodyResponse{}, nil
 }
 
 // putOptionalBinaryBodyCreateRequest creates the PutOptionalBinaryBody request.
@@ -793,7 +793,7 @@ func (client *ExplicitClient) PutRequiredBinaryBody(ctx context.Context, bodyPar
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ExplicitClientPutRequiredBinaryBodyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ExplicitClientPutRequiredBinaryBodyResponse{RawResponse: resp}, nil
+	return ExplicitClientPutRequiredBinaryBodyResponse{}, nil
 }
 
 // putRequiredBinaryBodyCreateRequest creates the PutRequiredBinaryBody request.

--- a/test/autorest/optionalgroup/zz_generated_implicit_client.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit_client.go
@@ -63,7 +63,7 @@ func (client *ImplicitClient) GetOptionalGlobalQuery(ctx context.Context, option
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ImplicitClientGetOptionalGlobalQueryResponse{}, runtime.NewResponseError(resp)
 	}
-	return ImplicitClientGetOptionalGlobalQueryResponse{RawResponse: resp}, nil
+	return ImplicitClientGetOptionalGlobalQueryResponse{}, nil
 }
 
 // getOptionalGlobalQueryCreateRequest creates the GetOptionalGlobalQuery request.
@@ -98,7 +98,7 @@ func (client *ImplicitClient) GetRequiredGlobalPath(ctx context.Context, options
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ImplicitClientGetRequiredGlobalPathResponse{}, runtime.NewResponseError(resp)
 	}
-	return ImplicitClientGetRequiredGlobalPathResponse{RawResponse: resp}, nil
+	return ImplicitClientGetRequiredGlobalPathResponse{}, nil
 }
 
 // getRequiredGlobalPathCreateRequest creates the GetRequiredGlobalPath request.
@@ -132,7 +132,7 @@ func (client *ImplicitClient) GetRequiredGlobalQuery(ctx context.Context, option
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ImplicitClientGetRequiredGlobalQueryResponse{}, runtime.NewResponseError(resp)
 	}
-	return ImplicitClientGetRequiredGlobalQueryResponse{RawResponse: resp}, nil
+	return ImplicitClientGetRequiredGlobalQueryResponse{}, nil
 }
 
 // getRequiredGlobalQueryCreateRequest creates the GetRequiredGlobalQuery request.
@@ -165,7 +165,7 @@ func (client *ImplicitClient) GetRequiredPath(ctx context.Context, pathParameter
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ImplicitClientGetRequiredPathResponse{}, runtime.NewResponseError(resp)
 	}
-	return ImplicitClientGetRequiredPathResponse{RawResponse: resp}, nil
+	return ImplicitClientGetRequiredPathResponse{}, nil
 }
 
 // getRequiredPathCreateRequest creates the GetRequiredPath request.
@@ -199,7 +199,7 @@ func (client *ImplicitClient) PutOptionalBinaryBody(ctx context.Context, options
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ImplicitClientPutOptionalBinaryBodyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ImplicitClientPutOptionalBinaryBodyResponse{RawResponse: resp}, nil
+	return ImplicitClientPutOptionalBinaryBodyResponse{}, nil
 }
 
 // putOptionalBinaryBodyCreateRequest creates the PutOptionalBinaryBody request.
@@ -232,7 +232,7 @@ func (client *ImplicitClient) PutOptionalBody(ctx context.Context, options *Impl
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ImplicitClientPutOptionalBodyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ImplicitClientPutOptionalBodyResponse{RawResponse: resp}, nil
+	return ImplicitClientPutOptionalBodyResponse{}, nil
 }
 
 // putOptionalBodyCreateRequest creates the PutOptionalBody request.
@@ -265,7 +265,7 @@ func (client *ImplicitClient) PutOptionalHeader(ctx context.Context, options *Im
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ImplicitClientPutOptionalHeaderResponse{}, runtime.NewResponseError(resp)
 	}
-	return ImplicitClientPutOptionalHeaderResponse{RawResponse: resp}, nil
+	return ImplicitClientPutOptionalHeaderResponse{}, nil
 }
 
 // putOptionalHeaderCreateRequest creates the PutOptionalHeader request.
@@ -298,7 +298,7 @@ func (client *ImplicitClient) PutOptionalQuery(ctx context.Context, options *Imp
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ImplicitClientPutOptionalQueryResponse{}, runtime.NewResponseError(resp)
 	}
-	return ImplicitClientPutOptionalQueryResponse{RawResponse: resp}, nil
+	return ImplicitClientPutOptionalQueryResponse{}, nil
 }
 
 // putOptionalQueryCreateRequest creates the PutOptionalQuery request.

--- a/test/autorest/optionalgroup/zz_generated_response_types.go
+++ b/test/autorest/optionalgroup/zz_generated_response_types.go
@@ -8,196 +8,162 @@
 
 package optionalgroup
 
-import "net/http"
-
 // ExplicitClientPostOptionalArrayHeaderResponse contains the response from method ExplicitClient.PostOptionalArrayHeader.
 type ExplicitClientPostOptionalArrayHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalArrayParameterResponse contains the response from method ExplicitClient.PostOptionalArrayParameter.
 type ExplicitClientPostOptionalArrayParameterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalArrayPropertyResponse contains the response from method ExplicitClient.PostOptionalArrayProperty.
 type ExplicitClientPostOptionalArrayPropertyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalClassParameterResponse contains the response from method ExplicitClient.PostOptionalClassParameter.
 type ExplicitClientPostOptionalClassParameterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalClassPropertyResponse contains the response from method ExplicitClient.PostOptionalClassProperty.
 type ExplicitClientPostOptionalClassPropertyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalIntegerHeaderResponse contains the response from method ExplicitClient.PostOptionalIntegerHeader.
 type ExplicitClientPostOptionalIntegerHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalIntegerParameterResponse contains the response from method ExplicitClient.PostOptionalIntegerParameter.
 type ExplicitClientPostOptionalIntegerParameterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalIntegerPropertyResponse contains the response from method ExplicitClient.PostOptionalIntegerProperty.
 type ExplicitClientPostOptionalIntegerPropertyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalStringHeaderResponse contains the response from method ExplicitClient.PostOptionalStringHeader.
 type ExplicitClientPostOptionalStringHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalStringParameterResponse contains the response from method ExplicitClient.PostOptionalStringParameter.
 type ExplicitClientPostOptionalStringParameterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostOptionalStringPropertyResponse contains the response from method ExplicitClient.PostOptionalStringProperty.
 type ExplicitClientPostOptionalStringPropertyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredArrayHeaderResponse contains the response from method ExplicitClient.PostRequiredArrayHeader.
 type ExplicitClientPostRequiredArrayHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredArrayParameterResponse contains the response from method ExplicitClient.PostRequiredArrayParameter.
 type ExplicitClientPostRequiredArrayParameterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredArrayPropertyResponse contains the response from method ExplicitClient.PostRequiredArrayProperty.
 type ExplicitClientPostRequiredArrayPropertyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredClassParameterResponse contains the response from method ExplicitClient.PostRequiredClassParameter.
 type ExplicitClientPostRequiredClassParameterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredClassPropertyResponse contains the response from method ExplicitClient.PostRequiredClassProperty.
 type ExplicitClientPostRequiredClassPropertyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredIntegerHeaderResponse contains the response from method ExplicitClient.PostRequiredIntegerHeader.
 type ExplicitClientPostRequiredIntegerHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredIntegerParameterResponse contains the response from method ExplicitClient.PostRequiredIntegerParameter.
 type ExplicitClientPostRequiredIntegerParameterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredIntegerPropertyResponse contains the response from method ExplicitClient.PostRequiredIntegerProperty.
 type ExplicitClientPostRequiredIntegerPropertyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredStringHeaderResponse contains the response from method ExplicitClient.PostRequiredStringHeader.
 type ExplicitClientPostRequiredStringHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredStringParameterResponse contains the response from method ExplicitClient.PostRequiredStringParameter.
 type ExplicitClientPostRequiredStringParameterResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPostRequiredStringPropertyResponse contains the response from method ExplicitClient.PostRequiredStringProperty.
 type ExplicitClientPostRequiredStringPropertyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPutOptionalBinaryBodyResponse contains the response from method ExplicitClient.PutOptionalBinaryBody.
 type ExplicitClientPutOptionalBinaryBodyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExplicitClientPutRequiredBinaryBodyResponse contains the response from method ExplicitClient.PutRequiredBinaryBody.
 type ExplicitClientPutRequiredBinaryBodyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImplicitClientGetOptionalGlobalQueryResponse contains the response from method ImplicitClient.GetOptionalGlobalQuery.
 type ImplicitClientGetOptionalGlobalQueryResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImplicitClientGetRequiredGlobalPathResponse contains the response from method ImplicitClient.GetRequiredGlobalPath.
 type ImplicitClientGetRequiredGlobalPathResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImplicitClientGetRequiredGlobalQueryResponse contains the response from method ImplicitClient.GetRequiredGlobalQuery.
 type ImplicitClientGetRequiredGlobalQueryResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImplicitClientGetRequiredPathResponse contains the response from method ImplicitClient.GetRequiredPath.
 type ImplicitClientGetRequiredPathResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImplicitClientPutOptionalBinaryBodyResponse contains the response from method ImplicitClient.PutOptionalBinaryBody.
 type ImplicitClientPutOptionalBinaryBodyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImplicitClientPutOptionalBodyResponse contains the response from method ImplicitClient.PutOptionalBody.
 type ImplicitClientPutOptionalBodyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImplicitClientPutOptionalHeaderResponse contains the response from method ImplicitClient.PutOptionalHeader.
 type ImplicitClientPutOptionalHeaderResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImplicitClientPutOptionalQueryResponse contains the response from method ImplicitClient.PutOptionalQuery.
 type ImplicitClientPutOptionalQueryResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -69,7 +69,7 @@ func (client *PagingClient) firstResponseEmptyCreateRequest(ctx context.Context,
 
 // firstResponseEmptyHandleResponse handles the FirstResponseEmpty response.
 func (client *PagingClient) firstResponseEmptyHandleResponse(resp *http.Response) (PagingClientFirstResponseEmptyResponse, error) {
-	result := PagingClientFirstResponseEmptyResponse{RawResponse: resp}
+	result := PagingClientFirstResponseEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResultValue); err != nil {
 		return PagingClientFirstResponseEmptyResponse{}, err
 	}
@@ -113,7 +113,7 @@ func (client *PagingClient) getMultiplePagesCreateRequest(ctx context.Context, o
 
 // getMultiplePagesHandleResponse handles the GetMultiplePages response.
 func (client *PagingClient) getMultiplePagesHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesResponse, error) {
-	result := PagingClientGetMultiplePagesResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetMultiplePagesResponse{}, err
 	}
@@ -149,7 +149,7 @@ func (client *PagingClient) getMultiplePagesFailureCreateRequest(ctx context.Con
 
 // getMultiplePagesFailureHandleResponse handles the GetMultiplePagesFailure response.
 func (client *PagingClient) getMultiplePagesFailureHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesFailureResponse, error) {
-	result := PagingClientGetMultiplePagesFailureResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesFailureResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetMultiplePagesFailureResponse{}, err
 	}
@@ -185,7 +185,7 @@ func (client *PagingClient) getMultiplePagesFailureURICreateRequest(ctx context.
 
 // getMultiplePagesFailureURIHandleResponse handles the GetMultiplePagesFailureURI response.
 func (client *PagingClient) getMultiplePagesFailureURIHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesFailureURIResponse, error) {
-	result := PagingClientGetMultiplePagesFailureURIResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesFailureURIResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetMultiplePagesFailureURIResponse{}, err
 	}
@@ -230,7 +230,7 @@ func (client *PagingClient) getMultiplePagesFragmentNextLinkCreateRequest(ctx co
 
 // getMultiplePagesFragmentNextLinkHandleResponse handles the GetMultiplePagesFragmentNextLink response.
 func (client *PagingClient) getMultiplePagesFragmentNextLinkHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesFragmentNextLinkResponse, error) {
-	result := PagingClientGetMultiplePagesFragmentNextLinkResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesFragmentNextLinkResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
 		return PagingClientGetMultiplePagesFragmentNextLinkResponse{}, err
 	}
@@ -274,7 +274,7 @@ func (client *PagingClient) getMultiplePagesFragmentWithGroupingNextLinkCreateRe
 
 // getMultiplePagesFragmentWithGroupingNextLinkHandleResponse handles the GetMultiplePagesFragmentWithGroupingNextLink response.
 func (client *PagingClient) getMultiplePagesFragmentWithGroupingNextLinkHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse, error) {
-	result := PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
 		return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, err
 	}
@@ -290,9 +290,7 @@ func (client *PagingClient) BeginGetMultiplePagesLRO(ctx context.Context, option
 	if err != nil {
 		return PagingClientGetMultiplePagesLROPollerResponse{}, err
 	}
-	result := PagingClientGetMultiplePagesLROPollerResponse{
-		RawResponse: resp,
-	}
+	result := PagingClientGetMultiplePagesLROPollerResponse{}
 	pt, err := armruntime.NewPoller("PagingClient.GetMultiplePagesLRO", "", resp, client.pl)
 	if err != nil {
 		return PagingClientGetMultiplePagesLROPollerResponse{}, err
@@ -343,7 +341,7 @@ func (client *PagingClient) getMultiplePagesLROCreateRequest(ctx context.Context
 
 // getMultiplePagesLROHandleResponse handles the GetMultiplePagesLRO response.
 func (client *PagingClient) getMultiplePagesLROHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesLROResponse, error) {
-	result := PagingClientGetMultiplePagesLROResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesLROResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetMultiplePagesLROResponse{}, err
 	}
@@ -380,7 +378,7 @@ func (client *PagingClient) getMultiplePagesRetryFirstCreateRequest(ctx context.
 
 // getMultiplePagesRetryFirstHandleResponse handles the GetMultiplePagesRetryFirst response.
 func (client *PagingClient) getMultiplePagesRetryFirstHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesRetryFirstResponse, error) {
-	result := PagingClientGetMultiplePagesRetryFirstResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesRetryFirstResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetMultiplePagesRetryFirstResponse{}, err
 	}
@@ -417,7 +415,7 @@ func (client *PagingClient) getMultiplePagesRetrySecondCreateRequest(ctx context
 
 // getMultiplePagesRetrySecondHandleResponse handles the GetMultiplePagesRetrySecond response.
 func (client *PagingClient) getMultiplePagesRetrySecondHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesRetrySecondResponse, error) {
-	result := PagingClientGetMultiplePagesRetrySecondResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesRetrySecondResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetMultiplePagesRetrySecondResponse{}, err
 	}
@@ -463,7 +461,7 @@ func (client *PagingClient) getMultiplePagesWithOffsetCreateRequest(ctx context.
 
 // getMultiplePagesWithOffsetHandleResponse handles the GetMultiplePagesWithOffset response.
 func (client *PagingClient) getMultiplePagesWithOffsetHandleResponse(resp *http.Response) (PagingClientGetMultiplePagesWithOffsetResponse, error) {
-	result := PagingClientGetMultiplePagesWithOffsetResponse{RawResponse: resp}
+	result := PagingClientGetMultiplePagesWithOffsetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetMultiplePagesWithOffsetResponse{}, err
 	}
@@ -499,7 +497,7 @@ func (client *PagingClient) getNoItemNamePagesCreateRequest(ctx context.Context,
 
 // getNoItemNamePagesHandleResponse handles the GetNoItemNamePages response.
 func (client *PagingClient) getNoItemNamePagesHandleResponse(resp *http.Response) (PagingClientGetNoItemNamePagesResponse, error) {
-	result := PagingClientGetNoItemNamePagesResponse{RawResponse: resp}
+	result := PagingClientGetNoItemNamePagesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResultValue); err != nil {
 		return PagingClientGetNoItemNamePagesResponse{}, err
 	}
@@ -532,7 +530,7 @@ func (client *PagingClient) getNullNextLinkNamePagesCreateRequest(ctx context.Co
 
 // getNullNextLinkNamePagesHandleResponse handles the GetNullNextLinkNamePages response.
 func (client *PagingClient) getNullNextLinkNamePagesHandleResponse(resp *http.Response) (PagingClientGetNullNextLinkNamePagesResponse, error) {
-	result := PagingClientGetNullNextLinkNamePagesResponse{RawResponse: resp}
+	result := PagingClientGetNullNextLinkNamePagesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetNullNextLinkNamePagesResponse{}, err
 	}
@@ -577,7 +575,7 @@ func (client *PagingClient) getODataMultiplePagesCreateRequest(ctx context.Conte
 
 // getODataMultiplePagesHandleResponse handles the GetODataMultiplePages response.
 func (client *PagingClient) getODataMultiplePagesHandleResponse(resp *http.Response) (PagingClientGetODataMultiplePagesResponse, error) {
-	result := PagingClientGetODataMultiplePagesResponse{RawResponse: resp}
+	result := PagingClientGetODataMultiplePagesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
 		return PagingClientGetODataMultiplePagesResponse{}, err
 	}
@@ -614,7 +612,7 @@ func (client *PagingClient) getPagingModelWithItemNameWithXMSClientNameCreateReq
 
 // getPagingModelWithItemNameWithXMSClientNameHandleResponse handles the GetPagingModelWithItemNameWithXMSClientName response.
 func (client *PagingClient) getPagingModelWithItemNameWithXMSClientNameHandleResponse(resp *http.Response) (PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse, error) {
-	result := PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{RawResponse: resp}
+	result := PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResultValueWithXMSClientName); err != nil {
 		return PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}, err
 	}
@@ -649,7 +647,7 @@ func (client *PagingClient) getSinglePagesCreateRequest(ctx context.Context, opt
 
 // getSinglePagesHandleResponse handles the GetSinglePages response.
 func (client *PagingClient) getSinglePagesHandleResponse(resp *http.Response) (PagingClientGetSinglePagesResponse, error) {
-	result := PagingClientGetSinglePagesResponse{RawResponse: resp}
+	result := PagingClientGetSinglePagesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetSinglePagesResponse{}, err
 	}
@@ -685,7 +683,7 @@ func (client *PagingClient) getSinglePagesFailureCreateRequest(ctx context.Conte
 
 // getSinglePagesFailureHandleResponse handles the GetSinglePagesFailure response.
 func (client *PagingClient) getSinglePagesFailureHandleResponse(resp *http.Response) (PagingClientGetSinglePagesFailureResponse, error) {
-	result := PagingClientGetSinglePagesFailureResponse{RawResponse: resp}
+	result := PagingClientGetSinglePagesFailureResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetSinglePagesFailureResponse{}, err
 	}
@@ -727,7 +725,7 @@ func (client *PagingClient) getWithQueryParamsCreateRequest(ctx context.Context,
 
 // getWithQueryParamsHandleResponse handles the GetWithQueryParams response.
 func (client *PagingClient) getWithQueryParamsHandleResponse(resp *http.Response) (PagingClientGetWithQueryParamsResponse, error) {
-	result := PagingClientGetWithQueryParamsResponse{RawResponse: resp}
+	result := PagingClientGetWithQueryParamsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientGetWithQueryParamsResponse{}, err
 	}
@@ -755,7 +753,7 @@ func (client *PagingClient) nextFragmentCreateRequest(ctx context.Context, apiVe
 
 // nextFragmentHandleResponse handles the NextFragment response.
 func (client *PagingClient) nextFragmentHandleResponse(resp *http.Response) (PagingClientNextFragmentResponse, error) {
-	result := PagingClientNextFragmentResponse{RawResponse: resp}
+	result := PagingClientNextFragmentResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
 		return PagingClientNextFragmentResponse{}, err
 	}
@@ -783,7 +781,7 @@ func (client *PagingClient) nextFragmentWithGroupingCreateRequest(ctx context.Co
 
 // nextFragmentWithGroupingHandleResponse handles the NextFragmentWithGrouping response.
 func (client *PagingClient) nextFragmentWithGroupingHandleResponse(resp *http.Response) (PagingClientNextFragmentWithGroupingResponse, error) {
-	result := PagingClientNextFragmentWithGroupingResponse{RawResponse: resp}
+	result := PagingClientNextFragmentWithGroupingResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
 		return PagingClientNextFragmentWithGroupingResponse{}, err
 	}
@@ -806,7 +804,7 @@ func (client *PagingClient) nextOperationWithQueryParamsCreateRequest(ctx contex
 
 // nextOperationWithQueryParamsHandleResponse handles the NextOperationWithQueryParams response.
 func (client *PagingClient) nextOperationWithQueryParamsHandleResponse(resp *http.Response) (PagingClientNextOperationWithQueryParamsResponse, error) {
-	result := PagingClientNextOperationWithQueryParamsResponse{RawResponse: resp}
+	result := PagingClientNextOperationWithQueryParamsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
 		return PagingClientNextOperationWithQueryParamsResponse{}, err
 	}

--- a/test/autorest/paginggroup/zz_generated_response_types.go
+++ b/test/autorest/paginggroup/zz_generated_response_types.go
@@ -11,63 +11,48 @@ package paginggroup
 import (
 	"context"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"net/http"
 	"time"
 )
 
 // PagingClientFirstResponseEmptyResponse contains the response from method PagingClient.FirstResponseEmpty.
 type PagingClientFirstResponseEmptyResponse struct {
 	ProductResultValue
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesFailureResponse contains the response from method PagingClient.GetMultiplePagesFailure.
 type PagingClientGetMultiplePagesFailureResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesFailureURIResponse contains the response from method PagingClient.GetMultiplePagesFailureURI.
 type PagingClientGetMultiplePagesFailureURIResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesFragmentNextLinkResponse contains the response from method PagingClient.GetMultiplePagesFragmentNextLink.
 type PagingClientGetMultiplePagesFragmentNextLinkResponse struct {
 	ODataProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse contains the response from method PagingClient.GetMultiplePagesFragmentWithGroupingNextLink.
 type PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse struct {
 	ODataProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesLROPollerResponse contains the response from method PagingClient.GetMultiplePagesLRO.
 type PagingClientGetMultiplePagesLROPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PagingClientGetMultiplePagesLROPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l PagingClientGetMultiplePagesLROPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (*PagingClientGetMultiplePagesLROPager, error) {
 	respType := &PagingClientGetMultiplePagesLROPager{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.ProductResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.ProductResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.current.RawResponse = resp
 	respType.client = l.Poller.client
 	return respType, nil
 }
@@ -82,116 +67,85 @@ func (l *PagingClientGetMultiplePagesLROPollerResponse) Resume(ctx context.Conte
 		pt:     pt,
 		client: client,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PagingClientGetMultiplePagesLROResponse contains the response from method PagingClient.GetMultiplePagesLRO.
 type PagingClientGetMultiplePagesLROResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesResponse contains the response from method PagingClient.GetMultiplePages.
 type PagingClientGetMultiplePagesResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesRetryFirstResponse contains the response from method PagingClient.GetMultiplePagesRetryFirst.
 type PagingClientGetMultiplePagesRetryFirstResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesRetrySecondResponse contains the response from method PagingClient.GetMultiplePagesRetrySecond.
 type PagingClientGetMultiplePagesRetrySecondResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetMultiplePagesWithOffsetResponse contains the response from method PagingClient.GetMultiplePagesWithOffset.
 type PagingClientGetMultiplePagesWithOffsetResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetNoItemNamePagesResponse contains the response from method PagingClient.GetNoItemNamePages.
 type PagingClientGetNoItemNamePagesResponse struct {
 	ProductResultValue
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetNullNextLinkNamePagesResponse contains the response from method PagingClient.GetNullNextLinkNamePages.
 type PagingClientGetNullNextLinkNamePagesResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetODataMultiplePagesResponse contains the response from method PagingClient.GetODataMultiplePages.
 type PagingClientGetODataMultiplePagesResponse struct {
 	ODataProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse contains the response from method PagingClient.GetPagingModelWithItemNameWithXMSClientName.
 type PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse struct {
 	ProductResultValueWithXMSClientName
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetSinglePagesFailureResponse contains the response from method PagingClient.GetSinglePagesFailure.
 type PagingClientGetSinglePagesFailureResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetSinglePagesResponse contains the response from method PagingClient.GetSinglePages.
 type PagingClientGetSinglePagesResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientGetWithQueryParamsResponse contains the response from method PagingClient.GetWithQueryParams.
 type PagingClientGetWithQueryParamsResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientNextFragmentResponse contains the response from method PagingClient.NextFragment.
 type PagingClientNextFragmentResponse struct {
 	ODataProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientNextFragmentWithGroupingResponse contains the response from method PagingClient.NextFragmentWithGrouping.
 type PagingClientNextFragmentWithGroupingResponse struct {
 	ODataProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PagingClientNextOperationWithQueryParamsResponse contains the response from method PagingClient.NextOperationWithQueryParams.
 type PagingClientNextOperationWithQueryParamsResponse struct {
 	ProductResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
+++ b/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
@@ -5,7 +5,7 @@ package paramgroupinggroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -20,8 +20,8 @@ func TestPostMultiParamGroups(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -32,8 +32,8 @@ func TestPostOptional(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -47,8 +47,8 @@ func TestPostRequired(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -59,7 +59,7 @@ func TestPostSharedParameterGroupObject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping_client.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping_client.go
@@ -56,7 +56,7 @@ func (client *ParameterGroupingClient) PostMultiParamGroups(ctx context.Context,
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ParameterGroupingClientPostMultiParamGroupsResponse{}, runtime.NewResponseError(resp)
 	}
-	return ParameterGroupingClientPostMultiParamGroupsResponse{RawResponse: resp}, nil
+	return ParameterGroupingClientPostMultiParamGroupsResponse{}, nil
 }
 
 // postMultiParamGroupsCreateRequest creates the PostMultiParamGroups request.
@@ -100,7 +100,7 @@ func (client *ParameterGroupingClient) PostOptional(ctx context.Context, options
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ParameterGroupingClientPostOptionalResponse{}, runtime.NewResponseError(resp)
 	}
-	return ParameterGroupingClientPostOptionalResponse{RawResponse: resp}, nil
+	return ParameterGroupingClientPostOptionalResponse{}, nil
 }
 
 // postOptionalCreateRequest creates the PostOptional request.
@@ -138,7 +138,7 @@ func (client *ParameterGroupingClient) PostRequired(ctx context.Context, paramet
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ParameterGroupingClientPostRequiredResponse{}, runtime.NewResponseError(resp)
 	}
-	return ParameterGroupingClientPostRequiredResponse{RawResponse: resp}, nil
+	return ParameterGroupingClientPostRequiredResponse{}, nil
 }
 
 // postRequiredCreateRequest creates the PostRequired request.
@@ -180,7 +180,7 @@ func (client *ParameterGroupingClient) PostReservedWords(ctx context.Context, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ParameterGroupingClientPostReservedWordsResponse{}, runtime.NewResponseError(resp)
 	}
-	return ParameterGroupingClientPostReservedWordsResponse{RawResponse: resp}, nil
+	return ParameterGroupingClientPostReservedWordsResponse{}, nil
 }
 
 // postReservedWordsCreateRequest creates the PostReservedWords request.
@@ -217,7 +217,7 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx contex
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ParameterGroupingClientPostSharedParameterGroupObjectResponse{}, runtime.NewResponseError(resp)
 	}
-	return ParameterGroupingClientPostSharedParameterGroupObjectResponse{RawResponse: resp}, nil
+	return ParameterGroupingClientPostSharedParameterGroupObjectResponse{}, nil
 }
 
 // postSharedParameterGroupObjectCreateRequest creates the PostSharedParameterGroupObject request.

--- a/test/autorest/paramgroupinggroup/zz_generated_response_types.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_response_types.go
@@ -8,34 +8,27 @@
 
 package paramgroupinggroup
 
-import "net/http"
-
 // ParameterGroupingClientPostMultiParamGroupsResponse contains the response from method ParameterGroupingClient.PostMultiParamGroups.
 type ParameterGroupingClientPostMultiParamGroupsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ParameterGroupingClientPostOptionalResponse contains the response from method ParameterGroupingClient.PostOptional.
 type ParameterGroupingClientPostOptionalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ParameterGroupingClientPostRequiredResponse contains the response from method ParameterGroupingClient.PostRequired.
 type ParameterGroupingClientPostRequiredResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ParameterGroupingClientPostReservedWordsResponse contains the response from method ParameterGroupingClient.PostReservedWords.
 type ParameterGroupingClientPostReservedWordsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ParameterGroupingClientPostSharedParameterGroupObjectResponse contains the response from method ParameterGroupingClient.PostSharedParameterGroupObject.
 type ParameterGroupingClientPostSharedParameterGroupObjectResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice_client.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice_client.go
@@ -71,7 +71,7 @@ func (client *AutoRestReportServiceClient) getOptionalReportCreateRequest(ctx co
 
 // getOptionalReportHandleResponse handles the GetOptionalReport response.
 func (client *AutoRestReportServiceClient) getOptionalReportHandleResponse(resp *http.Response) (AutoRestReportServiceClientGetOptionalReportResponse, error) {
-	result := AutoRestReportServiceClientGetOptionalReportResponse{RawResponse: resp}
+	result := AutoRestReportServiceClientGetOptionalReportResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return AutoRestReportServiceClientGetOptionalReportResponse{}, err
 	}
@@ -115,7 +115,7 @@ func (client *AutoRestReportServiceClient) getReportCreateRequest(ctx context.Co
 
 // getReportHandleResponse handles the GetReport response.
 func (client *AutoRestReportServiceClient) getReportHandleResponse(resp *http.Response) (AutoRestReportServiceClientGetReportResponse, error) {
-	result := AutoRestReportServiceClientGetReportResponse{RawResponse: resp}
+	result := AutoRestReportServiceClientGetReportResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return AutoRestReportServiceClientGetReportResponse{}, err
 	}

--- a/test/autorest/reportgroup/zz_generated_response_types.go
+++ b/test/autorest/reportgroup/zz_generated_response_types.go
@@ -8,22 +8,14 @@
 
 package reportgroup
 
-import "net/http"
-
 // AutoRestReportServiceClientGetOptionalReportResponse contains the response from method AutoRestReportServiceClient.GetOptionalReport.
 type AutoRestReportServiceClientGetOptionalReportResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of <integer>
 	Value map[string]*int32
 }
 
 // AutoRestReportServiceClientGetReportResponse contains the response from method AutoRestReportServiceClient.GetReport.
 type AutoRestReportServiceClientGetReportResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Dictionary of <integer>
 	Value map[string]*int32
 }

--- a/test/autorest/stringgroup/enum_test.go
+++ b/test/autorest/stringgroup/enum_test.go
@@ -5,7 +5,7 @@ package stringgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,9 +21,6 @@ func TestEnumGetNotExpandable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetNotExpandable: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, ColorsRedColor.ToPtr()); r != "" {
 		t.Fatal(r)
 	}
@@ -35,9 +32,6 @@ func TestEnumGetReferenced(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetReferenced: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, ColorsRedColor.ToPtr()); r != "" {
 		t.Fatal(r)
 	}
@@ -48,9 +42,6 @@ func TestEnumGetReferencedConstant(t *testing.T) {
 	result, err := client.GetReferencedConstant(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetReferencedConstant: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	val := "Sample String"
 	if r := cmp.Diff(result.RefColorConstant, RefColorConstant{Field1: &val}); r != "" {
@@ -64,8 +55,8 @@ func TestEnumPutNotExpandable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutNotExpandable: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -75,8 +66,8 @@ func TestEnumPutReferenced(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutReferenced: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -87,8 +78,8 @@ func TestEnumPutReferencedConstant(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutReferencedConstant: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 
 }

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -5,7 +5,7 @@ package stringgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -22,9 +22,6 @@ func TestStringGetMBCS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMBCS: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, to.StringPtr("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€")); r != "" {
 		t.Fatal(r)
 	}
@@ -36,8 +33,8 @@ func TestStringPutMBCS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutMBCS: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -46,9 +43,6 @@ func TestStringGetBase64Encoded(t *testing.T) {
 	result, err := client.GetBase64Encoded(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBase64Encoded: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	val := []byte("a string that gets encoded with base64")
 	if r := cmp.Diff(result.Value, val); r != "" {
@@ -62,9 +56,6 @@ func TestStringGetBase64URLEncoded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetBase64URLEncoded: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, []byte("a string that gets encoded with base64url")); r != "" {
 		t.Fatal(r)
 	}
@@ -75,9 +66,6 @@ func TestStringGetEmpty(t *testing.T) {
 	result, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(result.Value, to.StringPtr("")); r != "" {
 		t.Fatal(r)
@@ -90,8 +78,8 @@ func TestStringGetNotProvided(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -101,8 +89,8 @@ func TestStringGetNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -111,9 +99,6 @@ func TestStringGetNullBase64URLEncoded(t *testing.T) {
 	result, err := client.GetNullBase64URLEncoded(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNullBase64URLEncoded: %v", err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	if r := cmp.Diff(result.Value, ([]byte)(nil)); r != "" {
 		t.Fatal(r)
@@ -126,9 +111,6 @@ func TestStringGetWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetWhitespace: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if r := cmp.Diff(result.Value, to.StringPtr("    Now is the time for all good men to come to the aid of their country    ")); r != "" {
 		t.Fatal(r)
 	}
@@ -140,8 +122,8 @@ func TestStringPutBase64URLEncoded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBase64URLEncoded: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -151,8 +133,8 @@ func TestStringPutEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -162,8 +144,8 @@ func TestStringPutNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutNull: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -173,7 +155,7 @@ func TestStringPutWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutWhitespace: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/stringgroup/zz_generated_enum_client.go
+++ b/test/autorest/stringgroup/zz_generated_enum_client.go
@@ -65,7 +65,7 @@ func (client *EnumClient) getNotExpandableCreateRequest(ctx context.Context, opt
 
 // getNotExpandableHandleResponse handles the GetNotExpandable response.
 func (client *EnumClient) getNotExpandableHandleResponse(resp *http.Response) (EnumClientGetNotExpandableResponse, error) {
-	result := EnumClientGetNotExpandableResponse{RawResponse: resp}
+	result := EnumClientGetNotExpandableResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return EnumClientGetNotExpandableResponse{}, err
 	}
@@ -103,7 +103,7 @@ func (client *EnumClient) getReferencedCreateRequest(ctx context.Context, option
 
 // getReferencedHandleResponse handles the GetReferenced response.
 func (client *EnumClient) getReferencedHandleResponse(resp *http.Response) (EnumClientGetReferencedResponse, error) {
-	result := EnumClientGetReferencedResponse{RawResponse: resp}
+	result := EnumClientGetReferencedResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return EnumClientGetReferencedResponse{}, err
 	}
@@ -142,7 +142,7 @@ func (client *EnumClient) getReferencedConstantCreateRequest(ctx context.Context
 
 // getReferencedConstantHandleResponse handles the GetReferencedConstant response.
 func (client *EnumClient) getReferencedConstantHandleResponse(resp *http.Response) (EnumClientGetReferencedConstantResponse, error) {
-	result := EnumClientGetReferencedConstantResponse{RawResponse: resp}
+	result := EnumClientGetReferencedConstantResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RefColorConstant); err != nil {
 		return EnumClientGetReferencedConstantResponse{}, err
 	}
@@ -165,7 +165,7 @@ func (client *EnumClient) PutNotExpandable(ctx context.Context, stringBody Color
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return EnumClientPutNotExpandableResponse{}, runtime.NewResponseError(resp)
 	}
-	return EnumClientPutNotExpandableResponse{RawResponse: resp}, nil
+	return EnumClientPutNotExpandableResponse{}, nil
 }
 
 // putNotExpandableCreateRequest creates the PutNotExpandable request.
@@ -195,7 +195,7 @@ func (client *EnumClient) PutReferenced(ctx context.Context, enumStringBody Colo
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return EnumClientPutReferencedResponse{}, runtime.NewResponseError(resp)
 	}
-	return EnumClientPutReferencedResponse{RawResponse: resp}, nil
+	return EnumClientPutReferencedResponse{}, nil
 }
 
 // putReferencedCreateRequest creates the PutReferenced request.
@@ -226,7 +226,7 @@ func (client *EnumClient) PutReferencedConstant(ctx context.Context, enumStringB
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return EnumClientPutReferencedConstantResponse{}, runtime.NewResponseError(resp)
 	}
-	return EnumClientPutReferencedConstantResponse{RawResponse: resp}, nil
+	return EnumClientPutReferencedConstantResponse{}, nil
 }
 
 // putReferencedConstantCreateRequest creates the PutReferencedConstant request.

--- a/test/autorest/stringgroup/zz_generated_response_types.go
+++ b/test/autorest/stringgroup/zz_generated_response_types.go
@@ -8,13 +8,8 @@
 
 package stringgroup
 
-import "net/http"
-
 // EnumClientGetNotExpandableResponse contains the response from method EnumClient.GetNotExpandable.
 type EnumClientGetNotExpandableResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Referenced Color Enum Description.
 	Value *Colors
 }
@@ -22,125 +17,93 @@ type EnumClientGetNotExpandableResponse struct {
 // EnumClientGetReferencedConstantResponse contains the response from method EnumClient.GetReferencedConstant.
 type EnumClientGetReferencedConstantResponse struct {
 	RefColorConstant
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // EnumClientGetReferencedResponse contains the response from method EnumClient.GetReferenced.
 type EnumClientGetReferencedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Referenced Color Enum Description.
 	Value *Colors
 }
 
 // EnumClientPutNotExpandableResponse contains the response from method EnumClient.PutNotExpandable.
 type EnumClientPutNotExpandableResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // EnumClientPutReferencedConstantResponse contains the response from method EnumClient.PutReferencedConstant.
 type EnumClientPutReferencedConstantResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // EnumClientPutReferencedResponse contains the response from method EnumClient.PutReferenced.
 type EnumClientPutReferencedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // StringClientGetBase64EncodedResponse contains the response from method StringClient.GetBase64Encoded.
 type StringClientGetBase64EncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       []byte
+	Value []byte
 }
 
 // StringClientGetBase64URLEncodedResponse contains the response from method StringClient.GetBase64URLEncoded.
 type StringClientGetBase64URLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       []byte
+	Value []byte
 }
 
 // StringClientGetEmptyResponse contains the response from method StringClient.GetEmpty.
 type StringClientGetEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple string
 	Value *string
 }
 
 // StringClientGetMBCSResponse contains the response from method StringClient.GetMBCS.
 type StringClientGetMBCSResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple string
 	Value *string
 }
 
 // StringClientGetNotProvidedResponse contains the response from method StringClient.GetNotProvided.
 type StringClientGetNotProvidedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // StringClientGetNullBase64URLEncodedResponse contains the response from method StringClient.GetNullBase64URLEncoded.
 type StringClientGetNullBase64URLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       []byte
+	Value []byte
 }
 
 // StringClientGetNullResponse contains the response from method StringClient.GetNull.
 type StringClientGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // StringClientGetWhitespaceResponse contains the response from method StringClient.GetWhitespace.
 type StringClientGetWhitespaceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// simple string
 	Value *string
 }
 
 // StringClientPutBase64URLEncodedResponse contains the response from method StringClient.PutBase64URLEncoded.
 type StringClientPutBase64URLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // StringClientPutEmptyResponse contains the response from method StringClient.PutEmpty.
 type StringClientPutEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // StringClientPutMBCSResponse contains the response from method StringClient.PutMBCS.
 type StringClientPutMBCSResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // StringClientPutNullResponse contains the response from method StringClient.PutNull.
 type StringClientPutNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // StringClientPutWhitespaceResponse contains the response from method StringClient.PutWhitespace.
 type StringClientPutWhitespaceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/stringgroup/zz_generated_string_client.go
+++ b/test/autorest/stringgroup/zz_generated_string_client.go
@@ -65,7 +65,7 @@ func (client *StringClient) getBase64EncodedCreateRequest(ctx context.Context, o
 
 // getBase64EncodedHandleResponse handles the GetBase64Encoded response.
 func (client *StringClient) getBase64EncodedHandleResponse(resp *http.Response) (StringClientGetBase64EncodedResponse, error) {
-	result := StringClientGetBase64EncodedResponse{RawResponse: resp}
+	result := StringClientGetBase64EncodedResponse{}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
 		return StringClientGetBase64EncodedResponse{}, err
 	}
@@ -104,7 +104,7 @@ func (client *StringClient) getBase64URLEncodedCreateRequest(ctx context.Context
 
 // getBase64URLEncodedHandleResponse handles the GetBase64URLEncoded response.
 func (client *StringClient) getBase64URLEncodedHandleResponse(resp *http.Response) (StringClientGetBase64URLEncodedResponse, error) {
-	result := StringClientGetBase64URLEncodedResponse{RawResponse: resp}
+	result := StringClientGetBase64URLEncodedResponse{}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64URLFormat); err != nil {
 		return StringClientGetBase64URLEncodedResponse{}, err
 	}
@@ -142,7 +142,7 @@ func (client *StringClient) getEmptyCreateRequest(ctx context.Context, options *
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *StringClient) getEmptyHandleResponse(resp *http.Response) (StringClientGetEmptyResponse, error) {
-	result := StringClientGetEmptyResponse{RawResponse: resp}
+	result := StringClientGetEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return StringClientGetEmptyResponse{}, err
 	}
@@ -180,7 +180,7 @@ func (client *StringClient) getMBCSCreateRequest(ctx context.Context, options *S
 
 // getMBCSHandleResponse handles the GetMBCS response.
 func (client *StringClient) getMBCSHandleResponse(resp *http.Response) (StringClientGetMBCSResponse, error) {
-	result := StringClientGetMBCSResponse{RawResponse: resp}
+	result := StringClientGetMBCSResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return StringClientGetMBCSResponse{}, err
 	}
@@ -218,7 +218,7 @@ func (client *StringClient) getNotProvidedCreateRequest(ctx context.Context, opt
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *StringClient) getNotProvidedHandleResponse(resp *http.Response) (StringClientGetNotProvidedResponse, error) {
-	result := StringClientGetNotProvidedResponse{RawResponse: resp}
+	result := StringClientGetNotProvidedResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return StringClientGetNotProvidedResponse{}, err
 	}
@@ -256,7 +256,7 @@ func (client *StringClient) getNullCreateRequest(ctx context.Context, options *S
 
 // getNullHandleResponse handles the GetNull response.
 func (client *StringClient) getNullHandleResponse(resp *http.Response) (StringClientGetNullResponse, error) {
-	result := StringClientGetNullResponse{RawResponse: resp}
+	result := StringClientGetNullResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return StringClientGetNullResponse{}, err
 	}
@@ -295,7 +295,7 @@ func (client *StringClient) getNullBase64URLEncodedCreateRequest(ctx context.Con
 
 // getNullBase64URLEncodedHandleResponse handles the GetNullBase64URLEncoded response.
 func (client *StringClient) getNullBase64URLEncodedHandleResponse(resp *http.Response) (StringClientGetNullBase64URLEncodedResponse, error) {
-	result := StringClientGetNullBase64URLEncodedResponse{RawResponse: resp}
+	result := StringClientGetNullBase64URLEncodedResponse{}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64URLFormat); err != nil {
 		return StringClientGetNullBase64URLEncodedResponse{}, err
 	}
@@ -334,7 +334,7 @@ func (client *StringClient) getWhitespaceCreateRequest(ctx context.Context, opti
 
 // getWhitespaceHandleResponse handles the GetWhitespace response.
 func (client *StringClient) getWhitespaceHandleResponse(resp *http.Response) (StringClientGetWhitespaceResponse, error) {
-	result := StringClientGetWhitespaceResponse{RawResponse: resp}
+	result := StringClientGetWhitespaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return StringClientGetWhitespaceResponse{}, err
 	}
@@ -358,7 +358,7 @@ func (client *StringClient) PutBase64URLEncoded(ctx context.Context, stringBody 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return StringClientPutBase64URLEncodedResponse{}, runtime.NewResponseError(resp)
 	}
-	return StringClientPutBase64URLEncodedResponse{RawResponse: resp}, nil
+	return StringClientPutBase64URLEncodedResponse{}, nil
 }
 
 // putBase64URLEncodedCreateRequest creates the PutBase64URLEncoded request.
@@ -387,7 +387,7 @@ func (client *StringClient) PutEmpty(ctx context.Context, options *StringClientP
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return StringClientPutEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return StringClientPutEmptyResponse{RawResponse: resp}, nil
+	return StringClientPutEmptyResponse{}, nil
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
@@ -416,7 +416,7 @@ func (client *StringClient) PutMBCS(ctx context.Context, options *StringClientPu
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return StringClientPutMBCSResponse{}, runtime.NewResponseError(resp)
 	}
-	return StringClientPutMBCSResponse{RawResponse: resp}, nil
+	return StringClientPutMBCSResponse{}, nil
 }
 
 // putMBCSCreateRequest creates the PutMBCS request.
@@ -445,7 +445,7 @@ func (client *StringClient) PutNull(ctx context.Context, options *StringClientPu
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return StringClientPutNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return StringClientPutNullResponse{RawResponse: resp}, nil
+	return StringClientPutNullResponse{}, nil
 }
 
 // putNullCreateRequest creates the PutNull request.
@@ -478,7 +478,7 @@ func (client *StringClient) PutWhitespace(ctx context.Context, options *StringCl
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return StringClientPutWhitespaceResponse{}, runtime.NewResponseError(resp)
 	}
-	return StringClientPutWhitespaceResponse{RawResponse: resp}, nil
+	return StringClientPutWhitespaceResponse{}, nil
 }
 
 // putWhitespaceCreateRequest creates the PutWhitespace request.

--- a/test/autorest/urlgroup/pathitems_test.go
+++ b/test/autorest/urlgroup/pathitems_test.go
@@ -5,7 +5,7 @@ package urlgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -20,8 +20,8 @@ func TestGetAllWithValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -33,8 +33,8 @@ func TestGetGlobalAndLocalQueryNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -47,8 +47,8 @@ func TestGetGlobalQueryNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -58,7 +58,7 @@ func TestGetLocalPathItemQueryNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/urlgroup/paths_test.go
+++ b/test/autorest/urlgroup/paths_test.go
@@ -5,7 +5,7 @@ package urlgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -20,8 +20,8 @@ func TestArrayCSVInPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -31,8 +31,8 @@ func TestPathsBase64URL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -42,8 +42,8 @@ func TestPathsByteEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -53,8 +53,8 @@ func TestPathsByteMultiByte(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -74,8 +74,8 @@ func TestPathsDateNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusBadRequest {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -86,8 +86,8 @@ func TestPathsDateTimeNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusBadRequest {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -97,8 +97,8 @@ func TestPathsDateTimeValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -108,8 +108,8 @@ func TestPathsDateValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -119,8 +119,8 @@ func TestPathsDoubleDecimalNegative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -130,8 +130,8 @@ func TestPathsDoubleDecimalPositive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -151,8 +151,8 @@ func TestPathsEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -162,8 +162,8 @@ func TestPathsFloatScientificNegative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -173,8 +173,8 @@ func TestPathsFloatScientificPositive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -184,8 +184,8 @@ func TestPathsGetBooleanFalse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -195,8 +195,8 @@ func TestPathsGetBooleanTrue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -206,8 +206,8 @@ func TestPathsGetIntNegativeOneMillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -217,8 +217,8 @@ func TestPathsGetIntOneMillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -228,8 +228,8 @@ func TestPathsGetNegativeTenBillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -239,8 +239,8 @@ func TestPathsGetTenBillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -250,8 +250,8 @@ func TestPathsStringEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -270,8 +270,8 @@ func TestPathsStringURLEncoded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -281,8 +281,8 @@ func TestPathsStringURLNonEncoded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -292,8 +292,8 @@ func TestPathsStringUnicode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -307,7 +307,7 @@ func TestPathsUnixTimeURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -5,7 +5,7 @@ package urlgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -22,8 +22,8 @@ func TestArrayStringCSVEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -34,8 +34,8 @@ func TestArrayStringCSVNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -48,8 +48,8 @@ func TestArrayStringCsvValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -62,8 +62,8 @@ func TestArrayStringPipesValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -76,8 +76,8 @@ func TestArrayStringSsvValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -90,8 +90,8 @@ func TestArrayStringTsvValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -102,8 +102,8 @@ func TestByteEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -116,8 +116,8 @@ func TestByteMultiByte(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -128,8 +128,8 @@ func TestByteNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -140,8 +140,8 @@ func TestDateNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -152,8 +152,8 @@ func TestDateTimeNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -164,8 +164,8 @@ func TestDateTimeValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -176,8 +176,8 @@ func TestDateValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -188,8 +188,8 @@ func TestDoubleDecimalNegative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -200,8 +200,8 @@ func TestDoubleDecimalPositive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -212,8 +212,8 @@ func TestDoubleNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -224,8 +224,8 @@ func TestEnumNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -238,8 +238,8 @@ func TestEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -250,8 +250,8 @@ func TestFloatNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -262,8 +262,8 @@ func TestFloatScientificNegative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -274,8 +274,8 @@ func TestFloatScientificPositive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -286,8 +286,8 @@ func TestGetBooleanFalse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -298,8 +298,8 @@ func TestGetBooleanNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -310,8 +310,8 @@ func TestGetBooleanTrue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -322,8 +322,8 @@ func TestGetIntNegativeOneMillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -334,8 +334,8 @@ func TestGetIntNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -346,8 +346,8 @@ func TestGetIntOneMillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -358,8 +358,8 @@ func TestGetLongNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -370,8 +370,8 @@ func TestGetNegativeTenBillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -382,8 +382,8 @@ func TestGetTenBillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -394,8 +394,8 @@ func TestStringEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -406,8 +406,8 @@ func TestStringNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -418,8 +418,8 @@ func TestStringURLEncoded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -430,7 +430,7 @@ func TestStringUnicode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/urlgroup/zz_generated_pathitems_client.go
+++ b/test/autorest/urlgroup/zz_generated_pathitems_client.go
@@ -63,7 +63,7 @@ func (client *PathItemsClient) GetAllWithValues(ctx context.Context, pathItemStr
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathItemsClientGetAllWithValuesResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathItemsClientGetAllWithValuesResponse{RawResponse: resp}, nil
+	return PathItemsClientGetAllWithValuesResponse{}, nil
 }
 
 // getAllWithValuesCreateRequest creates the GetAllWithValues request.
@@ -120,7 +120,7 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNull(ctx context.Context, p
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathItemsClientGetGlobalAndLocalQueryNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathItemsClientGetGlobalAndLocalQueryNullResponse{RawResponse: resp}, nil
+	return PathItemsClientGetGlobalAndLocalQueryNullResponse{}, nil
 }
 
 // getGlobalAndLocalQueryNullCreateRequest creates the GetGlobalAndLocalQueryNull request.
@@ -177,7 +177,7 @@ func (client *PathItemsClient) GetGlobalQueryNull(ctx context.Context, pathItemS
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathItemsClientGetGlobalQueryNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathItemsClientGetGlobalQueryNullResponse{RawResponse: resp}, nil
+	return PathItemsClientGetGlobalQueryNullResponse{}, nil
 }
 
 // getGlobalQueryNullCreateRequest creates the GetGlobalQueryNull request.
@@ -234,7 +234,7 @@ func (client *PathItemsClient) GetLocalPathItemQueryNull(ctx context.Context, pa
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathItemsClientGetLocalPathItemQueryNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathItemsClientGetLocalPathItemQueryNullResponse{RawResponse: resp}, nil
+	return PathItemsClientGetLocalPathItemQueryNullResponse{}, nil
 }
 
 // getLocalPathItemQueryNullCreateRequest creates the GetLocalPathItemQueryNull request.

--- a/test/autorest/urlgroup/zz_generated_paths_client.go
+++ b/test/autorest/urlgroup/zz_generated_paths_client.go
@@ -55,7 +55,7 @@ func (client *PathsClient) ArrayCSVInPath(ctx context.Context, arrayPath []strin
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientArrayCSVInPathResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientArrayCSVInPathResponse{RawResponse: resp}, nil
+	return PathsClientArrayCSVInPathResponse{}, nil
 }
 
 // arrayCSVInPathCreateRequest creates the ArrayCSVInPath request.
@@ -86,7 +86,7 @@ func (client *PathsClient) Base64URL(ctx context.Context, base64URLPath []byte, 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientBase64URLResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientBase64URLResponse{RawResponse: resp}, nil
+	return PathsClientBase64URLResponse{}, nil
 }
 
 // base64URLCreateRequest creates the Base64URL request.
@@ -116,7 +116,7 @@ func (client *PathsClient) ByteEmpty(ctx context.Context, options *PathsClientBy
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientByteEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientByteEmptyResponse{RawResponse: resp}, nil
+	return PathsClientByteEmptyResponse{}, nil
 }
 
 // byteEmptyCreateRequest creates the ByteEmpty request.
@@ -147,7 +147,7 @@ func (client *PathsClient) ByteMultiByte(ctx context.Context, bytePath []byte, o
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientByteMultiByteResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientByteMultiByteResponse{RawResponse: resp}, nil
+	return PathsClientByteMultiByteResponse{}, nil
 }
 
 // byteMultiByteCreateRequest creates the ByteMultiByte request.
@@ -178,7 +178,7 @@ func (client *PathsClient) ByteNull(ctx context.Context, bytePath []byte, option
 	if !runtime.HasStatusCode(resp, http.StatusBadRequest) {
 		return PathsClientByteNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientByteNullResponse{RawResponse: resp}, nil
+	return PathsClientByteNullResponse{}, nil
 }
 
 // byteNullCreateRequest creates the ByteNull request.
@@ -209,7 +209,7 @@ func (client *PathsClient) DateNull(ctx context.Context, datePath time.Time, opt
 	if !runtime.HasStatusCode(resp, http.StatusBadRequest) {
 		return PathsClientDateNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientDateNullResponse{RawResponse: resp}, nil
+	return PathsClientDateNullResponse{}, nil
 }
 
 // dateNullCreateRequest creates the DateNull request.
@@ -240,7 +240,7 @@ func (client *PathsClient) DateTimeNull(ctx context.Context, dateTimePath time.T
 	if !runtime.HasStatusCode(resp, http.StatusBadRequest) {
 		return PathsClientDateTimeNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientDateTimeNullResponse{RawResponse: resp}, nil
+	return PathsClientDateTimeNullResponse{}, nil
 }
 
 // dateTimeNullCreateRequest creates the DateTimeNull request.
@@ -270,7 +270,7 @@ func (client *PathsClient) DateTimeValid(ctx context.Context, options *PathsClie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientDateTimeValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientDateTimeValidResponse{RawResponse: resp}, nil
+	return PathsClientDateTimeValidResponse{}, nil
 }
 
 // dateTimeValidCreateRequest creates the DateTimeValid request.
@@ -300,7 +300,7 @@ func (client *PathsClient) DateValid(ctx context.Context, options *PathsClientDa
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientDateValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientDateValidResponse{RawResponse: resp}, nil
+	return PathsClientDateValidResponse{}, nil
 }
 
 // dateValidCreateRequest creates the DateValid request.
@@ -331,7 +331,7 @@ func (client *PathsClient) DoubleDecimalNegative(ctx context.Context, options *P
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientDoubleDecimalNegativeResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientDoubleDecimalNegativeResponse{RawResponse: resp}, nil
+	return PathsClientDoubleDecimalNegativeResponse{}, nil
 }
 
 // doubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
@@ -362,7 +362,7 @@ func (client *PathsClient) DoubleDecimalPositive(ctx context.Context, options *P
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientDoubleDecimalPositiveResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientDoubleDecimalPositiveResponse{RawResponse: resp}, nil
+	return PathsClientDoubleDecimalPositiveResponse{}, nil
 }
 
 // doubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
@@ -393,7 +393,7 @@ func (client *PathsClient) EnumNull(ctx context.Context, enumPath URIColor, opti
 	if !runtime.HasStatusCode(resp, http.StatusBadRequest) {
 		return PathsClientEnumNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientEnumNullResponse{RawResponse: resp}, nil
+	return PathsClientEnumNullResponse{}, nil
 }
 
 // enumNullCreateRequest creates the EnumNull request.
@@ -427,7 +427,7 @@ func (client *PathsClient) EnumValid(ctx context.Context, enumPath URIColor, opt
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientEnumValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientEnumValidResponse{RawResponse: resp}, nil
+	return PathsClientEnumValidResponse{}, nil
 }
 
 // enumValidCreateRequest creates the EnumValid request.
@@ -461,7 +461,7 @@ func (client *PathsClient) FloatScientificNegative(ctx context.Context, options 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientFloatScientificNegativeResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientFloatScientificNegativeResponse{RawResponse: resp}, nil
+	return PathsClientFloatScientificNegativeResponse{}, nil
 }
 
 // floatScientificNegativeCreateRequest creates the FloatScientificNegative request.
@@ -492,7 +492,7 @@ func (client *PathsClient) FloatScientificPositive(ctx context.Context, options 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientFloatScientificPositiveResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientFloatScientificPositiveResponse{RawResponse: resp}, nil
+	return PathsClientFloatScientificPositiveResponse{}, nil
 }
 
 // floatScientificPositiveCreateRequest creates the FloatScientificPositive request.
@@ -522,7 +522,7 @@ func (client *PathsClient) GetBooleanFalse(ctx context.Context, options *PathsCl
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientGetBooleanFalseResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientGetBooleanFalseResponse{RawResponse: resp}, nil
+	return PathsClientGetBooleanFalseResponse{}, nil
 }
 
 // getBooleanFalseCreateRequest creates the GetBooleanFalse request.
@@ -552,7 +552,7 @@ func (client *PathsClient) GetBooleanTrue(ctx context.Context, options *PathsCli
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientGetBooleanTrueResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientGetBooleanTrueResponse{RawResponse: resp}, nil
+	return PathsClientGetBooleanTrueResponse{}, nil
 }
 
 // getBooleanTrueCreateRequest creates the GetBooleanTrue request.
@@ -583,7 +583,7 @@ func (client *PathsClient) GetIntNegativeOneMillion(ctx context.Context, options
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientGetIntNegativeOneMillionResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientGetIntNegativeOneMillionResponse{RawResponse: resp}, nil
+	return PathsClientGetIntNegativeOneMillionResponse{}, nil
 }
 
 // getIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
@@ -613,7 +613,7 @@ func (client *PathsClient) GetIntOneMillion(ctx context.Context, options *PathsC
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientGetIntOneMillionResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientGetIntOneMillionResponse{RawResponse: resp}, nil
+	return PathsClientGetIntOneMillionResponse{}, nil
 }
 
 // getIntOneMillionCreateRequest creates the GetIntOneMillion request.
@@ -644,7 +644,7 @@ func (client *PathsClient) GetNegativeTenBillion(ctx context.Context, options *P
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientGetNegativeTenBillionResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientGetNegativeTenBillionResponse{RawResponse: resp}, nil
+	return PathsClientGetNegativeTenBillionResponse{}, nil
 }
 
 // getNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
@@ -674,7 +674,7 @@ func (client *PathsClient) GetTenBillion(ctx context.Context, options *PathsClie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientGetTenBillionResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientGetTenBillionResponse{RawResponse: resp}, nil
+	return PathsClientGetTenBillionResponse{}, nil
 }
 
 // getTenBillionCreateRequest creates the GetTenBillion request.
@@ -704,7 +704,7 @@ func (client *PathsClient) StringEmpty(ctx context.Context, options *PathsClient
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientStringEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientStringEmptyResponse{RawResponse: resp}, nil
+	return PathsClientStringEmptyResponse{}, nil
 }
 
 // stringEmptyCreateRequest creates the StringEmpty request.
@@ -735,7 +735,7 @@ func (client *PathsClient) StringNull(ctx context.Context, stringPath string, op
 	if !runtime.HasStatusCode(resp, http.StatusBadRequest) {
 		return PathsClientStringNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientStringNullResponse{RawResponse: resp}, nil
+	return PathsClientStringNullResponse{}, nil
 }
 
 // stringNullCreateRequest creates the StringNull request.
@@ -768,7 +768,7 @@ func (client *PathsClient) StringURLEncoded(ctx context.Context, options *PathsC
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientStringURLEncodedResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientStringURLEncodedResponse{RawResponse: resp}, nil
+	return PathsClientStringURLEncodedResponse{}, nil
 }
 
 // stringURLEncodedCreateRequest creates the StringURLEncoded request.
@@ -799,7 +799,7 @@ func (client *PathsClient) StringURLNonEncoded(ctx context.Context, options *Pat
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientStringURLNonEncodedResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientStringURLNonEncodedResponse{RawResponse: resp}, nil
+	return PathsClientStringURLNonEncodedResponse{}, nil
 }
 
 // stringURLNonEncodedCreateRequest creates the StringURLNonEncoded request.
@@ -829,7 +829,7 @@ func (client *PathsClient) StringUnicode(ctx context.Context, options *PathsClie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientStringUnicodeResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientStringUnicodeResponse{RawResponse: resp}, nil
+	return PathsClientStringUnicodeResponse{}, nil
 }
 
 // stringUnicodeCreateRequest creates the StringUnicode request.
@@ -860,7 +860,7 @@ func (client *PathsClient) UnixTimeURL(ctx context.Context, unixTimeURLPath time
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return PathsClientUnixTimeURLResponse{}, runtime.NewResponseError(resp)
 	}
-	return PathsClientUnixTimeURLResponse{RawResponse: resp}, nil
+	return PathsClientUnixTimeURLResponse{}, nil
 }
 
 // unixTimeURLCreateRequest creates the UnixTimeURL request.

--- a/test/autorest/urlgroup/zz_generated_queries_client.go
+++ b/test/autorest/urlgroup/zz_generated_queries_client.go
@@ -54,7 +54,7 @@ func (client *QueriesClient) ArrayStringCSVEmpty(ctx context.Context, options *Q
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringCSVEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringCSVEmptyResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringCSVEmptyResponse{}, nil
 }
 
 // arrayStringCSVEmptyCreateRequest creates the ArrayStringCSVEmpty request.
@@ -89,7 +89,7 @@ func (client *QueriesClient) ArrayStringCSVNull(ctx context.Context, options *Qu
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringCSVNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringCSVNullResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringCSVNullResponse{}, nil
 }
 
 // arrayStringCSVNullCreateRequest creates the ArrayStringCSVNull request.
@@ -125,7 +125,7 @@ func (client *QueriesClient) ArrayStringCSVValid(ctx context.Context, options *Q
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringCSVValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringCSVValidResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringCSVValidResponse{}, nil
 }
 
 // arrayStringCSVValidCreateRequest creates the ArrayStringCSVValid request.
@@ -161,7 +161,7 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmpty(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringNoCollectionFormatEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringNoCollectionFormatEmptyResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringNoCollectionFormatEmptyResponse{}, nil
 }
 
 // arrayStringNoCollectionFormatEmptyCreateRequest creates the ArrayStringNoCollectionFormatEmpty request.
@@ -197,7 +197,7 @@ func (client *QueriesClient) ArrayStringPipesValid(ctx context.Context, options 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringPipesValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringPipesValidResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringPipesValidResponse{}, nil
 }
 
 // arrayStringPipesValidCreateRequest creates the ArrayStringPipesValid request.
@@ -233,7 +233,7 @@ func (client *QueriesClient) ArrayStringSsvValid(ctx context.Context, options *Q
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringSsvValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringSsvValidResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringSsvValidResponse{}, nil
 }
 
 // arrayStringSsvValidCreateRequest creates the ArrayStringSsvValid request.
@@ -269,7 +269,7 @@ func (client *QueriesClient) ArrayStringTsvValid(ctx context.Context, options *Q
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringTsvValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringTsvValidResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringTsvValidResponse{}, nil
 }
 
 // arrayStringTsvValidCreateRequest creates the ArrayStringTsvValid request.
@@ -303,7 +303,7 @@ func (client *QueriesClient) ByteEmpty(ctx context.Context, options *QueriesClie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientByteEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientByteEmptyResponse{RawResponse: resp}, nil
+	return QueriesClientByteEmptyResponse{}, nil
 }
 
 // byteEmptyCreateRequest creates the ByteEmpty request.
@@ -335,7 +335,7 @@ func (client *QueriesClient) ByteMultiByte(ctx context.Context, options *Queries
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientByteMultiByteResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientByteMultiByteResponse{RawResponse: resp}, nil
+	return QueriesClientByteMultiByteResponse{}, nil
 }
 
 // byteMultiByteCreateRequest creates the ByteMultiByte request.
@@ -369,7 +369,7 @@ func (client *QueriesClient) ByteNull(ctx context.Context, options *QueriesClien
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientByteNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientByteNullResponse{RawResponse: resp}, nil
+	return QueriesClientByteNullResponse{}, nil
 }
 
 // byteNullCreateRequest creates the ByteNull request.
@@ -403,7 +403,7 @@ func (client *QueriesClient) DateNull(ctx context.Context, options *QueriesClien
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientDateNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientDateNullResponse{RawResponse: resp}, nil
+	return QueriesClientDateNullResponse{}, nil
 }
 
 // dateNullCreateRequest creates the DateNull request.
@@ -437,7 +437,7 @@ func (client *QueriesClient) DateTimeNull(ctx context.Context, options *QueriesC
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientDateTimeNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientDateTimeNullResponse{RawResponse: resp}, nil
+	return QueriesClientDateTimeNullResponse{}, nil
 }
 
 // dateTimeNullCreateRequest creates the DateTimeNull request.
@@ -471,7 +471,7 @@ func (client *QueriesClient) DateTimeValid(ctx context.Context, options *Queries
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientDateTimeValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientDateTimeValidResponse{RawResponse: resp}, nil
+	return QueriesClientDateTimeValidResponse{}, nil
 }
 
 // dateTimeValidCreateRequest creates the DateTimeValid request.
@@ -503,7 +503,7 @@ func (client *QueriesClient) DateValid(ctx context.Context, options *QueriesClie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientDateValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientDateValidResponse{RawResponse: resp}, nil
+	return QueriesClientDateValidResponse{}, nil
 }
 
 // dateValidCreateRequest creates the DateValid request.
@@ -536,7 +536,7 @@ func (client *QueriesClient) DoubleDecimalNegative(ctx context.Context, options 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientDoubleDecimalNegativeResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientDoubleDecimalNegativeResponse{RawResponse: resp}, nil
+	return QueriesClientDoubleDecimalNegativeResponse{}, nil
 }
 
 // doubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
@@ -569,7 +569,7 @@ func (client *QueriesClient) DoubleDecimalPositive(ctx context.Context, options 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientDoubleDecimalPositiveResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientDoubleDecimalPositiveResponse{RawResponse: resp}, nil
+	return QueriesClientDoubleDecimalPositiveResponse{}, nil
 }
 
 // doubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
@@ -601,7 +601,7 @@ func (client *QueriesClient) DoubleNull(ctx context.Context, options *QueriesCli
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientDoubleNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientDoubleNullResponse{RawResponse: resp}, nil
+	return QueriesClientDoubleNullResponse{}, nil
 }
 
 // doubleNullCreateRequest creates the DoubleNull request.
@@ -635,7 +635,7 @@ func (client *QueriesClient) EnumNull(ctx context.Context, options *QueriesClien
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientEnumNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientEnumNullResponse{RawResponse: resp}, nil
+	return QueriesClientEnumNullResponse{}, nil
 }
 
 // enumNullCreateRequest creates the EnumNull request.
@@ -669,7 +669,7 @@ func (client *QueriesClient) EnumValid(ctx context.Context, options *QueriesClie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientEnumValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientEnumValidResponse{RawResponse: resp}, nil
+	return QueriesClientEnumValidResponse{}, nil
 }
 
 // enumValidCreateRequest creates the EnumValid request.
@@ -703,7 +703,7 @@ func (client *QueriesClient) FloatNull(ctx context.Context, options *QueriesClie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientFloatNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientFloatNullResponse{RawResponse: resp}, nil
+	return QueriesClientFloatNullResponse{}, nil
 }
 
 // floatNullCreateRequest creates the FloatNull request.
@@ -738,7 +738,7 @@ func (client *QueriesClient) FloatScientificNegative(ctx context.Context, option
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientFloatScientificNegativeResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientFloatScientificNegativeResponse{RawResponse: resp}, nil
+	return QueriesClientFloatScientificNegativeResponse{}, nil
 }
 
 // floatScientificNegativeCreateRequest creates the FloatScientificNegative request.
@@ -771,7 +771,7 @@ func (client *QueriesClient) FloatScientificPositive(ctx context.Context, option
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientFloatScientificPositiveResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientFloatScientificPositiveResponse{RawResponse: resp}, nil
+	return QueriesClientFloatScientificPositiveResponse{}, nil
 }
 
 // floatScientificPositiveCreateRequest creates the FloatScientificPositive request.
@@ -803,7 +803,7 @@ func (client *QueriesClient) GetBooleanFalse(ctx context.Context, options *Queri
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetBooleanFalseResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetBooleanFalseResponse{RawResponse: resp}, nil
+	return QueriesClientGetBooleanFalseResponse{}, nil
 }
 
 // getBooleanFalseCreateRequest creates the GetBooleanFalse request.
@@ -835,7 +835,7 @@ func (client *QueriesClient) GetBooleanNull(ctx context.Context, options *Querie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetBooleanNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetBooleanNullResponse{RawResponse: resp}, nil
+	return QueriesClientGetBooleanNullResponse{}, nil
 }
 
 // getBooleanNullCreateRequest creates the GetBooleanNull request.
@@ -869,7 +869,7 @@ func (client *QueriesClient) GetBooleanTrue(ctx context.Context, options *Querie
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetBooleanTrueResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetBooleanTrueResponse{RawResponse: resp}, nil
+	return QueriesClientGetBooleanTrueResponse{}, nil
 }
 
 // getBooleanTrueCreateRequest creates the GetBooleanTrue request.
@@ -902,7 +902,7 @@ func (client *QueriesClient) GetIntNegativeOneMillion(ctx context.Context, optio
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetIntNegativeOneMillionResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetIntNegativeOneMillionResponse{RawResponse: resp}, nil
+	return QueriesClientGetIntNegativeOneMillionResponse{}, nil
 }
 
 // getIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
@@ -934,7 +934,7 @@ func (client *QueriesClient) GetIntNull(ctx context.Context, options *QueriesCli
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetIntNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetIntNullResponse{RawResponse: resp}, nil
+	return QueriesClientGetIntNullResponse{}, nil
 }
 
 // getIntNullCreateRequest creates the GetIntNull request.
@@ -969,7 +969,7 @@ func (client *QueriesClient) GetIntOneMillion(ctx context.Context, options *Quer
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetIntOneMillionResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetIntOneMillionResponse{RawResponse: resp}, nil
+	return QueriesClientGetIntOneMillionResponse{}, nil
 }
 
 // getIntOneMillionCreateRequest creates the GetIntOneMillion request.
@@ -1001,7 +1001,7 @@ func (client *QueriesClient) GetLongNull(ctx context.Context, options *QueriesCl
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetLongNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetLongNullResponse{RawResponse: resp}, nil
+	return QueriesClientGetLongNullResponse{}, nil
 }
 
 // getLongNullCreateRequest creates the GetLongNull request.
@@ -1036,7 +1036,7 @@ func (client *QueriesClient) GetNegativeTenBillion(ctx context.Context, options 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetNegativeTenBillionResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetNegativeTenBillionResponse{RawResponse: resp}, nil
+	return QueriesClientGetNegativeTenBillionResponse{}, nil
 }
 
 // getNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
@@ -1068,7 +1068,7 @@ func (client *QueriesClient) GetTenBillion(ctx context.Context, options *Queries
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientGetTenBillionResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientGetTenBillionResponse{RawResponse: resp}, nil
+	return QueriesClientGetTenBillionResponse{}, nil
 }
 
 // getTenBillionCreateRequest creates the GetTenBillion request.
@@ -1100,7 +1100,7 @@ func (client *QueriesClient) StringEmpty(ctx context.Context, options *QueriesCl
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientStringEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientStringEmptyResponse{RawResponse: resp}, nil
+	return QueriesClientStringEmptyResponse{}, nil
 }
 
 // stringEmptyCreateRequest creates the StringEmpty request.
@@ -1132,7 +1132,7 @@ func (client *QueriesClient) StringNull(ctx context.Context, options *QueriesCli
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientStringNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientStringNullResponse{RawResponse: resp}, nil
+	return QueriesClientStringNullResponse{}, nil
 }
 
 // stringNullCreateRequest creates the StringNull request.
@@ -1167,7 +1167,7 @@ func (client *QueriesClient) StringURLEncoded(ctx context.Context, options *Quer
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientStringURLEncodedResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientStringURLEncodedResponse{RawResponse: resp}, nil
+	return QueriesClientStringURLEncodedResponse{}, nil
 }
 
 // stringURLEncodedCreateRequest creates the StringURLEncoded request.
@@ -1199,7 +1199,7 @@ func (client *QueriesClient) StringUnicode(ctx context.Context, options *Queries
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientStringUnicodeResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientStringUnicodeResponse{RawResponse: resp}, nil
+	return QueriesClientStringUnicodeResponse{}, nil
 }
 
 // stringUnicodeCreateRequest creates the StringUnicode request.

--- a/test/autorest/urlgroup/zz_generated_response_types.go
+++ b/test/autorest/urlgroup/zz_generated_response_types.go
@@ -8,400 +8,332 @@
 
 package urlgroup
 
-import "net/http"
-
 // PathItemsClientGetAllWithValuesResponse contains the response from method PathItemsClient.GetAllWithValues.
 type PathItemsClientGetAllWithValuesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathItemsClientGetGlobalAndLocalQueryNullResponse contains the response from method PathItemsClient.GetGlobalAndLocalQueryNull.
 type PathItemsClientGetGlobalAndLocalQueryNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathItemsClientGetGlobalQueryNullResponse contains the response from method PathItemsClient.GetGlobalQueryNull.
 type PathItemsClientGetGlobalQueryNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathItemsClientGetLocalPathItemQueryNullResponse contains the response from method PathItemsClient.GetLocalPathItemQueryNull.
 type PathItemsClientGetLocalPathItemQueryNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientArrayCSVInPathResponse contains the response from method PathsClient.ArrayCSVInPath.
 type PathsClientArrayCSVInPathResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientBase64URLResponse contains the response from method PathsClient.Base64URL.
 type PathsClientBase64URLResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientByteEmptyResponse contains the response from method PathsClient.ByteEmpty.
 type PathsClientByteEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientByteMultiByteResponse contains the response from method PathsClient.ByteMultiByte.
 type PathsClientByteMultiByteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientByteNullResponse contains the response from method PathsClient.ByteNull.
 type PathsClientByteNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientDateNullResponse contains the response from method PathsClient.DateNull.
 type PathsClientDateNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientDateTimeNullResponse contains the response from method PathsClient.DateTimeNull.
 type PathsClientDateTimeNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientDateTimeValidResponse contains the response from method PathsClient.DateTimeValid.
 type PathsClientDateTimeValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientDateValidResponse contains the response from method PathsClient.DateValid.
 type PathsClientDateValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientDoubleDecimalNegativeResponse contains the response from method PathsClient.DoubleDecimalNegative.
 type PathsClientDoubleDecimalNegativeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientDoubleDecimalPositiveResponse contains the response from method PathsClient.DoubleDecimalPositive.
 type PathsClientDoubleDecimalPositiveResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientEnumNullResponse contains the response from method PathsClient.EnumNull.
 type PathsClientEnumNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientEnumValidResponse contains the response from method PathsClient.EnumValid.
 type PathsClientEnumValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientFloatScientificNegativeResponse contains the response from method PathsClient.FloatScientificNegative.
 type PathsClientFloatScientificNegativeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientFloatScientificPositiveResponse contains the response from method PathsClient.FloatScientificPositive.
 type PathsClientFloatScientificPositiveResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientGetBooleanFalseResponse contains the response from method PathsClient.GetBooleanFalse.
 type PathsClientGetBooleanFalseResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientGetBooleanTrueResponse contains the response from method PathsClient.GetBooleanTrue.
 type PathsClientGetBooleanTrueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientGetIntNegativeOneMillionResponse contains the response from method PathsClient.GetIntNegativeOneMillion.
 type PathsClientGetIntNegativeOneMillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientGetIntOneMillionResponse contains the response from method PathsClient.GetIntOneMillion.
 type PathsClientGetIntOneMillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientGetNegativeTenBillionResponse contains the response from method PathsClient.GetNegativeTenBillion.
 type PathsClientGetNegativeTenBillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientGetTenBillionResponse contains the response from method PathsClient.GetTenBillion.
 type PathsClientGetTenBillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientStringEmptyResponse contains the response from method PathsClient.StringEmpty.
 type PathsClientStringEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientStringNullResponse contains the response from method PathsClient.StringNull.
 type PathsClientStringNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientStringURLEncodedResponse contains the response from method PathsClient.StringURLEncoded.
 type PathsClientStringURLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientStringURLNonEncodedResponse contains the response from method PathsClient.StringURLNonEncoded.
 type PathsClientStringURLNonEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientStringUnicodeResponse contains the response from method PathsClient.StringUnicode.
 type PathsClientStringUnicodeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PathsClientUnixTimeURLResponse contains the response from method PathsClient.UnixTimeURL.
 type PathsClientUnixTimeURLResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringCSVEmptyResponse contains the response from method QueriesClient.ArrayStringCSVEmpty.
 type QueriesClientArrayStringCSVEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringCSVNullResponse contains the response from method QueriesClient.ArrayStringCSVNull.
 type QueriesClientArrayStringCSVNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringCSVValidResponse contains the response from method QueriesClient.ArrayStringCSVValid.
 type QueriesClientArrayStringCSVValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringNoCollectionFormatEmptyResponse contains the response from method QueriesClient.ArrayStringNoCollectionFormatEmpty.
 type QueriesClientArrayStringNoCollectionFormatEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringPipesValidResponse contains the response from method QueriesClient.ArrayStringPipesValid.
 type QueriesClientArrayStringPipesValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringSsvValidResponse contains the response from method QueriesClient.ArrayStringSsvValid.
 type QueriesClientArrayStringSsvValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringTsvValidResponse contains the response from method QueriesClient.ArrayStringTsvValid.
 type QueriesClientArrayStringTsvValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientByteEmptyResponse contains the response from method QueriesClient.ByteEmpty.
 type QueriesClientByteEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientByteMultiByteResponse contains the response from method QueriesClient.ByteMultiByte.
 type QueriesClientByteMultiByteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientByteNullResponse contains the response from method QueriesClient.ByteNull.
 type QueriesClientByteNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientDateNullResponse contains the response from method QueriesClient.DateNull.
 type QueriesClientDateNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientDateTimeNullResponse contains the response from method QueriesClient.DateTimeNull.
 type QueriesClientDateTimeNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientDateTimeValidResponse contains the response from method QueriesClient.DateTimeValid.
 type QueriesClientDateTimeValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientDateValidResponse contains the response from method QueriesClient.DateValid.
 type QueriesClientDateValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientDoubleDecimalNegativeResponse contains the response from method QueriesClient.DoubleDecimalNegative.
 type QueriesClientDoubleDecimalNegativeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientDoubleDecimalPositiveResponse contains the response from method QueriesClient.DoubleDecimalPositive.
 type QueriesClientDoubleDecimalPositiveResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientDoubleNullResponse contains the response from method QueriesClient.DoubleNull.
 type QueriesClientDoubleNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientEnumNullResponse contains the response from method QueriesClient.EnumNull.
 type QueriesClientEnumNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientEnumValidResponse contains the response from method QueriesClient.EnumValid.
 type QueriesClientEnumValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientFloatNullResponse contains the response from method QueriesClient.FloatNull.
 type QueriesClientFloatNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientFloatScientificNegativeResponse contains the response from method QueriesClient.FloatScientificNegative.
 type QueriesClientFloatScientificNegativeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientFloatScientificPositiveResponse contains the response from method QueriesClient.FloatScientificPositive.
 type QueriesClientFloatScientificPositiveResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetBooleanFalseResponse contains the response from method QueriesClient.GetBooleanFalse.
 type QueriesClientGetBooleanFalseResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetBooleanNullResponse contains the response from method QueriesClient.GetBooleanNull.
 type QueriesClientGetBooleanNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetBooleanTrueResponse contains the response from method QueriesClient.GetBooleanTrue.
 type QueriesClientGetBooleanTrueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetIntNegativeOneMillionResponse contains the response from method QueriesClient.GetIntNegativeOneMillion.
 type QueriesClientGetIntNegativeOneMillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetIntNullResponse contains the response from method QueriesClient.GetIntNull.
 type QueriesClientGetIntNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetIntOneMillionResponse contains the response from method QueriesClient.GetIntOneMillion.
 type QueriesClientGetIntOneMillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetLongNullResponse contains the response from method QueriesClient.GetLongNull.
 type QueriesClientGetLongNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetNegativeTenBillionResponse contains the response from method QueriesClient.GetNegativeTenBillion.
 type QueriesClientGetNegativeTenBillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientGetTenBillionResponse contains the response from method QueriesClient.GetTenBillion.
 type QueriesClientGetTenBillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientStringEmptyResponse contains the response from method QueriesClient.StringEmpty.
 type QueriesClientStringEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientStringNullResponse contains the response from method QueriesClient.StringNull.
 type QueriesClientStringNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientStringURLEncodedResponse contains the response from method QueriesClient.StringURLEncoded.
 type QueriesClientStringURLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientStringUnicodeResponse contains the response from method QueriesClient.StringUnicode.
 type QueriesClientStringUnicodeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/urlmultigroup/urlmultigroup_test.go
+++ b/test/autorest/urlmultigroup/urlmultigroup_test.go
@@ -5,8 +5,8 @@ package urlmultigroup
 
 import (
 	"context"
-	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 )
 
@@ -22,8 +22,8 @@ func TestURLMultiArrayStringMultiEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArrayStringMultiEmpty: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -35,8 +35,8 @@ func TestURLMultiArrayStringMultiNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArrayStringMultiNull: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -53,7 +53,7 @@ func TestURLMultiArrayStringMultiValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArrayStringMultiValid: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/urlmultigroup/zz_generated_queries_client.go
+++ b/test/autorest/urlmultigroup/zz_generated_queries_client.go
@@ -50,7 +50,7 @@ func (client *QueriesClient) ArrayStringMultiEmpty(ctx context.Context, options 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringMultiEmptyResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringMultiEmptyResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringMultiEmptyResponse{}, nil
 }
 
 // arrayStringMultiEmptyCreateRequest creates the ArrayStringMultiEmpty request.
@@ -87,7 +87,7 @@ func (client *QueriesClient) ArrayStringMultiNull(ctx context.Context, options *
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringMultiNullResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringMultiNullResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringMultiNullResponse{}, nil
 }
 
 // arrayStringMultiNullCreateRequest creates the ArrayStringMultiNull request.
@@ -125,7 +125,7 @@ func (client *QueriesClient) ArrayStringMultiValid(ctx context.Context, options 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return QueriesClientArrayStringMultiValidResponse{}, runtime.NewResponseError(resp)
 	}
-	return QueriesClientArrayStringMultiValidResponse{RawResponse: resp}, nil
+	return QueriesClientArrayStringMultiValidResponse{}, nil
 }
 
 // arrayStringMultiValidCreateRequest creates the ArrayStringMultiValid request.

--- a/test/autorest/urlmultigroup/zz_generated_response_types.go
+++ b/test/autorest/urlmultigroup/zz_generated_response_types.go
@@ -8,22 +8,17 @@
 
 package urlmultigroup
 
-import "net/http"
-
 // QueriesClientArrayStringMultiEmptyResponse contains the response from method QueriesClient.ArrayStringMultiEmpty.
 type QueriesClientArrayStringMultiEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringMultiNullResponse contains the response from method QueriesClient.ArrayStringMultiNull.
 type QueriesClientArrayStringMultiNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // QueriesClientArrayStringMultiValidResponse contains the response from method QueriesClient.ArrayStringMultiValid.
 type QueriesClientArrayStringMultiValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -5,10 +5,11 @@ package validationgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/google/go-cmp/cmp"
 )
 
 func newAutoRestValidationTestClient() *AutoRestValidationTestClient {
@@ -21,26 +22,27 @@ func TestValidationGetWithConstantInPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetWithConstantInPath: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
 func TestValidationPostWithConstantInBody(t *testing.T) {
 	client := newAutoRestValidationTestClient()
-	result, err := client.PostWithConstantInBody(context.Background(), &AutoRestValidationTestClientPostWithConstantInBodyOptions{Body: &Product{
+	product := Product{
 		Child: &ChildProduct{
 			ConstProperty: to.StringPtr("constant")},
 		ConstString: to.StringPtr("constant"),
 		ConstInt:    to.Int32Ptr(0),
 		ConstChild: &ConstantProduct{
 			ConstProperty:  to.StringPtr("constant"),
-			ConstProperty2: to.StringPtr("constant2")}}})
+			ConstProperty2: to.StringPtr("constant2")}}
+	result, err := client.PostWithConstantInBody(context.Background(), &AutoRestValidationTestClientPostWithConstantInBodyOptions{Body: &product})
 	if err != nil {
 		t.Fatalf("PostWithConstantInBody: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if r := cmp.Diff(product, result.Product); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -61,7 +63,7 @@ func TestValidationValidationOfBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ValidationOfBody: %v", err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest_client.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest_client.go
@@ -57,7 +57,7 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPath(ctx context.Co
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return AutoRestValidationTestClientGetWithConstantInPathResponse{}, runtime.NewResponseError(resp)
 	}
-	return AutoRestValidationTestClientGetWithConstantInPathResponse{RawResponse: resp}, nil
+	return AutoRestValidationTestClientGetWithConstantInPathResponse{}, nil
 }
 
 // getWithConstantInPathCreateRequest creates the GetWithConstantInPath request.
@@ -107,7 +107,7 @@ func (client *AutoRestValidationTestClient) postWithConstantInBodyCreateRequest(
 
 // postWithConstantInBodyHandleResponse handles the PostWithConstantInBody response.
 func (client *AutoRestValidationTestClient) postWithConstantInBodyHandleResponse(resp *http.Response) (AutoRestValidationTestClientPostWithConstantInBodyResponse, error) {
-	result := AutoRestValidationTestClientPostWithConstantInBodyResponse{RawResponse: resp}
+	result := AutoRestValidationTestClientPostWithConstantInBodyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Product); err != nil {
 		return AutoRestValidationTestClientPostWithConstantInBodyResponse{}, err
 	}
@@ -163,7 +163,7 @@ func (client *AutoRestValidationTestClient) validationOfBodyCreateRequest(ctx co
 
 // validationOfBodyHandleResponse handles the ValidationOfBody response.
 func (client *AutoRestValidationTestClient) validationOfBodyHandleResponse(resp *http.Response) (AutoRestValidationTestClientValidationOfBodyResponse, error) {
-	result := AutoRestValidationTestClientValidationOfBodyResponse{RawResponse: resp}
+	result := AutoRestValidationTestClientValidationOfBodyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Product); err != nil {
 		return AutoRestValidationTestClientValidationOfBodyResponse{}, err
 	}
@@ -216,7 +216,7 @@ func (client *AutoRestValidationTestClient) validationOfMethodParametersCreateRe
 
 // validationOfMethodParametersHandleResponse handles the ValidationOfMethodParameters response.
 func (client *AutoRestValidationTestClient) validationOfMethodParametersHandleResponse(resp *http.Response) (AutoRestValidationTestClientValidationOfMethodParametersResponse, error) {
-	result := AutoRestValidationTestClientValidationOfMethodParametersResponse{RawResponse: resp}
+	result := AutoRestValidationTestClientValidationOfMethodParametersResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Product); err != nil {
 		return AutoRestValidationTestClientValidationOfMethodParametersResponse{}, err
 	}

--- a/test/autorest/validationgroup/zz_generated_response_types.go
+++ b/test/autorest/validationgroup/zz_generated_response_types.go
@@ -8,31 +8,22 @@
 
 package validationgroup
 
-import "net/http"
-
 // AutoRestValidationTestClientGetWithConstantInPathResponse contains the response from method AutoRestValidationTestClient.GetWithConstantInPath.
 type AutoRestValidationTestClientGetWithConstantInPathResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // AutoRestValidationTestClientPostWithConstantInBodyResponse contains the response from method AutoRestValidationTestClient.PostWithConstantInBody.
 type AutoRestValidationTestClientPostWithConstantInBodyResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AutoRestValidationTestClientValidationOfBodyResponse contains the response from method AutoRestValidationTestClient.ValidationOfBody.
 type AutoRestValidationTestClientValidationOfBodyResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AutoRestValidationTestClientValidationOfMethodParametersResponse contains the response from method AutoRestValidationTestClient.ValidationOfMethodParameters.
 type AutoRestValidationTestClientValidationOfMethodParametersResponse struct {
 	Product
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -5,7 +5,7 @@ package xmlgroup
 
 import (
 	"context"
-	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -36,9 +36,6 @@ func TestGetACLs(t *testing.T) {
 	result, err := client.GetACLs(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	expected := []*SignedIdentifier{
 		{
@@ -71,9 +68,6 @@ func TestGetComplexTypeRefNoMeta(t *testing.T) {
 	result, err := client.GetComplexTypeRefNoMeta(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	expected := RootWithRefAndNoMeta{
 		RefToModel: &ComplexTypeNoMeta{
@@ -109,9 +103,6 @@ func TestGetEmptyChildElement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	expected := Banana{
 		Name:       to.StringPtr("Unknown Banana"),
 		Expiration: toTimePtr(time.RFC3339Nano, "2012-02-24T00:53:52.789Z"),
@@ -128,9 +119,6 @@ func TestGetEmptyList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	expected := Slideshow{}
 	if r := cmp.Diff(result.Slideshow, expected); r != "" {
 		t.Fatal(r)
@@ -143,9 +131,6 @@ func TestGetEmptyRootList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	if result.Bananas != nil {
 		t.Fatal("expected nil slice")
 	}
@@ -156,9 +141,6 @@ func TestGetEmptyWrappedLists(t *testing.T) {
 	result, err := client.GetEmptyWrappedLists(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	expected := AppleBarrel{}
 	if r := cmp.Diff(result.AppleBarrel, expected); r != "" {
@@ -183,9 +165,6 @@ func TestGetRootList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	expected := []*Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
@@ -209,9 +188,6 @@ func TestGetRootListSingleItem(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	expected := []*Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
@@ -229,9 +205,6 @@ func TestGetServiceProperties(t *testing.T) {
 	result, err := client.GetServiceProperties(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	expected := StorageServiceProperties{
 		HourMetrics: &Metrics{
@@ -274,9 +247,6 @@ func TestGetSimple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	expected := Slideshow{
 		Author: to.StringPtr("Yours Truly"),
 		Date:   to.StringPtr("Date of publication"),
@@ -304,9 +274,6 @@ func TestGetWrappedLists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	expected := AppleBarrel{
 		BadApples:  to.StringPtrArray("Red Delicious"),
 		GoodApples: to.StringPtrArray("Fuji", "Gala"),
@@ -322,9 +289,6 @@ func TestGetXMsText(t *testing.T) {
 	result, err := client.GetXMsText(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
 	}
 	expected := ObjectWithXMsTextProperty{
 		Content:  to.StringPtr("I am text"),
@@ -343,8 +307,8 @@ func TestJSONInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -497,9 +461,6 @@ func TestListContainers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusOK {
-		t.Fatalf("unexpected status code %d", s)
-	}
 	expected := ListContainersResponse{
 		ServiceEndpoint: to.StringPtr("https://myaccount.blob.core.windows.net/"),
 		MaxResults:      to.Int32Ptr(3),
@@ -549,8 +510,8 @@ func TestPutACLs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -575,8 +536,8 @@ func TestPutComplexTypeRefNoMeta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -591,8 +552,8 @@ func TestPutComplexTypeRefWithMeta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -606,8 +567,8 @@ func TestPutEmptyChildElement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -619,8 +580,8 @@ func TestPutEmptyList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -630,8 +591,8 @@ func TestPutEmptyRootList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -644,8 +605,8 @@ func TestPutEmptyWrappedLists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -666,8 +627,8 @@ func TestPutRootList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -683,8 +644,8 @@ func TestPutRootListSingleItem(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -723,8 +684,8 @@ func TestPutServiceProperties(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -749,8 +710,8 @@ func TestPutSimple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }
 
@@ -763,7 +724,7 @@ func TestPutWrappedLists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := result.RawResponse.StatusCode; s != http.StatusCreated {
-		t.Fatalf("unexpected status code %d", s)
+	if !reflect.ValueOf(result).IsZero() {
+		t.Fatal("expected zero-value result")
 	}
 }

--- a/test/autorest/xmlgroup/zz_generated_response_types.go
+++ b/test/autorest/xmlgroup/zz_generated_response_types.go
@@ -8,13 +8,8 @@
 
 package xmlgroup
 
-import "net/http"
-
 // XMLClientGetACLsResponse contains the response from method XMLClient.GetACLs.
 type XMLClientGetACLsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// a collection of signed identifiers
 	SignedIdentifiers []*SignedIdentifier `xml:"SignedIdentifier"`
 }
@@ -22,223 +17,168 @@ type XMLClientGetACLsResponse struct {
 // XMLClientGetBytesResponse contains the response from method XMLClient.GetBytes.
 type XMLClientGetBytesResponse struct {
 	ModelWithByteProperty
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetComplexTypeRefNoMetaResponse contains the response from method XMLClient.GetComplexTypeRefNoMeta.
 type XMLClientGetComplexTypeRefNoMetaResponse struct {
 	RootWithRefAndNoMeta
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetComplexTypeRefWithMetaResponse contains the response from method XMLClient.GetComplexTypeRefWithMeta.
 type XMLClientGetComplexTypeRefWithMetaResponse struct {
 	RootWithRefAndMeta
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetEmptyChildElementResponse contains the response from method XMLClient.GetEmptyChildElement.
 type XMLClientGetEmptyChildElementResponse struct {
 	Banana
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetEmptyListResponse contains the response from method XMLClient.GetEmptyList.
 type XMLClientGetEmptyListResponse struct {
 	Slideshow
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetEmptyRootListResponse contains the response from method XMLClient.GetEmptyRootList.
 type XMLClientGetEmptyRootListResponse struct {
 	// Array of Banana
 	Bananas []*Banana `xml:"banana"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetEmptyWrappedListsResponse contains the response from method XMLClient.GetEmptyWrappedLists.
 type XMLClientGetEmptyWrappedListsResponse struct {
 	AppleBarrel
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetHeadersResponse contains the response from method XMLClient.GetHeaders.
 type XMLClientGetHeadersResponse struct {
 	// CustomHeader contains the information returned from the Custom-Header header response.
 	CustomHeader *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetRootListResponse contains the response from method XMLClient.GetRootList.
 type XMLClientGetRootListResponse struct {
 	// Array of Banana
 	Bananas []*Banana `xml:"banana"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetRootListSingleItemResponse contains the response from method XMLClient.GetRootListSingleItem.
 type XMLClientGetRootListSingleItemResponse struct {
 	// Array of Banana
 	Bananas []*Banana `xml:"banana"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetServicePropertiesResponse contains the response from method XMLClient.GetServiceProperties.
 type XMLClientGetServicePropertiesResponse struct {
 	StorageServiceProperties
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetSimpleResponse contains the response from method XMLClient.GetSimple.
 type XMLClientGetSimpleResponse struct {
 	Slideshow
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetURIResponse contains the response from method XMLClient.GetURI.
 type XMLClientGetURIResponse struct {
 	ModelWithURLProperty
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetWrappedListsResponse contains the response from method XMLClient.GetWrappedLists.
 type XMLClientGetWrappedListsResponse struct {
 	AppleBarrel
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientGetXMsTextResponse contains the response from method XMLClient.GetXMsText.
 type XMLClientGetXMsTextResponse struct {
 	ObjectWithXMsTextProperty
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientJSONInputResponse contains the response from method XMLClient.JSONInput.
 type XMLClientJSONInputResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientJSONOutputResponse contains the response from method XMLClient.JSONOutput.
 type XMLClientJSONOutputResponse struct {
 	JSONOutput
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientListBlobsResponse contains the response from method XMLClient.ListBlobs.
 type XMLClientListBlobsResponse struct {
 	ListBlobsResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientListContainersResponse contains the response from method XMLClient.ListContainers.
 type XMLClientListContainersResponse struct {
 	ListContainersResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // XMLClientPutACLsResponse contains the response from method XMLClient.PutACLs.
 type XMLClientPutACLsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutBinaryResponse contains the response from method XMLClient.PutBinary.
 type XMLClientPutBinaryResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutComplexTypeRefNoMetaResponse contains the response from method XMLClient.PutComplexTypeRefNoMeta.
 type XMLClientPutComplexTypeRefNoMetaResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutComplexTypeRefWithMetaResponse contains the response from method XMLClient.PutComplexTypeRefWithMeta.
 type XMLClientPutComplexTypeRefWithMetaResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutEmptyChildElementResponse contains the response from method XMLClient.PutEmptyChildElement.
 type XMLClientPutEmptyChildElementResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutEmptyListResponse contains the response from method XMLClient.PutEmptyList.
 type XMLClientPutEmptyListResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutEmptyRootListResponse contains the response from method XMLClient.PutEmptyRootList.
 type XMLClientPutEmptyRootListResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutEmptyWrappedListsResponse contains the response from method XMLClient.PutEmptyWrappedLists.
 type XMLClientPutEmptyWrappedListsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutRootListResponse contains the response from method XMLClient.PutRootList.
 type XMLClientPutRootListResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutRootListSingleItemResponse contains the response from method XMLClient.PutRootListSingleItem.
 type XMLClientPutRootListSingleItemResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutServicePropertiesResponse contains the response from method XMLClient.PutServiceProperties.
 type XMLClientPutServicePropertiesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutSimpleResponse contains the response from method XMLClient.PutSimple.
 type XMLClientPutSimpleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutURIResponse contains the response from method XMLClient.PutURI.
 type XMLClientPutURIResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // XMLClientPutWrappedListsResponse contains the response from method XMLClient.PutWrappedLists.
 type XMLClientPutWrappedListsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/autorest/xmlgroup/zz_generated_xml_client.go
+++ b/test/autorest/xmlgroup/zz_generated_xml_client.go
@@ -70,7 +70,7 @@ func (client *XMLClient) getACLsCreateRequest(ctx context.Context, options *XMLC
 
 // getACLsHandleResponse handles the GetACLs response.
 func (client *XMLClient) getACLsHandleResponse(resp *http.Response) (XMLClientGetACLsResponse, error) {
-	result := XMLClientGetACLsResponse{RawResponse: resp}
+	result := XMLClientGetACLsResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
 		return XMLClientGetACLsResponse{}, err
 	}
@@ -108,7 +108,7 @@ func (client *XMLClient) getBytesCreateRequest(ctx context.Context, options *XML
 
 // getBytesHandleResponse handles the GetBytes response.
 func (client *XMLClient) getBytesHandleResponse(resp *http.Response) (XMLClientGetBytesResponse, error) {
-	result := XMLClientGetBytesResponse{RawResponse: resp}
+	result := XMLClientGetBytesResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.ModelWithByteProperty); err != nil {
 		return XMLClientGetBytesResponse{}, err
 	}
@@ -147,7 +147,7 @@ func (client *XMLClient) getComplexTypeRefNoMetaCreateRequest(ctx context.Contex
 
 // getComplexTypeRefNoMetaHandleResponse handles the GetComplexTypeRefNoMeta response.
 func (client *XMLClient) getComplexTypeRefNoMetaHandleResponse(resp *http.Response) (XMLClientGetComplexTypeRefNoMetaResponse, error) {
-	result := XMLClientGetComplexTypeRefNoMetaResponse{RawResponse: resp}
+	result := XMLClientGetComplexTypeRefNoMetaResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.RootWithRefAndNoMeta); err != nil {
 		return XMLClientGetComplexTypeRefNoMetaResponse{}, err
 	}
@@ -186,7 +186,7 @@ func (client *XMLClient) getComplexTypeRefWithMetaCreateRequest(ctx context.Cont
 
 // getComplexTypeRefWithMetaHandleResponse handles the GetComplexTypeRefWithMeta response.
 func (client *XMLClient) getComplexTypeRefWithMetaHandleResponse(resp *http.Response) (XMLClientGetComplexTypeRefWithMetaResponse, error) {
-	result := XMLClientGetComplexTypeRefWithMetaResponse{RawResponse: resp}
+	result := XMLClientGetComplexTypeRefWithMetaResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.RootWithRefAndMeta); err != nil {
 		return XMLClientGetComplexTypeRefWithMetaResponse{}, err
 	}
@@ -225,7 +225,7 @@ func (client *XMLClient) getEmptyChildElementCreateRequest(ctx context.Context, 
 
 // getEmptyChildElementHandleResponse handles the GetEmptyChildElement response.
 func (client *XMLClient) getEmptyChildElementHandleResponse(resp *http.Response) (XMLClientGetEmptyChildElementResponse, error) {
-	result := XMLClientGetEmptyChildElementResponse{RawResponse: resp}
+	result := XMLClientGetEmptyChildElementResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.Banana); err != nil {
 		return XMLClientGetEmptyChildElementResponse{}, err
 	}
@@ -263,7 +263,7 @@ func (client *XMLClient) getEmptyListCreateRequest(ctx context.Context, options 
 
 // getEmptyListHandleResponse handles the GetEmptyList response.
 func (client *XMLClient) getEmptyListHandleResponse(resp *http.Response) (XMLClientGetEmptyListResponse, error) {
-	result := XMLClientGetEmptyListResponse{RawResponse: resp}
+	result := XMLClientGetEmptyListResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.Slideshow); err != nil {
 		return XMLClientGetEmptyListResponse{}, err
 	}
@@ -301,7 +301,7 @@ func (client *XMLClient) getEmptyRootListCreateRequest(ctx context.Context, opti
 
 // getEmptyRootListHandleResponse handles the GetEmptyRootList response.
 func (client *XMLClient) getEmptyRootListHandleResponse(resp *http.Response) (XMLClientGetEmptyRootListResponse, error) {
-	result := XMLClientGetEmptyRootListResponse{RawResponse: resp}
+	result := XMLClientGetEmptyRootListResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
 		return XMLClientGetEmptyRootListResponse{}, err
 	}
@@ -340,7 +340,7 @@ func (client *XMLClient) getEmptyWrappedListsCreateRequest(ctx context.Context, 
 
 // getEmptyWrappedListsHandleResponse handles the GetEmptyWrappedLists response.
 func (client *XMLClient) getEmptyWrappedListsHandleResponse(resp *http.Response) (XMLClientGetEmptyWrappedListsResponse, error) {
-	result := XMLClientGetEmptyWrappedListsResponse{RawResponse: resp}
+	result := XMLClientGetEmptyWrappedListsResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.AppleBarrel); err != nil {
 		return XMLClientGetEmptyWrappedListsResponse{}, err
 	}
@@ -377,7 +377,7 @@ func (client *XMLClient) getHeadersCreateRequest(ctx context.Context, options *X
 
 // getHeadersHandleResponse handles the GetHeaders response.
 func (client *XMLClient) getHeadersHandleResponse(resp *http.Response) (XMLClientGetHeadersResponse, error) {
-	result := XMLClientGetHeadersResponse{RawResponse: resp}
+	result := XMLClientGetHeadersResponse{}
 	if val := resp.Header.Get("Custom-Header"); val != "" {
 		result.CustomHeader = &val
 	}
@@ -415,7 +415,7 @@ func (client *XMLClient) getRootListCreateRequest(ctx context.Context, options *
 
 // getRootListHandleResponse handles the GetRootList response.
 func (client *XMLClient) getRootListHandleResponse(resp *http.Response) (XMLClientGetRootListResponse, error) {
-	result := XMLClientGetRootListResponse{RawResponse: resp}
+	result := XMLClientGetRootListResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
 		return XMLClientGetRootListResponse{}, err
 	}
@@ -454,7 +454,7 @@ func (client *XMLClient) getRootListSingleItemCreateRequest(ctx context.Context,
 
 // getRootListSingleItemHandleResponse handles the GetRootListSingleItem response.
 func (client *XMLClient) getRootListSingleItemHandleResponse(resp *http.Response) (XMLClientGetRootListSingleItemResponse, error) {
-	result := XMLClientGetRootListSingleItemResponse{RawResponse: resp}
+	result := XMLClientGetRootListSingleItemResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
 		return XMLClientGetRootListSingleItemResponse{}, err
 	}
@@ -497,7 +497,7 @@ func (client *XMLClient) getServicePropertiesCreateRequest(ctx context.Context, 
 
 // getServicePropertiesHandleResponse handles the GetServiceProperties response.
 func (client *XMLClient) getServicePropertiesHandleResponse(resp *http.Response) (XMLClientGetServicePropertiesResponse, error) {
-	result := XMLClientGetServicePropertiesResponse{RawResponse: resp}
+	result := XMLClientGetServicePropertiesResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.StorageServiceProperties); err != nil {
 		return XMLClientGetServicePropertiesResponse{}, err
 	}
@@ -535,7 +535,7 @@ func (client *XMLClient) getSimpleCreateRequest(ctx context.Context, options *XM
 
 // getSimpleHandleResponse handles the GetSimple response.
 func (client *XMLClient) getSimpleHandleResponse(resp *http.Response) (XMLClientGetSimpleResponse, error) {
-	result := XMLClientGetSimpleResponse{RawResponse: resp}
+	result := XMLClientGetSimpleResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.Slideshow); err != nil {
 		return XMLClientGetSimpleResponse{}, err
 	}
@@ -573,7 +573,7 @@ func (client *XMLClient) getURICreateRequest(ctx context.Context, options *XMLCl
 
 // getURIHandleResponse handles the GetURI response.
 func (client *XMLClient) getURIHandleResponse(resp *http.Response) (XMLClientGetURIResponse, error) {
-	result := XMLClientGetURIResponse{RawResponse: resp}
+	result := XMLClientGetURIResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.ModelWithURLProperty); err != nil {
 		return XMLClientGetURIResponse{}, err
 	}
@@ -611,7 +611,7 @@ func (client *XMLClient) getWrappedListsCreateRequest(ctx context.Context, optio
 
 // getWrappedListsHandleResponse handles the GetWrappedLists response.
 func (client *XMLClient) getWrappedListsHandleResponse(resp *http.Response) (XMLClientGetWrappedListsResponse, error) {
-	result := XMLClientGetWrappedListsResponse{RawResponse: resp}
+	result := XMLClientGetWrappedListsResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.AppleBarrel); err != nil {
 		return XMLClientGetWrappedListsResponse{}, err
 	}
@@ -650,7 +650,7 @@ func (client *XMLClient) getXMsTextCreateRequest(ctx context.Context, options *X
 
 // getXMsTextHandleResponse handles the GetXMsText response.
 func (client *XMLClient) getXMsTextHandleResponse(resp *http.Response) (XMLClientGetXMsTextResponse, error) {
-	result := XMLClientGetXMsTextResponse{RawResponse: resp}
+	result := XMLClientGetXMsTextResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.ObjectWithXMsTextProperty); err != nil {
 		return XMLClientGetXMsTextResponse{}, err
 	}
@@ -672,7 +672,7 @@ func (client *XMLClient) JSONInput(ctx context.Context, properties JSONInput, op
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return XMLClientJSONInputResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientJSONInputResponse{RawResponse: resp}, nil
+	return XMLClientJSONInputResponse{}, nil
 }
 
 // jsonInputCreateRequest creates the JSONInput request.
@@ -716,7 +716,7 @@ func (client *XMLClient) jsonOutputCreateRequest(ctx context.Context, options *X
 
 // jsonOutputHandleResponse handles the JSONOutput response.
 func (client *XMLClient) jsonOutputHandleResponse(resp *http.Response) (XMLClientJSONOutputResponse, error) {
-	result := XMLClientJSONOutputResponse{RawResponse: resp}
+	result := XMLClientJSONOutputResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.JSONOutput); err != nil {
 		return XMLClientJSONOutputResponse{}, err
 	}
@@ -758,7 +758,7 @@ func (client *XMLClient) listBlobsCreateRequest(ctx context.Context, options *XM
 
 // listBlobsHandleResponse handles the ListBlobs response.
 func (client *XMLClient) listBlobsHandleResponse(resp *http.Response) (XMLClientListBlobsResponse, error) {
-	result := XMLClientListBlobsResponse{RawResponse: resp}
+	result := XMLClientListBlobsResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.ListBlobsResponse); err != nil {
 		return XMLClientListBlobsResponse{}, err
 	}
@@ -799,7 +799,7 @@ func (client *XMLClient) listContainersCreateRequest(ctx context.Context, option
 
 // listContainersHandleResponse handles the ListContainers response.
 func (client *XMLClient) listContainersHandleResponse(resp *http.Response) (XMLClientListContainersResponse, error) {
-	result := XMLClientListContainersResponse{RawResponse: resp}
+	result := XMLClientListContainersResponse{}
 	if err := runtime.UnmarshalAsXML(resp, &result.ListContainersResponse); err != nil {
 		return XMLClientListContainersResponse{}, err
 	}
@@ -821,7 +821,7 @@ func (client *XMLClient) PutACLs(ctx context.Context, properties []*SignedIdenti
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutACLsResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutACLsResponse{RawResponse: resp}, nil
+	return XMLClientPutACLsResponse{}, nil
 }
 
 // putACLsCreateRequest creates the PutACLs request.
@@ -857,7 +857,7 @@ func (client *XMLClient) PutBinary(ctx context.Context, slideshow ModelWithByteP
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutBinaryResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutBinaryResponse{RawResponse: resp}, nil
+	return XMLClientPutBinaryResponse{}, nil
 }
 
 // putBinaryCreateRequest creates the PutBinary request.
@@ -887,7 +887,7 @@ func (client *XMLClient) PutComplexTypeRefNoMeta(ctx context.Context, model Root
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutComplexTypeRefNoMetaResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutComplexTypeRefNoMetaResponse{RawResponse: resp}, nil
+	return XMLClientPutComplexTypeRefNoMetaResponse{}, nil
 }
 
 // putComplexTypeRefNoMetaCreateRequest creates the PutComplexTypeRefNoMeta request.
@@ -916,7 +916,7 @@ func (client *XMLClient) PutComplexTypeRefWithMeta(ctx context.Context, model Ro
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutComplexTypeRefWithMetaResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutComplexTypeRefWithMetaResponse{RawResponse: resp}, nil
+	return XMLClientPutComplexTypeRefWithMetaResponse{}, nil
 }
 
 // putComplexTypeRefWithMetaCreateRequest creates the PutComplexTypeRefWithMeta request.
@@ -945,7 +945,7 @@ func (client *XMLClient) PutEmptyChildElement(ctx context.Context, banana Banana
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutEmptyChildElementResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutEmptyChildElementResponse{RawResponse: resp}, nil
+	return XMLClientPutEmptyChildElementResponse{}, nil
 }
 
 // putEmptyChildElementCreateRequest creates the PutEmptyChildElement request.
@@ -973,7 +973,7 @@ func (client *XMLClient) PutEmptyList(ctx context.Context, slideshow Slideshow, 
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutEmptyListResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutEmptyListResponse{RawResponse: resp}, nil
+	return XMLClientPutEmptyListResponse{}, nil
 }
 
 // putEmptyListCreateRequest creates the PutEmptyList request.
@@ -1001,7 +1001,7 @@ func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []*Banana
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutEmptyRootListResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutEmptyRootListResponse{RawResponse: resp}, nil
+	return XMLClientPutEmptyRootListResponse{}, nil
 }
 
 // putEmptyRootListCreateRequest creates the PutEmptyRootList request.
@@ -1034,7 +1034,7 @@ func (client *XMLClient) PutEmptyWrappedLists(ctx context.Context, appleBarrel A
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutEmptyWrappedListsResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutEmptyWrappedListsResponse{RawResponse: resp}, nil
+	return XMLClientPutEmptyWrappedListsResponse{}, nil
 }
 
 // putEmptyWrappedListsCreateRequest creates the PutEmptyWrappedLists request.
@@ -1062,7 +1062,7 @@ func (client *XMLClient) PutRootList(ctx context.Context, bananas []*Banana, opt
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutRootListResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutRootListResponse{RawResponse: resp}, nil
+	return XMLClientPutRootListResponse{}, nil
 }
 
 // putRootListCreateRequest creates the PutRootList request.
@@ -1095,7 +1095,7 @@ func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []*B
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutRootListSingleItemResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutRootListSingleItemResponse{RawResponse: resp}, nil
+	return XMLClientPutRootListSingleItemResponse{}, nil
 }
 
 // putRootListSingleItemCreateRequest creates the PutRootListSingleItem request.
@@ -1128,7 +1128,7 @@ func (client *XMLClient) PutServiceProperties(ctx context.Context, properties St
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutServicePropertiesResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutServicePropertiesResponse{RawResponse: resp}, nil
+	return XMLClientPutServicePropertiesResponse{}, nil
 }
 
 // putServicePropertiesCreateRequest creates the PutServiceProperties request.
@@ -1160,7 +1160,7 @@ func (client *XMLClient) PutSimple(ctx context.Context, slideshow Slideshow, opt
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutSimpleResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutSimpleResponse{RawResponse: resp}, nil
+	return XMLClientPutSimpleResponse{}, nil
 }
 
 // putSimpleCreateRequest creates the PutSimple request.
@@ -1189,7 +1189,7 @@ func (client *XMLClient) PutURI(ctx context.Context, model ModelWithURLProperty,
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutURIResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutURIResponse{RawResponse: resp}, nil
+	return XMLClientPutURIResponse{}, nil
 }
 
 // putURICreateRequest creates the PutURI request.
@@ -1218,7 +1218,7 @@ func (client *XMLClient) PutWrappedLists(ctx context.Context, wrappedLists Apple
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return XMLClientPutWrappedListsResponse{}, runtime.NewResponseError(resp)
 	}
-	return XMLClientPutWrappedListsResponse{RawResponse: resp}, nil
+	return XMLClientPutWrappedListsResponse{}, nil
 }
 
 // putWrappedListsCreateRequest creates the PutWrappedLists request.

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
@@ -100,7 +100,7 @@ func (client *AvailabilitySetsClient) createOrUpdateCreateRequest(ctx context.Co
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *AvailabilitySetsClient) createOrUpdateHandleResponse(resp *http.Response) (AvailabilitySetsClientCreateOrUpdateResponse, error) {
-	result := AvailabilitySetsClientCreateOrUpdateResponse{RawResponse: resp}
+	result := AvailabilitySetsClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySet); err != nil {
 		return AvailabilitySetsClientCreateOrUpdateResponse{}, err
 	}
@@ -124,7 +124,7 @@ func (client *AvailabilitySetsClient) Delete(ctx context.Context, resourceGroupN
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusNoContent) {
 		return AvailabilitySetsClientDeleteResponse{}, runtime.NewResponseError(resp)
 	}
-	return AvailabilitySetsClientDeleteResponse{RawResponse: resp}, nil
+	return AvailabilitySetsClientDeleteResponse{}, nil
 }
 
 // deleteCreateRequest creates the Delete request.
@@ -200,7 +200,7 @@ func (client *AvailabilitySetsClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client *AvailabilitySetsClient) getHandleResponse(resp *http.Response) (AvailabilitySetsClientGetResponse, error) {
-	result := AvailabilitySetsClientGetResponse{RawResponse: resp}
+	result := AvailabilitySetsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySet); err != nil {
 		return AvailabilitySetsClientGetResponse{}, err
 	}
@@ -247,7 +247,7 @@ func (client *AvailabilitySetsClient) listCreateRequest(ctx context.Context, res
 
 // listHandleResponse handles the List response.
 func (client *AvailabilitySetsClient) listHandleResponse(resp *http.Response) (AvailabilitySetsClientListResponse, error) {
-	result := AvailabilitySetsClientListResponse{RawResponse: resp}
+	result := AvailabilitySetsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySetListResult); err != nil {
 		return AvailabilitySetsClientListResponse{}, err
 	}
@@ -298,7 +298,7 @@ func (client *AvailabilitySetsClient) listAvailableSizesCreateRequest(ctx contex
 
 // listAvailableSizesHandleResponse handles the ListAvailableSizes response.
 func (client *AvailabilitySetsClient) listAvailableSizesHandleResponse(resp *http.Response) (AvailabilitySetsClientListAvailableSizesResponse, error) {
-	result := AvailabilitySetsClientListAvailableSizesResponse{RawResponse: resp}
+	result := AvailabilitySetsClientListAvailableSizesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineSizeListResult); err != nil {
 		return AvailabilitySetsClientListAvailableSizesResponse{}, err
 	}
@@ -344,7 +344,7 @@ func (client *AvailabilitySetsClient) listBySubscriptionCreateRequest(ctx contex
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *AvailabilitySetsClient) listBySubscriptionHandleResponse(resp *http.Response) (AvailabilitySetsClientListBySubscriptionResponse, error) {
-	result := AvailabilitySetsClientListBySubscriptionResponse{RawResponse: resp}
+	result := AvailabilitySetsClientListBySubscriptionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySetListResult); err != nil {
 		return AvailabilitySetsClientListBySubscriptionResponse{}, err
 	}
@@ -400,7 +400,7 @@ func (client *AvailabilitySetsClient) updateCreateRequest(ctx context.Context, r
 
 // updateHandleResponse handles the Update response.
 func (client *AvailabilitySetsClient) updateHandleResponse(resp *http.Response) (AvailabilitySetsClientUpdateResponse, error) {
-	result := AvailabilitySetsClientUpdateResponse{RawResponse: resp}
+	result := AvailabilitySetsClientUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySet); err != nil {
 		return AvailabilitySetsClientUpdateResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
@@ -63,9 +63,7 @@ func (client *ContainerServicesClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return ContainerServicesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ContainerServicesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ContainerServicesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ContainerServicesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return ContainerServicesClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *ContainerServicesClient) BeginDelete(ctx context.Context, resource
 	if err != nil {
 		return ContainerServicesClientDeletePollerResponse{}, err
 	}
-	result := ContainerServicesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ContainerServicesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ContainerServicesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return ContainerServicesClientDeletePollerResponse{}, err
@@ -242,7 +238,7 @@ func (client *ContainerServicesClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client *ContainerServicesClient) getHandleResponse(resp *http.Response) (ContainerServicesClientGetResponse, error) {
-	result := ContainerServicesClientGetResponse{RawResponse: resp}
+	result := ContainerServicesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerService); err != nil {
 		return ContainerServicesClientGetResponse{}, err
 	}
@@ -286,7 +282,7 @@ func (client *ContainerServicesClient) listCreateRequest(ctx context.Context, op
 
 // listHandleResponse handles the List response.
 func (client *ContainerServicesClient) listHandleResponse(resp *http.Response) (ContainerServicesClientListResponse, error) {
-	result := ContainerServicesClientListResponse{RawResponse: resp}
+	result := ContainerServicesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerServiceListResult); err != nil {
 		return ContainerServicesClientListResponse{}, err
 	}
@@ -336,7 +332,7 @@ func (client *ContainerServicesClient) listByResourceGroupCreateRequest(ctx cont
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ContainerServicesClient) listByResourceGroupHandleResponse(resp *http.Response) (ContainerServicesClientListByResourceGroupResponse, error) {
-	result := ContainerServicesClientListByResourceGroupResponse{RawResponse: resp}
+	result := ContainerServicesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerServiceListResult); err != nil {
 		return ContainerServicesClientListByResourceGroupResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups_client.go
@@ -101,7 +101,7 @@ func (client *DedicatedHostGroupsClient) createOrUpdateCreateRequest(ctx context
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *DedicatedHostGroupsClient) createOrUpdateHandleResponse(resp *http.Response) (DedicatedHostGroupsClientCreateOrUpdateResponse, error) {
-	result := DedicatedHostGroupsClientCreateOrUpdateResponse{RawResponse: resp}
+	result := DedicatedHostGroupsClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroup); err != nil {
 		return DedicatedHostGroupsClientCreateOrUpdateResponse{}, err
 	}
@@ -126,7 +126,7 @@ func (client *DedicatedHostGroupsClient) Delete(ctx context.Context, resourceGro
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusNoContent) {
 		return DedicatedHostGroupsClientDeleteResponse{}, runtime.NewResponseError(resp)
 	}
-	return DedicatedHostGroupsClientDeleteResponse{RawResponse: resp}, nil
+	return DedicatedHostGroupsClientDeleteResponse{}, nil
 }
 
 // deleteCreateRequest creates the Delete request.
@@ -202,7 +202,7 @@ func (client *DedicatedHostGroupsClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client *DedicatedHostGroupsClient) getHandleResponse(resp *http.Response) (DedicatedHostGroupsClientGetResponse, error) {
-	result := DedicatedHostGroupsClientGetResponse{RawResponse: resp}
+	result := DedicatedHostGroupsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroup); err != nil {
 		return DedicatedHostGroupsClientGetResponse{}, err
 	}
@@ -251,7 +251,7 @@ func (client *DedicatedHostGroupsClient) listByResourceGroupCreateRequest(ctx co
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *DedicatedHostGroupsClient) listByResourceGroupHandleResponse(resp *http.Response) (DedicatedHostGroupsClientListByResourceGroupResponse, error) {
-	result := DedicatedHostGroupsClientListByResourceGroupResponse{RawResponse: resp}
+	result := DedicatedHostGroupsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroupListResult); err != nil {
 		return DedicatedHostGroupsClientListByResourceGroupResponse{}, err
 	}
@@ -295,7 +295,7 @@ func (client *DedicatedHostGroupsClient) listBySubscriptionCreateRequest(ctx con
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *DedicatedHostGroupsClient) listBySubscriptionHandleResponse(resp *http.Response) (DedicatedHostGroupsClientListBySubscriptionResponse, error) {
-	result := DedicatedHostGroupsClientListBySubscriptionResponse{RawResponse: resp}
+	result := DedicatedHostGroupsClientListBySubscriptionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroupListResult); err != nil {
 		return DedicatedHostGroupsClientListBySubscriptionResponse{}, err
 	}
@@ -352,7 +352,7 @@ func (client *DedicatedHostGroupsClient) updateCreateRequest(ctx context.Context
 
 // updateHandleResponse handles the Update response.
 func (client *DedicatedHostGroupsClient) updateHandleResponse(resp *http.Response) (DedicatedHostGroupsClientUpdateResponse, error) {
-	result := DedicatedHostGroupsClientUpdateResponse{RawResponse: resp}
+	result := DedicatedHostGroupsClientUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroup); err != nil {
 		return DedicatedHostGroupsClientUpdateResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
@@ -63,9 +63,7 @@ func (client *DedicatedHostsClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return DedicatedHostsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := DedicatedHostsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := DedicatedHostsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DedicatedHostsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return DedicatedHostsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *DedicatedHostsClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return DedicatedHostsClientDeletePollerResponse{}, err
 	}
-	result := DedicatedHostsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := DedicatedHostsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DedicatedHostsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return DedicatedHostsClientDeletePollerResponse{}, err
@@ -250,7 +246,7 @@ func (client *DedicatedHostsClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client *DedicatedHostsClient) getHandleResponse(resp *http.Response) (DedicatedHostsClientGetResponse, error) {
-	result := DedicatedHostsClientGetResponse{RawResponse: resp}
+	result := DedicatedHostsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHost); err != nil {
 		return DedicatedHostsClientGetResponse{}, err
 	}
@@ -304,7 +300,7 @@ func (client *DedicatedHostsClient) listByHostGroupCreateRequest(ctx context.Con
 
 // listByHostGroupHandleResponse handles the ListByHostGroup response.
 func (client *DedicatedHostsClient) listByHostGroupHandleResponse(resp *http.Response) (DedicatedHostsClientListByHostGroupResponse, error) {
-	result := DedicatedHostsClientListByHostGroupResponse{RawResponse: resp}
+	result := DedicatedHostsClientListByHostGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostListResult); err != nil {
 		return DedicatedHostsClientListByHostGroupResponse{}, err
 	}
@@ -324,9 +320,7 @@ func (client *DedicatedHostsClient) BeginUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return DedicatedHostsClientUpdatePollerResponse{}, err
 	}
-	result := DedicatedHostsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := DedicatedHostsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DedicatedHostsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return DedicatedHostsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
@@ -64,9 +64,7 @@ func (client *DiskEncryptionSetsClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return DiskEncryptionSetsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := DiskEncryptionSetsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := DiskEncryptionSetsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DiskEncryptionSetsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return DiskEncryptionSetsClientCreateOrUpdatePollerResponse{}, err
@@ -133,9 +131,7 @@ func (client *DiskEncryptionSetsClient) BeginDelete(ctx context.Context, resourc
 	if err != nil {
 		return DiskEncryptionSetsClientDeletePollerResponse{}, err
 	}
-	result := DiskEncryptionSetsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := DiskEncryptionSetsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DiskEncryptionSetsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return DiskEncryptionSetsClientDeletePollerResponse{}, err
@@ -239,7 +235,7 @@ func (client *DiskEncryptionSetsClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client *DiskEncryptionSetsClient) getHandleResponse(resp *http.Response) (DiskEncryptionSetsClientGetResponse, error) {
-	result := DiskEncryptionSetsClientGetResponse{RawResponse: resp}
+	result := DiskEncryptionSetsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskEncryptionSet); err != nil {
 		return DiskEncryptionSetsClientGetResponse{}, err
 	}
@@ -281,7 +277,7 @@ func (client *DiskEncryptionSetsClient) listCreateRequest(ctx context.Context, o
 
 // listHandleResponse handles the List response.
 func (client *DiskEncryptionSetsClient) listHandleResponse(resp *http.Response) (DiskEncryptionSetsClientListResponse, error) {
-	result := DiskEncryptionSetsClientListResponse{RawResponse: resp}
+	result := DiskEncryptionSetsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskEncryptionSetList); err != nil {
 		return DiskEncryptionSetsClientListResponse{}, err
 	}
@@ -329,7 +325,7 @@ func (client *DiskEncryptionSetsClient) listByResourceGroupCreateRequest(ctx con
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *DiskEncryptionSetsClient) listByResourceGroupHandleResponse(resp *http.Response) (DiskEncryptionSetsClientListByResourceGroupResponse, error) {
-	result := DiskEncryptionSetsClientListByResourceGroupResponse{RawResponse: resp}
+	result := DiskEncryptionSetsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskEncryptionSetList); err != nil {
 		return DiskEncryptionSetsClientListByResourceGroupResponse{}, err
 	}
@@ -350,9 +346,7 @@ func (client *DiskEncryptionSetsClient) BeginUpdate(ctx context.Context, resourc
 	if err != nil {
 		return DiskEncryptionSetsClientUpdatePollerResponse{}, err
 	}
-	result := DiskEncryptionSetsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := DiskEncryptionSetsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DiskEncryptionSetsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return DiskEncryptionSetsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
@@ -64,9 +64,7 @@ func (client *DisksClient) BeginCreateOrUpdate(ctx context.Context, resourceGrou
 	if err != nil {
 		return DisksClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := DisksClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := DisksClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return DisksClientCreateOrUpdatePollerResponse{}, err
@@ -132,9 +130,7 @@ func (client *DisksClient) BeginDelete(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return DisksClientDeletePollerResponse{}, err
 	}
-	result := DisksClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := DisksClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return DisksClientDeletePollerResponse{}, err
@@ -237,7 +233,7 @@ func (client *DisksClient) getCreateRequest(ctx context.Context, resourceGroupNa
 
 // getHandleResponse handles the Get response.
 func (client *DisksClient) getHandleResponse(resp *http.Response) (DisksClientGetResponse, error) {
-	result := DisksClientGetResponse{RawResponse: resp}
+	result := DisksClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Disk); err != nil {
 		return DisksClientGetResponse{}, err
 	}
@@ -257,9 +253,7 @@ func (client *DisksClient) BeginGrantAccess(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return DisksClientGrantAccessPollerResponse{}, err
 	}
-	result := DisksClientGrantAccessPollerResponse{
-		RawResponse: resp,
-	}
+	result := DisksClientGrantAccessPollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.GrantAccess", "location", resp, client.pl)
 	if err != nil {
 		return DisksClientGrantAccessPollerResponse{}, err
@@ -348,7 +342,7 @@ func (client *DisksClient) listCreateRequest(ctx context.Context, options *Disks
 
 // listHandleResponse handles the List response.
 func (client *DisksClient) listHandleResponse(resp *http.Response) (DisksClientListResponse, error) {
-	result := DisksClientListResponse{RawResponse: resp}
+	result := DisksClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskList); err != nil {
 		return DisksClientListResponse{}, err
 	}
@@ -396,7 +390,7 @@ func (client *DisksClient) listByResourceGroupCreateRequest(ctx context.Context,
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *DisksClient) listByResourceGroupHandleResponse(resp *http.Response) (DisksClientListByResourceGroupResponse, error) {
-	result := DisksClientListByResourceGroupResponse{RawResponse: resp}
+	result := DisksClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskList); err != nil {
 		return DisksClientListByResourceGroupResponse{}, err
 	}
@@ -415,9 +409,7 @@ func (client *DisksClient) BeginRevokeAccess(ctx context.Context, resourceGroupN
 	if err != nil {
 		return DisksClientRevokeAccessPollerResponse{}, err
 	}
-	result := DisksClientRevokeAccessPollerResponse{
-		RawResponse: resp,
-	}
+	result := DisksClientRevokeAccessPollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.RevokeAccess", "location", resp, client.pl)
 	if err != nil {
 		return DisksClientRevokeAccessPollerResponse{}, err
@@ -483,9 +475,7 @@ func (client *DisksClient) BeginUpdate(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return DisksClientUpdatePollerResponse{}, err
 	}
-	result := DisksClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := DisksClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.Update", "", resp, client.pl)
 	if err != nil {
 		return DisksClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
@@ -63,9 +63,7 @@ func (client *GalleriesClient) BeginCreateOrUpdate(ctx context.Context, resource
 	if err != nil {
 		return GalleriesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := GalleriesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleriesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleriesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return GalleriesClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *GalleriesClient) BeginDelete(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return GalleriesClientDeletePollerResponse{}, err
 	}
-	result := GalleriesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleriesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleriesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return GalleriesClientDeletePollerResponse{}, err
@@ -233,7 +229,7 @@ func (client *GalleriesClient) getCreateRequest(ctx context.Context, resourceGro
 
 // getHandleResponse handles the Get response.
 func (client *GalleriesClient) getHandleResponse(resp *http.Response) (GalleriesClientGetResponse, error) {
-	result := GalleriesClientGetResponse{RawResponse: resp}
+	result := GalleriesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Gallery); err != nil {
 		return GalleriesClientGetResponse{}, err
 	}
@@ -275,7 +271,7 @@ func (client *GalleriesClient) listCreateRequest(ctx context.Context, options *G
 
 // listHandleResponse handles the List response.
 func (client *GalleriesClient) listHandleResponse(resp *http.Response) (GalleriesClientListResponse, error) {
-	result := GalleriesClientListResponse{RawResponse: resp}
+	result := GalleriesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryList); err != nil {
 		return GalleriesClientListResponse{}, err
 	}
@@ -323,7 +319,7 @@ func (client *GalleriesClient) listByResourceGroupCreateRequest(ctx context.Cont
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *GalleriesClient) listByResourceGroupHandleResponse(resp *http.Response) (GalleriesClientListByResourceGroupResponse, error) {
-	result := GalleriesClientListByResourceGroupResponse{RawResponse: resp}
+	result := GalleriesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryList); err != nil {
 		return GalleriesClientListByResourceGroupResponse{}, err
 	}
@@ -342,9 +338,7 @@ func (client *GalleriesClient) BeginUpdate(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return GalleriesClientUpdatePollerResponse{}, err
 	}
-	result := GalleriesClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleriesClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleriesClient.Update", "", resp, client.pl)
 	if err != nil {
 		return GalleriesClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
@@ -65,9 +65,7 @@ func (client *GalleryApplicationsClient) BeginCreateOrUpdate(ctx context.Context
 	if err != nil {
 		return GalleryApplicationsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := GalleryApplicationsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryApplicationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return GalleryApplicationsClientCreateOrUpdatePollerResponse{}, err
@@ -137,9 +135,7 @@ func (client *GalleryApplicationsClient) BeginDelete(ctx context.Context, resour
 	if err != nil {
 		return GalleryApplicationsClientDeletePollerResponse{}, err
 	}
-	result := GalleryApplicationsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryApplicationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return GalleryApplicationsClientDeletePollerResponse{}, err
@@ -250,7 +246,7 @@ func (client *GalleryApplicationsClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client *GalleryApplicationsClient) getHandleResponse(resp *http.Response) (GalleryApplicationsClientGetResponse, error) {
-	result := GalleryApplicationsClientGetResponse{RawResponse: resp}
+	result := GalleryApplicationsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryApplication); err != nil {
 		return GalleryApplicationsClientGetResponse{}, err
 	}
@@ -303,7 +299,7 @@ func (client *GalleryApplicationsClient) listByGalleryCreateRequest(ctx context.
 
 // listByGalleryHandleResponse handles the ListByGallery response.
 func (client *GalleryApplicationsClient) listByGalleryHandleResponse(resp *http.Response) (GalleryApplicationsClientListByGalleryResponse, error) {
-	result := GalleryApplicationsClientListByGalleryResponse{RawResponse: resp}
+	result := GalleryApplicationsClientListByGalleryResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryApplicationList); err != nil {
 		return GalleryApplicationsClientListByGalleryResponse{}, err
 	}
@@ -325,9 +321,7 @@ func (client *GalleryApplicationsClient) BeginUpdate(ctx context.Context, resour
 	if err != nil {
 		return GalleryApplicationsClientUpdatePollerResponse{}, err
 	}
-	result := GalleryApplicationsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryApplicationsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return GalleryApplicationsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
@@ -66,9 +66,7 @@ func (client *GalleryApplicationVersionsClient) BeginCreateOrUpdate(ctx context.
 	if err != nil {
 		return GalleryApplicationVersionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := GalleryApplicationVersionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryApplicationVersionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationVersionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return GalleryApplicationVersionsClientCreateOrUpdatePollerResponse{}, err
@@ -143,9 +141,7 @@ func (client *GalleryApplicationVersionsClient) BeginDelete(ctx context.Context,
 	if err != nil {
 		return GalleryApplicationVersionsClientDeletePollerResponse{}, err
 	}
-	result := GalleryApplicationVersionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryApplicationVersionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationVersionsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return GalleryApplicationVersionsClientDeletePollerResponse{}, err
@@ -269,7 +265,7 @@ func (client *GalleryApplicationVersionsClient) getCreateRequest(ctx context.Con
 
 // getHandleResponse handles the Get response.
 func (client *GalleryApplicationVersionsClient) getHandleResponse(resp *http.Response) (GalleryApplicationVersionsClientGetResponse, error) {
-	result := GalleryApplicationVersionsClientGetResponse{RawResponse: resp}
+	result := GalleryApplicationVersionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryApplicationVersion); err != nil {
 		return GalleryApplicationVersionsClientGetResponse{}, err
 	}
@@ -328,7 +324,7 @@ func (client *GalleryApplicationVersionsClient) listByGalleryApplicationCreateRe
 
 // listByGalleryApplicationHandleResponse handles the ListByGalleryApplication response.
 func (client *GalleryApplicationVersionsClient) listByGalleryApplicationHandleResponse(resp *http.Response) (GalleryApplicationVersionsClientListByGalleryApplicationResponse, error) {
-	result := GalleryApplicationVersionsClientListByGalleryApplicationResponse{RawResponse: resp}
+	result := GalleryApplicationVersionsClientListByGalleryApplicationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryApplicationVersionList); err != nil {
 		return GalleryApplicationVersionsClientListByGalleryApplicationResponse{}, err
 	}
@@ -351,9 +347,7 @@ func (client *GalleryApplicationVersionsClient) BeginUpdate(ctx context.Context,
 	if err != nil {
 		return GalleryApplicationVersionsClientUpdatePollerResponse{}, err
 	}
-	result := GalleryApplicationVersionsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryApplicationVersionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationVersionsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return GalleryApplicationVersionsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
@@ -65,9 +65,7 @@ func (client *GalleryImagesClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return GalleryImagesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := GalleryImagesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryImagesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImagesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return GalleryImagesClientCreateOrUpdatePollerResponse{}, err
@@ -137,9 +135,7 @@ func (client *GalleryImagesClient) BeginDelete(ctx context.Context, resourceGrou
 	if err != nil {
 		return GalleryImagesClientDeletePollerResponse{}, err
 	}
-	result := GalleryImagesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryImagesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImagesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return GalleryImagesClientDeletePollerResponse{}, err
@@ -250,7 +246,7 @@ func (client *GalleryImagesClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client *GalleryImagesClient) getHandleResponse(resp *http.Response) (GalleryImagesClientGetResponse, error) {
-	result := GalleryImagesClientGetResponse{RawResponse: resp}
+	result := GalleryImagesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryImage); err != nil {
 		return GalleryImagesClientGetResponse{}, err
 	}
@@ -303,7 +299,7 @@ func (client *GalleryImagesClient) listByGalleryCreateRequest(ctx context.Contex
 
 // listByGalleryHandleResponse handles the ListByGallery response.
 func (client *GalleryImagesClient) listByGalleryHandleResponse(resp *http.Response) (GalleryImagesClientListByGalleryResponse, error) {
-	result := GalleryImagesClientListByGalleryResponse{RawResponse: resp}
+	result := GalleryImagesClientListByGalleryResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryImageList); err != nil {
 		return GalleryImagesClientListByGalleryResponse{}, err
 	}
@@ -324,9 +320,7 @@ func (client *GalleryImagesClient) BeginUpdate(ctx context.Context, resourceGrou
 	if err != nil {
 		return GalleryImagesClientUpdatePollerResponse{}, err
 	}
-	result := GalleryImagesClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryImagesClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImagesClient.Update", "", resp, client.pl)
 	if err != nil {
 		return GalleryImagesClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
@@ -66,9 +66,7 @@ func (client *GalleryImageVersionsClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return GalleryImageVersionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := GalleryImageVersionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryImageVersionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImageVersionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return GalleryImageVersionsClientCreateOrUpdatePollerResponse{}, err
@@ -143,9 +141,7 @@ func (client *GalleryImageVersionsClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return GalleryImageVersionsClientDeletePollerResponse{}, err
 	}
-	result := GalleryImageVersionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryImageVersionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImageVersionsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return GalleryImageVersionsClientDeletePollerResponse{}, err
@@ -269,7 +265,7 @@ func (client *GalleryImageVersionsClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client *GalleryImageVersionsClient) getHandleResponse(resp *http.Response) (GalleryImageVersionsClientGetResponse, error) {
-	result := GalleryImageVersionsClientGetResponse{RawResponse: resp}
+	result := GalleryImageVersionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryImageVersion); err != nil {
 		return GalleryImageVersionsClientGetResponse{}, err
 	}
@@ -327,7 +323,7 @@ func (client *GalleryImageVersionsClient) listByGalleryImageCreateRequest(ctx co
 
 // listByGalleryImageHandleResponse handles the ListByGalleryImage response.
 func (client *GalleryImageVersionsClient) listByGalleryImageHandleResponse(resp *http.Response) (GalleryImageVersionsClientListByGalleryImageResponse, error) {
-	result := GalleryImageVersionsClientListByGalleryImageResponse{RawResponse: resp}
+	result := GalleryImageVersionsClientListByGalleryImageResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryImageVersionList); err != nil {
 		return GalleryImageVersionsClientListByGalleryImageResponse{}, err
 	}
@@ -350,9 +346,7 @@ func (client *GalleryImageVersionsClient) BeginUpdate(ctx context.Context, resou
 	if err != nil {
 		return GalleryImageVersionsClientUpdatePollerResponse{}, err
 	}
-	result := GalleryImageVersionsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := GalleryImageVersionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImageVersionsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return GalleryImageVersionsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
@@ -62,9 +62,7 @@ func (client *ImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return ImagesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ImagesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ImagesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ImagesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return ImagesClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *ImagesClient) BeginDelete(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return ImagesClientDeletePollerResponse{}, err
 	}
-	result := ImagesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ImagesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ImagesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return ImagesClientDeletePollerResponse{}, err
@@ -234,7 +230,7 @@ func (client *ImagesClient) getCreateRequest(ctx context.Context, resourceGroupN
 
 // getHandleResponse handles the Get response.
 func (client *ImagesClient) getHandleResponse(resp *http.Response) (ImagesClientGetResponse, error) {
-	result := ImagesClientGetResponse{RawResponse: resp}
+	result := ImagesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Image); err != nil {
 		return ImagesClientGetResponse{}, err
 	}
@@ -277,7 +273,7 @@ func (client *ImagesClient) listCreateRequest(ctx context.Context, options *Imag
 
 // listHandleResponse handles the List response.
 func (client *ImagesClient) listHandleResponse(resp *http.Response) (ImagesClientListResponse, error) {
-	result := ImagesClientListResponse{RawResponse: resp}
+	result := ImagesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ImageListResult); err != nil {
 		return ImagesClientListResponse{}, err
 	}
@@ -325,7 +321,7 @@ func (client *ImagesClient) listByResourceGroupCreateRequest(ctx context.Context
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ImagesClient) listByResourceGroupHandleResponse(resp *http.Response) (ImagesClientListByResourceGroupResponse, error) {
-	result := ImagesClientListByResourceGroupResponse{RawResponse: resp}
+	result := ImagesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ImageListResult); err != nil {
 		return ImagesClientListByResourceGroupResponse{}, err
 	}
@@ -343,9 +339,7 @@ func (client *ImagesClient) BeginUpdate(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return ImagesClientUpdatePollerResponse{}, err
 	}
-	result := ImagesClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ImagesClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ImagesClient.Update", "", resp, client.pl)
 	if err != nil {
 		return ImagesClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
@@ -62,9 +62,7 @@ func (client *LogAnalyticsClient) BeginExportRequestRateByInterval(ctx context.C
 	if err != nil {
 		return LogAnalyticsClientExportRequestRateByIntervalPollerResponse{}, err
 	}
-	result := LogAnalyticsClientExportRequestRateByIntervalPollerResponse{
-		RawResponse: resp,
-	}
+	result := LogAnalyticsClientExportRequestRateByIntervalPollerResponse{}
 	pt, err := armruntime.NewPoller("LogAnalyticsClient.ExportRequestRateByInterval", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return LogAnalyticsClientExportRequestRateByIntervalPollerResponse{}, err
@@ -127,9 +125,7 @@ func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Conte
 	if err != nil {
 		return LogAnalyticsClientExportThrottledRequestsPollerResponse{}, err
 	}
-	result := LogAnalyticsClientExportThrottledRequestsPollerResponse{
-		RawResponse: resp,
-	}
+	result := LogAnalyticsClientExportThrottledRequestsPollerResponse{}
 	pt, err := armruntime.NewPoller("LogAnalyticsClient.ExportThrottledRequests", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return LogAnalyticsClientExportThrottledRequestsPollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
@@ -71,7 +71,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 
 // listHandleResponse handles the List response.
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
-	result := OperationsClientListResponse{RawResponse: resp}
+	result := OperationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
@@ -43,11 +43,10 @@ func (p *ContainerServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final ContainerServicesClientCreateOrUpdateResponse will be returned.
 func (p *ContainerServicesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ContainerServicesClientCreateOrUpdateResponse, error) {
 	respType := ContainerServicesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ContainerService)
+	_, err := p.pt.FinalResponse(ctx, &respType.ContainerService)
 	if err != nil {
 		return ContainerServicesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -86,11 +85,10 @@ func (p *ContainerServicesClientDeletePoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final ContainerServicesClientDeleteResponse will be returned.
 func (p *ContainerServicesClientDeletePoller) FinalResponse(ctx context.Context) (ContainerServicesClientDeleteResponse, error) {
 	respType := ContainerServicesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ContainerServicesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -129,11 +127,10 @@ func (p *DedicatedHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final DedicatedHostsClientCreateOrUpdateResponse will be returned.
 func (p *DedicatedHostsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DedicatedHostsClientCreateOrUpdateResponse, error) {
 	respType := DedicatedHostsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DedicatedHost)
+	_, err := p.pt.FinalResponse(ctx, &respType.DedicatedHost)
 	if err != nil {
 		return DedicatedHostsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -172,11 +169,10 @@ func (p *DedicatedHostsClientDeletePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final DedicatedHostsClientDeleteResponse will be returned.
 func (p *DedicatedHostsClientDeletePoller) FinalResponse(ctx context.Context) (DedicatedHostsClientDeleteResponse, error) {
 	respType := DedicatedHostsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DedicatedHostsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -215,11 +211,10 @@ func (p *DedicatedHostsClientUpdatePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final DedicatedHostsClientUpdateResponse will be returned.
 func (p *DedicatedHostsClientUpdatePoller) FinalResponse(ctx context.Context) (DedicatedHostsClientUpdateResponse, error) {
 	respType := DedicatedHostsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DedicatedHost)
+	_, err := p.pt.FinalResponse(ctx, &respType.DedicatedHost)
 	if err != nil {
 		return DedicatedHostsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -258,11 +253,10 @@ func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final DiskEncryptionSetsClientCreateOrUpdateResponse will be returned.
 func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
 	respType := DiskEncryptionSetsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DiskEncryptionSet)
+	_, err := p.pt.FinalResponse(ctx, &respType.DiskEncryptionSet)
 	if err != nil {
 		return DiskEncryptionSetsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -301,11 +295,10 @@ func (p *DiskEncryptionSetsClientDeletePoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final DiskEncryptionSetsClientDeleteResponse will be returned.
 func (p *DiskEncryptionSetsClientDeletePoller) FinalResponse(ctx context.Context) (DiskEncryptionSetsClientDeleteResponse, error) {
 	respType := DiskEncryptionSetsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DiskEncryptionSetsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -344,11 +337,10 @@ func (p *DiskEncryptionSetsClientUpdatePoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final DiskEncryptionSetsClientUpdateResponse will be returned.
 func (p *DiskEncryptionSetsClientUpdatePoller) FinalResponse(ctx context.Context) (DiskEncryptionSetsClientUpdateResponse, error) {
 	respType := DiskEncryptionSetsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DiskEncryptionSet)
+	_, err := p.pt.FinalResponse(ctx, &respType.DiskEncryptionSet)
 	if err != nil {
 		return DiskEncryptionSetsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -387,11 +379,10 @@ func (p *DisksClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final DisksClientCreateOrUpdateResponse will be returned.
 func (p *DisksClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DisksClientCreateOrUpdateResponse, error) {
 	respType := DisksClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Disk)
+	_, err := p.pt.FinalResponse(ctx, &respType.Disk)
 	if err != nil {
 		return DisksClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -430,11 +421,10 @@ func (p *DisksClientDeletePoller) Poll(ctx context.Context) (*http.Response, err
 // If the final GET succeeded then the final DisksClientDeleteResponse will be returned.
 func (p *DisksClientDeletePoller) FinalResponse(ctx context.Context) (DisksClientDeleteResponse, error) {
 	respType := DisksClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DisksClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -473,11 +463,10 @@ func (p *DisksClientGrantAccessPoller) Poll(ctx context.Context) (*http.Response
 // If the final GET succeeded then the final DisksClientGrantAccessResponse will be returned.
 func (p *DisksClientGrantAccessPoller) FinalResponse(ctx context.Context) (DisksClientGrantAccessResponse, error) {
 	respType := DisksClientGrantAccessResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.AccessURI)
+	_, err := p.pt.FinalResponse(ctx, &respType.AccessURI)
 	if err != nil {
 		return DisksClientGrantAccessResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -516,11 +505,10 @@ func (p *DisksClientRevokeAccessPoller) Poll(ctx context.Context) (*http.Respons
 // If the final GET succeeded then the final DisksClientRevokeAccessResponse will be returned.
 func (p *DisksClientRevokeAccessPoller) FinalResponse(ctx context.Context) (DisksClientRevokeAccessResponse, error) {
 	respType := DisksClientRevokeAccessResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DisksClientRevokeAccessResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -559,11 +547,10 @@ func (p *DisksClientUpdatePoller) Poll(ctx context.Context) (*http.Response, err
 // If the final GET succeeded then the final DisksClientUpdateResponse will be returned.
 func (p *DisksClientUpdatePoller) FinalResponse(ctx context.Context) (DisksClientUpdateResponse, error) {
 	respType := DisksClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Disk)
+	_, err := p.pt.FinalResponse(ctx, &respType.Disk)
 	if err != nil {
 		return DisksClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -602,11 +589,10 @@ func (p *GalleriesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final GalleriesClientCreateOrUpdateResponse will be returned.
 func (p *GalleriesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleriesClientCreateOrUpdateResponse, error) {
 	respType := GalleriesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Gallery)
+	_, err := p.pt.FinalResponse(ctx, &respType.Gallery)
 	if err != nil {
 		return GalleriesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -645,11 +631,10 @@ func (p *GalleriesClientDeletePoller) Poll(ctx context.Context) (*http.Response,
 // If the final GET succeeded then the final GalleriesClientDeleteResponse will be returned.
 func (p *GalleriesClientDeletePoller) FinalResponse(ctx context.Context) (GalleriesClientDeleteResponse, error) {
 	respType := GalleriesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return GalleriesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -688,11 +673,10 @@ func (p *GalleriesClientUpdatePoller) Poll(ctx context.Context) (*http.Response,
 // If the final GET succeeded then the final GalleriesClientUpdateResponse will be returned.
 func (p *GalleriesClientUpdatePoller) FinalResponse(ctx context.Context) (GalleriesClientUpdateResponse, error) {
 	respType := GalleriesClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Gallery)
+	_, err := p.pt.FinalResponse(ctx, &respType.Gallery)
 	if err != nil {
 		return GalleriesClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -731,11 +715,10 @@ func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Poll(ctx context.
 // If the final GET succeeded then the final GalleryApplicationVersionsClientCreateOrUpdateResponse will be returned.
 func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
 	respType := GalleryApplicationVersionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GalleryApplicationVersion)
+	_, err := p.pt.FinalResponse(ctx, &respType.GalleryApplicationVersion)
 	if err != nil {
 		return GalleryApplicationVersionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -774,11 +757,10 @@ func (p *GalleryApplicationVersionsClientDeletePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final GalleryApplicationVersionsClientDeleteResponse will be returned.
 func (p *GalleryApplicationVersionsClientDeletePoller) FinalResponse(ctx context.Context) (GalleryApplicationVersionsClientDeleteResponse, error) {
 	respType := GalleryApplicationVersionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return GalleryApplicationVersionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -817,11 +799,10 @@ func (p *GalleryApplicationVersionsClientUpdatePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final GalleryApplicationVersionsClientUpdateResponse will be returned.
 func (p *GalleryApplicationVersionsClientUpdatePoller) FinalResponse(ctx context.Context) (GalleryApplicationVersionsClientUpdateResponse, error) {
 	respType := GalleryApplicationVersionsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GalleryApplicationVersion)
+	_, err := p.pt.FinalResponse(ctx, &respType.GalleryApplicationVersion)
 	if err != nil {
 		return GalleryApplicationVersionsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -860,11 +841,10 @@ func (p *GalleryApplicationsClientCreateOrUpdatePoller) Poll(ctx context.Context
 // If the final GET succeeded then the final GalleryApplicationsClientCreateOrUpdateResponse will be returned.
 func (p *GalleryApplicationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
 	respType := GalleryApplicationsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GalleryApplication)
+	_, err := p.pt.FinalResponse(ctx, &respType.GalleryApplication)
 	if err != nil {
 		return GalleryApplicationsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -903,11 +883,10 @@ func (p *GalleryApplicationsClientDeletePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final GalleryApplicationsClientDeleteResponse will be returned.
 func (p *GalleryApplicationsClientDeletePoller) FinalResponse(ctx context.Context) (GalleryApplicationsClientDeleteResponse, error) {
 	respType := GalleryApplicationsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return GalleryApplicationsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -946,11 +925,10 @@ func (p *GalleryApplicationsClientUpdatePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final GalleryApplicationsClientUpdateResponse will be returned.
 func (p *GalleryApplicationsClientUpdatePoller) FinalResponse(ctx context.Context) (GalleryApplicationsClientUpdateResponse, error) {
 	respType := GalleryApplicationsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GalleryApplication)
+	_, err := p.pt.FinalResponse(ctx, &respType.GalleryApplication)
 	if err != nil {
 		return GalleryApplicationsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -989,11 +967,10 @@ func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final GalleryImageVersionsClientCreateOrUpdateResponse will be returned.
 func (p *GalleryImageVersionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
 	respType := GalleryImageVersionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GalleryImageVersion)
+	_, err := p.pt.FinalResponse(ctx, &respType.GalleryImageVersion)
 	if err != nil {
 		return GalleryImageVersionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1032,11 +1009,10 @@ func (p *GalleryImageVersionsClientDeletePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final GalleryImageVersionsClientDeleteResponse will be returned.
 func (p *GalleryImageVersionsClientDeletePoller) FinalResponse(ctx context.Context) (GalleryImageVersionsClientDeleteResponse, error) {
 	respType := GalleryImageVersionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return GalleryImageVersionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1075,11 +1051,10 @@ func (p *GalleryImageVersionsClientUpdatePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final GalleryImageVersionsClientUpdateResponse will be returned.
 func (p *GalleryImageVersionsClientUpdatePoller) FinalResponse(ctx context.Context) (GalleryImageVersionsClientUpdateResponse, error) {
 	respType := GalleryImageVersionsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GalleryImageVersion)
+	_, err := p.pt.FinalResponse(ctx, &respType.GalleryImageVersion)
 	if err != nil {
 		return GalleryImageVersionsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1118,11 +1093,10 @@ func (p *GalleryImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final GalleryImagesClientCreateOrUpdateResponse will be returned.
 func (p *GalleryImagesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleryImagesClientCreateOrUpdateResponse, error) {
 	respType := GalleryImagesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GalleryImage)
+	_, err := p.pt.FinalResponse(ctx, &respType.GalleryImage)
 	if err != nil {
 		return GalleryImagesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1161,11 +1135,10 @@ func (p *GalleryImagesClientDeletePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final GalleryImagesClientDeleteResponse will be returned.
 func (p *GalleryImagesClientDeletePoller) FinalResponse(ctx context.Context) (GalleryImagesClientDeleteResponse, error) {
 	respType := GalleryImagesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return GalleryImagesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1204,11 +1177,10 @@ func (p *GalleryImagesClientUpdatePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final GalleryImagesClientUpdateResponse will be returned.
 func (p *GalleryImagesClientUpdatePoller) FinalResponse(ctx context.Context) (GalleryImagesClientUpdateResponse, error) {
 	respType := GalleryImagesClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GalleryImage)
+	_, err := p.pt.FinalResponse(ctx, &respType.GalleryImage)
 	if err != nil {
 		return GalleryImagesClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1247,11 +1219,10 @@ func (p *ImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final ImagesClientCreateOrUpdateResponse will be returned.
 func (p *ImagesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ImagesClientCreateOrUpdateResponse, error) {
 	respType := ImagesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Image)
+	_, err := p.pt.FinalResponse(ctx, &respType.Image)
 	if err != nil {
 		return ImagesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1290,11 +1261,10 @@ func (p *ImagesClientDeletePoller) Poll(ctx context.Context) (*http.Response, er
 // If the final GET succeeded then the final ImagesClientDeleteResponse will be returned.
 func (p *ImagesClientDeletePoller) FinalResponse(ctx context.Context) (ImagesClientDeleteResponse, error) {
 	respType := ImagesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ImagesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1333,11 +1303,10 @@ func (p *ImagesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, er
 // If the final GET succeeded then the final ImagesClientUpdateResponse will be returned.
 func (p *ImagesClientUpdatePoller) FinalResponse(ctx context.Context) (ImagesClientUpdateResponse, error) {
 	respType := ImagesClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Image)
+	_, err := p.pt.FinalResponse(ctx, &respType.Image)
 	if err != nil {
 		return ImagesClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1376,11 +1345,10 @@ func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Poll(ctx context.C
 // If the final GET succeeded then the final LogAnalyticsClientExportRequestRateByIntervalResponse will be returned.
 func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) FinalResponse(ctx context.Context) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
 	respType := LogAnalyticsClientExportRequestRateByIntervalResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.LogAnalyticsOperationResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.LogAnalyticsOperationResult)
 	if err != nil {
 		return LogAnalyticsClientExportRequestRateByIntervalResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1419,11 +1387,10 @@ func (p *LogAnalyticsClientExportThrottledRequestsPoller) Poll(ctx context.Conte
 // If the final GET succeeded then the final LogAnalyticsClientExportThrottledRequestsResponse will be returned.
 func (p *LogAnalyticsClientExportThrottledRequestsPoller) FinalResponse(ctx context.Context) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
 	respType := LogAnalyticsClientExportThrottledRequestsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.LogAnalyticsOperationResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.LogAnalyticsOperationResult)
 	if err != nil {
 		return LogAnalyticsClientExportThrottledRequestsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1462,11 +1429,10 @@ func (p *SnapshotsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final SnapshotsClientCreateOrUpdateResponse will be returned.
 func (p *SnapshotsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SnapshotsClientCreateOrUpdateResponse, error) {
 	respType := SnapshotsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Snapshot)
+	_, err := p.pt.FinalResponse(ctx, &respType.Snapshot)
 	if err != nil {
 		return SnapshotsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1505,11 +1471,10 @@ func (p *SnapshotsClientDeletePoller) Poll(ctx context.Context) (*http.Response,
 // If the final GET succeeded then the final SnapshotsClientDeleteResponse will be returned.
 func (p *SnapshotsClientDeletePoller) FinalResponse(ctx context.Context) (SnapshotsClientDeleteResponse, error) {
 	respType := SnapshotsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SnapshotsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1548,11 +1513,10 @@ func (p *SnapshotsClientGrantAccessPoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final SnapshotsClientGrantAccessResponse will be returned.
 func (p *SnapshotsClientGrantAccessPoller) FinalResponse(ctx context.Context) (SnapshotsClientGrantAccessResponse, error) {
 	respType := SnapshotsClientGrantAccessResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.AccessURI)
+	_, err := p.pt.FinalResponse(ctx, &respType.AccessURI)
 	if err != nil {
 		return SnapshotsClientGrantAccessResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1591,11 +1555,10 @@ func (p *SnapshotsClientRevokeAccessPoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final SnapshotsClientRevokeAccessResponse will be returned.
 func (p *SnapshotsClientRevokeAccessPoller) FinalResponse(ctx context.Context) (SnapshotsClientRevokeAccessResponse, error) {
 	respType := SnapshotsClientRevokeAccessResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SnapshotsClientRevokeAccessResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1634,11 +1597,10 @@ func (p *SnapshotsClientUpdatePoller) Poll(ctx context.Context) (*http.Response,
 // If the final GET succeeded then the final SnapshotsClientUpdateResponse will be returned.
 func (p *SnapshotsClientUpdatePoller) FinalResponse(ctx context.Context) (SnapshotsClientUpdateResponse, error) {
 	respType := SnapshotsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Snapshot)
+	_, err := p.pt.FinalResponse(ctx, &respType.Snapshot)
 	if err != nil {
 		return SnapshotsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1677,11 +1639,10 @@ func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Co
 // If the final GET succeeded then the final VirtualMachineExtensionsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachineExtensionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
 	if err != nil {
 		return VirtualMachineExtensionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1720,11 +1681,10 @@ func (p *VirtualMachineExtensionsClientDeletePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final VirtualMachineExtensionsClientDeleteResponse will be returned.
 func (p *VirtualMachineExtensionsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineExtensionsClientDeleteResponse, error) {
 	respType := VirtualMachineExtensionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineExtensionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1763,11 +1723,10 @@ func (p *VirtualMachineExtensionsClientUpdatePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final VirtualMachineExtensionsClientUpdateResponse will be returned.
 func (p *VirtualMachineExtensionsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineExtensionsClientUpdateResponse, error) {
 	respType := VirtualMachineExtensionsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
 	if err != nil {
 		return VirtualMachineExtensionsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1806,11 +1765,10 @@ func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Poll(ctx co
 // If the final GET succeeded then the final VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetExtension)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetExtension)
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1849,11 +1807,10 @@ func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Poll(ctx context.Co
 // If the final GET succeeded then the final VirtualMachineScaleSetExtensionsClientDeleteResponse will be returned.
 func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
 	respType := VirtualMachineScaleSetExtensionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1892,11 +1849,10 @@ func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Poll(ctx context.Co
 // If the final GET succeeded then the final VirtualMachineScaleSetExtensionsClientUpdateResponse will be returned.
 func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
 	respType := VirtualMachineScaleSetExtensionsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetExtension)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetExtension)
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1935,11 +1891,10 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Poll(ctx conte
 // If the final GET succeeded then the final VirtualMachineScaleSetRollingUpgradesClientCancelResponse will be returned.
 func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
 	respType := VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1978,11 +1933,10 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller)
 // If the final GET succeeded then the final VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse will be returned.
 func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
 	respType := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2021,11 +1975,10 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Poll(c
 // If the final GET succeeded then the final VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse will be returned.
 func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
 	respType := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2064,11 +2017,10 @@ func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Poll(ctx 
 // If the final GET succeeded then the final VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2107,11 +2059,10 @@ func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Poll(ctx context.
 // If the final GET succeeded then the final VirtualMachineScaleSetVMExtensionsClientDeleteResponse will be returned.
 func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
 	respType := VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2150,11 +2101,10 @@ func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Poll(ctx context.
 // If the final GET succeeded then the final VirtualMachineScaleSetVMExtensionsClientUpdateResponse will be returned.
 func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
 	respType := VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2193,11 +2143,10 @@ func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Poll(ctx context.Conte
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientDeallocateResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientDeallocateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientDeallocateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2236,11 +2185,10 @@ func (p *VirtualMachineScaleSetVMsClientDeletePoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientDeleteResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2279,11 +2227,10 @@ func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Poll(ctx conte
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientPerformMaintenanceResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2322,11 +2269,10 @@ func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Poll(ctx context.Context
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientPowerOffResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientPowerOffResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientPowerOffResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2365,11 +2311,10 @@ func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Poll(ctx context.Context
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientRedeployResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientRedeployPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientRedeployResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRedeployResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2408,11 +2353,10 @@ func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Poll(ctx context.Conte
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientReimageAllResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientReimageAllResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientReimageAllResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2451,11 +2395,10 @@ func (p *VirtualMachineScaleSetVMsClientReimagePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientReimageResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientReimagePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientReimageResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientReimageResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2494,11 +2437,10 @@ func (p *VirtualMachineScaleSetVMsClientRestartPoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientRestartResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientRestartPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientRestartResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRestartResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2537,11 +2479,10 @@ func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Poll(ctx context.Conte
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientRunCommandResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientRunCommandResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.RunCommandResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.RunCommandResult)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRunCommandResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2580,11 +2521,10 @@ func (p *VirtualMachineScaleSetVMsClientStartPoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientStartResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientStartPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientStartResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientStartResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientStartResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2623,11 +2563,10 @@ func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final VirtualMachineScaleSetVMsClientUpdateResponse will be returned.
 func (p *VirtualMachineScaleSetVMsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetVM)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetVM)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2666,11 +2605,10 @@ func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Poll(ctx context.Con
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachineScaleSetsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSet)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSet)
 	if err != nil {
 		return VirtualMachineScaleSetsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2709,11 +2647,10 @@ func (p *VirtualMachineScaleSetsClientDeallocatePoller) Poll(ctx context.Context
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientDeallocateResponse will be returned.
 func (p *VirtualMachineScaleSetsClientDeallocatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
 	respType := VirtualMachineScaleSetsClientDeallocateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeallocateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2752,11 +2689,10 @@ func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Poll(ctx context.Co
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientDeleteInstancesResponse will be returned.
 func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
 	respType := VirtualMachineScaleSetsClientDeleteInstancesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeleteInstancesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2795,11 +2731,10 @@ func (p *VirtualMachineScaleSetsClientDeletePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientDeleteResponse will be returned.
 func (p *VirtualMachineScaleSetsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientDeleteResponse, error) {
 	respType := VirtualMachineScaleSetsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2838,11 +2773,10 @@ func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Poll(ctx context
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientPerformMaintenanceResponse will be returned.
 func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
 	respType := VirtualMachineScaleSetsClientPerformMaintenanceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientPerformMaintenanceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2881,11 +2815,10 @@ func (p *VirtualMachineScaleSetsClientPowerOffPoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientPowerOffResponse will be returned.
 func (p *VirtualMachineScaleSetsClientPowerOffPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
 	respType := VirtualMachineScaleSetsClientPowerOffResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientPowerOffResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2924,11 +2857,10 @@ func (p *VirtualMachineScaleSetsClientRedeployPoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientRedeployResponse will be returned.
 func (p *VirtualMachineScaleSetsClientRedeployPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientRedeployResponse, error) {
 	respType := VirtualMachineScaleSetsClientRedeployResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientRedeployResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2967,11 +2899,10 @@ func (p *VirtualMachineScaleSetsClientReimageAllPoller) Poll(ctx context.Context
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientReimageAllResponse will be returned.
 func (p *VirtualMachineScaleSetsClientReimageAllPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
 	respType := VirtualMachineScaleSetsClientReimageAllResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientReimageAllResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3010,11 +2941,10 @@ func (p *VirtualMachineScaleSetsClientReimagePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientReimageResponse will be returned.
 func (p *VirtualMachineScaleSetsClientReimagePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientReimageResponse, error) {
 	respType := VirtualMachineScaleSetsClientReimageResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientReimageResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3053,11 +2983,10 @@ func (p *VirtualMachineScaleSetsClientRestartPoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientRestartResponse will be returned.
 func (p *VirtualMachineScaleSetsClientRestartPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientRestartResponse, error) {
 	respType := VirtualMachineScaleSetsClientRestartResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientRestartResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3096,11 +3025,10 @@ func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Poll(c
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse will be returned.
 func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
 	respType := VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3139,11 +3067,10 @@ func (p *VirtualMachineScaleSetsClientStartPoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientStartResponse will be returned.
 func (p *VirtualMachineScaleSetsClientStartPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientStartResponse, error) {
 	respType := VirtualMachineScaleSetsClientStartResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientStartResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3182,11 +3109,10 @@ func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Poll(ctx context.Co
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientUpdateInstancesResponse will be returned.
 func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
 	respType := VirtualMachineScaleSetsClientUpdateInstancesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachineScaleSetsClientUpdateInstancesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3225,11 +3151,10 @@ func (p *VirtualMachineScaleSetsClientUpdatePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final VirtualMachineScaleSetsClientUpdateResponse will be returned.
 func (p *VirtualMachineScaleSetsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientUpdateResponse, error) {
 	respType := VirtualMachineScaleSetsClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSet)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSet)
 	if err != nil {
 		return VirtualMachineScaleSetsClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3268,11 +3193,10 @@ func (p *VirtualMachinesClientCapturePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final VirtualMachinesClientCaptureResponse will be returned.
 func (p *VirtualMachinesClientCapturePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientCaptureResponse, error) {
 	respType := VirtualMachinesClientCaptureResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineCaptureResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineCaptureResult)
 	if err != nil {
 		return VirtualMachinesClientCaptureResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3311,11 +3235,10 @@ func (p *VirtualMachinesClientConvertToManagedDisksPoller) Poll(ctx context.Cont
 // If the final GET succeeded then the final VirtualMachinesClientConvertToManagedDisksResponse will be returned.
 func (p *VirtualMachinesClientConvertToManagedDisksPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
 	respType := VirtualMachinesClientConvertToManagedDisksResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientConvertToManagedDisksResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3354,11 +3277,10 @@ func (p *VirtualMachinesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final VirtualMachinesClientCreateOrUpdateResponse will be returned.
 func (p *VirtualMachinesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachinesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachine)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachine)
 	if err != nil {
 		return VirtualMachinesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3397,11 +3319,10 @@ func (p *VirtualMachinesClientDeallocatePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final VirtualMachinesClientDeallocateResponse will be returned.
 func (p *VirtualMachinesClientDeallocatePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientDeallocateResponse, error) {
 	respType := VirtualMachinesClientDeallocateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientDeallocateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3440,11 +3361,10 @@ func (p *VirtualMachinesClientDeletePoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final VirtualMachinesClientDeleteResponse will be returned.
 func (p *VirtualMachinesClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientDeleteResponse, error) {
 	respType := VirtualMachinesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3483,11 +3403,10 @@ func (p *VirtualMachinesClientPerformMaintenancePoller) Poll(ctx context.Context
 // If the final GET succeeded then the final VirtualMachinesClientPerformMaintenanceResponse will be returned.
 func (p *VirtualMachinesClientPerformMaintenancePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientPerformMaintenanceResponse, error) {
 	respType := VirtualMachinesClientPerformMaintenanceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientPerformMaintenanceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3526,11 +3445,10 @@ func (p *VirtualMachinesClientPowerOffPoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final VirtualMachinesClientPowerOffResponse will be returned.
 func (p *VirtualMachinesClientPowerOffPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientPowerOffResponse, error) {
 	respType := VirtualMachinesClientPowerOffResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientPowerOffResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3569,11 +3487,10 @@ func (p *VirtualMachinesClientReapplyPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final VirtualMachinesClientReapplyResponse will be returned.
 func (p *VirtualMachinesClientReapplyPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientReapplyResponse, error) {
 	respType := VirtualMachinesClientReapplyResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientReapplyResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3612,11 +3529,10 @@ func (p *VirtualMachinesClientRedeployPoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final VirtualMachinesClientRedeployResponse will be returned.
 func (p *VirtualMachinesClientRedeployPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientRedeployResponse, error) {
 	respType := VirtualMachinesClientRedeployResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientRedeployResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3655,11 +3571,10 @@ func (p *VirtualMachinesClientReimagePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final VirtualMachinesClientReimageResponse will be returned.
 func (p *VirtualMachinesClientReimagePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientReimageResponse, error) {
 	respType := VirtualMachinesClientReimageResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientReimageResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3698,11 +3613,10 @@ func (p *VirtualMachinesClientRestartPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final VirtualMachinesClientRestartResponse will be returned.
 func (p *VirtualMachinesClientRestartPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientRestartResponse, error) {
 	respType := VirtualMachinesClientRestartResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientRestartResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3741,11 +3655,10 @@ func (p *VirtualMachinesClientRunCommandPoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final VirtualMachinesClientRunCommandResponse will be returned.
 func (p *VirtualMachinesClientRunCommandPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientRunCommandResponse, error) {
 	respType := VirtualMachinesClientRunCommandResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.RunCommandResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.RunCommandResult)
 	if err != nil {
 		return VirtualMachinesClientRunCommandResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3784,11 +3697,10 @@ func (p *VirtualMachinesClientStartPoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final VirtualMachinesClientStartResponse will be returned.
 func (p *VirtualMachinesClientStartPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientStartResponse, error) {
 	respType := VirtualMachinesClientStartResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualMachinesClientStartResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3827,11 +3739,10 @@ func (p *VirtualMachinesClientUpdatePoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final VirtualMachinesClientUpdateResponse will be returned.
 func (p *VirtualMachinesClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientUpdateResponse, error) {
 	respType := VirtualMachinesClientUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualMachine)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachine)
 	if err != nil {
 		return VirtualMachinesClientUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups_client.go
@@ -100,7 +100,7 @@ func (client *ProximityPlacementGroupsClient) createOrUpdateCreateRequest(ctx co
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ProximityPlacementGroupsClient) createOrUpdateHandleResponse(resp *http.Response) (ProximityPlacementGroupsClientCreateOrUpdateResponse, error) {
-	result := ProximityPlacementGroupsClientCreateOrUpdateResponse{RawResponse: resp}
+	result := ProximityPlacementGroupsClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroup); err != nil {
 		return ProximityPlacementGroupsClientCreateOrUpdateResponse{}, err
 	}
@@ -125,7 +125,7 @@ func (client *ProximityPlacementGroupsClient) Delete(ctx context.Context, resour
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return ProximityPlacementGroupsClientDeleteResponse{}, runtime.NewResponseError(resp)
 	}
-	return ProximityPlacementGroupsClientDeleteResponse{RawResponse: resp}, nil
+	return ProximityPlacementGroupsClientDeleteResponse{}, nil
 }
 
 // deleteCreateRequest creates the Delete request.
@@ -205,7 +205,7 @@ func (client *ProximityPlacementGroupsClient) getCreateRequest(ctx context.Conte
 
 // getHandleResponse handles the Get response.
 func (client *ProximityPlacementGroupsClient) getHandleResponse(resp *http.Response) (ProximityPlacementGroupsClientGetResponse, error) {
-	result := ProximityPlacementGroupsClientGetResponse{RawResponse: resp}
+	result := ProximityPlacementGroupsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroup); err != nil {
 		return ProximityPlacementGroupsClientGetResponse{}, err
 	}
@@ -253,7 +253,7 @@ func (client *ProximityPlacementGroupsClient) listByResourceGroupCreateRequest(c
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ProximityPlacementGroupsClient) listByResourceGroupHandleResponse(resp *http.Response) (ProximityPlacementGroupsClientListByResourceGroupResponse, error) {
-	result := ProximityPlacementGroupsClientListByResourceGroupResponse{RawResponse: resp}
+	result := ProximityPlacementGroupsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroupListResult); err != nil {
 		return ProximityPlacementGroupsClientListByResourceGroupResponse{}, err
 	}
@@ -296,7 +296,7 @@ func (client *ProximityPlacementGroupsClient) listBySubscriptionCreateRequest(ct
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *ProximityPlacementGroupsClient) listBySubscriptionHandleResponse(resp *http.Response) (ProximityPlacementGroupsClientListBySubscriptionResponse, error) {
-	result := ProximityPlacementGroupsClientListBySubscriptionResponse{RawResponse: resp}
+	result := ProximityPlacementGroupsClientListBySubscriptionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroupListResult); err != nil {
 		return ProximityPlacementGroupsClientListBySubscriptionResponse{}, err
 	}
@@ -353,7 +353,7 @@ func (client *ProximityPlacementGroupsClient) updateCreateRequest(ctx context.Co
 
 // updateHandleResponse handles the Update response.
 func (client *ProximityPlacementGroupsClient) updateHandleResponse(resp *http.Response) (ProximityPlacementGroupsClientUpdateResponse, error) {
-	result := ProximityPlacementGroupsClientUpdateResponse{RawResponse: resp}
+	result := ProximityPlacementGroupsClientUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroup); err != nil {
 		return ProximityPlacementGroupsClientUpdateResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_resourceskus_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_resourceskus_client.go
@@ -88,7 +88,7 @@ func (client *ResourceSKUsClient) listCreateRequest(ctx context.Context, options
 
 // listHandleResponse handles the List response.
 func (client *ResourceSKUsClient) listHandleResponse(resp *http.Response) (ResourceSKUsClientListResponse, error) {
-	result := ResourceSKUsClientListResponse{RawResponse: resp}
+	result := ResourceSKUsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceSKUsResult); err != nil {
 		return ResourceSKUsClientListResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
@@ -11,65 +11,48 @@ package armcompute
 import (
 	"context"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"net/http"
 	"time"
 )
 
 // AvailabilitySetsClientCreateOrUpdateResponse contains the response from method AvailabilitySetsClient.CreateOrUpdate.
 type AvailabilitySetsClientCreateOrUpdateResponse struct {
 	AvailabilitySet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailabilitySetsClientDeleteResponse contains the response from method AvailabilitySetsClient.Delete.
 type AvailabilitySetsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // AvailabilitySetsClientGetResponse contains the response from method AvailabilitySetsClient.Get.
 type AvailabilitySetsClientGetResponse struct {
 	AvailabilitySet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailabilitySetsClientListAvailableSizesResponse contains the response from method AvailabilitySetsClient.ListAvailableSizes.
 type AvailabilitySetsClientListAvailableSizesResponse struct {
 	VirtualMachineSizeListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailabilitySetsClientListBySubscriptionResponse contains the response from method AvailabilitySetsClient.ListBySubscription.
 type AvailabilitySetsClientListBySubscriptionResponse struct {
 	AvailabilitySetListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailabilitySetsClientListResponse contains the response from method AvailabilitySetsClient.List.
 type AvailabilitySetsClientListResponse struct {
 	AvailabilitySetListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailabilitySetsClientUpdateResponse contains the response from method AvailabilitySetsClient.Update.
 type AvailabilitySetsClientUpdateResponse struct {
 	AvailabilitySet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ContainerServicesClientCreateOrUpdatePollerResponse contains the response from method ContainerServicesClient.CreateOrUpdate.
 type ContainerServicesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ContainerServicesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -77,11 +60,10 @@ type ContainerServicesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ContainerServicesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainerServicesClientCreateOrUpdateResponse, error) {
 	respType := ContainerServicesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ContainerService)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ContainerService)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -94,29 +76,23 @@ func (l *ContainerServicesClientCreateOrUpdatePollerResponse) Resume(ctx context
 	poller := &ContainerServicesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ContainerServicesClientCreateOrUpdateResponse contains the response from method ContainerServicesClient.CreateOrUpdate.
 type ContainerServicesClientCreateOrUpdateResponse struct {
 	ContainerService
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ContainerServicesClientDeletePollerResponse contains the response from method ContainerServicesClient.Delete.
 type ContainerServicesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ContainerServicesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -124,11 +100,10 @@ type ContainerServicesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ContainerServicesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainerServicesClientDeleteResponse, error) {
 	respType := ContainerServicesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -141,90 +116,68 @@ func (l *ContainerServicesClientDeletePollerResponse) Resume(ctx context.Context
 	poller := &ContainerServicesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ContainerServicesClientDeleteResponse contains the response from method ContainerServicesClient.Delete.
 type ContainerServicesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ContainerServicesClientGetResponse contains the response from method ContainerServicesClient.Get.
 type ContainerServicesClientGetResponse struct {
 	ContainerService
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ContainerServicesClientListByResourceGroupResponse contains the response from method ContainerServicesClient.ListByResourceGroup.
 type ContainerServicesClientListByResourceGroupResponse struct {
 	ContainerServiceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ContainerServicesClientListResponse contains the response from method ContainerServicesClient.List.
 type ContainerServicesClientListResponse struct {
 	ContainerServiceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostGroupsClientCreateOrUpdateResponse contains the response from method DedicatedHostGroupsClient.CreateOrUpdate.
 type DedicatedHostGroupsClientCreateOrUpdateResponse struct {
 	DedicatedHostGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostGroupsClientDeleteResponse contains the response from method DedicatedHostGroupsClient.Delete.
 type DedicatedHostGroupsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DedicatedHostGroupsClientGetResponse contains the response from method DedicatedHostGroupsClient.Get.
 type DedicatedHostGroupsClientGetResponse struct {
 	DedicatedHostGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostGroupsClientListByResourceGroupResponse contains the response from method DedicatedHostGroupsClient.ListByResourceGroup.
 type DedicatedHostGroupsClientListByResourceGroupResponse struct {
 	DedicatedHostGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostGroupsClientListBySubscriptionResponse contains the response from method DedicatedHostGroupsClient.ListBySubscription.
 type DedicatedHostGroupsClientListBySubscriptionResponse struct {
 	DedicatedHostGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostGroupsClientUpdateResponse contains the response from method DedicatedHostGroupsClient.Update.
 type DedicatedHostGroupsClientUpdateResponse struct {
 	DedicatedHostGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostsClientCreateOrUpdatePollerResponse contains the response from method DedicatedHostsClient.CreateOrUpdate.
 type DedicatedHostsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DedicatedHostsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -232,11 +185,10 @@ type DedicatedHostsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DedicatedHostsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientCreateOrUpdateResponse, error) {
 	respType := DedicatedHostsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DedicatedHost)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DedicatedHost)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -249,29 +201,23 @@ func (l *DedicatedHostsClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 	poller := &DedicatedHostsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DedicatedHostsClientCreateOrUpdateResponse contains the response from method DedicatedHostsClient.CreateOrUpdate.
 type DedicatedHostsClientCreateOrUpdateResponse struct {
 	DedicatedHost
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostsClientDeletePollerResponse contains the response from method DedicatedHostsClient.Delete.
 type DedicatedHostsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DedicatedHostsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -279,11 +225,10 @@ type DedicatedHostsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DedicatedHostsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientDeleteResponse, error) {
 	respType := DedicatedHostsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -296,42 +241,33 @@ func (l *DedicatedHostsClientDeletePollerResponse) Resume(ctx context.Context, c
 	poller := &DedicatedHostsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DedicatedHostsClientDeleteResponse contains the response from method DedicatedHostsClient.Delete.
 type DedicatedHostsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DedicatedHostsClientGetResponse contains the response from method DedicatedHostsClient.Get.
 type DedicatedHostsClientGetResponse struct {
 	DedicatedHost
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostsClientListByHostGroupResponse contains the response from method DedicatedHostsClient.ListByHostGroup.
 type DedicatedHostsClientListByHostGroupResponse struct {
 	DedicatedHostListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DedicatedHostsClientUpdatePollerResponse contains the response from method DedicatedHostsClient.Update.
 type DedicatedHostsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DedicatedHostsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -339,11 +275,10 @@ type DedicatedHostsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DedicatedHostsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientUpdateResponse, error) {
 	respType := DedicatedHostsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DedicatedHost)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DedicatedHost)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -356,29 +291,23 @@ func (l *DedicatedHostsClientUpdatePollerResponse) Resume(ctx context.Context, c
 	poller := &DedicatedHostsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DedicatedHostsClientUpdateResponse contains the response from method DedicatedHostsClient.Update.
 type DedicatedHostsClientUpdateResponse struct {
 	DedicatedHost
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DiskEncryptionSetsClientCreateOrUpdatePollerResponse contains the response from method DiskEncryptionSetsClient.CreateOrUpdate.
 type DiskEncryptionSetsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DiskEncryptionSetsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -386,11 +315,10 @@ type DiskEncryptionSetsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DiskEncryptionSetsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
 	respType := DiskEncryptionSetsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DiskEncryptionSet)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DiskEncryptionSet)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -403,29 +331,23 @@ func (l *DiskEncryptionSetsClientCreateOrUpdatePollerResponse) Resume(ctx contex
 	poller := &DiskEncryptionSetsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DiskEncryptionSetsClientCreateOrUpdateResponse contains the response from method DiskEncryptionSetsClient.CreateOrUpdate.
 type DiskEncryptionSetsClientCreateOrUpdateResponse struct {
 	DiskEncryptionSet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DiskEncryptionSetsClientDeletePollerResponse contains the response from method DiskEncryptionSetsClient.Delete.
 type DiskEncryptionSetsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DiskEncryptionSetsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -433,11 +355,10 @@ type DiskEncryptionSetsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DiskEncryptionSetsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientDeleteResponse, error) {
 	respType := DiskEncryptionSetsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -450,49 +371,38 @@ func (l *DiskEncryptionSetsClientDeletePollerResponse) Resume(ctx context.Contex
 	poller := &DiskEncryptionSetsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DiskEncryptionSetsClientDeleteResponse contains the response from method DiskEncryptionSetsClient.Delete.
 type DiskEncryptionSetsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DiskEncryptionSetsClientGetResponse contains the response from method DiskEncryptionSetsClient.Get.
 type DiskEncryptionSetsClientGetResponse struct {
 	DiskEncryptionSet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DiskEncryptionSetsClientListByResourceGroupResponse contains the response from method DiskEncryptionSetsClient.ListByResourceGroup.
 type DiskEncryptionSetsClientListByResourceGroupResponse struct {
 	DiskEncryptionSetList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DiskEncryptionSetsClientListResponse contains the response from method DiskEncryptionSetsClient.List.
 type DiskEncryptionSetsClientListResponse struct {
 	DiskEncryptionSetList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DiskEncryptionSetsClientUpdatePollerResponse contains the response from method DiskEncryptionSetsClient.Update.
 type DiskEncryptionSetsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DiskEncryptionSetsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -500,11 +410,10 @@ type DiskEncryptionSetsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DiskEncryptionSetsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientUpdateResponse, error) {
 	respType := DiskEncryptionSetsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DiskEncryptionSet)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DiskEncryptionSet)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -517,29 +426,23 @@ func (l *DiskEncryptionSetsClientUpdatePollerResponse) Resume(ctx context.Contex
 	poller := &DiskEncryptionSetsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DiskEncryptionSetsClientUpdateResponse contains the response from method DiskEncryptionSetsClient.Update.
 type DiskEncryptionSetsClientUpdateResponse struct {
 	DiskEncryptionSet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DisksClientCreateOrUpdatePollerResponse contains the response from method DisksClient.CreateOrUpdate.
 type DisksClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DisksClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -547,11 +450,10 @@ type DisksClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DisksClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientCreateOrUpdateResponse, error) {
 	respType := DisksClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Disk)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Disk)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -564,29 +466,23 @@ func (l *DisksClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, cl
 	poller := &DisksClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DisksClientCreateOrUpdateResponse contains the response from method DisksClient.CreateOrUpdate.
 type DisksClientCreateOrUpdateResponse struct {
 	Disk
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DisksClientDeletePollerResponse contains the response from method DisksClient.Delete.
 type DisksClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DisksClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -594,11 +490,10 @@ type DisksClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DisksClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientDeleteResponse, error) {
 	respType := DisksClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -611,35 +506,28 @@ func (l *DisksClientDeletePollerResponse) Resume(ctx context.Context, client *Di
 	poller := &DisksClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DisksClientDeleteResponse contains the response from method DisksClient.Delete.
 type DisksClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DisksClientGetResponse contains the response from method DisksClient.Get.
 type DisksClientGetResponse struct {
 	Disk
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DisksClientGrantAccessPollerResponse contains the response from method DisksClient.GrantAccess.
 type DisksClientGrantAccessPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DisksClientGrantAccessPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -647,11 +535,10 @@ type DisksClientGrantAccessPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DisksClientGrantAccessPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientGrantAccessResponse, error) {
 	respType := DisksClientGrantAccessResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AccessURI)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AccessURI)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -664,43 +551,33 @@ func (l *DisksClientGrantAccessPollerResponse) Resume(ctx context.Context, clien
 	poller := &DisksClientGrantAccessPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DisksClientGrantAccessResponse contains the response from method DisksClient.GrantAccess.
 type DisksClientGrantAccessResponse struct {
 	AccessURI
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DisksClientListByResourceGroupResponse contains the response from method DisksClient.ListByResourceGroup.
 type DisksClientListByResourceGroupResponse struct {
 	DiskList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DisksClientListResponse contains the response from method DisksClient.List.
 type DisksClientListResponse struct {
 	DiskList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DisksClientRevokeAccessPollerResponse contains the response from method DisksClient.RevokeAccess.
 type DisksClientRevokeAccessPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DisksClientRevokeAccessPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -708,11 +585,10 @@ type DisksClientRevokeAccessPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DisksClientRevokeAccessPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientRevokeAccessResponse, error) {
 	respType := DisksClientRevokeAccessResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -725,28 +601,23 @@ func (l *DisksClientRevokeAccessPollerResponse) Resume(ctx context.Context, clie
 	poller := &DisksClientRevokeAccessPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DisksClientRevokeAccessResponse contains the response from method DisksClient.RevokeAccess.
 type DisksClientRevokeAccessResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DisksClientUpdatePollerResponse contains the response from method DisksClient.Update.
 type DisksClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DisksClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -754,11 +625,10 @@ type DisksClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DisksClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientUpdateResponse, error) {
 	respType := DisksClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Disk)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Disk)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -771,29 +641,23 @@ func (l *DisksClientUpdatePollerResponse) Resume(ctx context.Context, client *Di
 	poller := &DisksClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DisksClientUpdateResponse contains the response from method DisksClient.Update.
 type DisksClientUpdateResponse struct {
 	Disk
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleriesClientCreateOrUpdatePollerResponse contains the response from method GalleriesClient.CreateOrUpdate.
 type GalleriesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleriesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -801,11 +665,10 @@ type GalleriesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleriesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientCreateOrUpdateResponse, error) {
 	respType := GalleriesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Gallery)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Gallery)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -818,29 +681,23 @@ func (l *GalleriesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context
 	poller := &GalleriesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleriesClientCreateOrUpdateResponse contains the response from method GalleriesClient.CreateOrUpdate.
 type GalleriesClientCreateOrUpdateResponse struct {
 	Gallery
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleriesClientDeletePollerResponse contains the response from method GalleriesClient.Delete.
 type GalleriesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleriesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -848,11 +705,10 @@ type GalleriesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleriesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientDeleteResponse, error) {
 	respType := GalleriesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -865,49 +721,38 @@ func (l *GalleriesClientDeletePollerResponse) Resume(ctx context.Context, client
 	poller := &GalleriesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleriesClientDeleteResponse contains the response from method GalleriesClient.Delete.
 type GalleriesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // GalleriesClientGetResponse contains the response from method GalleriesClient.Get.
 type GalleriesClientGetResponse struct {
 	Gallery
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleriesClientListByResourceGroupResponse contains the response from method GalleriesClient.ListByResourceGroup.
 type GalleriesClientListByResourceGroupResponse struct {
 	GalleryList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleriesClientListResponse contains the response from method GalleriesClient.List.
 type GalleriesClientListResponse struct {
 	GalleryList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleriesClientUpdatePollerResponse contains the response from method GalleriesClient.Update.
 type GalleriesClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleriesClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -915,11 +760,10 @@ type GalleriesClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleriesClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientUpdateResponse, error) {
 	respType := GalleriesClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Gallery)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Gallery)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -932,29 +776,23 @@ func (l *GalleriesClientUpdatePollerResponse) Resume(ctx context.Context, client
 	poller := &GalleriesClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleriesClientUpdateResponse contains the response from method GalleriesClient.Update.
 type GalleriesClientUpdateResponse struct {
 	Gallery
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryApplicationVersionsClientCreateOrUpdatePollerResponse contains the response from method GalleryApplicationVersionsClient.CreateOrUpdate.
 type GalleryApplicationVersionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryApplicationVersionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -962,11 +800,10 @@ type GalleryApplicationVersionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryApplicationVersionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
 	respType := GalleryApplicationVersionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplicationVersion)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplicationVersion)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -979,29 +816,23 @@ func (l *GalleryApplicationVersionsClientCreateOrUpdatePollerResponse) Resume(ct
 	poller := &GalleryApplicationVersionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryApplicationVersionsClientCreateOrUpdateResponse contains the response from method GalleryApplicationVersionsClient.CreateOrUpdate.
 type GalleryApplicationVersionsClientCreateOrUpdateResponse struct {
 	GalleryApplicationVersion
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryApplicationVersionsClientDeletePollerResponse contains the response from method GalleryApplicationVersionsClient.Delete.
 type GalleryApplicationVersionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryApplicationVersionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1009,11 +840,10 @@ type GalleryApplicationVersionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryApplicationVersionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientDeleteResponse, error) {
 	respType := GalleryApplicationVersionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1026,42 +856,33 @@ func (l *GalleryApplicationVersionsClientDeletePollerResponse) Resume(ctx contex
 	poller := &GalleryApplicationVersionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryApplicationVersionsClientDeleteResponse contains the response from method GalleryApplicationVersionsClient.Delete.
 type GalleryApplicationVersionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // GalleryApplicationVersionsClientGetResponse contains the response from method GalleryApplicationVersionsClient.Get.
 type GalleryApplicationVersionsClientGetResponse struct {
 	GalleryApplicationVersion
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryApplicationVersionsClientListByGalleryApplicationResponse contains the response from method GalleryApplicationVersionsClient.ListByGalleryApplication.
 type GalleryApplicationVersionsClientListByGalleryApplicationResponse struct {
 	GalleryApplicationVersionList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryApplicationVersionsClientUpdatePollerResponse contains the response from method GalleryApplicationVersionsClient.Update.
 type GalleryApplicationVersionsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryApplicationVersionsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1069,11 +890,10 @@ type GalleryApplicationVersionsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryApplicationVersionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientUpdateResponse, error) {
 	respType := GalleryApplicationVersionsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplicationVersion)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplicationVersion)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1086,29 +906,23 @@ func (l *GalleryApplicationVersionsClientUpdatePollerResponse) Resume(ctx contex
 	poller := &GalleryApplicationVersionsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryApplicationVersionsClientUpdateResponse contains the response from method GalleryApplicationVersionsClient.Update.
 type GalleryApplicationVersionsClientUpdateResponse struct {
 	GalleryApplicationVersion
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryApplicationsClientCreateOrUpdatePollerResponse contains the response from method GalleryApplicationsClient.CreateOrUpdate.
 type GalleryApplicationsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryApplicationsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1116,11 +930,10 @@ type GalleryApplicationsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryApplicationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
 	respType := GalleryApplicationsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplication)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplication)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1133,29 +946,23 @@ func (l *GalleryApplicationsClientCreateOrUpdatePollerResponse) Resume(ctx conte
 	poller := &GalleryApplicationsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryApplicationsClientCreateOrUpdateResponse contains the response from method GalleryApplicationsClient.CreateOrUpdate.
 type GalleryApplicationsClientCreateOrUpdateResponse struct {
 	GalleryApplication
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryApplicationsClientDeletePollerResponse contains the response from method GalleryApplicationsClient.Delete.
 type GalleryApplicationsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryApplicationsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1163,11 +970,10 @@ type GalleryApplicationsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryApplicationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientDeleteResponse, error) {
 	respType := GalleryApplicationsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1180,42 +986,33 @@ func (l *GalleryApplicationsClientDeletePollerResponse) Resume(ctx context.Conte
 	poller := &GalleryApplicationsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryApplicationsClientDeleteResponse contains the response from method GalleryApplicationsClient.Delete.
 type GalleryApplicationsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // GalleryApplicationsClientGetResponse contains the response from method GalleryApplicationsClient.Get.
 type GalleryApplicationsClientGetResponse struct {
 	GalleryApplication
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryApplicationsClientListByGalleryResponse contains the response from method GalleryApplicationsClient.ListByGallery.
 type GalleryApplicationsClientListByGalleryResponse struct {
 	GalleryApplicationList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryApplicationsClientUpdatePollerResponse contains the response from method GalleryApplicationsClient.Update.
 type GalleryApplicationsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryApplicationsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1223,11 +1020,10 @@ type GalleryApplicationsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryApplicationsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientUpdateResponse, error) {
 	respType := GalleryApplicationsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplication)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplication)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1240,29 +1036,23 @@ func (l *GalleryApplicationsClientUpdatePollerResponse) Resume(ctx context.Conte
 	poller := &GalleryApplicationsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryApplicationsClientUpdateResponse contains the response from method GalleryApplicationsClient.Update.
 type GalleryApplicationsClientUpdateResponse struct {
 	GalleryApplication
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryImageVersionsClientCreateOrUpdatePollerResponse contains the response from method GalleryImageVersionsClient.CreateOrUpdate.
 type GalleryImageVersionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryImageVersionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1270,11 +1060,10 @@ type GalleryImageVersionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryImageVersionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
 	respType := GalleryImageVersionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImageVersion)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImageVersion)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1287,29 +1076,23 @@ func (l *GalleryImageVersionsClientCreateOrUpdatePollerResponse) Resume(ctx cont
 	poller := &GalleryImageVersionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryImageVersionsClientCreateOrUpdateResponse contains the response from method GalleryImageVersionsClient.CreateOrUpdate.
 type GalleryImageVersionsClientCreateOrUpdateResponse struct {
 	GalleryImageVersion
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryImageVersionsClientDeletePollerResponse contains the response from method GalleryImageVersionsClient.Delete.
 type GalleryImageVersionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryImageVersionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1317,11 +1100,10 @@ type GalleryImageVersionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryImageVersionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientDeleteResponse, error) {
 	respType := GalleryImageVersionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1334,42 +1116,33 @@ func (l *GalleryImageVersionsClientDeletePollerResponse) Resume(ctx context.Cont
 	poller := &GalleryImageVersionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryImageVersionsClientDeleteResponse contains the response from method GalleryImageVersionsClient.Delete.
 type GalleryImageVersionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // GalleryImageVersionsClientGetResponse contains the response from method GalleryImageVersionsClient.Get.
 type GalleryImageVersionsClientGetResponse struct {
 	GalleryImageVersion
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryImageVersionsClientListByGalleryImageResponse contains the response from method GalleryImageVersionsClient.ListByGalleryImage.
 type GalleryImageVersionsClientListByGalleryImageResponse struct {
 	GalleryImageVersionList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryImageVersionsClientUpdatePollerResponse contains the response from method GalleryImageVersionsClient.Update.
 type GalleryImageVersionsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryImageVersionsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1377,11 +1150,10 @@ type GalleryImageVersionsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryImageVersionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientUpdateResponse, error) {
 	respType := GalleryImageVersionsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImageVersion)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImageVersion)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1394,29 +1166,23 @@ func (l *GalleryImageVersionsClientUpdatePollerResponse) Resume(ctx context.Cont
 	poller := &GalleryImageVersionsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryImageVersionsClientUpdateResponse contains the response from method GalleryImageVersionsClient.Update.
 type GalleryImageVersionsClientUpdateResponse struct {
 	GalleryImageVersion
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryImagesClientCreateOrUpdatePollerResponse contains the response from method GalleryImagesClient.CreateOrUpdate.
 type GalleryImagesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryImagesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1424,11 +1190,10 @@ type GalleryImagesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryImagesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientCreateOrUpdateResponse, error) {
 	respType := GalleryImagesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImage)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImage)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1441,29 +1206,23 @@ func (l *GalleryImagesClientCreateOrUpdatePollerResponse) Resume(ctx context.Con
 	poller := &GalleryImagesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryImagesClientCreateOrUpdateResponse contains the response from method GalleryImagesClient.CreateOrUpdate.
 type GalleryImagesClientCreateOrUpdateResponse struct {
 	GalleryImage
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryImagesClientDeletePollerResponse contains the response from method GalleryImagesClient.Delete.
 type GalleryImagesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryImagesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1471,11 +1230,10 @@ type GalleryImagesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryImagesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientDeleteResponse, error) {
 	respType := GalleryImagesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1488,42 +1246,33 @@ func (l *GalleryImagesClientDeletePollerResponse) Resume(ctx context.Context, cl
 	poller := &GalleryImagesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryImagesClientDeleteResponse contains the response from method GalleryImagesClient.Delete.
 type GalleryImagesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // GalleryImagesClientGetResponse contains the response from method GalleryImagesClient.Get.
 type GalleryImagesClientGetResponse struct {
 	GalleryImage
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryImagesClientListByGalleryResponse contains the response from method GalleryImagesClient.ListByGallery.
 type GalleryImagesClientListByGalleryResponse struct {
 	GalleryImageList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // GalleryImagesClientUpdatePollerResponse contains the response from method GalleryImagesClient.Update.
 type GalleryImagesClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *GalleryImagesClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1531,11 +1280,10 @@ type GalleryImagesClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l GalleryImagesClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientUpdateResponse, error) {
 	respType := GalleryImagesClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImage)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImage)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1548,29 +1296,23 @@ func (l *GalleryImagesClientUpdatePollerResponse) Resume(ctx context.Context, cl
 	poller := &GalleryImagesClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // GalleryImagesClientUpdateResponse contains the response from method GalleryImagesClient.Update.
 type GalleryImagesClientUpdateResponse struct {
 	GalleryImage
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ImagesClientCreateOrUpdatePollerResponse contains the response from method ImagesClient.CreateOrUpdate.
 type ImagesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ImagesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1578,11 +1320,10 @@ type ImagesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ImagesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientCreateOrUpdateResponse, error) {
 	respType := ImagesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Image)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Image)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1595,29 +1336,23 @@ func (l *ImagesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 	poller := &ImagesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ImagesClientCreateOrUpdateResponse contains the response from method ImagesClient.CreateOrUpdate.
 type ImagesClientCreateOrUpdateResponse struct {
 	Image
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ImagesClientDeletePollerResponse contains the response from method ImagesClient.Delete.
 type ImagesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ImagesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1625,11 +1360,10 @@ type ImagesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ImagesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientDeleteResponse, error) {
 	respType := ImagesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1642,49 +1376,38 @@ func (l *ImagesClientDeletePollerResponse) Resume(ctx context.Context, client *I
 	poller := &ImagesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ImagesClientDeleteResponse contains the response from method ImagesClient.Delete.
 type ImagesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ImagesClientGetResponse contains the response from method ImagesClient.Get.
 type ImagesClientGetResponse struct {
 	Image
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ImagesClientListByResourceGroupResponse contains the response from method ImagesClient.ListByResourceGroup.
 type ImagesClientListByResourceGroupResponse struct {
 	ImageListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ImagesClientListResponse contains the response from method ImagesClient.List.
 type ImagesClientListResponse struct {
 	ImageListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ImagesClientUpdatePollerResponse contains the response from method ImagesClient.Update.
 type ImagesClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ImagesClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1692,11 +1415,10 @@ type ImagesClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ImagesClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientUpdateResponse, error) {
 	respType := ImagesClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Image)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Image)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1709,29 +1431,23 @@ func (l *ImagesClientUpdatePollerResponse) Resume(ctx context.Context, client *I
 	poller := &ImagesClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ImagesClientUpdateResponse contains the response from method ImagesClient.Update.
 type ImagesClientUpdateResponse struct {
 	Image
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LogAnalyticsClientExportRequestRateByIntervalPollerResponse contains the response from method LogAnalyticsClient.ExportRequestRateByInterval.
 type LogAnalyticsClientExportRequestRateByIntervalPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LogAnalyticsClientExportRequestRateByIntervalPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1739,11 +1455,10 @@ type LogAnalyticsClientExportRequestRateByIntervalPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l LogAnalyticsClientExportRequestRateByIntervalPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
 	respType := LogAnalyticsClientExportRequestRateByIntervalResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LogAnalyticsOperationResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LogAnalyticsOperationResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1756,29 +1471,23 @@ func (l *LogAnalyticsClientExportRequestRateByIntervalPollerResponse) Resume(ctx
 	poller := &LogAnalyticsClientExportRequestRateByIntervalPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LogAnalyticsClientExportRequestRateByIntervalResponse contains the response from method LogAnalyticsClient.ExportRequestRateByInterval.
 type LogAnalyticsClientExportRequestRateByIntervalResponse struct {
 	LogAnalyticsOperationResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LogAnalyticsClientExportThrottledRequestsPollerResponse contains the response from method LogAnalyticsClient.ExportThrottledRequests.
 type LogAnalyticsClientExportThrottledRequestsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LogAnalyticsClientExportThrottledRequestsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1786,11 +1495,10 @@ type LogAnalyticsClientExportThrottledRequestsPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l LogAnalyticsClientExportThrottledRequestsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
 	respType := LogAnalyticsClientExportThrottledRequestsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LogAnalyticsOperationResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LogAnalyticsOperationResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1803,132 +1511,98 @@ func (l *LogAnalyticsClientExportThrottledRequestsPollerResponse) Resume(ctx con
 	poller := &LogAnalyticsClientExportThrottledRequestsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LogAnalyticsClientExportThrottledRequestsResponse contains the response from method LogAnalyticsClient.ExportThrottledRequests.
 type LogAnalyticsClientExportThrottledRequestsResponse struct {
 	LogAnalyticsOperationResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OperationsClientListResponse contains the response from method OperationsClient.List.
 type OperationsClientListResponse struct {
 	OperationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProximityPlacementGroupsClientCreateOrUpdateResponse contains the response from method ProximityPlacementGroupsClient.CreateOrUpdate.
 type ProximityPlacementGroupsClientCreateOrUpdateResponse struct {
 	ProximityPlacementGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProximityPlacementGroupsClientDeleteResponse contains the response from method ProximityPlacementGroupsClient.Delete.
 type ProximityPlacementGroupsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ProximityPlacementGroupsClientGetResponse contains the response from method ProximityPlacementGroupsClient.Get.
 type ProximityPlacementGroupsClientGetResponse struct {
 	ProximityPlacementGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProximityPlacementGroupsClientListByResourceGroupResponse contains the response from method ProximityPlacementGroupsClient.ListByResourceGroup.
 type ProximityPlacementGroupsClientListByResourceGroupResponse struct {
 	ProximityPlacementGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProximityPlacementGroupsClientListBySubscriptionResponse contains the response from method ProximityPlacementGroupsClient.ListBySubscription.
 type ProximityPlacementGroupsClientListBySubscriptionResponse struct {
 	ProximityPlacementGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProximityPlacementGroupsClientUpdateResponse contains the response from method ProximityPlacementGroupsClient.Update.
 type ProximityPlacementGroupsClientUpdateResponse struct {
 	ProximityPlacementGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ResourceSKUsClientListResponse contains the response from method ResourceSKUsClient.List.
 type ResourceSKUsClientListResponse struct {
 	ResourceSKUsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SSHPublicKeysClientCreateResponse contains the response from method SSHPublicKeysClient.Create.
 type SSHPublicKeysClientCreateResponse struct {
 	SSHPublicKeyResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SSHPublicKeysClientDeleteResponse contains the response from method SSHPublicKeysClient.Delete.
 type SSHPublicKeysClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SSHPublicKeysClientGenerateKeyPairResponse contains the response from method SSHPublicKeysClient.GenerateKeyPair.
 type SSHPublicKeysClientGenerateKeyPairResponse struct {
 	SSHPublicKeyGenerateKeyPairResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SSHPublicKeysClientGetResponse contains the response from method SSHPublicKeysClient.Get.
 type SSHPublicKeysClientGetResponse struct {
 	SSHPublicKeyResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SSHPublicKeysClientListByResourceGroupResponse contains the response from method SSHPublicKeysClient.ListByResourceGroup.
 type SSHPublicKeysClientListByResourceGroupResponse struct {
 	SSHPublicKeysGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SSHPublicKeysClientListBySubscriptionResponse contains the response from method SSHPublicKeysClient.ListBySubscription.
 type SSHPublicKeysClientListBySubscriptionResponse struct {
 	SSHPublicKeysGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SSHPublicKeysClientUpdateResponse contains the response from method SSHPublicKeysClient.Update.
 type SSHPublicKeysClientUpdateResponse struct {
 	SSHPublicKeyResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SnapshotsClientCreateOrUpdatePollerResponse contains the response from method SnapshotsClient.CreateOrUpdate.
 type SnapshotsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SnapshotsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1936,11 +1610,10 @@ type SnapshotsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SnapshotsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientCreateOrUpdateResponse, error) {
 	respType := SnapshotsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Snapshot)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Snapshot)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1953,29 +1626,23 @@ func (l *SnapshotsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context
 	poller := &SnapshotsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SnapshotsClientCreateOrUpdateResponse contains the response from method SnapshotsClient.CreateOrUpdate.
 type SnapshotsClientCreateOrUpdateResponse struct {
 	Snapshot
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SnapshotsClientDeletePollerResponse contains the response from method SnapshotsClient.Delete.
 type SnapshotsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SnapshotsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1983,11 +1650,10 @@ type SnapshotsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SnapshotsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientDeleteResponse, error) {
 	respType := SnapshotsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2000,35 +1666,28 @@ func (l *SnapshotsClientDeletePollerResponse) Resume(ctx context.Context, client
 	poller := &SnapshotsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SnapshotsClientDeleteResponse contains the response from method SnapshotsClient.Delete.
 type SnapshotsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SnapshotsClientGetResponse contains the response from method SnapshotsClient.Get.
 type SnapshotsClientGetResponse struct {
 	Snapshot
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SnapshotsClientGrantAccessPollerResponse contains the response from method SnapshotsClient.GrantAccess.
 type SnapshotsClientGrantAccessPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SnapshotsClientGrantAccessPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2036,11 +1695,10 @@ type SnapshotsClientGrantAccessPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SnapshotsClientGrantAccessPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientGrantAccessResponse, error) {
 	respType := SnapshotsClientGrantAccessResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AccessURI)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AccessURI)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2053,43 +1711,33 @@ func (l *SnapshotsClientGrantAccessPollerResponse) Resume(ctx context.Context, c
 	poller := &SnapshotsClientGrantAccessPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SnapshotsClientGrantAccessResponse contains the response from method SnapshotsClient.GrantAccess.
 type SnapshotsClientGrantAccessResponse struct {
 	AccessURI
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SnapshotsClientListByResourceGroupResponse contains the response from method SnapshotsClient.ListByResourceGroup.
 type SnapshotsClientListByResourceGroupResponse struct {
 	SnapshotList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SnapshotsClientListResponse contains the response from method SnapshotsClient.List.
 type SnapshotsClientListResponse struct {
 	SnapshotList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SnapshotsClientRevokeAccessPollerResponse contains the response from method SnapshotsClient.RevokeAccess.
 type SnapshotsClientRevokeAccessPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SnapshotsClientRevokeAccessPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2097,11 +1745,10 @@ type SnapshotsClientRevokeAccessPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SnapshotsClientRevokeAccessPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientRevokeAccessResponse, error) {
 	respType := SnapshotsClientRevokeAccessResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2114,28 +1761,23 @@ func (l *SnapshotsClientRevokeAccessPollerResponse) Resume(ctx context.Context, 
 	poller := &SnapshotsClientRevokeAccessPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SnapshotsClientRevokeAccessResponse contains the response from method SnapshotsClient.RevokeAccess.
 type SnapshotsClientRevokeAccessResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SnapshotsClientUpdatePollerResponse contains the response from method SnapshotsClient.Update.
 type SnapshotsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SnapshotsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2143,11 +1785,10 @@ type SnapshotsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SnapshotsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientUpdateResponse, error) {
 	respType := SnapshotsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Snapshot)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Snapshot)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2160,50 +1801,37 @@ func (l *SnapshotsClientUpdatePollerResponse) Resume(ctx context.Context, client
 	poller := &SnapshotsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SnapshotsClientUpdateResponse contains the response from method SnapshotsClient.Update.
 type SnapshotsClientUpdateResponse struct {
 	Snapshot
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UsageClientListResponse contains the response from method UsageClient.List.
 type UsageClientListResponse struct {
 	ListUsagesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineExtensionImagesClientGetResponse contains the response from method VirtualMachineExtensionImagesClient.Get.
 type VirtualMachineExtensionImagesClientGetResponse struct {
 	VirtualMachineExtensionImage
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineExtensionImagesClientListTypesResponse contains the response from method VirtualMachineExtensionImagesClient.ListTypes.
 type VirtualMachineExtensionImagesClientListTypesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Array of VirtualMachineExtensionImage
 	VirtualMachineExtensionImageArray []*VirtualMachineExtensionImage
 }
 
 // VirtualMachineExtensionImagesClientListVersionsResponse contains the response from method VirtualMachineExtensionImagesClient.ListVersions.
 type VirtualMachineExtensionImagesClientListVersionsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Array of VirtualMachineExtensionImage
 	VirtualMachineExtensionImageArray []*VirtualMachineExtensionImage
 }
@@ -2212,9 +1840,6 @@ type VirtualMachineExtensionImagesClientListVersionsResponse struct {
 type VirtualMachineExtensionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineExtensionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2222,11 +1847,10 @@ type VirtualMachineExtensionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineExtensionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachineExtensionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2239,29 +1863,23 @@ func (l *VirtualMachineExtensionsClientCreateOrUpdatePollerResponse) Resume(ctx 
 	poller := &VirtualMachineExtensionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineExtensionsClient.CreateOrUpdate.
 type VirtualMachineExtensionsClientCreateOrUpdateResponse struct {
 	VirtualMachineExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineExtensionsClientDeletePollerResponse contains the response from method VirtualMachineExtensionsClient.Delete.
 type VirtualMachineExtensionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineExtensionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2269,11 +1887,10 @@ type VirtualMachineExtensionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineExtensionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientDeleteResponse, error) {
 	respType := VirtualMachineExtensionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2286,42 +1903,33 @@ func (l *VirtualMachineExtensionsClientDeletePollerResponse) Resume(ctx context.
 	poller := &VirtualMachineExtensionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineExtensionsClientDeleteResponse contains the response from method VirtualMachineExtensionsClient.Delete.
 type VirtualMachineExtensionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineExtensionsClientGetResponse contains the response from method VirtualMachineExtensionsClient.Get.
 type VirtualMachineExtensionsClientGetResponse struct {
 	VirtualMachineExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineExtensionsClientListResponse contains the response from method VirtualMachineExtensionsClient.List.
 type VirtualMachineExtensionsClientListResponse struct {
 	VirtualMachineExtensionsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineExtensionsClient.Update.
 type VirtualMachineExtensionsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineExtensionsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2329,11 +1937,10 @@ type VirtualMachineExtensionsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineExtensionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientUpdateResponse, error) {
 	respType := VirtualMachineExtensionsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2346,61 +1953,44 @@ func (l *VirtualMachineExtensionsClientUpdatePollerResponse) Resume(ctx context.
 	poller := &VirtualMachineExtensionsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineExtensionsClientUpdateResponse contains the response from method VirtualMachineExtensionsClient.Update.
 type VirtualMachineExtensionsClientUpdateResponse struct {
 	VirtualMachineExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineImagesClientGetResponse contains the response from method VirtualMachineImagesClient.Get.
 type VirtualMachineImagesClientGetResponse struct {
 	VirtualMachineImage
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineImagesClientListOffersResponse contains the response from method VirtualMachineImagesClient.ListOffers.
 type VirtualMachineImagesClientListOffersResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Array of VirtualMachineImageResource
 	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
 
 // VirtualMachineImagesClientListPublishersResponse contains the response from method VirtualMachineImagesClient.ListPublishers.
 type VirtualMachineImagesClientListPublishersResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Array of VirtualMachineImageResource
 	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
 
 // VirtualMachineImagesClientListResponse contains the response from method VirtualMachineImagesClient.List.
 type VirtualMachineImagesClientListResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Array of VirtualMachineImageResource
 	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
 
 // VirtualMachineImagesClientListSKUsResponse contains the response from method VirtualMachineImagesClient.ListSKUs.
 type VirtualMachineImagesClientListSKUsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Array of VirtualMachineImageResource
 	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
@@ -2408,24 +1998,17 @@ type VirtualMachineImagesClientListSKUsResponse struct {
 // VirtualMachineRunCommandsClientGetResponse contains the response from method VirtualMachineRunCommandsClient.Get.
 type VirtualMachineRunCommandsClientGetResponse struct {
 	RunCommandDocument
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineRunCommandsClientListResponse contains the response from method VirtualMachineRunCommandsClient.List.
 type VirtualMachineRunCommandsClientListResponse struct {
 	RunCommandListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.CreateOrUpdate.
 type VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2433,11 +2016,10 @@ type VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetExtension)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetExtension)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2451,29 +2033,23 @@ func (l *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse) Res
 	poller := &VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetExtensionsClient.CreateOrUpdate.
 type VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse struct {
 	VirtualMachineScaleSetExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetExtensionsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Delete.
 type VirtualMachineScaleSetExtensionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetExtensionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2481,11 +2057,10 @@ type VirtualMachineScaleSetExtensionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetExtensionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
 	respType := VirtualMachineScaleSetExtensionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2498,42 +2073,33 @@ func (l *VirtualMachineScaleSetExtensionsClientDeletePollerResponse) Resume(ctx 
 	poller := &VirtualMachineScaleSetExtensionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetExtensionsClientDeleteResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Delete.
 type VirtualMachineScaleSetExtensionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetExtensionsClientGetResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Get.
 type VirtualMachineScaleSetExtensionsClientGetResponse struct {
 	VirtualMachineScaleSetExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetExtensionsClientListResponse contains the response from method VirtualMachineScaleSetExtensionsClient.List.
 type VirtualMachineScaleSetExtensionsClientListResponse struct {
 	VirtualMachineScaleSetExtensionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Update.
 type VirtualMachineScaleSetExtensionsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetExtensionsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2541,11 +2107,10 @@ type VirtualMachineScaleSetExtensionsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetExtensionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
 	respType := VirtualMachineScaleSetExtensionsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetExtension)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetExtension)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2558,29 +2123,23 @@ func (l *VirtualMachineScaleSetExtensionsClientUpdatePollerResponse) Resume(ctx 
 	poller := &VirtualMachineScaleSetExtensionsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetExtensionsClientUpdateResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Update.
 type VirtualMachineScaleSetExtensionsClientUpdateResponse struct {
 	VirtualMachineScaleSetExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.Cancel.
 type VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetRollingUpgradesClientCancelPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2588,11 +2147,10 @@ type VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
 	respType := VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2606,35 +2164,28 @@ func (l *VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse) Resume
 	poller := &VirtualMachineScaleSetRollingUpgradesClientCancelPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientCancelResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.Cancel.
 type VirtualMachineScaleSetRollingUpgradesClientCancelResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.GetLatest.
 type VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse struct {
 	RollingUpgradeStatusInfo
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade.
 type VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2642,11 +2193,10 @@ type VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerRespo
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
 	respType := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2660,28 +2210,23 @@ func (l *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerR
 	poller := &VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade.
 type VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade.
 type VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2689,11 +2234,10 @@ type VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse str
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
 	respType := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2707,28 +2251,23 @@ func (l *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse
 	poller := &VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade.
 type VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate.
 type VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2736,11 +2275,10 @@ type VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse struct
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2754,29 +2292,23 @@ func (l *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse) R
 	poller := &VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate.
 type VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse struct {
 	VirtualMachineExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Delete.
 type VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMExtensionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2784,11 +2316,10 @@ type VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
 	respType := VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2801,42 +2332,33 @@ func (l *VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse) Resume(ct
 	poller := &VirtualMachineScaleSetVMExtensionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMExtensionsClientDeleteResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Delete.
 type VirtualMachineScaleSetVMExtensionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMExtensionsClientGetResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Get.
 type VirtualMachineScaleSetVMExtensionsClientGetResponse struct {
 	VirtualMachineExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetVMExtensionsClientListResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.List.
 type VirtualMachineScaleSetVMExtensionsClientListResponse struct {
 	VirtualMachineExtensionsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Update.
 type VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMExtensionsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2844,11 +2366,10 @@ type VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
 	respType := VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2861,29 +2382,23 @@ func (l *VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse) Resume(ct
 	poller := &VirtualMachineScaleSetVMExtensionsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMExtensionsClientUpdateResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Update.
 type VirtualMachineScaleSetVMExtensionsClientUpdateResponse struct {
 	VirtualMachineExtension
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetVMsClientDeallocatePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Deallocate.
 type VirtualMachineScaleSetVMsClientDeallocatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientDeallocatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2891,11 +2406,10 @@ type VirtualMachineScaleSetVMsClientDeallocatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientDeallocatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientDeallocateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2908,28 +2422,23 @@ func (l *VirtualMachineScaleSetVMsClientDeallocatePollerResponse) Resume(ctx con
 	poller := &VirtualMachineScaleSetVMsClientDeallocatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientDeallocateResponse contains the response from method VirtualMachineScaleSetVMsClient.Deallocate.
 type VirtualMachineScaleSetVMsClientDeallocateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Delete.
 type VirtualMachineScaleSetVMsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2937,11 +2446,10 @@ type VirtualMachineScaleSetVMsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2954,49 +2462,38 @@ func (l *VirtualMachineScaleSetVMsClientDeletePollerResponse) Resume(ctx context
 	poller := &VirtualMachineScaleSetVMsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientDeleteResponse contains the response from method VirtualMachineScaleSetVMsClient.Delete.
 type VirtualMachineScaleSetVMsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientGetInstanceViewResponse contains the response from method VirtualMachineScaleSetVMsClient.GetInstanceView.
 type VirtualMachineScaleSetVMsClientGetInstanceViewResponse struct {
 	VirtualMachineScaleSetVMInstanceView
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetVMsClientGetResponse contains the response from method VirtualMachineScaleSetVMsClient.Get.
 type VirtualMachineScaleSetVMsClientGetResponse struct {
 	VirtualMachineScaleSetVM
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetVMsClientListResponse contains the response from method VirtualMachineScaleSetVMsClient.List.
 type VirtualMachineScaleSetVMsClientListResponse struct {
 	VirtualMachineScaleSetVMListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.PerformMaintenance.
 type VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientPerformMaintenancePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3004,11 +2501,10 @@ type VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3022,28 +2518,23 @@ func (l *VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse) Resume
 	poller := &VirtualMachineScaleSetVMsClientPerformMaintenancePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientPerformMaintenanceResponse contains the response from method VirtualMachineScaleSetVMsClient.PerformMaintenance.
 type VirtualMachineScaleSetVMsClientPerformMaintenanceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientPowerOffPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.PowerOff.
 type VirtualMachineScaleSetVMsClientPowerOffPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientPowerOffPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3051,11 +2542,10 @@ type VirtualMachineScaleSetVMsClientPowerOffPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientPowerOffPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientPowerOffResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3068,28 +2558,23 @@ func (l *VirtualMachineScaleSetVMsClientPowerOffPollerResponse) Resume(ctx conte
 	poller := &VirtualMachineScaleSetVMsClientPowerOffPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientPowerOffResponse contains the response from method VirtualMachineScaleSetVMsClient.PowerOff.
 type VirtualMachineScaleSetVMsClientPowerOffResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientRedeployPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Redeploy.
 type VirtualMachineScaleSetVMsClientRedeployPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientRedeployPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3097,11 +2582,10 @@ type VirtualMachineScaleSetVMsClientRedeployPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientRedeployPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientRedeployResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3114,28 +2598,23 @@ func (l *VirtualMachineScaleSetVMsClientRedeployPollerResponse) Resume(ctx conte
 	poller := &VirtualMachineScaleSetVMsClientRedeployPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientRedeployResponse contains the response from method VirtualMachineScaleSetVMsClient.Redeploy.
 type VirtualMachineScaleSetVMsClientRedeployResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientReimageAllPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.ReimageAll.
 type VirtualMachineScaleSetVMsClientReimageAllPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientReimageAllPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3143,11 +2622,10 @@ type VirtualMachineScaleSetVMsClientReimageAllPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientReimageAllPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientReimageAllResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3160,28 +2638,23 @@ func (l *VirtualMachineScaleSetVMsClientReimageAllPollerResponse) Resume(ctx con
 	poller := &VirtualMachineScaleSetVMsClientReimageAllPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientReimageAllResponse contains the response from method VirtualMachineScaleSetVMsClient.ReimageAll.
 type VirtualMachineScaleSetVMsClientReimageAllResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientReimagePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Reimage.
 type VirtualMachineScaleSetVMsClientReimagePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientReimagePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3189,11 +2662,10 @@ type VirtualMachineScaleSetVMsClientReimagePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientReimagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientReimageResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3206,28 +2678,23 @@ func (l *VirtualMachineScaleSetVMsClientReimagePollerResponse) Resume(ctx contex
 	poller := &VirtualMachineScaleSetVMsClientReimagePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientReimageResponse contains the response from method VirtualMachineScaleSetVMsClient.Reimage.
 type VirtualMachineScaleSetVMsClientReimageResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientRestartPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Restart.
 type VirtualMachineScaleSetVMsClientRestartPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientRestartPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3235,11 +2702,10 @@ type VirtualMachineScaleSetVMsClientRestartPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientRestartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientRestartResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3252,28 +2718,23 @@ func (l *VirtualMachineScaleSetVMsClientRestartPollerResponse) Resume(ctx contex
 	poller := &VirtualMachineScaleSetVMsClientRestartPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientRestartResponse contains the response from method VirtualMachineScaleSetVMsClient.Restart.
 type VirtualMachineScaleSetVMsClientRestartResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientRunCommandPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.RunCommand.
 type VirtualMachineScaleSetVMsClientRunCommandPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientRunCommandPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3281,11 +2742,10 @@ type VirtualMachineScaleSetVMsClientRunCommandPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientRunCommandPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientRunCommandResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RunCommandResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RunCommandResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3298,35 +2758,28 @@ func (l *VirtualMachineScaleSetVMsClientRunCommandPollerResponse) Resume(ctx con
 	poller := &VirtualMachineScaleSetVMsClientRunCommandPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientRunCommandResponse contains the response from method VirtualMachineScaleSetVMsClient.RunCommand.
 type VirtualMachineScaleSetVMsClientRunCommandResponse struct {
 	RunCommandResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetVMsClientSimulateEvictionResponse contains the response from method VirtualMachineScaleSetVMsClient.SimulateEviction.
 type VirtualMachineScaleSetVMsClientSimulateEvictionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientStartPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Start.
 type VirtualMachineScaleSetVMsClientStartPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientStartPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3334,11 +2787,10 @@ type VirtualMachineScaleSetVMsClientStartPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientStartResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientStartResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3351,28 +2803,23 @@ func (l *VirtualMachineScaleSetVMsClientStartPollerResponse) Resume(ctx context.
 	poller := &VirtualMachineScaleSetVMsClientStartPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientStartResponse contains the response from method VirtualMachineScaleSetVMsClient.Start.
 type VirtualMachineScaleSetVMsClientStartResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetVMsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Update.
 type VirtualMachineScaleSetVMsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetVMsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3380,11 +2827,10 @@ type VirtualMachineScaleSetVMsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetVMsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
 	respType := VirtualMachineScaleSetVMsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetVM)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetVM)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3397,35 +2843,28 @@ func (l *VirtualMachineScaleSetVMsClientUpdatePollerResponse) Resume(ctx context
 	poller := &VirtualMachineScaleSetVMsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetVMsClientUpdateResponse contains the response from method VirtualMachineScaleSetVMsClient.Update.
 type VirtualMachineScaleSetVMsClientUpdateResponse struct {
 	VirtualMachineScaleSetVM
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientConvertToSinglePlacementGroupResponse contains the response from method VirtualMachineScaleSetsClient.ConvertToSinglePlacementGroup.
 type VirtualMachineScaleSetsClientConvertToSinglePlacementGroupResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse contains the response from method VirtualMachineScaleSetsClient.CreateOrUpdate.
 type VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3433,11 +2872,10 @@ type VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachineScaleSetsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSet)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSet)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3450,29 +2888,23 @@ func (l *VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse) Resume(ctx c
 	poller := &VirtualMachineScaleSetsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetsClient.CreateOrUpdate.
 type VirtualMachineScaleSetsClientCreateOrUpdateResponse struct {
 	VirtualMachineScaleSet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientDeallocatePollerResponse contains the response from method VirtualMachineScaleSetsClient.Deallocate.
 type VirtualMachineScaleSetsClientDeallocatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientDeallocatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3480,11 +2912,10 @@ type VirtualMachineScaleSetsClientDeallocatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientDeallocatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
 	respType := VirtualMachineScaleSetsClientDeallocateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3497,28 +2928,23 @@ func (l *VirtualMachineScaleSetsClientDeallocatePollerResponse) Resume(ctx conte
 	poller := &VirtualMachineScaleSetsClientDeallocatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientDeallocateResponse contains the response from method VirtualMachineScaleSetsClient.Deallocate.
 type VirtualMachineScaleSetsClientDeallocateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientDeleteInstancesPollerResponse contains the response from method VirtualMachineScaleSetsClient.DeleteInstances.
 type VirtualMachineScaleSetsClientDeleteInstancesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientDeleteInstancesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3526,11 +2952,10 @@ type VirtualMachineScaleSetsClientDeleteInstancesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientDeleteInstancesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
 	respType := VirtualMachineScaleSetsClientDeleteInstancesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3543,28 +2968,23 @@ func (l *VirtualMachineScaleSetsClientDeleteInstancesPollerResponse) Resume(ctx 
 	poller := &VirtualMachineScaleSetsClientDeleteInstancesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientDeleteInstancesResponse contains the response from method VirtualMachineScaleSetsClient.DeleteInstances.
 type VirtualMachineScaleSetsClientDeleteInstancesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetsClient.Delete.
 type VirtualMachineScaleSetsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3572,11 +2992,10 @@ type VirtualMachineScaleSetsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeleteResponse, error) {
 	respType := VirtualMachineScaleSetsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3589,78 +3008,59 @@ func (l *VirtualMachineScaleSetsClientDeletePollerResponse) Resume(ctx context.C
 	poller := &VirtualMachineScaleSetsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientDeleteResponse contains the response from method VirtualMachineScaleSetsClient.Delete.
 type VirtualMachineScaleSetsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse contains the response from method
 // VirtualMachineScaleSetsClient.ForceRecoveryServiceFabricPlatformUpdateDomainWalk.
 type VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse struct {
 	RecoveryWalkResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientGetInstanceViewResponse contains the response from method VirtualMachineScaleSetsClient.GetInstanceView.
 type VirtualMachineScaleSetsClientGetInstanceViewResponse struct {
 	VirtualMachineScaleSetInstanceView
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse contains the response from method VirtualMachineScaleSetsClient.GetOSUpgradeHistory.
 type VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse struct {
 	VirtualMachineScaleSetListOSUpgradeHistory
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientGetResponse contains the response from method VirtualMachineScaleSetsClient.Get.
 type VirtualMachineScaleSetsClientGetResponse struct {
 	VirtualMachineScaleSet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientListAllResponse contains the response from method VirtualMachineScaleSetsClient.ListAll.
 type VirtualMachineScaleSetsClientListAllResponse struct {
 	VirtualMachineScaleSetListWithLinkResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientListResponse contains the response from method VirtualMachineScaleSetsClient.List.
 type VirtualMachineScaleSetsClientListResponse struct {
 	VirtualMachineScaleSetListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientListSKUsResponse contains the response from method VirtualMachineScaleSetsClient.ListSKUs.
 type VirtualMachineScaleSetsClientListSKUsResponse struct {
 	VirtualMachineScaleSetListSKUsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineScaleSetsClientPerformMaintenancePollerResponse contains the response from method VirtualMachineScaleSetsClient.PerformMaintenance.
 type VirtualMachineScaleSetsClientPerformMaintenancePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientPerformMaintenancePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3668,11 +3068,10 @@ type VirtualMachineScaleSetsClientPerformMaintenancePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientPerformMaintenancePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
 	respType := VirtualMachineScaleSetsClientPerformMaintenanceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3685,28 +3084,23 @@ func (l *VirtualMachineScaleSetsClientPerformMaintenancePollerResponse) Resume(c
 	poller := &VirtualMachineScaleSetsClientPerformMaintenancePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientPerformMaintenanceResponse contains the response from method VirtualMachineScaleSetsClient.PerformMaintenance.
 type VirtualMachineScaleSetsClientPerformMaintenanceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientPowerOffPollerResponse contains the response from method VirtualMachineScaleSetsClient.PowerOff.
 type VirtualMachineScaleSetsClientPowerOffPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientPowerOffPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3714,11 +3108,10 @@ type VirtualMachineScaleSetsClientPowerOffPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientPowerOffPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
 	respType := VirtualMachineScaleSetsClientPowerOffResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3731,28 +3124,23 @@ func (l *VirtualMachineScaleSetsClientPowerOffPollerResponse) Resume(ctx context
 	poller := &VirtualMachineScaleSetsClientPowerOffPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientPowerOffResponse contains the response from method VirtualMachineScaleSetsClient.PowerOff.
 type VirtualMachineScaleSetsClientPowerOffResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientRedeployPollerResponse contains the response from method VirtualMachineScaleSetsClient.Redeploy.
 type VirtualMachineScaleSetsClientRedeployPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientRedeployPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3760,11 +3148,10 @@ type VirtualMachineScaleSetsClientRedeployPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientRedeployPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientRedeployResponse, error) {
 	respType := VirtualMachineScaleSetsClientRedeployResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3777,28 +3164,23 @@ func (l *VirtualMachineScaleSetsClientRedeployPollerResponse) Resume(ctx context
 	poller := &VirtualMachineScaleSetsClientRedeployPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientRedeployResponse contains the response from method VirtualMachineScaleSetsClient.Redeploy.
 type VirtualMachineScaleSetsClientRedeployResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientReimageAllPollerResponse contains the response from method VirtualMachineScaleSetsClient.ReimageAll.
 type VirtualMachineScaleSetsClientReimageAllPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientReimageAllPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3806,11 +3188,10 @@ type VirtualMachineScaleSetsClientReimageAllPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientReimageAllPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
 	respType := VirtualMachineScaleSetsClientReimageAllResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3823,28 +3204,23 @@ func (l *VirtualMachineScaleSetsClientReimageAllPollerResponse) Resume(ctx conte
 	poller := &VirtualMachineScaleSetsClientReimageAllPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientReimageAllResponse contains the response from method VirtualMachineScaleSetsClient.ReimageAll.
 type VirtualMachineScaleSetsClientReimageAllResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientReimagePollerResponse contains the response from method VirtualMachineScaleSetsClient.Reimage.
 type VirtualMachineScaleSetsClientReimagePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientReimagePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3852,11 +3228,10 @@ type VirtualMachineScaleSetsClientReimagePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientReimagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientReimageResponse, error) {
 	respType := VirtualMachineScaleSetsClientReimageResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3869,28 +3244,23 @@ func (l *VirtualMachineScaleSetsClientReimagePollerResponse) Resume(ctx context.
 	poller := &VirtualMachineScaleSetsClientReimagePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientReimageResponse contains the response from method VirtualMachineScaleSetsClient.Reimage.
 type VirtualMachineScaleSetsClientReimageResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientRestartPollerResponse contains the response from method VirtualMachineScaleSetsClient.Restart.
 type VirtualMachineScaleSetsClientRestartPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientRestartPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3898,11 +3268,10 @@ type VirtualMachineScaleSetsClientRestartPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientRestartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientRestartResponse, error) {
 	respType := VirtualMachineScaleSetsClientRestartResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3915,28 +3284,23 @@ func (l *VirtualMachineScaleSetsClientRestartPollerResponse) Resume(ctx context.
 	poller := &VirtualMachineScaleSetsClientRestartPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientRestartResponse contains the response from method VirtualMachineScaleSetsClient.Restart.
 type VirtualMachineScaleSetsClientRestartResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse contains the response from method VirtualMachineScaleSetsClient.SetOrchestrationServiceState.
 type VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3944,11 +3308,10 @@ type VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse str
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
 	respType := VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3962,28 +3325,23 @@ func (l *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse
 	poller := &VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse contains the response from method VirtualMachineScaleSetsClient.SetOrchestrationServiceState.
 type VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientStartPollerResponse contains the response from method VirtualMachineScaleSetsClient.Start.
 type VirtualMachineScaleSetsClientStartPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientStartPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3991,11 +3349,10 @@ type VirtualMachineScaleSetsClientStartPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientStartResponse, error) {
 	respType := VirtualMachineScaleSetsClientStartResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4008,28 +3365,23 @@ func (l *VirtualMachineScaleSetsClientStartPollerResponse) Resume(ctx context.Co
 	poller := &VirtualMachineScaleSetsClientStartPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientStartResponse contains the response from method VirtualMachineScaleSetsClient.Start.
 type VirtualMachineScaleSetsClientStartResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientUpdateInstancesPollerResponse contains the response from method VirtualMachineScaleSetsClient.UpdateInstances.
 type VirtualMachineScaleSetsClientUpdateInstancesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientUpdateInstancesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4037,11 +3389,10 @@ type VirtualMachineScaleSetsClientUpdateInstancesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientUpdateInstancesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
 	respType := VirtualMachineScaleSetsClientUpdateInstancesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4054,28 +3405,23 @@ func (l *VirtualMachineScaleSetsClientUpdateInstancesPollerResponse) Resume(ctx 
 	poller := &VirtualMachineScaleSetsClientUpdateInstancesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientUpdateInstancesResponse contains the response from method VirtualMachineScaleSetsClient.UpdateInstances.
 type VirtualMachineScaleSetsClientUpdateInstancesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachineScaleSetsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetsClient.Update.
 type VirtualMachineScaleSetsClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachineScaleSetsClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4083,11 +3429,10 @@ type VirtualMachineScaleSetsClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachineScaleSetsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientUpdateResponse, error) {
 	respType := VirtualMachineScaleSetsClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSet)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSet)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4100,36 +3445,28 @@ func (l *VirtualMachineScaleSetsClientUpdatePollerResponse) Resume(ctx context.C
 	poller := &VirtualMachineScaleSetsClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachineScaleSetsClientUpdateResponse contains the response from method VirtualMachineScaleSetsClient.Update.
 type VirtualMachineScaleSetsClientUpdateResponse struct {
 	VirtualMachineScaleSet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachineSizesClientListResponse contains the response from method VirtualMachineSizesClient.List.
 type VirtualMachineSizesClientListResponse struct {
 	VirtualMachineSizeListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientCapturePollerResponse contains the response from method VirtualMachinesClient.Capture.
 type VirtualMachinesClientCapturePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientCapturePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4137,11 +3474,10 @@ type VirtualMachinesClientCapturePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientCaptureResponse, error) {
 	respType := VirtualMachinesClientCaptureResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineCaptureResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineCaptureResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4154,29 +3490,23 @@ func (l *VirtualMachinesClientCapturePollerResponse) Resume(ctx context.Context,
 	poller := &VirtualMachinesClientCapturePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientCaptureResponse contains the response from method VirtualMachinesClient.Capture.
 type VirtualMachinesClientCaptureResponse struct {
 	VirtualMachineCaptureResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientConvertToManagedDisksPollerResponse contains the response from method VirtualMachinesClient.ConvertToManagedDisks.
 type VirtualMachinesClientConvertToManagedDisksPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientConvertToManagedDisksPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4184,11 +3514,10 @@ type VirtualMachinesClientConvertToManagedDisksPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientConvertToManagedDisksPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
 	respType := VirtualMachinesClientConvertToManagedDisksResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4201,28 +3530,23 @@ func (l *VirtualMachinesClientConvertToManagedDisksPollerResponse) Resume(ctx co
 	poller := &VirtualMachinesClientConvertToManagedDisksPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientConvertToManagedDisksResponse contains the response from method VirtualMachinesClient.ConvertToManagedDisks.
 type VirtualMachinesClientConvertToManagedDisksResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientCreateOrUpdatePollerResponse contains the response from method VirtualMachinesClient.CreateOrUpdate.
 type VirtualMachinesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4230,11 +3554,10 @@ type VirtualMachinesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientCreateOrUpdateResponse, error) {
 	respType := VirtualMachinesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachine)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachine)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4247,29 +3570,23 @@ func (l *VirtualMachinesClientCreateOrUpdatePollerResponse) Resume(ctx context.C
 	poller := &VirtualMachinesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientCreateOrUpdateResponse contains the response from method VirtualMachinesClient.CreateOrUpdate.
 type VirtualMachinesClientCreateOrUpdateResponse struct {
 	VirtualMachine
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientDeallocatePollerResponse contains the response from method VirtualMachinesClient.Deallocate.
 type VirtualMachinesClientDeallocatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientDeallocatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4277,11 +3594,10 @@ type VirtualMachinesClientDeallocatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientDeallocatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientDeallocateResponse, error) {
 	respType := VirtualMachinesClientDeallocateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4294,28 +3610,23 @@ func (l *VirtualMachinesClientDeallocatePollerResponse) Resume(ctx context.Conte
 	poller := &VirtualMachinesClientDeallocatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientDeallocateResponse contains the response from method VirtualMachinesClient.Deallocate.
 type VirtualMachinesClientDeallocateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientDeletePollerResponse contains the response from method VirtualMachinesClient.Delete.
 type VirtualMachinesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4323,11 +3634,10 @@ type VirtualMachinesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientDeleteResponse, error) {
 	respType := VirtualMachinesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4340,76 +3650,58 @@ func (l *VirtualMachinesClientDeletePollerResponse) Resume(ctx context.Context, 
 	poller := &VirtualMachinesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientDeleteResponse contains the response from method VirtualMachinesClient.Delete.
 type VirtualMachinesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientGeneralizeResponse contains the response from method VirtualMachinesClient.Generalize.
 type VirtualMachinesClientGeneralizeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientGetResponse contains the response from method VirtualMachinesClient.Get.
 type VirtualMachinesClientGetResponse struct {
 	VirtualMachine
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientInstanceViewResponse contains the response from method VirtualMachinesClient.InstanceView.
 type VirtualMachinesClientInstanceViewResponse struct {
 	VirtualMachineInstanceView
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientListAllResponse contains the response from method VirtualMachinesClient.ListAll.
 type VirtualMachinesClientListAllResponse struct {
 	VirtualMachineListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientListAvailableSizesResponse contains the response from method VirtualMachinesClient.ListAvailableSizes.
 type VirtualMachinesClientListAvailableSizesResponse struct {
 	VirtualMachineSizeListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientListByLocationResponse contains the response from method VirtualMachinesClient.ListByLocation.
 type VirtualMachinesClientListByLocationResponse struct {
 	VirtualMachineListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientListResponse contains the response from method VirtualMachinesClient.List.
 type VirtualMachinesClientListResponse struct {
 	VirtualMachineListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientPerformMaintenancePollerResponse contains the response from method VirtualMachinesClient.PerformMaintenance.
 type VirtualMachinesClientPerformMaintenancePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientPerformMaintenancePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4417,11 +3709,10 @@ type VirtualMachinesClientPerformMaintenancePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientPerformMaintenancePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientPerformMaintenanceResponse, error) {
 	respType := VirtualMachinesClientPerformMaintenanceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4434,28 +3725,23 @@ func (l *VirtualMachinesClientPerformMaintenancePollerResponse) Resume(ctx conte
 	poller := &VirtualMachinesClientPerformMaintenancePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientPerformMaintenanceResponse contains the response from method VirtualMachinesClient.PerformMaintenance.
 type VirtualMachinesClientPerformMaintenanceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientPowerOffPollerResponse contains the response from method VirtualMachinesClient.PowerOff.
 type VirtualMachinesClientPowerOffPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientPowerOffPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4463,11 +3749,10 @@ type VirtualMachinesClientPowerOffPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientPowerOffPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientPowerOffResponse, error) {
 	respType := VirtualMachinesClientPowerOffResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4480,28 +3765,23 @@ func (l *VirtualMachinesClientPowerOffPollerResponse) Resume(ctx context.Context
 	poller := &VirtualMachinesClientPowerOffPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientPowerOffResponse contains the response from method VirtualMachinesClient.PowerOff.
 type VirtualMachinesClientPowerOffResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientReapplyPollerResponse contains the response from method VirtualMachinesClient.Reapply.
 type VirtualMachinesClientReapplyPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientReapplyPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4509,11 +3789,10 @@ type VirtualMachinesClientReapplyPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientReapplyPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientReapplyResponse, error) {
 	respType := VirtualMachinesClientReapplyResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4526,28 +3805,23 @@ func (l *VirtualMachinesClientReapplyPollerResponse) Resume(ctx context.Context,
 	poller := &VirtualMachinesClientReapplyPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientReapplyResponse contains the response from method VirtualMachinesClient.Reapply.
 type VirtualMachinesClientReapplyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientRedeployPollerResponse contains the response from method VirtualMachinesClient.Redeploy.
 type VirtualMachinesClientRedeployPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientRedeployPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4555,11 +3829,10 @@ type VirtualMachinesClientRedeployPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientRedeployPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRedeployResponse, error) {
 	respType := VirtualMachinesClientRedeployResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4572,28 +3845,23 @@ func (l *VirtualMachinesClientRedeployPollerResponse) Resume(ctx context.Context
 	poller := &VirtualMachinesClientRedeployPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientRedeployResponse contains the response from method VirtualMachinesClient.Redeploy.
 type VirtualMachinesClientRedeployResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientReimagePollerResponse contains the response from method VirtualMachinesClient.Reimage.
 type VirtualMachinesClientReimagePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientReimagePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4601,11 +3869,10 @@ type VirtualMachinesClientReimagePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientReimagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientReimageResponse, error) {
 	respType := VirtualMachinesClientReimageResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4618,28 +3885,23 @@ func (l *VirtualMachinesClientReimagePollerResponse) Resume(ctx context.Context,
 	poller := &VirtualMachinesClientReimagePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientReimageResponse contains the response from method VirtualMachinesClient.Reimage.
 type VirtualMachinesClientReimageResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientRestartPollerResponse contains the response from method VirtualMachinesClient.Restart.
 type VirtualMachinesClientRestartPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientRestartPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4647,11 +3909,10 @@ type VirtualMachinesClientRestartPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientRestartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRestartResponse, error) {
 	respType := VirtualMachinesClientRestartResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4664,28 +3925,23 @@ func (l *VirtualMachinesClientRestartPollerResponse) Resume(ctx context.Context,
 	poller := &VirtualMachinesClientRestartPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientRestartResponse contains the response from method VirtualMachinesClient.Restart.
 type VirtualMachinesClientRestartResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientRunCommandPollerResponse contains the response from method VirtualMachinesClient.RunCommand.
 type VirtualMachinesClientRunCommandPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientRunCommandPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4693,11 +3949,10 @@ type VirtualMachinesClientRunCommandPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientRunCommandPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRunCommandResponse, error) {
 	respType := VirtualMachinesClientRunCommandResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RunCommandResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RunCommandResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4710,35 +3965,28 @@ func (l *VirtualMachinesClientRunCommandPollerResponse) Resume(ctx context.Conte
 	poller := &VirtualMachinesClientRunCommandPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientRunCommandResponse contains the response from method VirtualMachinesClient.RunCommand.
 type VirtualMachinesClientRunCommandResponse struct {
 	RunCommandResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualMachinesClientSimulateEvictionResponse contains the response from method VirtualMachinesClient.SimulateEviction.
 type VirtualMachinesClientSimulateEvictionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientStartPollerResponse contains the response from method VirtualMachinesClient.Start.
 type VirtualMachinesClientStartPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientStartPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4746,11 +3994,10 @@ type VirtualMachinesClientStartPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientStartResponse, error) {
 	respType := VirtualMachinesClientStartResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4763,28 +4010,23 @@ func (l *VirtualMachinesClientStartPollerResponse) Resume(ctx context.Context, c
 	poller := &VirtualMachinesClientStartPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientStartResponse contains the response from method VirtualMachinesClient.Start.
 type VirtualMachinesClientStartResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualMachinesClientUpdatePollerResponse contains the response from method VirtualMachinesClient.Update.
 type VirtualMachinesClientUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualMachinesClientUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4792,11 +4034,10 @@ type VirtualMachinesClientUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualMachinesClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientUpdateResponse, error) {
 	respType := VirtualMachinesClientUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachine)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachine)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4809,18 +4050,15 @@ func (l *VirtualMachinesClientUpdatePollerResponse) Resume(ctx context.Context, 
 	poller := &VirtualMachinesClientUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualMachinesClientUpdateResponse contains the response from method VirtualMachinesClient.Update.
 type VirtualMachinesClientUpdateResponse struct {
 	VirtualMachine
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
@@ -64,9 +64,7 @@ func (client *SnapshotsClient) BeginCreateOrUpdate(ctx context.Context, resource
 	if err != nil {
 		return SnapshotsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := SnapshotsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := SnapshotsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return SnapshotsClientCreateOrUpdatePollerResponse{}, err
@@ -132,9 +130,7 @@ func (client *SnapshotsClient) BeginDelete(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return SnapshotsClientDeletePollerResponse{}, err
 	}
-	result := SnapshotsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := SnapshotsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return SnapshotsClientDeletePollerResponse{}, err
@@ -237,7 +233,7 @@ func (client *SnapshotsClient) getCreateRequest(ctx context.Context, resourceGro
 
 // getHandleResponse handles the Get response.
 func (client *SnapshotsClient) getHandleResponse(resp *http.Response) (SnapshotsClientGetResponse, error) {
-	result := SnapshotsClientGetResponse{RawResponse: resp}
+	result := SnapshotsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Snapshot); err != nil {
 		return SnapshotsClientGetResponse{}, err
 	}
@@ -258,9 +254,7 @@ func (client *SnapshotsClient) BeginGrantAccess(ctx context.Context, resourceGro
 	if err != nil {
 		return SnapshotsClientGrantAccessPollerResponse{}, err
 	}
-	result := SnapshotsClientGrantAccessPollerResponse{
-		RawResponse: resp,
-	}
+	result := SnapshotsClientGrantAccessPollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.GrantAccess", "location", resp, client.pl)
 	if err != nil {
 		return SnapshotsClientGrantAccessPollerResponse{}, err
@@ -349,7 +343,7 @@ func (client *SnapshotsClient) listCreateRequest(ctx context.Context, options *S
 
 // listHandleResponse handles the List response.
 func (client *SnapshotsClient) listHandleResponse(resp *http.Response) (SnapshotsClientListResponse, error) {
-	result := SnapshotsClientListResponse{RawResponse: resp}
+	result := SnapshotsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SnapshotList); err != nil {
 		return SnapshotsClientListResponse{}, err
 	}
@@ -397,7 +391,7 @@ func (client *SnapshotsClient) listByResourceGroupCreateRequest(ctx context.Cont
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *SnapshotsClient) listByResourceGroupHandleResponse(resp *http.Response) (SnapshotsClientListByResourceGroupResponse, error) {
-	result := SnapshotsClientListByResourceGroupResponse{RawResponse: resp}
+	result := SnapshotsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SnapshotList); err != nil {
 		return SnapshotsClientListByResourceGroupResponse{}, err
 	}
@@ -417,9 +411,7 @@ func (client *SnapshotsClient) BeginRevokeAccess(ctx context.Context, resourceGr
 	if err != nil {
 		return SnapshotsClientRevokeAccessPollerResponse{}, err
 	}
-	result := SnapshotsClientRevokeAccessPollerResponse{
-		RawResponse: resp,
-	}
+	result := SnapshotsClientRevokeAccessPollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.RevokeAccess", "location", resp, client.pl)
 	if err != nil {
 		return SnapshotsClientRevokeAccessPollerResponse{}, err
@@ -485,9 +477,7 @@ func (client *SnapshotsClient) BeginUpdate(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return SnapshotsClientUpdatePollerResponse{}, err
 	}
-	result := SnapshotsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := SnapshotsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return SnapshotsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys_client.go
@@ -99,7 +99,7 @@ func (client *SSHPublicKeysClient) createCreateRequest(ctx context.Context, reso
 
 // createHandleResponse handles the Create response.
 func (client *SSHPublicKeysClient) createHandleResponse(resp *http.Response) (SSHPublicKeysClientCreateResponse, error) {
-	result := SSHPublicKeysClientCreateResponse{RawResponse: resp}
+	result := SSHPublicKeysClientCreateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeyResource); err != nil {
 		return SSHPublicKeysClientCreateResponse{}, err
 	}
@@ -123,7 +123,7 @@ func (client *SSHPublicKeysClient) Delete(ctx context.Context, resourceGroupName
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusNoContent) {
 		return SSHPublicKeysClientDeleteResponse{}, runtime.NewResponseError(resp)
 	}
-	return SSHPublicKeysClientDeleteResponse{RawResponse: resp}, nil
+	return SSHPublicKeysClientDeleteResponse{}, nil
 }
 
 // deleteCreateRequest creates the Delete request.
@@ -202,7 +202,7 @@ func (client *SSHPublicKeysClient) generateKeyPairCreateRequest(ctx context.Cont
 
 // generateKeyPairHandleResponse handles the GenerateKeyPair response.
 func (client *SSHPublicKeysClient) generateKeyPairHandleResponse(resp *http.Response) (SSHPublicKeysClientGenerateKeyPairResponse, error) {
-	result := SSHPublicKeysClientGenerateKeyPairResponse{RawResponse: resp}
+	result := SSHPublicKeysClientGenerateKeyPairResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeyGenerateKeyPairResult); err != nil {
 		return SSHPublicKeysClientGenerateKeyPairResponse{}, err
 	}
@@ -257,7 +257,7 @@ func (client *SSHPublicKeysClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client *SSHPublicKeysClient) getHandleResponse(resp *http.Response) (SSHPublicKeysClientGetResponse, error) {
-	result := SSHPublicKeysClientGetResponse{RawResponse: resp}
+	result := SSHPublicKeysClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeyResource); err != nil {
 		return SSHPublicKeysClientGetResponse{}, err
 	}
@@ -306,7 +306,7 @@ func (client *SSHPublicKeysClient) listByResourceGroupCreateRequest(ctx context.
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *SSHPublicKeysClient) listByResourceGroupHandleResponse(resp *http.Response) (SSHPublicKeysClientListByResourceGroupResponse, error) {
-	result := SSHPublicKeysClientListByResourceGroupResponse{RawResponse: resp}
+	result := SSHPublicKeysClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeysGroupListResult); err != nil {
 		return SSHPublicKeysClientListByResourceGroupResponse{}, err
 	}
@@ -350,7 +350,7 @@ func (client *SSHPublicKeysClient) listBySubscriptionCreateRequest(ctx context.C
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *SSHPublicKeysClient) listBySubscriptionHandleResponse(resp *http.Response) (SSHPublicKeysClientListBySubscriptionResponse, error) {
-	result := SSHPublicKeysClientListBySubscriptionResponse{RawResponse: resp}
+	result := SSHPublicKeysClientListBySubscriptionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeysGroupListResult); err != nil {
 		return SSHPublicKeysClientListBySubscriptionResponse{}, err
 	}
@@ -406,7 +406,7 @@ func (client *SSHPublicKeysClient) updateCreateRequest(ctx context.Context, reso
 
 // updateHandleResponse handles the Update response.
 func (client *SSHPublicKeysClient) updateHandleResponse(resp *http.Response) (SSHPublicKeysClientUpdateResponse, error) {
-	result := SSHPublicKeysClientUpdateResponse{RawResponse: resp}
+	result := SSHPublicKeysClientUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeyResource); err != nil {
 		return SSHPublicKeysClientUpdateResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_usage_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_usage_client.go
@@ -91,7 +91,7 @@ func (client *UsageClient) listCreateRequest(ctx context.Context, location strin
 
 // listHandleResponse handles the List response.
 func (client *UsageClient) listHandleResponse(resp *http.Response) (UsageClientListResponse, error) {
-	result := UsageClientListResponse{RawResponse: resp}
+	result := UsageClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListUsagesResult); err != nil {
 		return UsageClientListResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages_client.go
@@ -107,7 +107,7 @@ func (client *VirtualMachineExtensionImagesClient) getCreateRequest(ctx context.
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachineExtensionImagesClient) getHandleResponse(resp *http.Response) (VirtualMachineExtensionImagesClientGetResponse, error) {
-	result := VirtualMachineExtensionImagesClientGetResponse{RawResponse: resp}
+	result := VirtualMachineExtensionImagesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionImage); err != nil {
 		return VirtualMachineExtensionImagesClientGetResponse{}, err
 	}
@@ -162,7 +162,7 @@ func (client *VirtualMachineExtensionImagesClient) listTypesCreateRequest(ctx co
 
 // listTypesHandleResponse handles the ListTypes response.
 func (client *VirtualMachineExtensionImagesClient) listTypesHandleResponse(resp *http.Response) (VirtualMachineExtensionImagesClientListTypesResponse, error) {
-	result := VirtualMachineExtensionImagesClientListTypesResponse{RawResponse: resp}
+	result := VirtualMachineExtensionImagesClientListTypesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionImageArray); err != nil {
 		return VirtualMachineExtensionImagesClientListTypesResponse{}, err
 	}
@@ -230,7 +230,7 @@ func (client *VirtualMachineExtensionImagesClient) listVersionsCreateRequest(ctx
 
 // listVersionsHandleResponse handles the ListVersions response.
 func (client *VirtualMachineExtensionImagesClient) listVersionsHandleResponse(resp *http.Response) (VirtualMachineExtensionImagesClientListVersionsResponse, error) {
-	result := VirtualMachineExtensionImagesClientListVersionsResponse{RawResponse: resp}
+	result := VirtualMachineExtensionImagesClientListVersionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionImageArray); err != nil {
 		return VirtualMachineExtensionImagesClientListVersionsResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
@@ -63,9 +63,7 @@ func (client *VirtualMachineExtensionsClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return VirtualMachineExtensionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineExtensionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineExtensionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineExtensionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineExtensionsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *VirtualMachineExtensionsClient) BeginDelete(ctx context.Context, r
 	if err != nil {
 		return VirtualMachineExtensionsClientDeletePollerResponse{}, err
 	}
-	result := VirtualMachineExtensionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineExtensionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineExtensionsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineExtensionsClientDeletePollerResponse{}, err
@@ -251,7 +247,7 @@ func (client *VirtualMachineExtensionsClient) getCreateRequest(ctx context.Conte
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachineExtensionsClient) getHandleResponse(resp *http.Response) (VirtualMachineExtensionsClientGetResponse, error) {
-	result := VirtualMachineExtensionsClientGetResponse{RawResponse: resp}
+	result := VirtualMachineExtensionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtension); err != nil {
 		return VirtualMachineExtensionsClientGetResponse{}, err
 	}
@@ -310,7 +306,7 @@ func (client *VirtualMachineExtensionsClient) listCreateRequest(ctx context.Cont
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineExtensionsClient) listHandleResponse(resp *http.Response) (VirtualMachineExtensionsClientListResponse, error) {
-	result := VirtualMachineExtensionsClientListResponse{RawResponse: resp}
+	result := VirtualMachineExtensionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionsListResult); err != nil {
 		return VirtualMachineExtensionsClientListResponse{}, err
 	}
@@ -330,9 +326,7 @@ func (client *VirtualMachineExtensionsClient) BeginUpdate(ctx context.Context, r
 	if err != nil {
 		return VirtualMachineExtensionsClientUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineExtensionsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineExtensionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineExtensionsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineExtensionsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages_client.go
@@ -115,7 +115,7 @@ func (client *VirtualMachineImagesClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachineImagesClient) getHandleResponse(resp *http.Response) (VirtualMachineImagesClientGetResponse, error) {
-	result := VirtualMachineImagesClientGetResponse{RawResponse: resp}
+	result := VirtualMachineImagesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImage); err != nil {
 		return VirtualMachineImagesClientGetResponse{}, err
 	}
@@ -190,7 +190,7 @@ func (client *VirtualMachineImagesClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineImagesClient) listHandleResponse(resp *http.Response) (VirtualMachineImagesClientListResponse, error) {
-	result := VirtualMachineImagesClientListResponse{RawResponse: resp}
+	result := VirtualMachineImagesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImageResourceArray); err != nil {
 		return VirtualMachineImagesClientListResponse{}, err
 	}
@@ -246,7 +246,7 @@ func (client *VirtualMachineImagesClient) listOffersCreateRequest(ctx context.Co
 
 // listOffersHandleResponse handles the ListOffers response.
 func (client *VirtualMachineImagesClient) listOffersHandleResponse(resp *http.Response) (VirtualMachineImagesClientListOffersResponse, error) {
-	result := VirtualMachineImagesClientListOffersResponse{RawResponse: resp}
+	result := VirtualMachineImagesClientListOffersResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImageResourceArray); err != nil {
 		return VirtualMachineImagesClientListOffersResponse{}, err
 	}
@@ -297,7 +297,7 @@ func (client *VirtualMachineImagesClient) listPublishersCreateRequest(ctx contex
 
 // listPublishersHandleResponse handles the ListPublishers response.
 func (client *VirtualMachineImagesClient) listPublishersHandleResponse(resp *http.Response) (VirtualMachineImagesClientListPublishersResponse, error) {
-	result := VirtualMachineImagesClientListPublishersResponse{RawResponse: resp}
+	result := VirtualMachineImagesClientListPublishersResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImageResourceArray); err != nil {
 		return VirtualMachineImagesClientListPublishersResponse{}, err
 	}
@@ -358,7 +358,7 @@ func (client *VirtualMachineImagesClient) listSKUsCreateRequest(ctx context.Cont
 
 // listSKUsHandleResponse handles the ListSKUs response.
 func (client *VirtualMachineImagesClient) listSKUsHandleResponse(resp *http.Response) (VirtualMachineImagesClientListSKUsResponse, error) {
-	result := VirtualMachineImagesClientListSKUsResponse{RawResponse: resp}
+	result := VirtualMachineImagesClientListSKUsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImageResourceArray); err != nil {
 		return VirtualMachineImagesClientListSKUsResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands_client.go
@@ -99,7 +99,7 @@ func (client *VirtualMachineRunCommandsClient) getCreateRequest(ctx context.Cont
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachineRunCommandsClient) getHandleResponse(resp *http.Response) (VirtualMachineRunCommandsClientGetResponse, error) {
-	result := VirtualMachineRunCommandsClientGetResponse{RawResponse: resp}
+	result := VirtualMachineRunCommandsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RunCommandDocument); err != nil {
 		return VirtualMachineRunCommandsClientGetResponse{}, err
 	}
@@ -147,7 +147,7 @@ func (client *VirtualMachineRunCommandsClient) listCreateRequest(ctx context.Con
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineRunCommandsClient) listHandleResponse(resp *http.Response) (VirtualMachineRunCommandsClientListResponse, error) {
-	result := VirtualMachineRunCommandsClientListResponse{RawResponse: resp}
+	result := VirtualMachineRunCommandsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RunCommandListResult); err != nil {
 		return VirtualMachineRunCommandsClientListResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
@@ -64,9 +64,7 @@ func (client *VirtualMachinesClient) BeginCapture(ctx context.Context, resourceG
 	if err != nil {
 		return VirtualMachinesClientCapturePollerResponse{}, err
 	}
-	result := VirtualMachinesClientCapturePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Capture", "location", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientCapturePollerResponse{}, err
@@ -136,9 +134,7 @@ func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Cont
 	if err != nil {
 		return VirtualMachinesClientConvertToManagedDisksPollerResponse{}, err
 	}
-	result := VirtualMachinesClientConvertToManagedDisksPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientConvertToManagedDisksPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.ConvertToManagedDisks", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientConvertToManagedDisksPollerResponse{}, err
@@ -208,9 +204,7 @@ func (client *VirtualMachinesClient) BeginCreateOrUpdate(ctx context.Context, re
 	if err != nil {
 		return VirtualMachinesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualMachinesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientCreateOrUpdatePollerResponse{}, err
@@ -277,9 +271,7 @@ func (client *VirtualMachinesClient) BeginDeallocate(ctx context.Context, resour
 	if err != nil {
 		return VirtualMachinesClientDeallocatePollerResponse{}, err
 	}
-	result := VirtualMachinesClientDeallocatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientDeallocatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Deallocate", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientDeallocatePollerResponse{}, err
@@ -344,9 +336,7 @@ func (client *VirtualMachinesClient) BeginDelete(ctx context.Context, resourceGr
 	if err != nil {
 		return VirtualMachinesClientDeletePollerResponse{}, err
 	}
-	result := VirtualMachinesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientDeletePollerResponse{}, err
@@ -421,7 +411,7 @@ func (client *VirtualMachinesClient) Generalize(ctx context.Context, resourceGro
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return VirtualMachinesClientGeneralizeResponse{}, runtime.NewResponseError(resp)
 	}
-	return VirtualMachinesClientGeneralizeResponse{RawResponse: resp}, nil
+	return VirtualMachinesClientGeneralizeResponse{}, nil
 }
 
 // generalizeCreateRequest creates the Generalize request.
@@ -500,7 +490,7 @@ func (client *VirtualMachinesClient) getCreateRequest(ctx context.Context, resou
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachinesClient) getHandleResponse(resp *http.Response) (VirtualMachinesClientGetResponse, error) {
-	result := VirtualMachinesClientGetResponse{RawResponse: resp}
+	result := VirtualMachinesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachine); err != nil {
 		return VirtualMachinesClientGetResponse{}, err
 	}
@@ -556,7 +546,7 @@ func (client *VirtualMachinesClient) instanceViewCreateRequest(ctx context.Conte
 
 // instanceViewHandleResponse handles the InstanceView response.
 func (client *VirtualMachinesClient) instanceViewHandleResponse(resp *http.Response) (VirtualMachinesClientInstanceViewResponse, error) {
-	result := VirtualMachinesClientInstanceViewResponse{RawResponse: resp}
+	result := VirtualMachinesClientInstanceViewResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineInstanceView); err != nil {
 		return VirtualMachinesClientInstanceViewResponse{}, err
 	}
@@ -604,7 +594,7 @@ func (client *VirtualMachinesClient) listCreateRequest(ctx context.Context, reso
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachinesClient) listHandleResponse(resp *http.Response) (VirtualMachinesClientListResponse, error) {
-	result := VirtualMachinesClientListResponse{RawResponse: resp}
+	result := VirtualMachinesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineListResult); err != nil {
 		return VirtualMachinesClientListResponse{}, err
 	}
@@ -650,7 +640,7 @@ func (client *VirtualMachinesClient) listAllCreateRequest(ctx context.Context, o
 
 // listAllHandleResponse handles the ListAll response.
 func (client *VirtualMachinesClient) listAllHandleResponse(resp *http.Response) (VirtualMachinesClientListAllResponse, error) {
-	result := VirtualMachinesClientListAllResponse{RawResponse: resp}
+	result := VirtualMachinesClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineListResult); err != nil {
 		return VirtualMachinesClientListAllResponse{}, err
 	}
@@ -700,7 +690,7 @@ func (client *VirtualMachinesClient) listAvailableSizesCreateRequest(ctx context
 
 // listAvailableSizesHandleResponse handles the ListAvailableSizes response.
 func (client *VirtualMachinesClient) listAvailableSizesHandleResponse(resp *http.Response) (VirtualMachinesClientListAvailableSizesResponse, error) {
-	result := VirtualMachinesClientListAvailableSizesResponse{RawResponse: resp}
+	result := VirtualMachinesClientListAvailableSizesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineSizeListResult); err != nil {
 		return VirtualMachinesClientListAvailableSizesResponse{}, err
 	}
@@ -748,7 +738,7 @@ func (client *VirtualMachinesClient) listByLocationCreateRequest(ctx context.Con
 
 // listByLocationHandleResponse handles the ListByLocation response.
 func (client *VirtualMachinesClient) listByLocationHandleResponse(resp *http.Response) (VirtualMachinesClientListByLocationResponse, error) {
-	result := VirtualMachinesClientListByLocationResponse{RawResponse: resp}
+	result := VirtualMachinesClientListByLocationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineListResult); err != nil {
 		return VirtualMachinesClientListByLocationResponse{}, err
 	}
@@ -767,9 +757,7 @@ func (client *VirtualMachinesClient) BeginPerformMaintenance(ctx context.Context
 	if err != nil {
 		return VirtualMachinesClientPerformMaintenancePollerResponse{}, err
 	}
-	result := VirtualMachinesClientPerformMaintenancePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientPerformMaintenancePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.PerformMaintenance", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientPerformMaintenancePollerResponse{}, err
@@ -835,9 +823,7 @@ func (client *VirtualMachinesClient) BeginPowerOff(ctx context.Context, resource
 	if err != nil {
 		return VirtualMachinesClientPowerOffPollerResponse{}, err
 	}
-	result := VirtualMachinesClientPowerOffPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientPowerOffPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.PowerOff", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientPowerOffPollerResponse{}, err
@@ -905,9 +891,7 @@ func (client *VirtualMachinesClient) BeginReapply(ctx context.Context, resourceG
 	if err != nil {
 		return VirtualMachinesClientReapplyPollerResponse{}, err
 	}
-	result := VirtualMachinesClientReapplyPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientReapplyPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Reapply", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientReapplyPollerResponse{}, err
@@ -972,9 +956,7 @@ func (client *VirtualMachinesClient) BeginRedeploy(ctx context.Context, resource
 	if err != nil {
 		return VirtualMachinesClientRedeployPollerResponse{}, err
 	}
-	result := VirtualMachinesClientRedeployPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientRedeployPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Redeploy", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientRedeployPollerResponse{}, err
@@ -1038,9 +1020,7 @@ func (client *VirtualMachinesClient) BeginReimage(ctx context.Context, resourceG
 	if err != nil {
 		return VirtualMachinesClientReimagePollerResponse{}, err
 	}
-	result := VirtualMachinesClientReimagePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientReimagePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Reimage", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientReimagePollerResponse{}, err
@@ -1107,9 +1087,7 @@ func (client *VirtualMachinesClient) BeginRestart(ctx context.Context, resourceG
 	if err != nil {
 		return VirtualMachinesClientRestartPollerResponse{}, err
 	}
-	result := VirtualMachinesClientRestartPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientRestartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Restart", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientRestartPollerResponse{}, err
@@ -1174,9 +1152,7 @@ func (client *VirtualMachinesClient) BeginRunCommand(ctx context.Context, resour
 	if err != nil {
 		return VirtualMachinesClientRunCommandPollerResponse{}, err
 	}
-	result := VirtualMachinesClientRunCommandPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientRunCommandPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.RunCommand", "location", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientRunCommandPollerResponse{}, err
@@ -1249,7 +1225,7 @@ func (client *VirtualMachinesClient) SimulateEviction(ctx context.Context, resou
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return VirtualMachinesClientSimulateEvictionResponse{}, runtime.NewResponseError(resp)
 	}
-	return VirtualMachinesClientSimulateEvictionResponse{RawResponse: resp}, nil
+	return VirtualMachinesClientSimulateEvictionResponse{}, nil
 }
 
 // simulateEvictionCreateRequest creates the SimulateEviction request.
@@ -1288,9 +1264,7 @@ func (client *VirtualMachinesClient) BeginStart(ctx context.Context, resourceGro
 	if err != nil {
 		return VirtualMachinesClientStartPollerResponse{}, err
 	}
-	result := VirtualMachinesClientStartPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Start", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientStartPollerResponse{}, err
@@ -1355,9 +1329,7 @@ func (client *VirtualMachinesClient) BeginUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return VirtualMachinesClientUpdatePollerResponse{}, err
 	}
-	result := VirtualMachinesClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachinesClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Update", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachinesClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
@@ -63,9 +63,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginCreateOrUpdate(ctx co
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetExtensionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginDelete(ctx context.Co
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientDeletePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetExtensionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetExtensionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetExtensionsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientDeletePollerResponse{}, err
@@ -251,7 +247,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) getCreateRequest(ctx conte
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachineScaleSetExtensionsClient) getHandleResponse(resp *http.Response) (VirtualMachineScaleSetExtensionsClientGetResponse, error) {
-	result := VirtualMachineScaleSetExtensionsClientGetResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetExtensionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetExtension); err != nil {
 		return VirtualMachineScaleSetExtensionsClientGetResponse{}, err
 	}
@@ -304,7 +300,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) listCreateRequest(ctx cont
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineScaleSetExtensionsClient) listHandleResponse(resp *http.Response) (VirtualMachineScaleSetExtensionsClientListResponse, error) {
-	result := VirtualMachineScaleSetExtensionsClientListResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetExtensionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetExtensionListResult); err != nil {
 		return VirtualMachineScaleSetExtensionsClientListResponse{}, err
 	}
@@ -324,9 +320,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginUpdate(ctx context.Co
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetExtensionsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetExtensionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetExtensionsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetExtensionsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
@@ -61,9 +61,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginCancel(ctx conte
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetRollingUpgradesClient.Cancel", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse{}, err
@@ -165,7 +163,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) getLatestCreateReques
 
 // getLatestHandleResponse handles the GetLatest response.
 func (client *VirtualMachineScaleSetRollingUpgradesClient) getLatestHandleResponse(resp *http.Response) (VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse, error) {
-	result := VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RollingUpgradeStatusInfo); err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse{}, err
 	}
@@ -185,9 +183,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUp
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse{}, err
@@ -255,9 +251,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(c
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
@@ -70,7 +70,7 @@ func (client *VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroup(ctx c
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return VirtualMachineScaleSetsClientConvertToSinglePlacementGroupResponse{}, runtime.NewResponseError(resp)
 	}
-	return VirtualMachineScaleSetsClientConvertToSinglePlacementGroupResponse{RawResponse: resp}, nil
+	return VirtualMachineScaleSetsClientConvertToSinglePlacementGroupResponse{}, nil
 }
 
 // convertToSinglePlacementGroupCreateRequest creates the ConvertToSinglePlacementGroup request.
@@ -110,9 +110,7 @@ func (client *VirtualMachineScaleSetsClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse{}, err
@@ -179,9 +177,7 @@ func (client *VirtualMachineScaleSetsClient) BeginDeallocate(ctx context.Context
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeallocatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientDeallocatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientDeallocatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Deallocate", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeallocatePollerResponse{}, err
@@ -250,9 +246,7 @@ func (client *VirtualMachineScaleSetsClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeletePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeletePollerResponse{}, err
@@ -317,9 +311,7 @@ func (client *VirtualMachineScaleSetsClient) BeginDeleteInstances(ctx context.Co
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeleteInstancesPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientDeleteInstancesPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientDeleteInstancesPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.DeleteInstances", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientDeleteInstancesPollerResponse{}, err
@@ -424,7 +416,7 @@ func (client *VirtualMachineScaleSetsClient) forceRecoveryServiceFabricPlatformU
 
 // forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleResponse handles the ForceRecoveryServiceFabricPlatformUpdateDomainWalk response.
 func (client *VirtualMachineScaleSetsClient) forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleResponse(resp *http.Response) (VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse, error) {
-	result := VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RecoveryWalkResponse); err != nil {
 		return VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse{}, err
 	}
@@ -480,7 +472,7 @@ func (client *VirtualMachineScaleSetsClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachineScaleSetsClient) getHandleResponse(resp *http.Response) (VirtualMachineScaleSetsClientGetResponse, error) {
-	result := VirtualMachineScaleSetsClientGetResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSet); err != nil {
 		return VirtualMachineScaleSetsClientGetResponse{}, err
 	}
@@ -536,7 +528,7 @@ func (client *VirtualMachineScaleSetsClient) getInstanceViewCreateRequest(ctx co
 
 // getInstanceViewHandleResponse handles the GetInstanceView response.
 func (client *VirtualMachineScaleSetsClient) getInstanceViewHandleResponse(resp *http.Response) (VirtualMachineScaleSetsClientGetInstanceViewResponse, error) {
-	result := VirtualMachineScaleSetsClientGetInstanceViewResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetsClientGetInstanceViewResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetInstanceView); err != nil {
 		return VirtualMachineScaleSetsClientGetInstanceViewResponse{}, err
 	}
@@ -589,7 +581,7 @@ func (client *VirtualMachineScaleSetsClient) getOSUpgradeHistoryCreateRequest(ct
 
 // getOSUpgradeHistoryHandleResponse handles the GetOSUpgradeHistory response.
 func (client *VirtualMachineScaleSetsClient) getOSUpgradeHistoryHandleResponse(resp *http.Response) (VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse, error) {
-	result := VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetListOSUpgradeHistory); err != nil {
 		return VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse{}, err
 	}
@@ -637,7 +629,7 @@ func (client *VirtualMachineScaleSetsClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineScaleSetsClient) listHandleResponse(resp *http.Response) (VirtualMachineScaleSetsClientListResponse, error) {
-	result := VirtualMachineScaleSetsClientListResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetListResult); err != nil {
 		return VirtualMachineScaleSetsClientListResponse{}, err
 	}
@@ -682,7 +674,7 @@ func (client *VirtualMachineScaleSetsClient) listAllCreateRequest(ctx context.Co
 
 // listAllHandleResponse handles the ListAll response.
 func (client *VirtualMachineScaleSetsClient) listAllHandleResponse(resp *http.Response) (VirtualMachineScaleSetsClientListAllResponse, error) {
-	result := VirtualMachineScaleSetsClientListAllResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetsClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetListWithLinkResult); err != nil {
 		return VirtualMachineScaleSetsClientListAllResponse{}, err
 	}
@@ -736,7 +728,7 @@ func (client *VirtualMachineScaleSetsClient) listSKUsCreateRequest(ctx context.C
 
 // listSKUsHandleResponse handles the ListSKUs response.
 func (client *VirtualMachineScaleSetsClient) listSKUsHandleResponse(resp *http.Response) (VirtualMachineScaleSetsClientListSKUsResponse, error) {
-	result := VirtualMachineScaleSetsClientListSKUsResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetsClientListSKUsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetListSKUsResult); err != nil {
 		return VirtualMachineScaleSetsClientListSKUsResponse{}, err
 	}
@@ -756,9 +748,7 @@ func (client *VirtualMachineScaleSetsClient) BeginPerformMaintenance(ctx context
 	if err != nil {
 		return VirtualMachineScaleSetsClientPerformMaintenancePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientPerformMaintenancePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientPerformMaintenancePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.PerformMaintenance", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientPerformMaintenancePollerResponse{}, err
@@ -829,9 +819,7 @@ func (client *VirtualMachineScaleSetsClient) BeginPowerOff(ctx context.Context, 
 	if err != nil {
 		return VirtualMachineScaleSetsClientPowerOffPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientPowerOffPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientPowerOffPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.PowerOff", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientPowerOffPollerResponse{}, err
@@ -904,9 +892,7 @@ func (client *VirtualMachineScaleSetsClient) BeginRedeploy(ctx context.Context, 
 	if err != nil {
 		return VirtualMachineScaleSetsClientRedeployPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientRedeployPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientRedeployPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Redeploy", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientRedeployPollerResponse{}, err
@@ -976,9 +962,7 @@ func (client *VirtualMachineScaleSetsClient) BeginReimage(ctx context.Context, r
 	if err != nil {
 		return VirtualMachineScaleSetsClientReimagePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientReimagePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientReimagePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Reimage", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientReimagePollerResponse{}, err
@@ -1048,9 +1032,7 @@ func (client *VirtualMachineScaleSetsClient) BeginReimageAll(ctx context.Context
 	if err != nil {
 		return VirtualMachineScaleSetsClientReimageAllPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientReimageAllPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientReimageAllPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.ReimageAll", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientReimageAllPollerResponse{}, err
@@ -1118,9 +1100,7 @@ func (client *VirtualMachineScaleSetsClient) BeginRestart(ctx context.Context, r
 	if err != nil {
 		return VirtualMachineScaleSetsClientRestartPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientRestartPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientRestartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Restart", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientRestartPollerResponse{}, err
@@ -1188,9 +1168,7 @@ func (client *VirtualMachineScaleSetsClient) BeginSetOrchestrationServiceState(c
 	if err != nil {
 		return VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.SetOrchestrationServiceState", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse{}, err
@@ -1254,9 +1232,7 @@ func (client *VirtualMachineScaleSetsClient) BeginStart(ctx context.Context, res
 	if err != nil {
 		return VirtualMachineScaleSetsClientStartPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientStartPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Start", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientStartPollerResponse{}, err
@@ -1324,9 +1300,7 @@ func (client *VirtualMachineScaleSetsClient) BeginUpdate(ctx context.Context, re
 	if err != nil {
 		return VirtualMachineScaleSetsClientUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientUpdatePollerResponse{}, err
@@ -1392,9 +1366,7 @@ func (client *VirtualMachineScaleSetsClient) BeginUpdateInstances(ctx context.Co
 	if err != nil {
 		return VirtualMachineScaleSetsClientUpdateInstancesPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetsClientUpdateInstancesPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetsClientUpdateInstancesPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.UpdateInstances", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetsClientUpdateInstancesPollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
@@ -64,9 +64,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginCreateOrUpdate(ctx 
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse{}, err
@@ -141,9 +139,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginDelete(ctx context.
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMExtensionsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse{}, err
@@ -267,7 +263,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) getCreateRequest(ctx con
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachineScaleSetVMExtensionsClient) getHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMExtensionsClientGetResponse, error) {
-	result := VirtualMachineScaleSetVMExtensionsClientGetResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetVMExtensionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtension); err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientGetResponse{}, err
 	}
@@ -331,7 +327,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) listCreateRequest(ctx co
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineScaleSetVMExtensionsClient) listHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMExtensionsClientListResponse, error) {
-	result := VirtualMachineScaleSetVMExtensionsClientListResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetVMExtensionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionsListResult); err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientListResponse{}, err
 	}
@@ -352,9 +348,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginUpdate(ctx context.
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMExtensionsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
@@ -65,9 +65,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginDeallocate(ctx context.Conte
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientDeallocatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientDeallocatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientDeallocatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Deallocate", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientDeallocatePollerResponse{}, err
@@ -138,9 +136,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginDelete(ctx context.Context, 
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientDeletePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientDeletePollerResponse{}, err
@@ -254,7 +250,7 @@ func (client *VirtualMachineScaleSetVMsClient) getCreateRequest(ctx context.Cont
 
 // getHandleResponse handles the Get response.
 func (client *VirtualMachineScaleSetVMsClient) getHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMsClientGetResponse, error) {
-	result := VirtualMachineScaleSetVMsClientGetResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetVMsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetVM); err != nil {
 		return VirtualMachineScaleSetVMsClientGetResponse{}, err
 	}
@@ -315,7 +311,7 @@ func (client *VirtualMachineScaleSetVMsClient) getInstanceViewCreateRequest(ctx 
 
 // getInstanceViewHandleResponse handles the GetInstanceView response.
 func (client *VirtualMachineScaleSetVMsClient) getInstanceViewHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMsClientGetInstanceViewResponse, error) {
-	result := VirtualMachineScaleSetVMsClientGetInstanceViewResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetVMsClientGetInstanceViewResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetVMInstanceView); err != nil {
 		return VirtualMachineScaleSetVMsClientGetInstanceViewResponse{}, err
 	}
@@ -377,7 +373,7 @@ func (client *VirtualMachineScaleSetVMsClient) listCreateRequest(ctx context.Con
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineScaleSetVMsClient) listHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMsClientListResponse, error) {
-	result := VirtualMachineScaleSetVMsClientListResponse{RawResponse: resp}
+	result := VirtualMachineScaleSetVMsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetVMListResult); err != nil {
 		return VirtualMachineScaleSetVMsClientListResponse{}, err
 	}
@@ -397,9 +393,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginPerformMaintenance(ctx conte
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.PerformMaintenance", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse{}, err
@@ -471,9 +465,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginPowerOff(ctx context.Context
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientPowerOffPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientPowerOffPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientPowerOffPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.PowerOff", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientPowerOffPollerResponse{}, err
@@ -548,9 +540,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRedeploy(ctx context.Context
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRedeployPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientRedeployPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientRedeployPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Redeploy", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRedeployPollerResponse{}, err
@@ -620,9 +610,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginReimage(ctx context.Context,
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientReimagePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientReimagePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientReimagePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Reimage", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientReimagePollerResponse{}, err
@@ -695,9 +683,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginReimageAll(ctx context.Conte
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientReimageAllPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientReimageAllPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientReimageAllPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.ReimageAll", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientReimageAllPollerResponse{}, err
@@ -767,9 +753,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRestart(ctx context.Context,
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRestartPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientRestartPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientRestartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Restart", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRestartPollerResponse{}, err
@@ -839,9 +823,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRunCommand(ctx context.Conte
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRunCommandPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientRunCommandPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientRunCommandPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.RunCommand", "location", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientRunCommandPollerResponse{}, err
@@ -919,7 +901,7 @@ func (client *VirtualMachineScaleSetVMsClient) SimulateEviction(ctx context.Cont
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return VirtualMachineScaleSetVMsClientSimulateEvictionResponse{}, runtime.NewResponseError(resp)
 	}
-	return VirtualMachineScaleSetVMsClientSimulateEvictionResponse{RawResponse: resp}, nil
+	return VirtualMachineScaleSetVMsClientSimulateEvictionResponse{}, nil
 }
 
 // simulateEvictionCreateRequest creates the SimulateEviction request.
@@ -963,9 +945,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginStart(ctx context.Context, r
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientStartPollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientStartPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Start", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientStartPollerResponse{}, err
@@ -1035,9 +1015,7 @@ func (client *VirtualMachineScaleSetVMsClient) BeginUpdate(ctx context.Context, 
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientUpdatePollerResponse{}, err
 	}
-	result := VirtualMachineScaleSetVMsClientUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualMachineScaleSetVMsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Update", "", resp, client.pl)
 	if err != nil {
 		return VirtualMachineScaleSetVMsClientUpdatePollerResponse{}, err

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
@@ -88,7 +88,7 @@ func (client *VirtualMachineSizesClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineSizesClient) listHandleResponse(resp *http.Response) (VirtualMachineSizesClientListResponse, error) {
-	result := VirtualMachineSizesClientListResponse{RawResponse: resp}
+	result := VirtualMachineSizesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineSizeListResult); err != nil {
 		return VirtualMachineSizesClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_aggregatedcost_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_aggregatedcost_client.go
@@ -90,7 +90,7 @@ func (client *AggregatedCostClient) getByManagementGroupCreateRequest(ctx contex
 
 // getByManagementGroupHandleResponse handles the GetByManagementGroup response.
 func (client *AggregatedCostClient) getByManagementGroupHandleResponse(resp *http.Response) (AggregatedCostClientGetByManagementGroupResponse, error) {
-	result := AggregatedCostClientGetByManagementGroupResponse{RawResponse: resp}
+	result := AggregatedCostClientGetByManagementGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ManagementGroupAggregatedCostResult); err != nil {
 		return AggregatedCostClientGetByManagementGroupResponse{}, err
 	}
@@ -143,7 +143,7 @@ func (client *AggregatedCostClient) getForBillingPeriodByManagementGroupCreateRe
 
 // getForBillingPeriodByManagementGroupHandleResponse handles the GetForBillingPeriodByManagementGroup response.
 func (client *AggregatedCostClient) getForBillingPeriodByManagementGroupHandleResponse(resp *http.Response) (AggregatedCostClientGetForBillingPeriodByManagementGroupResponse, error) {
-	result := AggregatedCostClientGetForBillingPeriodByManagementGroupResponse{RawResponse: resp}
+	result := AggregatedCostClientGetForBillingPeriodByManagementGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ManagementGroupAggregatedCostResult); err != nil {
 		return AggregatedCostClientGetForBillingPeriodByManagementGroupResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_balances_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_balances_client.go
@@ -87,7 +87,7 @@ func (client *BalancesClient) getByBillingAccountCreateRequest(ctx context.Conte
 
 // getByBillingAccountHandleResponse handles the GetByBillingAccount response.
 func (client *BalancesClient) getByBillingAccountHandleResponse(resp *http.Response) (BalancesClientGetByBillingAccountResponse, error) {
-	result := BalancesClientGetByBillingAccountResponse{RawResponse: resp}
+	result := BalancesClientGetByBillingAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Balance); err != nil {
 		return BalancesClientGetByBillingAccountResponse{}, err
 	}
@@ -140,7 +140,7 @@ func (client *BalancesClient) getForBillingPeriodByBillingAccountCreateRequest(c
 
 // getForBillingPeriodByBillingAccountHandleResponse handles the GetForBillingPeriodByBillingAccount response.
 func (client *BalancesClient) getForBillingPeriodByBillingAccountHandleResponse(resp *http.Response) (BalancesClientGetForBillingPeriodByBillingAccountResponse, error) {
-	result := BalancesClientGetForBillingPeriodByBillingAccountResponse{RawResponse: resp}
+	result := BalancesClientGetForBillingPeriodByBillingAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Balance); err != nil {
 		return BalancesClientGetForBillingPeriodByBillingAccountResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_budgets_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_budgets_client.go
@@ -98,7 +98,7 @@ func (client *BudgetsClient) createOrUpdateCreateRequest(ctx context.Context, sc
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *BudgetsClient) createOrUpdateHandleResponse(resp *http.Response) (BudgetsClientCreateOrUpdateResponse, error) {
-	result := BudgetsClientCreateOrUpdateResponse{RawResponse: resp}
+	result := BudgetsClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Budget); err != nil {
 		return BudgetsClientCreateOrUpdateResponse{}, err
 	}
@@ -130,7 +130,7 @@ func (client *BudgetsClient) Delete(ctx context.Context, scope string, budgetNam
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return BudgetsClientDeleteResponse{}, runtime.NewResponseError(resp)
 	}
-	return BudgetsClientDeleteResponse{RawResponse: resp}, nil
+	return BudgetsClientDeleteResponse{}, nil
 }
 
 // deleteCreateRequest creates the Delete request.
@@ -201,7 +201,7 @@ func (client *BudgetsClient) getCreateRequest(ctx context.Context, scope string,
 
 // getHandleResponse handles the Get response.
 func (client *BudgetsClient) getHandleResponse(resp *http.Response) (BudgetsClientGetResponse, error) {
-	result := BudgetsClientGetResponse{RawResponse: resp}
+	result := BudgetsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Budget); err != nil {
 		return BudgetsClientGetResponse{}, err
 	}
@@ -249,7 +249,7 @@ func (client *BudgetsClient) listCreateRequest(ctx context.Context, scope string
 
 // listHandleResponse handles the List response.
 func (client *BudgetsClient) listHandleResponse(resp *http.Response) (BudgetsClientListResponse, error) {
-	result := BudgetsClientListResponse{RawResponse: resp}
+	result := BudgetsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BudgetsListResult); err != nil {
 		return BudgetsClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_charges_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_charges_client.go
@@ -104,7 +104,7 @@ func (client *ChargesClient) listCreateRequest(ctx context.Context, scope string
 
 // listHandleResponse handles the List response.
 func (client *ChargesClient) listHandleResponse(resp *http.Response) (ChargesClientListResponse, error) {
-	result := ChargesClientListResponse{RawResponse: resp}
+	result := ChargesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ChargesListResult); err != nil {
 		return ChargesClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_credits_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_credits_client.go
@@ -82,7 +82,7 @@ func (client *CreditsClient) getCreateRequest(ctx context.Context, scope string,
 
 // getHandleResponse handles the Get response.
 func (client *CreditsClient) getHandleResponse(resp *http.Response) (CreditsClientGetResponse, error) {
-	result := CreditsClientGetResponse{RawResponse: resp}
+	result := CreditsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CreditSummary); err != nil {
 		return CreditsClientGetResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_events_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_events_client.go
@@ -83,7 +83,7 @@ func (client *EventsClient) listCreateRequest(ctx context.Context, startDate str
 
 // listHandleResponse handles the List response.
 func (client *EventsClient) listHandleResponse(resp *http.Response) (EventsClientListResponse, error) {
-	result := EventsClientListResponse{RawResponse: resp}
+	result := EventsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Events); err != nil {
 		return EventsClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_forecasts_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_forecasts_client.go
@@ -86,7 +86,7 @@ func (client *ForecastsClient) listCreateRequest(ctx context.Context, options *F
 
 // listHandleResponse handles the List response.
 func (client *ForecastsClient) listHandleResponse(resp *http.Response) (ForecastsClientListResponse, error) {
-	result := ForecastsClientListResponse{RawResponse: resp}
+	result := ForecastsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ForecastsListResult); err != nil {
 		return ForecastsClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_lots_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_lots_client.go
@@ -79,7 +79,7 @@ func (client *LotsClient) listCreateRequest(ctx context.Context, scope string, o
 
 // listHandleResponse handles the List response.
 func (client *LotsClient) listHandleResponse(resp *http.Response) (LotsClientListResponse, error) {
-	result := LotsClientListResponse{RawResponse: resp}
+	result := LotsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Lots); err != nil {
 		return LotsClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_marketplaces_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_marketplaces_client.go
@@ -96,7 +96,7 @@ func (client *MarketplacesClient) listCreateRequest(ctx context.Context, scope s
 
 // listHandleResponse handles the List response.
 func (client *MarketplacesClient) listHandleResponse(resp *http.Response) (MarketplacesClientListResponse, error) {
-	result := MarketplacesClientListResponse{RawResponse: resp}
+	result := MarketplacesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MarketplacesListResult); err != nil {
 		return MarketplacesClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_operations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_operations_client.go
@@ -74,7 +74,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 
 // listHandleResponse handles the List response.
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
-	result := OperationsClientListResponse{RawResponse: resp}
+	result := OperationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_pricesheet_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_pricesheet_client.go
@@ -98,7 +98,7 @@ func (client *PriceSheetClient) getCreateRequest(ctx context.Context, options *P
 
 // getHandleResponse handles the Get response.
 func (client *PriceSheetClient) getHandleResponse(resp *http.Response) (PriceSheetClientGetResponse, error) {
-	result := PriceSheetClientGetResponse{RawResponse: resp}
+	result := PriceSheetClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PriceSheetResult); err != nil {
 		return PriceSheetClientGetResponse{}, err
 	}
@@ -159,7 +159,7 @@ func (client *PriceSheetClient) getByBillingPeriodCreateRequest(ctx context.Cont
 
 // getByBillingPeriodHandleResponse handles the GetByBillingPeriod response.
 func (client *PriceSheetClient) getByBillingPeriodHandleResponse(resp *http.Response) (PriceSheetClientGetByBillingPeriodResponse, error) {
-	result := PriceSheetClientGetByBillingPeriodResponse{RawResponse: resp}
+	result := PriceSheetClientGetByBillingPeriodResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PriceSheetResult); err != nil {
 		return PriceSheetClientGetByBillingPeriodResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendationdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendationdetails_client.go
@@ -97,7 +97,7 @@ func (client *ReservationRecommendationDetailsClient) getCreateRequest(ctx conte
 
 // getHandleResponse handles the Get response.
 func (client *ReservationRecommendationDetailsClient) getHandleResponse(resp *http.Response) (ReservationRecommendationDetailsClientGetResponse, error) {
-	result := ReservationRecommendationDetailsClientGetResponse{RawResponse: resp}
+	result := ReservationRecommendationDetailsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationRecommendationDetailsModel); err != nil {
 		return ReservationRecommendationDetailsClientGetResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendations_client.go
@@ -86,7 +86,7 @@ func (client *ReservationRecommendationsClient) listCreateRequest(ctx context.Co
 
 // listHandleResponse handles the List response.
 func (client *ReservationRecommendationsClient) listHandleResponse(resp *http.Response) (ReservationRecommendationsClientListResponse, error) {
-	result := ReservationRecommendationsClientListResponse{RawResponse: resp}
+	result := ReservationRecommendationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationRecommendationsListResult); err != nil {
 		return ReservationRecommendationsClientListResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationsdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationsdetails_client.go
@@ -98,7 +98,7 @@ func (client *ReservationsDetailsClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client *ReservationsDetailsClient) listHandleResponse(resp *http.Response) (ReservationsDetailsClientListResponse, error) {
-	result := ReservationsDetailsClientListResponse{RawResponse: resp}
+	result := ReservationsDetailsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationDetailsListResult); err != nil {
 		return ReservationsDetailsClientListResponse{}, err
 	}
@@ -145,7 +145,7 @@ func (client *ReservationsDetailsClient) listByReservationOrderCreateRequest(ctx
 
 // listByReservationOrderHandleResponse handles the ListByReservationOrder response.
 func (client *ReservationsDetailsClient) listByReservationOrderHandleResponse(resp *http.Response) (ReservationsDetailsClientListByReservationOrderResponse, error) {
-	result := ReservationsDetailsClientListByReservationOrderResponse{RawResponse: resp}
+	result := ReservationsDetailsClientListByReservationOrderResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationDetailsListResult); err != nil {
 		return ReservationsDetailsClientListByReservationOrderResponse{}, err
 	}
@@ -197,7 +197,7 @@ func (client *ReservationsDetailsClient) listByReservationOrderAndReservationCre
 
 // listByReservationOrderAndReservationHandleResponse handles the ListByReservationOrderAndReservation response.
 func (client *ReservationsDetailsClient) listByReservationOrderAndReservationHandleResponse(resp *http.Response) (ReservationsDetailsClientListByReservationOrderAndReservationResponse, error) {
-	result := ReservationsDetailsClientListByReservationOrderAndReservationResponse{RawResponse: resp}
+	result := ReservationsDetailsClientListByReservationOrderAndReservationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationDetailsListResult); err != nil {
 		return ReservationsDetailsClientListByReservationOrderAndReservationResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationssummaries_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationssummaries_client.go
@@ -100,7 +100,7 @@ func (client *ReservationsSummariesClient) listCreateRequest(ctx context.Context
 
 // listHandleResponse handles the List response.
 func (client *ReservationsSummariesClient) listHandleResponse(resp *http.Response) (ReservationsSummariesClientListResponse, error) {
-	result := ReservationsSummariesClientListResponse{RawResponse: resp}
+	result := ReservationsSummariesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationSummariesListResult); err != nil {
 		return ReservationsSummariesClientListResponse{}, err
 	}
@@ -149,7 +149,7 @@ func (client *ReservationsSummariesClient) listByReservationOrderCreateRequest(c
 
 // listByReservationOrderHandleResponse handles the ListByReservationOrder response.
 func (client *ReservationsSummariesClient) listByReservationOrderHandleResponse(resp *http.Response) (ReservationsSummariesClientListByReservationOrderResponse, error) {
-	result := ReservationsSummariesClientListByReservationOrderResponse{RawResponse: resp}
+	result := ReservationsSummariesClientListByReservationOrderResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationSummariesListResult); err != nil {
 		return ReservationsSummariesClientListByReservationOrderResponse{}, err
 	}
@@ -203,7 +203,7 @@ func (client *ReservationsSummariesClient) listByReservationOrderAndReservationC
 
 // listByReservationOrderAndReservationHandleResponse handles the ListByReservationOrderAndReservation response.
 func (client *ReservationsSummariesClient) listByReservationOrderAndReservationHandleResponse(resp *http.Response) (ReservationsSummariesClientListByReservationOrderAndReservationResponse, error) {
-	result := ReservationsSummariesClientListByReservationOrderAndReservationResponse{RawResponse: resp}
+	result := ReservationsSummariesClientListByReservationOrderAndReservationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationSummariesListResult); err != nil {
 		return ReservationsSummariesClientListByReservationOrderAndReservationResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationtransactions_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationtransactions_client.go
@@ -86,7 +86,7 @@ func (client *ReservationTransactionsClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *ReservationTransactionsClient) listHandleResponse(resp *http.Response) (ReservationTransactionsClientListResponse, error) {
-	result := ReservationTransactionsClientListResponse{RawResponse: resp}
+	result := ReservationTransactionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationTransactionsListResult); err != nil {
 		return ReservationTransactionsClientListResponse{}, err
 	}
@@ -138,7 +138,7 @@ func (client *ReservationTransactionsClient) listByBillingProfileCreateRequest(c
 
 // listByBillingProfileHandleResponse handles the ListByBillingProfile response.
 func (client *ReservationTransactionsClient) listByBillingProfileHandleResponse(resp *http.Response) (ReservationTransactionsClientListByBillingProfileResponse, error) {
-	result := ReservationTransactionsClientListByBillingProfileResponse{RawResponse: resp}
+	result := ReservationTransactionsClientListByBillingProfileResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ModernReservationTransactionsListResult); err != nil {
 		return ReservationTransactionsClientListByBillingProfileResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_response_types.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_response_types.go
@@ -8,206 +8,147 @@
 
 package armconsumption
 
-import "net/http"
-
 // AggregatedCostClientGetByManagementGroupResponse contains the response from method AggregatedCostClient.GetByManagementGroup.
 type AggregatedCostClientGetByManagementGroupResponse struct {
 	ManagementGroupAggregatedCostResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AggregatedCostClientGetForBillingPeriodByManagementGroupResponse contains the response from method AggregatedCostClient.GetForBillingPeriodByManagementGroup.
 type AggregatedCostClientGetForBillingPeriodByManagementGroupResponse struct {
 	ManagementGroupAggregatedCostResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BalancesClientGetByBillingAccountResponse contains the response from method BalancesClient.GetByBillingAccount.
 type BalancesClientGetByBillingAccountResponse struct {
 	Balance
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BalancesClientGetForBillingPeriodByBillingAccountResponse contains the response from method BalancesClient.GetForBillingPeriodByBillingAccount.
 type BalancesClientGetForBillingPeriodByBillingAccountResponse struct {
 	Balance
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BudgetsClientCreateOrUpdateResponse contains the response from method BudgetsClient.CreateOrUpdate.
 type BudgetsClientCreateOrUpdateResponse struct {
 	Budget
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BudgetsClientDeleteResponse contains the response from method BudgetsClient.Delete.
 type BudgetsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // BudgetsClientGetResponse contains the response from method BudgetsClient.Get.
 type BudgetsClientGetResponse struct {
 	Budget
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BudgetsClientListResponse contains the response from method BudgetsClient.List.
 type BudgetsClientListResponse struct {
 	BudgetsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ChargesClientListResponse contains the response from method ChargesClient.List.
 type ChargesClientListResponse struct {
 	ChargesListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // CreditsClientGetResponse contains the response from method CreditsClient.Get.
 type CreditsClientGetResponse struct {
 	CreditSummary
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // EventsClientListResponse contains the response from method EventsClient.List.
 type EventsClientListResponse struct {
 	Events
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ForecastsClientListResponse contains the response from method ForecastsClient.List.
 type ForecastsClientListResponse struct {
 	ForecastsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LotsClientListResponse contains the response from method LotsClient.List.
 type LotsClientListResponse struct {
 	Lots
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MarketplacesClientListResponse contains the response from method MarketplacesClient.List.
 type MarketplacesClientListResponse struct {
 	MarketplacesListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OperationsClientListResponse contains the response from method OperationsClient.List.
 type OperationsClientListResponse struct {
 	OperationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PriceSheetClientGetByBillingPeriodResponse contains the response from method PriceSheetClient.GetByBillingPeriod.
 type PriceSheetClientGetByBillingPeriodResponse struct {
 	PriceSheetResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PriceSheetClientGetResponse contains the response from method PriceSheetClient.Get.
 type PriceSheetClientGetResponse struct {
 	PriceSheetResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationRecommendationDetailsClientGetResponse contains the response from method ReservationRecommendationDetailsClient.Get.
 type ReservationRecommendationDetailsClientGetResponse struct {
 	ReservationRecommendationDetailsModel
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationRecommendationsClientListResponse contains the response from method ReservationRecommendationsClient.List.
 type ReservationRecommendationsClientListResponse struct {
 	ReservationRecommendationsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationTransactionsClientListByBillingProfileResponse contains the response from method ReservationTransactionsClient.ListByBillingProfile.
 type ReservationTransactionsClientListByBillingProfileResponse struct {
 	ModernReservationTransactionsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationTransactionsClientListResponse contains the response from method ReservationTransactionsClient.List.
 type ReservationTransactionsClientListResponse struct {
 	ReservationTransactionsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationsDetailsClientListByReservationOrderAndReservationResponse contains the response from method ReservationsDetailsClient.ListByReservationOrderAndReservation.
 type ReservationsDetailsClientListByReservationOrderAndReservationResponse struct {
 	ReservationDetailsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationsDetailsClientListByReservationOrderResponse contains the response from method ReservationsDetailsClient.ListByReservationOrder.
 type ReservationsDetailsClientListByReservationOrderResponse struct {
 	ReservationDetailsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationsDetailsClientListResponse contains the response from method ReservationsDetailsClient.List.
 type ReservationsDetailsClientListResponse struct {
 	ReservationDetailsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationsSummariesClientListByReservationOrderAndReservationResponse contains the response from method ReservationsSummariesClient.ListByReservationOrderAndReservation.
 type ReservationsSummariesClientListByReservationOrderAndReservationResponse struct {
 	ReservationSummariesListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationsSummariesClientListByReservationOrderResponse contains the response from method ReservationsSummariesClient.ListByReservationOrder.
 type ReservationsSummariesClientListByReservationOrderResponse struct {
 	ReservationSummariesListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ReservationsSummariesClientListResponse contains the response from method ReservationsSummariesClient.List.
 type ReservationsSummariesClientListResponse struct {
 	ReservationSummariesListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // TagsClientGetResponse contains the response from method TagsClient.Get.
 type TagsClientGetResponse struct {
 	TagsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UsageDetailsClientListResponse contains the response from method UsageDetailsClient.List.
 type UsageDetailsClientListResponse struct {
 	UsageDetailsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_tags_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_tags_client.go
@@ -86,7 +86,7 @@ func (client *TagsClient) getCreateRequest(ctx context.Context, scope string, op
 
 // getHandleResponse handles the Get response.
 func (client *TagsClient) getHandleResponse(resp *http.Response) (TagsClientGetResponse, error) {
-	result := TagsClientGetResponse{RawResponse: resp}
+	result := TagsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TagsResult); err != nil {
 		return TagsClientGetResponse{}, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_usagedetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_usagedetails_client.go
@@ -109,7 +109,7 @@ func (client *UsageDetailsClient) listCreateRequest(ctx context.Context, scope s
 
 // listHandleResponse handles the List response.
 func (client *UsageDetailsClient) listHandleResponse(resp *http.Response) (UsageDetailsClientListResponse, error) {
-	result := UsageDetailsClientListResponse{RawResponse: resp}
+	result := UsageDetailsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UsageDetailsListResult); err != nil {
 		return UsageDetailsClientListResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_addons_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_addons_client.go
@@ -63,9 +63,7 @@ func (client *AddonsClient) BeginCreateOrUpdate(ctx context.Context, deviceName 
 	if err != nil {
 		return AddonsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := AddonsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := AddonsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("AddonsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return AddonsClientCreateOrUpdatePollerResponse{}, err
@@ -139,9 +137,7 @@ func (client *AddonsClient) BeginDelete(ctx context.Context, deviceName string, 
 	if err != nil {
 		return AddonsClientDeletePollerResponse{}, err
 	}
-	result := AddonsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := AddonsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("AddonsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return AddonsClientDeletePollerResponse{}, err
@@ -261,7 +257,7 @@ func (client *AddonsClient) getCreateRequest(ctx context.Context, deviceName str
 
 // getHandleResponse handles the Get response.
 func (client *AddonsClient) getHandleResponse(resp *http.Response) (AddonsClientGetResponse, error) {
-	result := AddonsClientGetResponse{RawResponse: resp}
+	result := AddonsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return AddonsClientGetResponse{}, err
 	}
@@ -318,7 +314,7 @@ func (client *AddonsClient) listByRoleCreateRequest(ctx context.Context, deviceN
 
 // listByRoleHandleResponse handles the ListByRole response.
 func (client *AddonsClient) listByRoleHandleResponse(resp *http.Response) (AddonsClientListByRoleResponse, error) {
-	result := AddonsClientListByRoleResponse{RawResponse: resp}
+	result := AddonsClientListByRoleResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AddonList); err != nil {
 		return AddonsClientListByRoleResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_alerts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_alerts_client.go
@@ -102,7 +102,7 @@ func (client *AlertsClient) getCreateRequest(ctx context.Context, deviceName str
 
 // getHandleResponse handles the Get response.
 func (client *AlertsClient) getHandleResponse(resp *http.Response) (AlertsClientGetResponse, error) {
-	result := AlertsClientGetResponse{RawResponse: resp}
+	result := AlertsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Alert); err != nil {
 		return AlertsClientGetResponse{}, err
 	}
@@ -155,7 +155,7 @@ func (client *AlertsClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Con
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *AlertsClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (AlertsClientListByDataBoxEdgeDeviceResponse, error) {
-	result := AlertsClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := AlertsClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AlertList); err != nil {
 		return AlertsClientListByDataBoxEdgeDeviceResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_availableskus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_availableskus_client.go
@@ -84,7 +84,7 @@ func (client *AvailableSKUsClient) listCreateRequest(ctx context.Context, option
 
 // listHandleResponse handles the List response.
 func (client *AvailableSKUsClient) listHandleResponse(resp *http.Response) (AvailableSKUsClientListResponse, error) {
-	result := AvailableSKUsClientListResponse{RawResponse: resp}
+	result := AvailableSKUsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SKUList); err != nil {
 		return AvailableSKUsClientListResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
@@ -62,9 +62,7 @@ func (client *BandwidthSchedulesClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return BandwidthSchedulesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := BandwidthSchedulesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := BandwidthSchedulesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("BandwidthSchedulesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return BandwidthSchedulesClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *BandwidthSchedulesClient) BeginDelete(ctx context.Context, deviceN
 	if err != nil {
 		return BandwidthSchedulesClientDeletePollerResponse{}, err
 	}
-	result := BandwidthSchedulesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := BandwidthSchedulesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("BandwidthSchedulesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return BandwidthSchedulesClientDeletePollerResponse{}, err
@@ -247,7 +243,7 @@ func (client *BandwidthSchedulesClient) getCreateRequest(ctx context.Context, de
 
 // getHandleResponse handles the Get response.
 func (client *BandwidthSchedulesClient) getHandleResponse(resp *http.Response) (BandwidthSchedulesClientGetResponse, error) {
-	result := BandwidthSchedulesClientGetResponse{RawResponse: resp}
+	result := BandwidthSchedulesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BandwidthSchedule); err != nil {
 		return BandwidthSchedulesClientGetResponse{}, err
 	}
@@ -300,7 +296,7 @@ func (client *BandwidthSchedulesClient) listByDataBoxEdgeDeviceCreateRequest(ctx
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *BandwidthSchedulesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse, error) {
-	result := BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BandwidthSchedulesList); err != nil {
 		return BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
@@ -63,9 +63,7 @@ func (client *ContainersClient) BeginCreateOrUpdate(ctx context.Context, deviceN
 	if err != nil {
 		return ContainersClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ContainersClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ContainersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ContainersClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return ContainersClientCreateOrUpdatePollerResponse{}, err
@@ -139,9 +137,7 @@ func (client *ContainersClient) BeginDelete(ctx context.Context, deviceName stri
 	if err != nil {
 		return ContainersClientDeletePollerResponse{}, err
 	}
-	result := ContainersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ContainersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ContainersClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return ContainersClientDeletePollerResponse{}, err
@@ -261,7 +257,7 @@ func (client *ContainersClient) getCreateRequest(ctx context.Context, deviceName
 
 // getHandleResponse handles the Get response.
 func (client *ContainersClient) getHandleResponse(resp *http.Response) (ContainersClientGetResponse, error) {
-	result := ContainersClientGetResponse{RawResponse: resp}
+	result := ContainersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Container); err != nil {
 		return ContainersClientGetResponse{}, err
 	}
@@ -319,7 +315,7 @@ func (client *ContainersClient) listByStorageAccountCreateRequest(ctx context.Co
 
 // listByStorageAccountHandleResponse handles the ListByStorageAccount response.
 func (client *ContainersClient) listByStorageAccountHandleResponse(resp *http.Response) (ContainersClientListByStorageAccountResponse, error) {
-	result := ContainersClientListByStorageAccountResponse{RawResponse: resp}
+	result := ContainersClientListByStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerList); err != nil {
 		return ContainersClientListByStorageAccountResponse{}, err
 	}
@@ -338,9 +334,7 @@ func (client *ContainersClient) BeginRefresh(ctx context.Context, deviceName str
 	if err != nil {
 		return ContainersClientRefreshPollerResponse{}, err
 	}
-	result := ContainersClientRefreshPollerResponse{
-		RawResponse: resp,
-	}
+	result := ContainersClientRefreshPollerResponse{}
 	pt, err := armruntime.NewPoller("ContainersClient.Refresh", "", resp, client.pl)
 	if err != nil {
 		return ContainersClientRefreshPollerResponse{}, err

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_devices_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_devices_client.go
@@ -98,7 +98,7 @@ func (client *DevicesClient) createOrUpdateCreateRequest(ctx context.Context, de
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *DevicesClient) createOrUpdateHandleResponse(resp *http.Response) (DevicesClientCreateOrUpdateResponse, error) {
-	result := DevicesClientCreateOrUpdateResponse{RawResponse: resp}
+	result := DevicesClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Device); err != nil {
 		return DevicesClientCreateOrUpdateResponse{}, err
 	}
@@ -117,9 +117,7 @@ func (client *DevicesClient) BeginCreateOrUpdateSecuritySettings(ctx context.Con
 	if err != nil {
 		return DevicesClientCreateOrUpdateSecuritySettingsPollerResponse{}, err
 	}
-	result := DevicesClientCreateOrUpdateSecuritySettingsPollerResponse{
-		RawResponse: resp,
-	}
+	result := DevicesClientCreateOrUpdateSecuritySettingsPollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.CreateOrUpdateSecuritySettings", "", resp, client.pl)
 	if err != nil {
 		return DevicesClientCreateOrUpdateSecuritySettingsPollerResponse{}, err
@@ -183,9 +181,7 @@ func (client *DevicesClient) BeginDelete(ctx context.Context, deviceName string,
 	if err != nil {
 		return DevicesClientDeletePollerResponse{}, err
 	}
-	result := DevicesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := DevicesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return DevicesClientDeletePollerResponse{}, err
@@ -250,9 +246,7 @@ func (client *DevicesClient) BeginDownloadUpdates(ctx context.Context, deviceNam
 	if err != nil {
 		return DevicesClientDownloadUpdatesPollerResponse{}, err
 	}
-	result := DevicesClientDownloadUpdatesPollerResponse{
-		RawResponse: resp,
-	}
+	result := DevicesClientDownloadUpdatesPollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.DownloadUpdates", "", resp, client.pl)
 	if err != nil {
 		return DevicesClientDownloadUpdatesPollerResponse{}, err
@@ -355,7 +349,7 @@ func (client *DevicesClient) generateCertificateCreateRequest(ctx context.Contex
 
 // generateCertificateHandleResponse handles the GenerateCertificate response.
 func (client *DevicesClient) generateCertificateHandleResponse(resp *http.Response) (DevicesClientGenerateCertificateResponse, error) {
-	result := DevicesClientGenerateCertificateResponse{RawResponse: resp}
+	result := DevicesClientGenerateCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GenerateCertResponse); err != nil {
 		return DevicesClientGenerateCertificateResponse{}, err
 	}
@@ -410,7 +404,7 @@ func (client *DevicesClient) getCreateRequest(ctx context.Context, deviceName st
 
 // getHandleResponse handles the Get response.
 func (client *DevicesClient) getHandleResponse(resp *http.Response) (DevicesClientGetResponse, error) {
-	result := DevicesClientGetResponse{RawResponse: resp}
+	result := DevicesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Device); err != nil {
 		return DevicesClientGetResponse{}, err
 	}
@@ -466,7 +460,7 @@ func (client *DevicesClient) getExtendedInformationCreateRequest(ctx context.Con
 
 // getExtendedInformationHandleResponse handles the GetExtendedInformation response.
 func (client *DevicesClient) getExtendedInformationHandleResponse(resp *http.Response) (DevicesClientGetExtendedInformationResponse, error) {
-	result := DevicesClientGetExtendedInformationResponse{RawResponse: resp}
+	result := DevicesClientGetExtendedInformationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeviceExtendedInfo); err != nil {
 		return DevicesClientGetExtendedInformationResponse{}, err
 	}
@@ -522,7 +516,7 @@ func (client *DevicesClient) getNetworkSettingsCreateRequest(ctx context.Context
 
 // getNetworkSettingsHandleResponse handles the GetNetworkSettings response.
 func (client *DevicesClient) getNetworkSettingsHandleResponse(resp *http.Response) (DevicesClientGetNetworkSettingsResponse, error) {
-	result := DevicesClientGetNetworkSettingsResponse{RawResponse: resp}
+	result := DevicesClientGetNetworkSettingsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSettings); err != nil {
 		return DevicesClientGetNetworkSettingsResponse{}, err
 	}
@@ -579,7 +573,7 @@ func (client *DevicesClient) getUpdateSummaryCreateRequest(ctx context.Context, 
 
 // getUpdateSummaryHandleResponse handles the GetUpdateSummary response.
 func (client *DevicesClient) getUpdateSummaryHandleResponse(resp *http.Response) (DevicesClientGetUpdateSummaryResponse, error) {
-	result := DevicesClientGetUpdateSummaryResponse{RawResponse: resp}
+	result := DevicesClientGetUpdateSummaryResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UpdateSummary); err != nil {
 		return DevicesClientGetUpdateSummaryResponse{}, err
 	}
@@ -597,9 +591,7 @@ func (client *DevicesClient) BeginInstallUpdates(ctx context.Context, deviceName
 	if err != nil {
 		return DevicesClientInstallUpdatesPollerResponse{}, err
 	}
-	result := DevicesClientInstallUpdatesPollerResponse{
-		RawResponse: resp,
-	}
+	result := DevicesClientInstallUpdatesPollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.InstallUpdates", "", resp, client.pl)
 	if err != nil {
 		return DevicesClientInstallUpdatesPollerResponse{}, err
@@ -697,7 +689,7 @@ func (client *DevicesClient) listByResourceGroupCreateRequest(ctx context.Contex
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *DevicesClient) listByResourceGroupHandleResponse(resp *http.Response) (DevicesClientListByResourceGroupResponse, error) {
-	result := DevicesClientListByResourceGroupResponse{RawResponse: resp}
+	result := DevicesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeviceList); err != nil {
 		return DevicesClientListByResourceGroupResponse{}, err
 	}
@@ -743,7 +735,7 @@ func (client *DevicesClient) listBySubscriptionCreateRequest(ctx context.Context
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *DevicesClient) listBySubscriptionHandleResponse(resp *http.Response) (DevicesClientListBySubscriptionResponse, error) {
-	result := DevicesClientListBySubscriptionResponse{RawResponse: resp}
+	result := DevicesClientListBySubscriptionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeviceList); err != nil {
 		return DevicesClientListBySubscriptionResponse{}, err
 	}
@@ -761,9 +753,7 @@ func (client *DevicesClient) BeginScanForUpdates(ctx context.Context, deviceName
 	if err != nil {
 		return DevicesClientScanForUpdatesPollerResponse{}, err
 	}
-	result := DevicesClientScanForUpdatesPollerResponse{
-		RawResponse: resp,
-	}
+	result := DevicesClientScanForUpdatesPollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.ScanForUpdates", "", resp, client.pl)
 	if err != nil {
 		return DevicesClientScanForUpdatesPollerResponse{}, err
@@ -866,7 +856,7 @@ func (client *DevicesClient) updateCreateRequest(ctx context.Context, deviceName
 
 // updateHandleResponse handles the Update response.
 func (client *DevicesClient) updateHandleResponse(resp *http.Response) (DevicesClientUpdateResponse, error) {
-	result := DevicesClientUpdateResponse{RawResponse: resp}
+	result := DevicesClientUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Device); err != nil {
 		return DevicesClientUpdateResponse{}, err
 	}
@@ -923,7 +913,7 @@ func (client *DevicesClient) updateExtendedInformationCreateRequest(ctx context.
 
 // updateExtendedInformationHandleResponse handles the UpdateExtendedInformation response.
 func (client *DevicesClient) updateExtendedInformationHandleResponse(resp *http.Response) (DevicesClientUpdateExtendedInformationResponse, error) {
-	result := DevicesClientUpdateExtendedInformationResponse{RawResponse: resp}
+	result := DevicesClientUpdateExtendedInformationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeviceExtendedInfo); err != nil {
 		return DevicesClientUpdateExtendedInformationResponse{}, err
 	}
@@ -980,7 +970,7 @@ func (client *DevicesClient) uploadCertificateCreateRequest(ctx context.Context,
 
 // uploadCertificateHandleResponse handles the UploadCertificate response.
 func (client *DevicesClient) uploadCertificateHandleResponse(resp *http.Response) (DevicesClientUploadCertificateResponse, error) {
-	result := DevicesClientUploadCertificateResponse{RawResponse: resp}
+	result := DevicesClientUploadCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UploadCertificateResponse); err != nil {
 		return DevicesClientUploadCertificateResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_diagnosticsettings_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_diagnosticsettings_client.go
@@ -99,7 +99,7 @@ func (client *DiagnosticSettingsClient) getDiagnosticProactiveLogCollectionSetti
 
 // getDiagnosticProactiveLogCollectionSettingsHandleResponse handles the GetDiagnosticProactiveLogCollectionSettings response.
 func (client *DiagnosticSettingsClient) getDiagnosticProactiveLogCollectionSettingsHandleResponse(resp *http.Response) (DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse, error) {
-	result := DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse{RawResponse: resp}
+	result := DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiagnosticProactiveLogCollectionSettings); err != nil {
 		return DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse{}, err
 	}
@@ -156,7 +156,7 @@ func (client *DiagnosticSettingsClient) getDiagnosticRemoteSupportSettingsCreate
 
 // getDiagnosticRemoteSupportSettingsHandleResponse handles the GetDiagnosticRemoteSupportSettings response.
 func (client *DiagnosticSettingsClient) getDiagnosticRemoteSupportSettingsHandleResponse(resp *http.Response) (DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse, error) {
-	result := DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse{RawResponse: resp}
+	result := DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiagnosticRemoteSupportSettings); err != nil {
 		return DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse{}, err
 	}
@@ -176,9 +176,7 @@ func (client *DiagnosticSettingsClient) BeginUpdateDiagnosticProactiveLogCollect
 	if err != nil {
 		return DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse{}, err
 	}
-	result := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse{
-		RawResponse: resp,
-	}
+	result := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse{}
 	pt, err := armruntime.NewPoller("DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings", "", resp, client.pl)
 	if err != nil {
 		return DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse{}, err
@@ -246,9 +244,7 @@ func (client *DiagnosticSettingsClient) BeginUpdateDiagnosticRemoteSupportSettin
 	if err != nil {
 		return DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse{}, err
 	}
-	result := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse{
-		RawResponse: resp,
-	}
+	result := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse{}
 	pt, err := armruntime.NewPoller("DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings", "", resp, client.pl)
 	if err != nil {
 		return DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse{}, err

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_jobs_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_jobs_client.go
@@ -102,7 +102,7 @@ func (client *JobsClient) getCreateRequest(ctx context.Context, deviceName strin
 
 // getHandleResponse handles the Get response.
 func (client *JobsClient) getHandleResponse(resp *http.Response) (JobsClientGetResponse, error) {
-	result := JobsClientGetResponse{RawResponse: resp}
+	result := JobsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Job); err != nil {
 		return JobsClientGetResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
@@ -62,9 +62,7 @@ func (client *MonitoringConfigClient) BeginCreateOrUpdate(ctx context.Context, d
 	if err != nil {
 		return MonitoringConfigClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := MonitoringConfigClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := MonitoringConfigClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("MonitoringConfigClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return MonitoringConfigClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *MonitoringConfigClient) BeginDelete(ctx context.Context, deviceNam
 	if err != nil {
 		return MonitoringConfigClientDeletePollerResponse{}, err
 	}
-	result := MonitoringConfigClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := MonitoringConfigClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("MonitoringConfigClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return MonitoringConfigClientDeletePollerResponse{}, err
@@ -247,7 +243,7 @@ func (client *MonitoringConfigClient) getCreateRequest(ctx context.Context, devi
 
 // getHandleResponse handles the Get response.
 func (client *MonitoringConfigClient) getHandleResponse(resp *http.Response) (MonitoringConfigClientGetResponse, error) {
-	result := MonitoringConfigClientGetResponse{RawResponse: resp}
+	result := MonitoringConfigClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MonitoringMetricConfiguration); err != nil {
 		return MonitoringConfigClientGetResponse{}, err
 	}
@@ -304,7 +300,7 @@ func (client *MonitoringConfigClient) listCreateRequest(ctx context.Context, dev
 
 // listHandleResponse handles the List response.
 func (client *MonitoringConfigClient) listHandleResponse(resp *http.Response) (MonitoringConfigClientListResponse, error) {
-	result := MonitoringConfigClientListResponse{RawResponse: resp}
+	result := MonitoringConfigClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MonitoringMetricConfigurationList); err != nil {
 		return MonitoringConfigClientListResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_nodes_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_nodes_client.go
@@ -95,7 +95,7 @@ func (client *NodesClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Cont
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *NodesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (NodesClientListByDataBoxEdgeDeviceResponse, error) {
-	result := NodesClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := NodesClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NodeList); err != nil {
 		return NodesClientListByDataBoxEdgeDeviceResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operations_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operations_client.go
@@ -74,7 +74,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 
 // listHandleResponse handles the List response.
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
-	result := OperationsClientListResponse{RawResponse: resp}
+	result := OperationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationsList); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operationsstatus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operationsstatus_client.go
@@ -102,7 +102,7 @@ func (client *OperationsStatusClient) getCreateRequest(ctx context.Context, devi
 
 // getHandleResponse handles the Get response.
 func (client *OperationsStatusClient) getHandleResponse(resp *http.Response) (OperationsStatusClientGetResponse, error) {
-	result := OperationsStatusClientGetResponse{RawResponse: resp}
+	result := OperationsStatusClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Job); err != nil {
 		return OperationsStatusClientGetResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
@@ -61,9 +61,7 @@ func (client *OrdersClient) BeginCreateOrUpdate(ctx context.Context, deviceName 
 	if err != nil {
 		return OrdersClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := OrdersClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := OrdersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("OrdersClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return OrdersClientCreateOrUpdatePollerResponse{}, err
@@ -127,9 +125,7 @@ func (client *OrdersClient) BeginDelete(ctx context.Context, deviceName string, 
 	if err != nil {
 		return OrdersClientDeletePollerResponse{}, err
 	}
-	result := OrdersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := OrdersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("OrdersClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return OrdersClientDeletePollerResponse{}, err
@@ -231,7 +227,7 @@ func (client *OrdersClient) getCreateRequest(ctx context.Context, deviceName str
 
 // getHandleResponse handles the Get response.
 func (client *OrdersClient) getHandleResponse(resp *http.Response) (OrdersClientGetResponse, error) {
-	result := OrdersClientGetResponse{RawResponse: resp}
+	result := OrdersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Order); err != nil {
 		return OrdersClientGetResponse{}, err
 	}
@@ -284,7 +280,7 @@ func (client *OrdersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Con
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *OrdersClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (OrdersClientListByDataBoxEdgeDeviceResponse, error) {
-	result := OrdersClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := OrdersClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OrderList); err != nil {
 		return OrdersClientListByDataBoxEdgeDeviceResponse{}, err
 	}
@@ -339,7 +335,7 @@ func (client *OrdersClient) listDCAccessCodeCreateRequest(ctx context.Context, d
 
 // listDCAccessCodeHandleResponse handles the ListDCAccessCode response.
 func (client *OrdersClient) listDCAccessCodeHandleResponse(resp *http.Response) (OrdersClientListDCAccessCodeResponse, error) {
-	result := OrdersClientListDCAccessCodeResponse{RawResponse: resp}
+	result := OrdersClientListDCAccessCodeResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DCAccessCode); err != nil {
 		return OrdersClientListDCAccessCodeResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pollers.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pollers.go
@@ -43,11 +43,10 @@ func (p *AddonsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final AddonsClientCreateOrUpdateResponse will be returned.
 func (p *AddonsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (AddonsClientCreateOrUpdateResponse, error) {
 	respType := AddonsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType)
+	_, err := p.pt.FinalResponse(ctx, &respType)
 	if err != nil {
 		return AddonsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -86,11 +85,10 @@ func (p *AddonsClientDeletePoller) Poll(ctx context.Context) (*http.Response, er
 // If the final GET succeeded then the final AddonsClientDeleteResponse will be returned.
 func (p *AddonsClientDeletePoller) FinalResponse(ctx context.Context) (AddonsClientDeleteResponse, error) {
 	respType := AddonsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return AddonsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -129,11 +127,10 @@ func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final BandwidthSchedulesClientCreateOrUpdateResponse will be returned.
 func (p *BandwidthSchedulesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
 	respType := BandwidthSchedulesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.BandwidthSchedule)
+	_, err := p.pt.FinalResponse(ctx, &respType.BandwidthSchedule)
 	if err != nil {
 		return BandwidthSchedulesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -172,11 +169,10 @@ func (p *BandwidthSchedulesClientDeletePoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final BandwidthSchedulesClientDeleteResponse will be returned.
 func (p *BandwidthSchedulesClientDeletePoller) FinalResponse(ctx context.Context) (BandwidthSchedulesClientDeleteResponse, error) {
 	respType := BandwidthSchedulesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return BandwidthSchedulesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -215,11 +211,10 @@ func (p *ContainersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final ContainersClientCreateOrUpdateResponse will be returned.
 func (p *ContainersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ContainersClientCreateOrUpdateResponse, error) {
 	respType := ContainersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Container)
+	_, err := p.pt.FinalResponse(ctx, &respType.Container)
 	if err != nil {
 		return ContainersClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -258,11 +253,10 @@ func (p *ContainersClientDeletePoller) Poll(ctx context.Context) (*http.Response
 // If the final GET succeeded then the final ContainersClientDeleteResponse will be returned.
 func (p *ContainersClientDeletePoller) FinalResponse(ctx context.Context) (ContainersClientDeleteResponse, error) {
 	respType := ContainersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ContainersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -301,11 +295,10 @@ func (p *ContainersClientRefreshPoller) Poll(ctx context.Context) (*http.Respons
 // If the final GET succeeded then the final ContainersClientRefreshResponse will be returned.
 func (p *ContainersClientRefreshPoller) FinalResponse(ctx context.Context) (ContainersClientRefreshResponse, error) {
 	respType := ContainersClientRefreshResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ContainersClientRefreshResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -344,11 +337,10 @@ func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Poll(ctx context.Con
 // If the final GET succeeded then the final DevicesClientCreateOrUpdateSecuritySettingsResponse will be returned.
 func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) FinalResponse(ctx context.Context) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
 	respType := DevicesClientCreateOrUpdateSecuritySettingsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DevicesClientCreateOrUpdateSecuritySettingsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -387,11 +379,10 @@ func (p *DevicesClientDeletePoller) Poll(ctx context.Context) (*http.Response, e
 // If the final GET succeeded then the final DevicesClientDeleteResponse will be returned.
 func (p *DevicesClientDeletePoller) FinalResponse(ctx context.Context) (DevicesClientDeleteResponse, error) {
 	respType := DevicesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DevicesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -430,11 +421,10 @@ func (p *DevicesClientDownloadUpdatesPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final DevicesClientDownloadUpdatesResponse will be returned.
 func (p *DevicesClientDownloadUpdatesPoller) FinalResponse(ctx context.Context) (DevicesClientDownloadUpdatesResponse, error) {
 	respType := DevicesClientDownloadUpdatesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DevicesClientDownloadUpdatesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -473,11 +463,10 @@ func (p *DevicesClientInstallUpdatesPoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final DevicesClientInstallUpdatesResponse will be returned.
 func (p *DevicesClientInstallUpdatesPoller) FinalResponse(ctx context.Context) (DevicesClientInstallUpdatesResponse, error) {
 	respType := DevicesClientInstallUpdatesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DevicesClientInstallUpdatesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -516,11 +505,10 @@ func (p *DevicesClientScanForUpdatesPoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final DevicesClientScanForUpdatesResponse will be returned.
 func (p *DevicesClientScanForUpdatesPoller) FinalResponse(ctx context.Context) (DevicesClientScanForUpdatesResponse, error) {
 	respType := DevicesClientScanForUpdatesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DevicesClientScanForUpdatesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -559,11 +547,10 @@ func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsP
 // If the final GET succeeded then the final DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse will be returned.
 func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) FinalResponse(ctx context.Context) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
 	respType := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -602,11 +589,10 @@ func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Po
 // If the final GET succeeded then the final DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse will be returned.
 func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) FinalResponse(ctx context.Context) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
 	respType := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -645,11 +631,10 @@ func (p *MonitoringConfigClientCreateOrUpdatePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final MonitoringConfigClientCreateOrUpdateResponse will be returned.
 func (p *MonitoringConfigClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (MonitoringConfigClientCreateOrUpdateResponse, error) {
 	respType := MonitoringConfigClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.MonitoringMetricConfiguration)
+	_, err := p.pt.FinalResponse(ctx, &respType.MonitoringMetricConfiguration)
 	if err != nil {
 		return MonitoringConfigClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -688,11 +673,10 @@ func (p *MonitoringConfigClientDeletePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final MonitoringConfigClientDeleteResponse will be returned.
 func (p *MonitoringConfigClientDeletePoller) FinalResponse(ctx context.Context) (MonitoringConfigClientDeleteResponse, error) {
 	respType := MonitoringConfigClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return MonitoringConfigClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -731,11 +715,10 @@ func (p *OrdersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final OrdersClientCreateOrUpdateResponse will be returned.
 func (p *OrdersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (OrdersClientCreateOrUpdateResponse, error) {
 	respType := OrdersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Order)
+	_, err := p.pt.FinalResponse(ctx, &respType.Order)
 	if err != nil {
 		return OrdersClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -774,11 +757,10 @@ func (p *OrdersClientDeletePoller) Poll(ctx context.Context) (*http.Response, er
 // If the final GET succeeded then the final OrdersClientDeleteResponse will be returned.
 func (p *OrdersClientDeletePoller) FinalResponse(ctx context.Context) (OrdersClientDeleteResponse, error) {
 	respType := OrdersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return OrdersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -817,11 +799,10 @@ func (p *RolesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final RolesClientCreateOrUpdateResponse will be returned.
 func (p *RolesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RolesClientCreateOrUpdateResponse, error) {
 	respType := RolesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType)
+	_, err := p.pt.FinalResponse(ctx, &respType)
 	if err != nil {
 		return RolesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -860,11 +841,10 @@ func (p *RolesClientDeletePoller) Poll(ctx context.Context) (*http.Response, err
 // If the final GET succeeded then the final RolesClientDeleteResponse will be returned.
 func (p *RolesClientDeletePoller) FinalResponse(ctx context.Context) (RolesClientDeleteResponse, error) {
 	respType := RolesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return RolesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -903,11 +883,10 @@ func (p *SharesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final SharesClientCreateOrUpdateResponse will be returned.
 func (p *SharesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SharesClientCreateOrUpdateResponse, error) {
 	respType := SharesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Share)
+	_, err := p.pt.FinalResponse(ctx, &respType.Share)
 	if err != nil {
 		return SharesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -946,11 +925,10 @@ func (p *SharesClientDeletePoller) Poll(ctx context.Context) (*http.Response, er
 // If the final GET succeeded then the final SharesClientDeleteResponse will be returned.
 func (p *SharesClientDeletePoller) FinalResponse(ctx context.Context) (SharesClientDeleteResponse, error) {
 	respType := SharesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SharesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -989,11 +967,10 @@ func (p *SharesClientRefreshPoller) Poll(ctx context.Context) (*http.Response, e
 // If the final GET succeeded then the final SharesClientRefreshResponse will be returned.
 func (p *SharesClientRefreshPoller) FinalResponse(ctx context.Context) (SharesClientRefreshResponse, error) {
 	respType := SharesClientRefreshResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SharesClientRefreshResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1032,11 +1009,10 @@ func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Poll(ctx context.C
 // If the final GET succeeded then the final StorageAccountCredentialsClientCreateOrUpdateResponse will be returned.
 func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
 	respType := StorageAccountCredentialsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.StorageAccountCredential)
+	_, err := p.pt.FinalResponse(ctx, &respType.StorageAccountCredential)
 	if err != nil {
 		return StorageAccountCredentialsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1075,11 +1051,10 @@ func (p *StorageAccountCredentialsClientDeletePoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final StorageAccountCredentialsClientDeleteResponse will be returned.
 func (p *StorageAccountCredentialsClientDeletePoller) FinalResponse(ctx context.Context) (StorageAccountCredentialsClientDeleteResponse, error) {
 	respType := StorageAccountCredentialsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return StorageAccountCredentialsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1118,11 +1093,10 @@ func (p *StorageAccountsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final StorageAccountsClientCreateOrUpdateResponse will be returned.
 func (p *StorageAccountsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (StorageAccountsClientCreateOrUpdateResponse, error) {
 	respType := StorageAccountsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.StorageAccount)
+	_, err := p.pt.FinalResponse(ctx, &respType.StorageAccount)
 	if err != nil {
 		return StorageAccountsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1161,11 +1135,10 @@ func (p *StorageAccountsClientDeletePoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final StorageAccountsClientDeleteResponse will be returned.
 func (p *StorageAccountsClientDeletePoller) FinalResponse(ctx context.Context) (StorageAccountsClientDeleteResponse, error) {
 	respType := StorageAccountsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return StorageAccountsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1204,11 +1177,10 @@ func (p *SupportPackagesClientTriggerSupportPackagePoller) Poll(ctx context.Cont
 // If the final GET succeeded then the final SupportPackagesClientTriggerSupportPackageResponse will be returned.
 func (p *SupportPackagesClientTriggerSupportPackagePoller) FinalResponse(ctx context.Context) (SupportPackagesClientTriggerSupportPackageResponse, error) {
 	respType := SupportPackagesClientTriggerSupportPackageResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SupportPackagesClientTriggerSupportPackageResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1247,11 +1219,10 @@ func (p *TriggersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final TriggersClientCreateOrUpdateResponse will be returned.
 func (p *TriggersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (TriggersClientCreateOrUpdateResponse, error) {
 	respType := TriggersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType)
+	_, err := p.pt.FinalResponse(ctx, &respType)
 	if err != nil {
 		return TriggersClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1290,11 +1261,10 @@ func (p *TriggersClientDeletePoller) Poll(ctx context.Context) (*http.Response, 
 // If the final GET succeeded then the final TriggersClientDeleteResponse will be returned.
 func (p *TriggersClientDeletePoller) FinalResponse(ctx context.Context) (TriggersClientDeleteResponse, error) {
 	respType := TriggersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return TriggersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1333,11 +1303,10 @@ func (p *UsersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final UsersClientCreateOrUpdateResponse will be returned.
 func (p *UsersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (UsersClientCreateOrUpdateResponse, error) {
 	respType := UsersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.User)
+	_, err := p.pt.FinalResponse(ctx, &respType.User)
 	if err != nil {
 		return UsersClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1376,11 +1345,10 @@ func (p *UsersClientDeletePoller) Poll(ctx context.Context) (*http.Response, err
 // If the final GET succeeded then the final UsersClientDeleteResponse will be returned.
 func (p *UsersClientDeletePoller) FinalResponse(ctx context.Context) (UsersClientDeleteResponse, error) {
 	respType := UsersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return UsersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_response_types.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_response_types.go
@@ -11,7 +11,6 @@ package armdataboxedge
 import (
 	"context"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"net/http"
 	"time"
 )
 
@@ -19,9 +18,6 @@ import (
 type AddonsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *AddonsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -29,11 +25,10 @@ type AddonsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l AddonsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsClientCreateOrUpdateResponse, error) {
 	respType := AddonsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -46,20 +41,17 @@ func (l *AddonsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 	poller := &AddonsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // AddonsClientCreateOrUpdateResponse contains the response from method AddonsClient.CreateOrUpdate.
 type AddonsClientCreateOrUpdateResponse struct {
 	AddonClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AddonsClientCreateOrUpdateResponse.
@@ -76,9 +68,6 @@ func (a *AddonsClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error {
 type AddonsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *AddonsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -86,11 +75,10 @@ type AddonsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l AddonsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsClientDeleteResponse, error) {
 	respType := AddonsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -103,26 +91,22 @@ func (l *AddonsClientDeletePollerResponse) Resume(ctx context.Context, client *A
 	poller := &AddonsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // AddonsClientDeleteResponse contains the response from method AddonsClient.Delete.
 type AddonsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // AddonsClientGetResponse contains the response from method AddonsClient.Get.
 type AddonsClientGetResponse struct {
 	AddonClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AddonsClientGetResponse.
@@ -138,38 +122,27 @@ func (a *AddonsClientGetResponse) UnmarshalJSON(data []byte) error {
 // AddonsClientListByRoleResponse contains the response from method AddonsClient.ListByRole.
 type AddonsClientListByRoleResponse struct {
 	AddonList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AlertsClientGetResponse contains the response from method AlertsClient.Get.
 type AlertsClientGetResponse struct {
 	Alert
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AlertsClientListByDataBoxEdgeDeviceResponse contains the response from method AlertsClient.ListByDataBoxEdgeDevice.
 type AlertsClientListByDataBoxEdgeDeviceResponse struct {
 	AlertList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailableSKUsClientListResponse contains the response from method AvailableSKUsClient.List.
 type AvailableSKUsClientListResponse struct {
 	SKUList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BandwidthSchedulesClientCreateOrUpdatePollerResponse contains the response from method BandwidthSchedulesClient.CreateOrUpdate.
 type BandwidthSchedulesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *BandwidthSchedulesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -177,11 +150,10 @@ type BandwidthSchedulesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l BandwidthSchedulesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
 	respType := BandwidthSchedulesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BandwidthSchedule)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BandwidthSchedule)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -194,29 +166,23 @@ func (l *BandwidthSchedulesClientCreateOrUpdatePollerResponse) Resume(ctx contex
 	poller := &BandwidthSchedulesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // BandwidthSchedulesClientCreateOrUpdateResponse contains the response from method BandwidthSchedulesClient.CreateOrUpdate.
 type BandwidthSchedulesClientCreateOrUpdateResponse struct {
 	BandwidthSchedule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BandwidthSchedulesClientDeletePollerResponse contains the response from method BandwidthSchedulesClient.Delete.
 type BandwidthSchedulesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *BandwidthSchedulesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -224,11 +190,10 @@ type BandwidthSchedulesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l BandwidthSchedulesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BandwidthSchedulesClientDeleteResponse, error) {
 	respType := BandwidthSchedulesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -241,42 +206,33 @@ func (l *BandwidthSchedulesClientDeletePollerResponse) Resume(ctx context.Contex
 	poller := &BandwidthSchedulesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // BandwidthSchedulesClientDeleteResponse contains the response from method BandwidthSchedulesClient.Delete.
 type BandwidthSchedulesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // BandwidthSchedulesClientGetResponse contains the response from method BandwidthSchedulesClient.Get.
 type BandwidthSchedulesClientGetResponse struct {
 	BandwidthSchedule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse contains the response from method BandwidthSchedulesClient.ListByDataBoxEdgeDevice.
 type BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse struct {
 	BandwidthSchedulesList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ContainersClientCreateOrUpdatePollerResponse contains the response from method ContainersClient.CreateOrUpdate.
 type ContainersClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ContainersClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -284,11 +240,10 @@ type ContainersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ContainersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientCreateOrUpdateResponse, error) {
 	respType := ContainersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Container)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Container)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -301,29 +256,23 @@ func (l *ContainersClientCreateOrUpdatePollerResponse) Resume(ctx context.Contex
 	poller := &ContainersClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ContainersClientCreateOrUpdateResponse contains the response from method ContainersClient.CreateOrUpdate.
 type ContainersClientCreateOrUpdateResponse struct {
 	Container
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ContainersClientDeletePollerResponse contains the response from method ContainersClient.Delete.
 type ContainersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ContainersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -331,11 +280,10 @@ type ContainersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ContainersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientDeleteResponse, error) {
 	respType := ContainersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -348,42 +296,33 @@ func (l *ContainersClientDeletePollerResponse) Resume(ctx context.Context, clien
 	poller := &ContainersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ContainersClientDeleteResponse contains the response from method ContainersClient.Delete.
 type ContainersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ContainersClientGetResponse contains the response from method ContainersClient.Get.
 type ContainersClientGetResponse struct {
 	Container
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ContainersClientListByStorageAccountResponse contains the response from method ContainersClient.ListByStorageAccount.
 type ContainersClientListByStorageAccountResponse struct {
 	ContainerList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ContainersClientRefreshPollerResponse contains the response from method ContainersClient.Refresh.
 type ContainersClientRefreshPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ContainersClientRefreshPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -391,11 +330,10 @@ type ContainersClientRefreshPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ContainersClientRefreshPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientRefreshResponse, error) {
 	respType := ContainersClientRefreshResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -408,35 +346,28 @@ func (l *ContainersClientRefreshPollerResponse) Resume(ctx context.Context, clie
 	poller := &ContainersClientRefreshPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ContainersClientRefreshResponse contains the response from method ContainersClient.Refresh.
 type ContainersClientRefreshResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DevicesClientCreateOrUpdateResponse contains the response from method DevicesClient.CreateOrUpdate.
 type DevicesClientCreateOrUpdateResponse struct {
 	Device
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientCreateOrUpdateSecuritySettingsPollerResponse contains the response from method DevicesClient.CreateOrUpdateSecuritySettings.
 type DevicesClientCreateOrUpdateSecuritySettingsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DevicesClientCreateOrUpdateSecuritySettingsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -444,11 +375,10 @@ type DevicesClientCreateOrUpdateSecuritySettingsPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesClientCreateOrUpdateSecuritySettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
 	respType := DevicesClientCreateOrUpdateSecuritySettingsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -461,28 +391,23 @@ func (l *DevicesClientCreateOrUpdateSecuritySettingsPollerResponse) Resume(ctx c
 	poller := &DevicesClientCreateOrUpdateSecuritySettingsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DevicesClientCreateOrUpdateSecuritySettingsResponse contains the response from method DevicesClient.CreateOrUpdateSecuritySettings.
 type DevicesClientCreateOrUpdateSecuritySettingsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DevicesClientDeletePollerResponse contains the response from method DevicesClient.Delete.
 type DevicesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DevicesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -490,11 +415,10 @@ type DevicesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientDeleteResponse, error) {
 	respType := DevicesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -507,28 +431,23 @@ func (l *DevicesClientDeletePollerResponse) Resume(ctx context.Context, client *
 	poller := &DevicesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DevicesClientDeleteResponse contains the response from method DevicesClient.Delete.
 type DevicesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DevicesClientDownloadUpdatesPollerResponse contains the response from method DevicesClient.DownloadUpdates.
 type DevicesClientDownloadUpdatesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DevicesClientDownloadUpdatesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -536,11 +455,10 @@ type DevicesClientDownloadUpdatesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesClientDownloadUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientDownloadUpdatesResponse, error) {
 	respType := DevicesClientDownloadUpdatesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -553,63 +471,48 @@ func (l *DevicesClientDownloadUpdatesPollerResponse) Resume(ctx context.Context,
 	poller := &DevicesClientDownloadUpdatesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DevicesClientDownloadUpdatesResponse contains the response from method DevicesClient.DownloadUpdates.
 type DevicesClientDownloadUpdatesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DevicesClientGenerateCertificateResponse contains the response from method DevicesClient.GenerateCertificate.
 type DevicesClientGenerateCertificateResponse struct {
 	GenerateCertResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientGetExtendedInformationResponse contains the response from method DevicesClient.GetExtendedInformation.
 type DevicesClientGetExtendedInformationResponse struct {
 	DeviceExtendedInfo
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientGetNetworkSettingsResponse contains the response from method DevicesClient.GetNetworkSettings.
 type DevicesClientGetNetworkSettingsResponse struct {
 	NetworkSettings
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientGetResponse contains the response from method DevicesClient.Get.
 type DevicesClientGetResponse struct {
 	Device
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientGetUpdateSummaryResponse contains the response from method DevicesClient.GetUpdateSummary.
 type DevicesClientGetUpdateSummaryResponse struct {
 	UpdateSummary
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientInstallUpdatesPollerResponse contains the response from method DevicesClient.InstallUpdates.
 type DevicesClientInstallUpdatesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DevicesClientInstallUpdatesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -617,11 +520,10 @@ type DevicesClientInstallUpdatesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesClientInstallUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientInstallUpdatesResponse, error) {
 	respType := DevicesClientInstallUpdatesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -634,42 +536,33 @@ func (l *DevicesClientInstallUpdatesPollerResponse) Resume(ctx context.Context, 
 	poller := &DevicesClientInstallUpdatesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DevicesClientInstallUpdatesResponse contains the response from method DevicesClient.InstallUpdates.
 type DevicesClientInstallUpdatesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DevicesClientListByResourceGroupResponse contains the response from method DevicesClient.ListByResourceGroup.
 type DevicesClientListByResourceGroupResponse struct {
 	DeviceList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientListBySubscriptionResponse contains the response from method DevicesClient.ListBySubscription.
 type DevicesClientListBySubscriptionResponse struct {
 	DeviceList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientScanForUpdatesPollerResponse contains the response from method DevicesClient.ScanForUpdates.
 type DevicesClientScanForUpdatesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DevicesClientScanForUpdatesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -677,11 +570,10 @@ type DevicesClientScanForUpdatesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DevicesClientScanForUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientScanForUpdatesResponse, error) {
 	respType := DevicesClientScanForUpdatesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -694,54 +586,42 @@ func (l *DevicesClientScanForUpdatesPollerResponse) Resume(ctx context.Context, 
 	poller := &DevicesClientScanForUpdatesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DevicesClientScanForUpdatesResponse contains the response from method DevicesClient.ScanForUpdates.
 type DevicesClientScanForUpdatesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DevicesClientUpdateExtendedInformationResponse contains the response from method DevicesClient.UpdateExtendedInformation.
 type DevicesClientUpdateExtendedInformationResponse struct {
 	DeviceExtendedInfo
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientUpdateResponse contains the response from method DevicesClient.Update.
 type DevicesClientUpdateResponse struct {
 	Device
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DevicesClientUploadCertificateResponse contains the response from method DevicesClient.UploadCertificate.
 type DevicesClientUploadCertificateResponse struct {
 	UploadCertificateResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse contains the response from method DiagnosticSettingsClient.GetDiagnosticProactiveLogCollectionSettings.
 type DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse struct {
 	DiagnosticProactiveLogCollectionSettings
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse contains the response from method DiagnosticSettingsClient.GetDiagnosticRemoteSupportSettings.
 type DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse struct {
 	DiagnosticRemoteSupportSettings
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse contains the response from method
@@ -749,9 +629,6 @@ type DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse struct {
 type DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -759,11 +636,10 @@ type DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPolle
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
 	respType := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -777,28 +653,23 @@ func (l *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsP
 	poller := &DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse contains the response from method DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings.
 type DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse contains the response from method DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings.
 type DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -806,11 +677,10 @@ type DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
 	respType := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -824,35 +694,28 @@ func (l *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResp
 	poller := &DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse contains the response from method DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings.
 type DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // JobsClientGetResponse contains the response from method JobsClient.Get.
 type JobsClientGetResponse struct {
 	Job
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MonitoringConfigClientCreateOrUpdatePollerResponse contains the response from method MonitoringConfigClient.CreateOrUpdate.
 type MonitoringConfigClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *MonitoringConfigClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -860,11 +723,10 @@ type MonitoringConfigClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l MonitoringConfigClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (MonitoringConfigClientCreateOrUpdateResponse, error) {
 	respType := MonitoringConfigClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.MonitoringMetricConfiguration)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.MonitoringMetricConfiguration)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -877,29 +739,23 @@ func (l *MonitoringConfigClientCreateOrUpdatePollerResponse) Resume(ctx context.
 	poller := &MonitoringConfigClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // MonitoringConfigClientCreateOrUpdateResponse contains the response from method MonitoringConfigClient.CreateOrUpdate.
 type MonitoringConfigClientCreateOrUpdateResponse struct {
 	MonitoringMetricConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MonitoringConfigClientDeletePollerResponse contains the response from method MonitoringConfigClient.Delete.
 type MonitoringConfigClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *MonitoringConfigClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -907,11 +763,10 @@ type MonitoringConfigClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l MonitoringConfigClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (MonitoringConfigClientDeleteResponse, error) {
 	respType := MonitoringConfigClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -924,63 +779,48 @@ func (l *MonitoringConfigClientDeletePollerResponse) Resume(ctx context.Context,
 	poller := &MonitoringConfigClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // MonitoringConfigClientDeleteResponse contains the response from method MonitoringConfigClient.Delete.
 type MonitoringConfigClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // MonitoringConfigClientGetResponse contains the response from method MonitoringConfigClient.Get.
 type MonitoringConfigClientGetResponse struct {
 	MonitoringMetricConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // MonitoringConfigClientListResponse contains the response from method MonitoringConfigClient.List.
 type MonitoringConfigClientListResponse struct {
 	MonitoringMetricConfigurationList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // NodesClientListByDataBoxEdgeDeviceResponse contains the response from method NodesClient.ListByDataBoxEdgeDevice.
 type NodesClientListByDataBoxEdgeDeviceResponse struct {
 	NodeList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OperationsClientListResponse contains the response from method OperationsClient.List.
 type OperationsClientListResponse struct {
 	OperationsList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OperationsStatusClientGetResponse contains the response from method OperationsStatusClient.Get.
 type OperationsStatusClientGetResponse struct {
 	Job
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OrdersClientCreateOrUpdatePollerResponse contains the response from method OrdersClient.CreateOrUpdate.
 type OrdersClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *OrdersClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -988,11 +828,10 @@ type OrdersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l OrdersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (OrdersClientCreateOrUpdateResponse, error) {
 	respType := OrdersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Order)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Order)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1005,29 +844,23 @@ func (l *OrdersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 	poller := &OrdersClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // OrdersClientCreateOrUpdateResponse contains the response from method OrdersClient.CreateOrUpdate.
 type OrdersClientCreateOrUpdateResponse struct {
 	Order
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OrdersClientDeletePollerResponse contains the response from method OrdersClient.Delete.
 type OrdersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *OrdersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1035,11 +868,10 @@ type OrdersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l OrdersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (OrdersClientDeleteResponse, error) {
 	respType := OrdersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1052,49 +884,38 @@ func (l *OrdersClientDeletePollerResponse) Resume(ctx context.Context, client *O
 	poller := &OrdersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // OrdersClientDeleteResponse contains the response from method OrdersClient.Delete.
 type OrdersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // OrdersClientGetResponse contains the response from method OrdersClient.Get.
 type OrdersClientGetResponse struct {
 	Order
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OrdersClientListByDataBoxEdgeDeviceResponse contains the response from method OrdersClient.ListByDataBoxEdgeDevice.
 type OrdersClientListByDataBoxEdgeDeviceResponse struct {
 	OrderList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OrdersClientListDCAccessCodeResponse contains the response from method OrdersClient.ListDCAccessCode.
 type OrdersClientListDCAccessCodeResponse struct {
 	DCAccessCode
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RolesClientCreateOrUpdatePollerResponse contains the response from method RolesClient.CreateOrUpdate.
 type RolesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RolesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1102,11 +923,10 @@ type RolesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RolesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RolesClientCreateOrUpdateResponse, error) {
 	respType := RolesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1119,20 +939,17 @@ func (l *RolesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, cl
 	poller := &RolesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RolesClientCreateOrUpdateResponse contains the response from method RolesClient.CreateOrUpdate.
 type RolesClientCreateOrUpdateResponse struct {
 	RoleClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type RolesClientCreateOrUpdateResponse.
@@ -1149,9 +966,6 @@ func (r *RolesClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error {
 type RolesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RolesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1159,11 +973,10 @@ type RolesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RolesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RolesClientDeleteResponse, error) {
 	respType := RolesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1176,26 +989,22 @@ func (l *RolesClientDeletePollerResponse) Resume(ctx context.Context, client *Ro
 	poller := &RolesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RolesClientDeleteResponse contains the response from method RolesClient.Delete.
 type RolesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // RolesClientGetResponse contains the response from method RolesClient.Get.
 type RolesClientGetResponse struct {
 	RoleClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type RolesClientGetResponse.
@@ -1211,17 +1020,12 @@ func (r *RolesClientGetResponse) UnmarshalJSON(data []byte) error {
 // RolesClientListByDataBoxEdgeDeviceResponse contains the response from method RolesClient.ListByDataBoxEdgeDevice.
 type RolesClientListByDataBoxEdgeDeviceResponse struct {
 	RoleList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SharesClientCreateOrUpdatePollerResponse contains the response from method SharesClient.CreateOrUpdate.
 type SharesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SharesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1229,11 +1033,10 @@ type SharesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SharesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientCreateOrUpdateResponse, error) {
 	respType := SharesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Share)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Share)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1246,29 +1049,23 @@ func (l *SharesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 	poller := &SharesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SharesClientCreateOrUpdateResponse contains the response from method SharesClient.CreateOrUpdate.
 type SharesClientCreateOrUpdateResponse struct {
 	Share
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SharesClientDeletePollerResponse contains the response from method SharesClient.Delete.
 type SharesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SharesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1276,11 +1073,10 @@ type SharesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SharesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientDeleteResponse, error) {
 	respType := SharesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1293,42 +1089,33 @@ func (l *SharesClientDeletePollerResponse) Resume(ctx context.Context, client *S
 	poller := &SharesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SharesClientDeleteResponse contains the response from method SharesClient.Delete.
 type SharesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SharesClientGetResponse contains the response from method SharesClient.Get.
 type SharesClientGetResponse struct {
 	Share
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SharesClientListByDataBoxEdgeDeviceResponse contains the response from method SharesClient.ListByDataBoxEdgeDevice.
 type SharesClientListByDataBoxEdgeDeviceResponse struct {
 	ShareList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SharesClientRefreshPollerResponse contains the response from method SharesClient.Refresh.
 type SharesClientRefreshPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SharesClientRefreshPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1336,11 +1123,10 @@ type SharesClientRefreshPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SharesClientRefreshPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientRefreshResponse, error) {
 	respType := SharesClientRefreshResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1353,28 +1139,23 @@ func (l *SharesClientRefreshPollerResponse) Resume(ctx context.Context, client *
 	poller := &SharesClientRefreshPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SharesClientRefreshResponse contains the response from method SharesClient.Refresh.
 type SharesClientRefreshResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // StorageAccountCredentialsClientCreateOrUpdatePollerResponse contains the response from method StorageAccountCredentialsClient.CreateOrUpdate.
 type StorageAccountCredentialsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *StorageAccountCredentialsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1382,11 +1163,10 @@ type StorageAccountCredentialsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l StorageAccountCredentialsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
 	respType := StorageAccountCredentialsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.StorageAccountCredential)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.StorageAccountCredential)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1399,29 +1179,23 @@ func (l *StorageAccountCredentialsClientCreateOrUpdatePollerResponse) Resume(ctx
 	poller := &StorageAccountCredentialsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // StorageAccountCredentialsClientCreateOrUpdateResponse contains the response from method StorageAccountCredentialsClient.CreateOrUpdate.
 type StorageAccountCredentialsClientCreateOrUpdateResponse struct {
 	StorageAccountCredential
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // StorageAccountCredentialsClientDeletePollerResponse contains the response from method StorageAccountCredentialsClient.Delete.
 type StorageAccountCredentialsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *StorageAccountCredentialsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1429,11 +1203,10 @@ type StorageAccountCredentialsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l StorageAccountCredentialsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountCredentialsClientDeleteResponse, error) {
 	respType := StorageAccountCredentialsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1446,42 +1219,33 @@ func (l *StorageAccountCredentialsClientDeletePollerResponse) Resume(ctx context
 	poller := &StorageAccountCredentialsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // StorageAccountCredentialsClientDeleteResponse contains the response from method StorageAccountCredentialsClient.Delete.
 type StorageAccountCredentialsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // StorageAccountCredentialsClientGetResponse contains the response from method StorageAccountCredentialsClient.Get.
 type StorageAccountCredentialsClientGetResponse struct {
 	StorageAccountCredential
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse contains the response from method StorageAccountCredentialsClient.ListByDataBoxEdgeDevice.
 type StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse struct {
 	StorageAccountCredentialList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // StorageAccountsClientCreateOrUpdatePollerResponse contains the response from method StorageAccountsClient.CreateOrUpdate.
 type StorageAccountsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *StorageAccountsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1489,11 +1253,10 @@ type StorageAccountsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l StorageAccountsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountsClientCreateOrUpdateResponse, error) {
 	respType := StorageAccountsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.StorageAccount)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.StorageAccount)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1506,29 +1269,23 @@ func (l *StorageAccountsClientCreateOrUpdatePollerResponse) Resume(ctx context.C
 	poller := &StorageAccountsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // StorageAccountsClientCreateOrUpdateResponse contains the response from method StorageAccountsClient.CreateOrUpdate.
 type StorageAccountsClientCreateOrUpdateResponse struct {
 	StorageAccount
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // StorageAccountsClientDeletePollerResponse contains the response from method StorageAccountsClient.Delete.
 type StorageAccountsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *StorageAccountsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1536,11 +1293,10 @@ type StorageAccountsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l StorageAccountsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountsClientDeleteResponse, error) {
 	respType := StorageAccountsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1553,42 +1309,33 @@ func (l *StorageAccountsClientDeletePollerResponse) Resume(ctx context.Context, 
 	poller := &StorageAccountsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // StorageAccountsClientDeleteResponse contains the response from method StorageAccountsClient.Delete.
 type StorageAccountsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // StorageAccountsClientGetResponse contains the response from method StorageAccountsClient.Get.
 type StorageAccountsClientGetResponse struct {
 	StorageAccount
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // StorageAccountsClientListByDataBoxEdgeDeviceResponse contains the response from method StorageAccountsClient.ListByDataBoxEdgeDevice.
 type StorageAccountsClientListByDataBoxEdgeDeviceResponse struct {
 	StorageAccountList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SupportPackagesClientTriggerSupportPackagePollerResponse contains the response from method SupportPackagesClient.TriggerSupportPackage.
 type SupportPackagesClientTriggerSupportPackagePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SupportPackagesClientTriggerSupportPackagePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1596,11 +1343,10 @@ type SupportPackagesClientTriggerSupportPackagePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SupportPackagesClientTriggerSupportPackagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SupportPackagesClientTriggerSupportPackageResponse, error) {
 	respType := SupportPackagesClientTriggerSupportPackageResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1613,28 +1359,23 @@ func (l *SupportPackagesClientTriggerSupportPackagePollerResponse) Resume(ctx co
 	poller := &SupportPackagesClientTriggerSupportPackagePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SupportPackagesClientTriggerSupportPackageResponse contains the response from method SupportPackagesClient.TriggerSupportPackage.
 type SupportPackagesClientTriggerSupportPackageResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // TriggersClientCreateOrUpdatePollerResponse contains the response from method TriggersClient.CreateOrUpdate.
 type TriggersClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *TriggersClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1642,11 +1383,10 @@ type TriggersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l TriggersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersClientCreateOrUpdateResponse, error) {
 	respType := TriggersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1659,20 +1399,17 @@ func (l *TriggersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context,
 	poller := &TriggersClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // TriggersClientCreateOrUpdateResponse contains the response from method TriggersClient.CreateOrUpdate.
 type TriggersClientCreateOrUpdateResponse struct {
 	TriggerClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type TriggersClientCreateOrUpdateResponse.
@@ -1689,9 +1426,6 @@ func (t *TriggersClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error 
 type TriggersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *TriggersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1699,11 +1433,10 @@ type TriggersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l TriggersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersClientDeleteResponse, error) {
 	respType := TriggersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1716,26 +1449,22 @@ func (l *TriggersClientDeletePollerResponse) Resume(ctx context.Context, client 
 	poller := &TriggersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // TriggersClientDeleteResponse contains the response from method TriggersClient.Delete.
 type TriggersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // TriggersClientGetResponse contains the response from method TriggersClient.Get.
 type TriggersClientGetResponse struct {
 	TriggerClassification
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type TriggersClientGetResponse.
@@ -1751,17 +1480,12 @@ func (t *TriggersClientGetResponse) UnmarshalJSON(data []byte) error {
 // TriggersClientListByDataBoxEdgeDeviceResponse contains the response from method TriggersClient.ListByDataBoxEdgeDevice.
 type TriggersClientListByDataBoxEdgeDeviceResponse struct {
 	TriggerList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UsersClientCreateOrUpdatePollerResponse contains the response from method UsersClient.CreateOrUpdate.
 type UsersClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *UsersClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1769,11 +1493,10 @@ type UsersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l UsersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (UsersClientCreateOrUpdateResponse, error) {
 	respType := UsersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.User)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.User)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1786,29 +1509,23 @@ func (l *UsersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, cl
 	poller := &UsersClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // UsersClientCreateOrUpdateResponse contains the response from method UsersClient.CreateOrUpdate.
 type UsersClientCreateOrUpdateResponse struct {
 	User
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UsersClientDeletePollerResponse contains the response from method UsersClient.Delete.
 type UsersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *UsersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1816,11 +1533,10 @@ type UsersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l UsersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (UsersClientDeleteResponse, error) {
 	respType := UsersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1833,31 +1549,25 @@ func (l *UsersClientDeletePollerResponse) Resume(ctx context.Context, client *Us
 	poller := &UsersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // UsersClientDeleteResponse contains the response from method UsersClient.Delete.
 type UsersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // UsersClientGetResponse contains the response from method UsersClient.Get.
 type UsersClientGetResponse struct {
 	User
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // UsersClientListByDataBoxEdgeDeviceResponse contains the response from method UsersClient.ListByDataBoxEdgeDevice.
 type UsersClientListByDataBoxEdgeDeviceResponse struct {
 	UserList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_roles_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_roles_client.go
@@ -62,9 +62,7 @@ func (client *RolesClient) BeginCreateOrUpdate(ctx context.Context, deviceName s
 	if err != nil {
 		return RolesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := RolesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := RolesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RolesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return RolesClientCreateOrUpdatePollerResponse{}, err
@@ -133,9 +131,7 @@ func (client *RolesClient) BeginDelete(ctx context.Context, deviceName string, n
 	if err != nil {
 		return RolesClientDeletePollerResponse{}, err
 	}
-	result := RolesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := RolesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RolesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return RolesClientDeletePollerResponse{}, err
@@ -246,7 +242,7 @@ func (client *RolesClient) getCreateRequest(ctx context.Context, deviceName stri
 
 // getHandleResponse handles the Get response.
 func (client *RolesClient) getHandleResponse(resp *http.Response) (RolesClientGetResponse, error) {
-	result := RolesClientGetResponse{RawResponse: resp}
+	result := RolesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return RolesClientGetResponse{}, err
 	}
@@ -299,7 +295,7 @@ func (client *RolesClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Cont
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *RolesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (RolesClientListByDataBoxEdgeDeviceResponse, error) {
-	result := RolesClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := RolesClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleList); err != nil {
 		return RolesClientListByDataBoxEdgeDeviceResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
@@ -62,9 +62,7 @@ func (client *SharesClient) BeginCreateOrUpdate(ctx context.Context, deviceName 
 	if err != nil {
 		return SharesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := SharesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := SharesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SharesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return SharesClientCreateOrUpdatePollerResponse{}, err
@@ -133,9 +131,7 @@ func (client *SharesClient) BeginDelete(ctx context.Context, deviceName string, 
 	if err != nil {
 		return SharesClientDeletePollerResponse{}, err
 	}
-	result := SharesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := SharesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SharesClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return SharesClientDeletePollerResponse{}, err
@@ -246,7 +242,7 @@ func (client *SharesClient) getCreateRequest(ctx context.Context, deviceName str
 
 // getHandleResponse handles the Get response.
 func (client *SharesClient) getHandleResponse(resp *http.Response) (SharesClientGetResponse, error) {
-	result := SharesClientGetResponse{RawResponse: resp}
+	result := SharesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Share); err != nil {
 		return SharesClientGetResponse{}, err
 	}
@@ -299,7 +295,7 @@ func (client *SharesClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Con
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *SharesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (SharesClientListByDataBoxEdgeDeviceResponse, error) {
-	result := SharesClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := SharesClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ShareList); err != nil {
 		return SharesClientListByDataBoxEdgeDeviceResponse{}, err
 	}
@@ -317,9 +313,7 @@ func (client *SharesClient) BeginRefresh(ctx context.Context, deviceName string,
 	if err != nil {
 		return SharesClientRefreshPollerResponse{}, err
 	}
-	result := SharesClientRefreshPollerResponse{
-		RawResponse: resp,
-	}
+	result := SharesClientRefreshPollerResponse{}
 	pt, err := armruntime.NewPoller("SharesClient.Refresh", "", resp, client.pl)
 	if err != nil {
 		return SharesClientRefreshPollerResponse{}, err

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
@@ -62,9 +62,7 @@ func (client *StorageAccountCredentialsClient) BeginCreateOrUpdate(ctx context.C
 	if err != nil {
 		return StorageAccountCredentialsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := StorageAccountCredentialsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := StorageAccountCredentialsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("StorageAccountCredentialsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return StorageAccountCredentialsClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *StorageAccountCredentialsClient) BeginDelete(ctx context.Context, 
 	if err != nil {
 		return StorageAccountCredentialsClientDeletePollerResponse{}, err
 	}
-	result := StorageAccountCredentialsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := StorageAccountCredentialsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("StorageAccountCredentialsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return StorageAccountCredentialsClientDeletePollerResponse{}, err
@@ -248,7 +244,7 @@ func (client *StorageAccountCredentialsClient) getCreateRequest(ctx context.Cont
 
 // getHandleResponse handles the Get response.
 func (client *StorageAccountCredentialsClient) getHandleResponse(resp *http.Response) (StorageAccountCredentialsClientGetResponse, error) {
-	result := StorageAccountCredentialsClientGetResponse{RawResponse: resp}
+	result := StorageAccountCredentialsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageAccountCredential); err != nil {
 		return StorageAccountCredentialsClientGetResponse{}, err
 	}
@@ -301,7 +297,7 @@ func (client *StorageAccountCredentialsClient) listByDataBoxEdgeDeviceCreateRequ
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *StorageAccountCredentialsClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse, error) {
-	result := StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageAccountCredentialList); err != nil {
 		return StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
@@ -62,9 +62,7 @@ func (client *StorageAccountsClient) BeginCreateOrUpdate(ctx context.Context, de
 	if err != nil {
 		return StorageAccountsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := StorageAccountsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := StorageAccountsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("StorageAccountsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return StorageAccountsClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *StorageAccountsClient) BeginDelete(ctx context.Context, deviceName
 	if err != nil {
 		return StorageAccountsClientDeletePollerResponse{}, err
 	}
-	result := StorageAccountsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := StorageAccountsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("StorageAccountsClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return StorageAccountsClientDeletePollerResponse{}, err
@@ -247,7 +243,7 @@ func (client *StorageAccountsClient) getCreateRequest(ctx context.Context, devic
 
 // getHandleResponse handles the Get response.
 func (client *StorageAccountsClient) getHandleResponse(resp *http.Response) (StorageAccountsClientGetResponse, error) {
-	result := StorageAccountsClientGetResponse{RawResponse: resp}
+	result := StorageAccountsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageAccount); err != nil {
 		return StorageAccountsClientGetResponse{}, err
 	}
@@ -300,7 +296,7 @@ func (client *StorageAccountsClient) listByDataBoxEdgeDeviceCreateRequest(ctx co
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *StorageAccountsClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (StorageAccountsClientListByDataBoxEdgeDeviceResponse, error) {
-	result := StorageAccountsClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := StorageAccountsClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageAccountList); err != nil {
 		return StorageAccountsClientListByDataBoxEdgeDeviceResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_supportpackages_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_supportpackages_client.go
@@ -61,9 +61,7 @@ func (client *SupportPackagesClient) BeginTriggerSupportPackage(ctx context.Cont
 	if err != nil {
 		return SupportPackagesClientTriggerSupportPackagePollerResponse{}, err
 	}
-	result := SupportPackagesClientTriggerSupportPackagePollerResponse{
-		RawResponse: resp,
-	}
+	result := SupportPackagesClientTriggerSupportPackagePollerResponse{}
 	pt, err := armruntime.NewPoller("SupportPackagesClient.TriggerSupportPackage", "", resp, client.pl)
 	if err != nil {
 		return SupportPackagesClientTriggerSupportPackagePollerResponse{}, err

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
@@ -62,9 +62,7 @@ func (client *TriggersClient) BeginCreateOrUpdate(ctx context.Context, deviceNam
 	if err != nil {
 		return TriggersClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := TriggersClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := TriggersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("TriggersClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return TriggersClientCreateOrUpdatePollerResponse{}, err
@@ -133,9 +131,7 @@ func (client *TriggersClient) BeginDelete(ctx context.Context, deviceName string
 	if err != nil {
 		return TriggersClientDeletePollerResponse{}, err
 	}
-	result := TriggersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := TriggersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("TriggersClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return TriggersClientDeletePollerResponse{}, err
@@ -246,7 +242,7 @@ func (client *TriggersClient) getCreateRequest(ctx context.Context, deviceName s
 
 // getHandleResponse handles the Get response.
 func (client *TriggersClient) getHandleResponse(resp *http.Response) (TriggersClientGetResponse, error) {
-	result := TriggersClientGetResponse{RawResponse: resp}
+	result := TriggersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
 		return TriggersClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *TriggersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.C
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *TriggersClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (TriggersClientListByDataBoxEdgeDeviceResponse, error) {
-	result := TriggersClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := TriggersClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerList); err != nil {
 		return TriggersClientListByDataBoxEdgeDeviceResponse{}, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
@@ -63,9 +63,7 @@ func (client *UsersClient) BeginCreateOrUpdate(ctx context.Context, deviceName s
 	if err != nil {
 		return UsersClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := UsersClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := UsersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("UsersClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
 		return UsersClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *UsersClient) BeginDelete(ctx context.Context, deviceName string, n
 	if err != nil {
 		return UsersClientDeletePollerResponse{}, err
 	}
-	result := UsersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := UsersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("UsersClient.Delete", "", resp, client.pl)
 	if err != nil {
 		return UsersClientDeletePollerResponse{}, err
@@ -247,7 +243,7 @@ func (client *UsersClient) getCreateRequest(ctx context.Context, deviceName stri
 
 // getHandleResponse handles the Get response.
 func (client *UsersClient) getHandleResponse(resp *http.Response) (UsersClientGetResponse, error) {
-	result := UsersClientGetResponse{RawResponse: resp}
+	result := UsersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.User); err != nil {
 		return UsersClientGetResponse{}, err
 	}
@@ -303,7 +299,7 @@ func (client *UsersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Cont
 
 // listByDataBoxEdgeDeviceHandleResponse handles the ListByDataBoxEdgeDevice response.
 func (client *UsersClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (UsersClientListByDataBoxEdgeDeviceResponse, error) {
-	result := UsersClientListByDataBoxEdgeDeviceResponse{RawResponse: resp}
+	result := UsersClientListByDataBoxEdgeDeviceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UserList); err != nil {
 		return UsersClientListByDataBoxEdgeDeviceResponse{}, err
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_generated_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_client.go
@@ -77,7 +77,7 @@ func (client *Client) backupCertificateCreateRequest(ctx context.Context, vaultB
 
 // backupCertificateHandleResponse handles the BackupCertificate response.
 func (client *Client) backupCertificateHandleResponse(resp *http.Response) (ClientBackupCertificateResponse, error) {
-	result := ClientBackupCertificateResponse{RawResponse: resp}
+	result := ClientBackupCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupCertificateResult); err != nil {
 		return ClientBackupCertificateResponse{}, err
 	}
@@ -135,7 +135,7 @@ func (client *Client) backupKeyCreateRequest(ctx context.Context, vaultBaseURL s
 
 // backupKeyHandleResponse handles the BackupKey response.
 func (client *Client) backupKeyHandleResponse(resp *http.Response) (ClientBackupKeyResponse, error) {
-	result := ClientBackupKeyResponse{RawResponse: resp}
+	result := ClientBackupKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupKeyResult); err != nil {
 		return ClientBackupKeyResponse{}, err
 	}
@@ -185,7 +185,7 @@ func (client *Client) backupSecretCreateRequest(ctx context.Context, vaultBaseUR
 
 // backupSecretHandleResponse handles the BackupSecret response.
 func (client *Client) backupSecretHandleResponse(resp *http.Response) (ClientBackupSecretResponse, error) {
-	result := ClientBackupSecretResponse{RawResponse: resp}
+	result := ClientBackupSecretResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupSecretResult); err != nil {
 		return ClientBackupSecretResponse{}, err
 	}
@@ -235,7 +235,7 @@ func (client *Client) backupStorageAccountCreateRequest(ctx context.Context, vau
 
 // backupStorageAccountHandleResponse handles the BackupStorageAccount response.
 func (client *Client) backupStorageAccountHandleResponse(resp *http.Response) (ClientBackupStorageAccountResponse, error) {
-	result := ClientBackupStorageAccountResponse{RawResponse: resp}
+	result := ClientBackupStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupStorageResult); err != nil {
 		return ClientBackupStorageAccountResponse{}, err
 	}
@@ -286,7 +286,7 @@ func (client *Client) createCertificateCreateRequest(ctx context.Context, vaultB
 
 // createCertificateHandleResponse handles the CreateCertificate response.
 func (client *Client) createCertificateHandleResponse(resp *http.Response) (ClientCreateCertificateResponse, error) {
-	result := ClientCreateCertificateResponse{RawResponse: resp}
+	result := ClientCreateCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
 		return ClientCreateCertificateResponse{}, err
 	}
@@ -338,7 +338,7 @@ func (client *Client) createKeyCreateRequest(ctx context.Context, vaultBaseURL s
 
 // createKeyHandleResponse handles the CreateKey response.
 func (client *Client) createKeyHandleResponse(resp *http.Response) (ClientCreateKeyResponse, error) {
-	result := ClientCreateKeyResponse{RawResponse: resp}
+	result := ClientCreateKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return ClientCreateKeyResponse{}, err
 	}
@@ -397,7 +397,7 @@ func (client *Client) decryptCreateRequest(ctx context.Context, vaultBaseURL str
 
 // decryptHandleResponse handles the Decrypt response.
 func (client *Client) decryptHandleResponse(resp *http.Response) (ClientDecryptResponse, error) {
-	result := ClientDecryptResponse{RawResponse: resp}
+	result := ClientDecryptResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return ClientDecryptResponse{}, err
 	}
@@ -448,7 +448,7 @@ func (client *Client) deleteCertificateCreateRequest(ctx context.Context, vaultB
 
 // deleteCertificateHandleResponse handles the DeleteCertificate response.
 func (client *Client) deleteCertificateHandleResponse(resp *http.Response) (ClientDeleteCertificateResponse, error) {
-	result := ClientDeleteCertificateResponse{RawResponse: resp}
+	result := ClientDeleteCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateBundle); err != nil {
 		return ClientDeleteCertificateResponse{}, err
 	}
@@ -494,7 +494,7 @@ func (client *Client) deleteCertificateContactsCreateRequest(ctx context.Context
 
 // deleteCertificateContactsHandleResponse handles the DeleteCertificateContacts response.
 func (client *Client) deleteCertificateContactsHandleResponse(resp *http.Response) (ClientDeleteCertificateContactsResponse, error) {
-	result := ClientDeleteCertificateContactsResponse{RawResponse: resp}
+	result := ClientDeleteCertificateContactsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
 		return ClientDeleteCertificateContactsResponse{}, err
 	}
@@ -545,7 +545,7 @@ func (client *Client) deleteCertificateIssuerCreateRequest(ctx context.Context, 
 
 // deleteCertificateIssuerHandleResponse handles the DeleteCertificateIssuer response.
 func (client *Client) deleteCertificateIssuerHandleResponse(resp *http.Response) (ClientDeleteCertificateIssuerResponse, error) {
-	result := ClientDeleteCertificateIssuerResponse{RawResponse: resp}
+	result := ClientDeleteCertificateIssuerResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
 		return ClientDeleteCertificateIssuerResponse{}, err
 	}
@@ -596,7 +596,7 @@ func (client *Client) deleteCertificateOperationCreateRequest(ctx context.Contex
 
 // deleteCertificateOperationHandleResponse handles the DeleteCertificateOperation response.
 func (client *Client) deleteCertificateOperationHandleResponse(resp *http.Response) (ClientDeleteCertificateOperationResponse, error) {
-	result := ClientDeleteCertificateOperationResponse{RawResponse: resp}
+	result := ClientDeleteCertificateOperationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
 		return ClientDeleteCertificateOperationResponse{}, err
 	}
@@ -647,7 +647,7 @@ func (client *Client) deleteKeyCreateRequest(ctx context.Context, vaultBaseURL s
 
 // deleteKeyHandleResponse handles the DeleteKey response.
 func (client *Client) deleteKeyHandleResponse(resp *http.Response) (ClientDeleteKeyResponse, error) {
-	result := ClientDeleteKeyResponse{RawResponse: resp}
+	result := ClientDeleteKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyBundle); err != nil {
 		return ClientDeleteKeyResponse{}, err
 	}
@@ -702,7 +702,7 @@ func (client *Client) deleteSasDefinitionCreateRequest(ctx context.Context, vaul
 
 // deleteSasDefinitionHandleResponse handles the DeleteSasDefinition response.
 func (client *Client) deleteSasDefinitionHandleResponse(resp *http.Response) (ClientDeleteSasDefinitionResponse, error) {
-	result := ClientDeleteSasDefinitionResponse{RawResponse: resp}
+	result := ClientDeleteSasDefinitionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionBundle); err != nil {
 		return ClientDeleteSasDefinitionResponse{}, err
 	}
@@ -752,7 +752,7 @@ func (client *Client) deleteSecretCreateRequest(ctx context.Context, vaultBaseUR
 
 // deleteSecretHandleResponse handles the DeleteSecret response.
 func (client *Client) deleteSecretHandleResponse(resp *http.Response) (ClientDeleteSecretResponse, error) {
-	result := ClientDeleteSecretResponse{RawResponse: resp}
+	result := ClientDeleteSecretResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretBundle); err != nil {
 		return ClientDeleteSecretResponse{}, err
 	}
@@ -801,7 +801,7 @@ func (client *Client) deleteStorageAccountCreateRequest(ctx context.Context, vau
 
 // deleteStorageAccountHandleResponse handles the DeleteStorageAccount response.
 func (client *Client) deleteStorageAccountHandleResponse(resp *http.Response) (ClientDeleteStorageAccountResponse, error) {
-	result := ClientDeleteStorageAccountResponse{RawResponse: resp}
+	result := ClientDeleteStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageBundle); err != nil {
 		return ClientDeleteStorageAccountResponse{}, err
 	}
@@ -862,7 +862,7 @@ func (client *Client) encryptCreateRequest(ctx context.Context, vaultBaseURL str
 
 // encryptHandleResponse handles the Encrypt response.
 func (client *Client) encryptHandleResponse(resp *http.Response) (ClientEncryptResponse, error) {
-	result := ClientEncryptResponse{RawResponse: resp}
+	result := ClientEncryptResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return ClientEncryptResponse{}, err
 	}
@@ -878,9 +878,7 @@ func (client *Client) BeginFullBackup(ctx context.Context, vaultBaseURL string, 
 	if err != nil {
 		return ClientFullBackupPollerResponse{}, err
 	}
-	result := ClientFullBackupPollerResponse{
-		RawResponse: resp,
-	}
+	result := ClientFullBackupPollerResponse{}
 	pt, err := runtime.NewPoller("Client.FullBackup", resp, client.pl)
 	if err != nil {
 		return ClientFullBackupPollerResponse{}, err
@@ -969,7 +967,7 @@ func (client *Client) fullBackupStatusCreateRequest(ctx context.Context, vaultBa
 
 // fullBackupStatusHandleResponse handles the FullBackupStatus response.
 func (client *Client) fullBackupStatusHandleResponse(resp *http.Response) (ClientFullBackupStatusResponse, error) {
-	result := ClientFullBackupStatusResponse{RawResponse: resp}
+	result := ClientFullBackupStatusResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FullBackupOperation); err != nil {
 		return ClientFullBackupStatusResponse{}, err
 	}
@@ -987,9 +985,7 @@ func (client *Client) BeginFullRestoreOperation(ctx context.Context, vaultBaseUR
 	if err != nil {
 		return ClientFullRestoreOperationPollerResponse{}, err
 	}
-	result := ClientFullRestoreOperationPollerResponse{
-		RawResponse: resp,
-	}
+	result := ClientFullRestoreOperationPollerResponse{}
 	pt, err := runtime.NewPoller("Client.FullRestoreOperation", resp, client.pl)
 	if err != nil {
 		return ClientFullRestoreOperationPollerResponse{}, err
@@ -1085,7 +1081,7 @@ func (client *Client) getCertificateCreateRequest(ctx context.Context, vaultBase
 
 // getCertificateHandleResponse handles the GetCertificate response.
 func (client *Client) getCertificateHandleResponse(resp *http.Response) (ClientGetCertificateResponse, error) {
-	result := ClientGetCertificateResponse{RawResponse: resp}
+	result := ClientGetCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return ClientGetCertificateResponse{}, err
 	}
@@ -1130,7 +1126,7 @@ func (client *Client) getCertificateContactsCreateRequest(ctx context.Context, v
 
 // getCertificateContactsHandleResponse handles the GetCertificateContacts response.
 func (client *Client) getCertificateContactsHandleResponse(resp *http.Response) (ClientGetCertificateContactsResponse, error) {
-	result := ClientGetCertificateContactsResponse{RawResponse: resp}
+	result := ClientGetCertificateContactsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
 		return ClientGetCertificateContactsResponse{}, err
 	}
@@ -1180,7 +1176,7 @@ func (client *Client) getCertificateIssuerCreateRequest(ctx context.Context, vau
 
 // getCertificateIssuerHandleResponse handles the GetCertificateIssuer response.
 func (client *Client) getCertificateIssuerHandleResponse(resp *http.Response) (ClientGetCertificateIssuerResponse, error) {
-	result := ClientGetCertificateIssuerResponse{RawResponse: resp}
+	result := ClientGetCertificateIssuerResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
 		return ClientGetCertificateIssuerResponse{}, err
 	}
@@ -1225,7 +1221,7 @@ func (client *Client) getCertificateIssuersCreateRequest(ctx context.Context, va
 
 // getCertificateIssuersHandleResponse handles the GetCertificateIssuers response.
 func (client *Client) getCertificateIssuersHandleResponse(resp *http.Response) (ClientGetCertificateIssuersResponse, error) {
-	result := ClientGetCertificateIssuersResponse{RawResponse: resp}
+	result := ClientGetCertificateIssuersResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateIssuerListResult); err != nil {
 		return ClientGetCertificateIssuersResponse{}, err
 	}
@@ -1276,7 +1272,7 @@ func (client *Client) getCertificateOperationCreateRequest(ctx context.Context, 
 
 // getCertificateOperationHandleResponse handles the GetCertificateOperation response.
 func (client *Client) getCertificateOperationHandleResponse(resp *http.Response) (ClientGetCertificateOperationResponse, error) {
-	result := ClientGetCertificateOperationResponse{RawResponse: resp}
+	result := ClientGetCertificateOperationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
 		return ClientGetCertificateOperationResponse{}, err
 	}
@@ -1326,7 +1322,7 @@ func (client *Client) getCertificatePolicyCreateRequest(ctx context.Context, vau
 
 // getCertificatePolicyHandleResponse handles the GetCertificatePolicy response.
 func (client *Client) getCertificatePolicyHandleResponse(resp *http.Response) (ClientGetCertificatePolicyResponse, error) {
-	result := ClientGetCertificatePolicyResponse{RawResponse: resp}
+	result := ClientGetCertificatePolicyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificatePolicy); err != nil {
 		return ClientGetCertificatePolicyResponse{}, err
 	}
@@ -1376,7 +1372,7 @@ func (client *Client) getCertificateVersionsCreateRequest(ctx context.Context, v
 
 // getCertificateVersionsHandleResponse handles the GetCertificateVersions response.
 func (client *Client) getCertificateVersionsHandleResponse(resp *http.Response) (ClientGetCertificateVersionsResponse, error) {
-	result := ClientGetCertificateVersionsResponse{RawResponse: resp}
+	result := ClientGetCertificateVersionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateListResult); err != nil {
 		return ClientGetCertificateVersionsResponse{}, err
 	}
@@ -1424,7 +1420,7 @@ func (client *Client) getCertificatesCreateRequest(ctx context.Context, vaultBas
 
 // getCertificatesHandleResponse handles the GetCertificates response.
 func (client *Client) getCertificatesHandleResponse(resp *http.Response) (ClientGetCertificatesResponse, error) {
-	result := ClientGetCertificatesResponse{RawResponse: resp}
+	result := ClientGetCertificatesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateListResult); err != nil {
 		return ClientGetCertificatesResponse{}, err
 	}
@@ -1475,7 +1471,7 @@ func (client *Client) getDeletedCertificateCreateRequest(ctx context.Context, va
 
 // getDeletedCertificateHandleResponse handles the GetDeletedCertificate response.
 func (client *Client) getDeletedCertificateHandleResponse(resp *http.Response) (ClientGetDeletedCertificateResponse, error) {
-	result := ClientGetDeletedCertificateResponse{RawResponse: resp}
+	result := ClientGetDeletedCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateBundle); err != nil {
 		return ClientGetDeletedCertificateResponse{}, err
 	}
@@ -1525,7 +1521,7 @@ func (client *Client) getDeletedCertificatesCreateRequest(ctx context.Context, v
 
 // getDeletedCertificatesHandleResponse handles the GetDeletedCertificates response.
 func (client *Client) getDeletedCertificatesHandleResponse(resp *http.Response) (ClientGetDeletedCertificatesResponse, error) {
-	result := ClientGetDeletedCertificatesResponse{RawResponse: resp}
+	result := ClientGetDeletedCertificatesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateListResult); err != nil {
 		return ClientGetDeletedCertificatesResponse{}, err
 	}
@@ -1576,7 +1572,7 @@ func (client *Client) getDeletedKeyCreateRequest(ctx context.Context, vaultBaseU
 
 // getDeletedKeyHandleResponse handles the GetDeletedKey response.
 func (client *Client) getDeletedKeyHandleResponse(resp *http.Response) (ClientGetDeletedKeyResponse, error) {
-	result := ClientGetDeletedKeyResponse{RawResponse: resp}
+	result := ClientGetDeletedKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyBundle); err != nil {
 		return ClientGetDeletedKeyResponse{}, err
 	}
@@ -1624,7 +1620,7 @@ func (client *Client) getDeletedKeysCreateRequest(ctx context.Context, vaultBase
 
 // getDeletedKeysHandleResponse handles the GetDeletedKeys response.
 func (client *Client) getDeletedKeysHandleResponse(resp *http.Response) (ClientGetDeletedKeysResponse, error) {
-	result := ClientGetDeletedKeysResponse{RawResponse: resp}
+	result := ClientGetDeletedKeysResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyListResult); err != nil {
 		return ClientGetDeletedKeysResponse{}, err
 	}
@@ -1680,7 +1676,7 @@ func (client *Client) getDeletedSasDefinitionCreateRequest(ctx context.Context, 
 
 // getDeletedSasDefinitionHandleResponse handles the GetDeletedSasDefinition response.
 func (client *Client) getDeletedSasDefinitionHandleResponse(resp *http.Response) (ClientGetDeletedSasDefinitionResponse, error) {
-	result := ClientGetDeletedSasDefinitionResponse{RawResponse: resp}
+	result := ClientGetDeletedSasDefinitionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionBundle); err != nil {
 		return ClientGetDeletedSasDefinitionResponse{}, err
 	}
@@ -1731,7 +1727,7 @@ func (client *Client) getDeletedSasDefinitionsCreateRequest(ctx context.Context,
 
 // getDeletedSasDefinitionsHandleResponse handles the GetDeletedSasDefinitions response.
 func (client *Client) getDeletedSasDefinitionsHandleResponse(resp *http.Response) (ClientGetDeletedSasDefinitionsResponse, error) {
-	result := ClientGetDeletedSasDefinitionsResponse{RawResponse: resp}
+	result := ClientGetDeletedSasDefinitionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionListResult); err != nil {
 		return ClientGetDeletedSasDefinitionsResponse{}, err
 	}
@@ -1781,7 +1777,7 @@ func (client *Client) getDeletedSecretCreateRequest(ctx context.Context, vaultBa
 
 // getDeletedSecretHandleResponse handles the GetDeletedSecret response.
 func (client *Client) getDeletedSecretHandleResponse(resp *http.Response) (ClientGetDeletedSecretResponse, error) {
-	result := ClientGetDeletedSecretResponse{RawResponse: resp}
+	result := ClientGetDeletedSecretResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretBundle); err != nil {
 		return ClientGetDeletedSecretResponse{}, err
 	}
@@ -1826,7 +1822,7 @@ func (client *Client) getDeletedSecretsCreateRequest(ctx context.Context, vaultB
 
 // getDeletedSecretsHandleResponse handles the GetDeletedSecrets response.
 func (client *Client) getDeletedSecretsHandleResponse(resp *http.Response) (ClientGetDeletedSecretsResponse, error) {
-	result := ClientGetDeletedSecretsResponse{RawResponse: resp}
+	result := ClientGetDeletedSecretsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretListResult); err != nil {
 		return ClientGetDeletedSecretsResponse{}, err
 	}
@@ -1877,7 +1873,7 @@ func (client *Client) getDeletedStorageAccountCreateRequest(ctx context.Context,
 
 // getDeletedStorageAccountHandleResponse handles the GetDeletedStorageAccount response.
 func (client *Client) getDeletedStorageAccountHandleResponse(resp *http.Response) (ClientGetDeletedStorageAccountResponse, error) {
-	result := ClientGetDeletedStorageAccountResponse{RawResponse: resp}
+	result := ClientGetDeletedStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageBundle); err != nil {
 		return ClientGetDeletedStorageAccountResponse{}, err
 	}
@@ -1923,7 +1919,7 @@ func (client *Client) getDeletedStorageAccountsCreateRequest(ctx context.Context
 
 // getDeletedStorageAccountsHandleResponse handles the GetDeletedStorageAccounts response.
 func (client *Client) getDeletedStorageAccountsHandleResponse(resp *http.Response) (ClientGetDeletedStorageAccountsResponse, error) {
-	result := ClientGetDeletedStorageAccountsResponse{RawResponse: resp}
+	result := ClientGetDeletedStorageAccountsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageListResult); err != nil {
 		return ClientGetDeletedStorageAccountsResponse{}, err
 	}
@@ -1979,7 +1975,7 @@ func (client *Client) getKeyCreateRequest(ctx context.Context, vaultBaseURL stri
 
 // getKeyHandleResponse handles the GetKey response.
 func (client *Client) getKeyHandleResponse(resp *http.Response) (ClientGetKeyResponse, error) {
-	result := ClientGetKeyResponse{RawResponse: resp}
+	result := ClientGetKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return ClientGetKeyResponse{}, err
 	}
@@ -2029,7 +2025,7 @@ func (client *Client) getKeyVersionsCreateRequest(ctx context.Context, vaultBase
 
 // getKeyVersionsHandleResponse handles the GetKeyVersions response.
 func (client *Client) getKeyVersionsHandleResponse(resp *http.Response) (ClientGetKeyVersionsResponse, error) {
-	result := ClientGetKeyVersionsResponse{RawResponse: resp}
+	result := ClientGetKeyVersionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyListResult); err != nil {
 		return ClientGetKeyVersionsResponse{}, err
 	}
@@ -2076,7 +2072,7 @@ func (client *Client) getKeysCreateRequest(ctx context.Context, vaultBaseURL str
 
 // getKeysHandleResponse handles the GetKeys response.
 func (client *Client) getKeysHandleResponse(resp *http.Response) (ClientGetKeysResponse, error) {
-	result := ClientGetKeysResponse{RawResponse: resp}
+	result := ClientGetKeysResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyListResult); err != nil {
 		return ClientGetKeysResponse{}, err
 	}
@@ -2131,7 +2127,7 @@ func (client *Client) getSasDefinitionCreateRequest(ctx context.Context, vaultBa
 
 // getSasDefinitionHandleResponse handles the GetSasDefinition response.
 func (client *Client) getSasDefinitionHandleResponse(resp *http.Response) (ClientGetSasDefinitionResponse, error) {
-	result := ClientGetSasDefinitionResponse{RawResponse: resp}
+	result := ClientGetSasDefinitionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
 		return ClientGetSasDefinitionResponse{}, err
 	}
@@ -2181,7 +2177,7 @@ func (client *Client) getSasDefinitionsCreateRequest(ctx context.Context, vaultB
 
 // getSasDefinitionsHandleResponse handles the GetSasDefinitions response.
 func (client *Client) getSasDefinitionsHandleResponse(resp *http.Response) (ClientGetSasDefinitionsResponse, error) {
-	result := ClientGetSasDefinitionsResponse{RawResponse: resp}
+	result := ClientGetSasDefinitionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionListResult); err != nil {
 		return ClientGetSasDefinitionsResponse{}, err
 	}
@@ -2237,7 +2233,7 @@ func (client *Client) getSecretCreateRequest(ctx context.Context, vaultBaseURL s
 
 // getSecretHandleResponse handles the GetSecret response.
 func (client *Client) getSecretHandleResponse(resp *http.Response) (ClientGetSecretResponse, error) {
-	result := ClientGetSecretResponse{RawResponse: resp}
+	result := ClientGetSecretResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return ClientGetSecretResponse{}, err
 	}
@@ -2287,7 +2283,7 @@ func (client *Client) getSecretVersionsCreateRequest(ctx context.Context, vaultB
 
 // getSecretVersionsHandleResponse handles the GetSecretVersions response.
 func (client *Client) getSecretVersionsHandleResponse(resp *http.Response) (ClientGetSecretVersionsResponse, error) {
-	result := ClientGetSecretVersionsResponse{RawResponse: resp}
+	result := ClientGetSecretVersionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretListResult); err != nil {
 		return ClientGetSecretVersionsResponse{}, err
 	}
@@ -2333,7 +2329,7 @@ func (client *Client) getSecretsCreateRequest(ctx context.Context, vaultBaseURL 
 
 // getSecretsHandleResponse handles the GetSecrets response.
 func (client *Client) getSecretsHandleResponse(resp *http.Response) (ClientGetSecretsResponse, error) {
-	result := ClientGetSecretsResponse{RawResponse: resp}
+	result := ClientGetSecretsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretListResult); err != nil {
 		return ClientGetSecretsResponse{}, err
 	}
@@ -2382,7 +2378,7 @@ func (client *Client) getStorageAccountCreateRequest(ctx context.Context, vaultB
 
 // getStorageAccountHandleResponse handles the GetStorageAccount response.
 func (client *Client) getStorageAccountHandleResponse(resp *http.Response) (ClientGetStorageAccountResponse, error) {
-	result := ClientGetStorageAccountResponse{RawResponse: resp}
+	result := ClientGetStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return ClientGetStorageAccountResponse{}, err
 	}
@@ -2427,7 +2423,7 @@ func (client *Client) getStorageAccountsCreateRequest(ctx context.Context, vault
 
 // getStorageAccountsHandleResponse handles the GetStorageAccounts response.
 func (client *Client) getStorageAccountsHandleResponse(resp *http.Response) (ClientGetStorageAccountsResponse, error) {
-	result := ClientGetStorageAccountsResponse{RawResponse: resp}
+	result := ClientGetStorageAccountsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageListResult); err != nil {
 		return ClientGetStorageAccountsResponse{}, err
 	}
@@ -2479,7 +2475,7 @@ func (client *Client) importCertificateCreateRequest(ctx context.Context, vaultB
 
 // importCertificateHandleResponse handles the ImportCertificate response.
 func (client *Client) importCertificateHandleResponse(resp *http.Response) (ClientImportCertificateResponse, error) {
-	result := ClientImportCertificateResponse{RawResponse: resp}
+	result := ClientImportCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return ClientImportCertificateResponse{}, err
 	}
@@ -2531,7 +2527,7 @@ func (client *Client) importKeyCreateRequest(ctx context.Context, vaultBaseURL s
 
 // importKeyHandleResponse handles the ImportKey response.
 func (client *Client) importKeyHandleResponse(resp *http.Response) (ClientImportKeyResponse, error) {
-	result := ClientImportKeyResponse{RawResponse: resp}
+	result := ClientImportKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return ClientImportKeyResponse{}, err
 	}
@@ -2583,7 +2579,7 @@ func (client *Client) mergeCertificateCreateRequest(ctx context.Context, vaultBa
 
 // mergeCertificateHandleResponse handles the MergeCertificate response.
 func (client *Client) mergeCertificateHandleResponse(resp *http.Response) (ClientMergeCertificateResponse, error) {
-	result := ClientMergeCertificateResponse{RawResponse: resp}
+	result := ClientMergeCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return ClientMergeCertificateResponse{}, err
 	}
@@ -2610,7 +2606,7 @@ func (client *Client) PurgeDeletedCertificate(ctx context.Context, vaultBaseURL 
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return ClientPurgeDeletedCertificateResponse{}, runtime.NewResponseError(resp)
 	}
-	return ClientPurgeDeletedCertificateResponse{RawResponse: resp}, nil
+	return ClientPurgeDeletedCertificateResponse{}, nil
 }
 
 // purgeDeletedCertificateCreateRequest creates the PurgeDeletedCertificate request.
@@ -2652,7 +2648,7 @@ func (client *Client) PurgeDeletedKey(ctx context.Context, vaultBaseURL string, 
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return ClientPurgeDeletedKeyResponse{}, runtime.NewResponseError(resp)
 	}
-	return ClientPurgeDeletedKeyResponse{RawResponse: resp}, nil
+	return ClientPurgeDeletedKeyResponse{}, nil
 }
 
 // purgeDeletedKeyCreateRequest creates the PurgeDeletedKey request.
@@ -2694,7 +2690,7 @@ func (client *Client) PurgeDeletedSecret(ctx context.Context, vaultBaseURL strin
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return ClientPurgeDeletedSecretResponse{}, runtime.NewResponseError(resp)
 	}
-	return ClientPurgeDeletedSecretResponse{RawResponse: resp}, nil
+	return ClientPurgeDeletedSecretResponse{}, nil
 }
 
 // purgeDeletedSecretCreateRequest creates the PurgeDeletedSecret request.
@@ -2737,7 +2733,7 @@ func (client *Client) PurgeDeletedStorageAccount(ctx context.Context, vaultBaseU
 	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
 		return ClientPurgeDeletedStorageAccountResponse{}, runtime.NewResponseError(resp)
 	}
-	return ClientPurgeDeletedStorageAccountResponse{RawResponse: resp}, nil
+	return ClientPurgeDeletedStorageAccountResponse{}, nil
 }
 
 // purgeDeletedStorageAccountCreateRequest creates the PurgeDeletedStorageAccount request.
@@ -2805,7 +2801,7 @@ func (client *Client) recoverDeletedCertificateCreateRequest(ctx context.Context
 
 // recoverDeletedCertificateHandleResponse handles the RecoverDeletedCertificate response.
 func (client *Client) recoverDeletedCertificateHandleResponse(resp *http.Response) (ClientRecoverDeletedCertificateResponse, error) {
-	result := ClientRecoverDeletedCertificateResponse{RawResponse: resp}
+	result := ClientRecoverDeletedCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return ClientRecoverDeletedCertificateResponse{}, err
 	}
@@ -2857,7 +2853,7 @@ func (client *Client) recoverDeletedKeyCreateRequest(ctx context.Context, vaultB
 
 // recoverDeletedKeyHandleResponse handles the RecoverDeletedKey response.
 func (client *Client) recoverDeletedKeyHandleResponse(resp *http.Response) (ClientRecoverDeletedKeyResponse, error) {
-	result := ClientRecoverDeletedKeyResponse{RawResponse: resp}
+	result := ClientRecoverDeletedKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return ClientRecoverDeletedKeyResponse{}, err
 	}
@@ -2913,7 +2909,7 @@ func (client *Client) recoverDeletedSasDefinitionCreateRequest(ctx context.Conte
 
 // recoverDeletedSasDefinitionHandleResponse handles the RecoverDeletedSasDefinition response.
 func (client *Client) recoverDeletedSasDefinitionHandleResponse(resp *http.Response) (ClientRecoverDeletedSasDefinitionResponse, error) {
-	result := ClientRecoverDeletedSasDefinitionResponse{RawResponse: resp}
+	result := ClientRecoverDeletedSasDefinitionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
 		return ClientRecoverDeletedSasDefinitionResponse{}, err
 	}
@@ -2963,7 +2959,7 @@ func (client *Client) recoverDeletedSecretCreateRequest(ctx context.Context, vau
 
 // recoverDeletedSecretHandleResponse handles the RecoverDeletedSecret response.
 func (client *Client) recoverDeletedSecretHandleResponse(resp *http.Response) (ClientRecoverDeletedSecretResponse, error) {
-	result := ClientRecoverDeletedSecretResponse{RawResponse: resp}
+	result := ClientRecoverDeletedSecretResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return ClientRecoverDeletedSecretResponse{}, err
 	}
@@ -3014,7 +3010,7 @@ func (client *Client) recoverDeletedStorageAccountCreateRequest(ctx context.Cont
 
 // recoverDeletedStorageAccountHandleResponse handles the RecoverDeletedStorageAccount response.
 func (client *Client) recoverDeletedStorageAccountHandleResponse(resp *http.Response) (ClientRecoverDeletedStorageAccountResponse, error) {
-	result := ClientRecoverDeletedStorageAccountResponse{RawResponse: resp}
+	result := ClientRecoverDeletedStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return ClientRecoverDeletedStorageAccountResponse{}, err
 	}
@@ -3066,7 +3062,7 @@ func (client *Client) regenerateStorageAccountKeyCreateRequest(ctx context.Conte
 
 // regenerateStorageAccountKeyHandleResponse handles the RegenerateStorageAccountKey response.
 func (client *Client) regenerateStorageAccountKeyHandleResponse(resp *http.Response) (ClientRegenerateStorageAccountKeyResponse, error) {
-	result := ClientRegenerateStorageAccountKeyResponse{RawResponse: resp}
+	result := ClientRegenerateStorageAccountKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return ClientRegenerateStorageAccountKeyResponse{}, err
 	}
@@ -3112,7 +3108,7 @@ func (client *Client) restoreCertificateCreateRequest(ctx context.Context, vault
 
 // restoreCertificateHandleResponse handles the RestoreCertificate response.
 func (client *Client) restoreCertificateHandleResponse(resp *http.Response) (ClientRestoreCertificateResponse, error) {
-	result := ClientRestoreCertificateResponse{RawResponse: resp}
+	result := ClientRestoreCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return ClientRestoreCertificateResponse{}, err
 	}
@@ -3165,7 +3161,7 @@ func (client *Client) restoreKeyCreateRequest(ctx context.Context, vaultBaseURL 
 
 // restoreKeyHandleResponse handles the RestoreKey response.
 func (client *Client) restoreKeyHandleResponse(resp *http.Response) (ClientRestoreKeyResponse, error) {
-	result := ClientRestoreKeyResponse{RawResponse: resp}
+	result := ClientRestoreKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return ClientRestoreKeyResponse{}, err
 	}
@@ -3211,7 +3207,7 @@ func (client *Client) restoreSecretCreateRequest(ctx context.Context, vaultBaseU
 
 // restoreSecretHandleResponse handles the RestoreSecret response.
 func (client *Client) restoreSecretHandleResponse(resp *http.Response) (ClientRestoreSecretResponse, error) {
-	result := ClientRestoreSecretResponse{RawResponse: resp}
+	result := ClientRestoreSecretResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return ClientRestoreSecretResponse{}, err
 	}
@@ -3260,7 +3256,7 @@ func (client *Client) restoreStatusCreateRequest(ctx context.Context, vaultBaseU
 
 // restoreStatusHandleResponse handles the RestoreStatus response.
 func (client *Client) restoreStatusHandleResponse(resp *http.Response) (ClientRestoreStatusResponse, error) {
-	result := ClientRestoreStatusResponse{RawResponse: resp}
+	result := ClientRestoreStatusResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RestoreOperation); err != nil {
 		return ClientRestoreStatusResponse{}, err
 	}
@@ -3305,7 +3301,7 @@ func (client *Client) restoreStorageAccountCreateRequest(ctx context.Context, va
 
 // restoreStorageAccountHandleResponse handles the RestoreStorageAccount response.
 func (client *Client) restoreStorageAccountHandleResponse(resp *http.Response) (ClientRestoreStorageAccountResponse, error) {
-	result := ClientRestoreStorageAccountResponse{RawResponse: resp}
+	result := ClientRestoreStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return ClientRestoreStorageAccountResponse{}, err
 	}
@@ -3324,9 +3320,7 @@ func (client *Client) BeginSelectiveKeyRestoreOperation(ctx context.Context, vau
 	if err != nil {
 		return ClientSelectiveKeyRestoreOperationPollerResponse{}, err
 	}
-	result := ClientSelectiveKeyRestoreOperationPollerResponse{
-		RawResponse: resp,
-	}
+	result := ClientSelectiveKeyRestoreOperationPollerResponse{}
 	pt, err := runtime.NewPoller("Client.SelectiveKeyRestoreOperation", resp, client.pl)
 	if err != nil {
 		return ClientSelectiveKeyRestoreOperationPollerResponse{}, err
@@ -3417,7 +3411,7 @@ func (client *Client) setCertificateContactsCreateRequest(ctx context.Context, v
 
 // setCertificateContactsHandleResponse handles the SetCertificateContacts response.
 func (client *Client) setCertificateContactsHandleResponse(resp *http.Response) (ClientSetCertificateContactsResponse, error) {
-	result := ClientSetCertificateContactsResponse{RawResponse: resp}
+	result := ClientSetCertificateContactsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
 		return ClientSetCertificateContactsResponse{}, err
 	}
@@ -3468,7 +3462,7 @@ func (client *Client) setCertificateIssuerCreateRequest(ctx context.Context, vau
 
 // setCertificateIssuerHandleResponse handles the SetCertificateIssuer response.
 func (client *Client) setCertificateIssuerHandleResponse(resp *http.Response) (ClientSetCertificateIssuerResponse, error) {
-	result := ClientSetCertificateIssuerResponse{RawResponse: resp}
+	result := ClientSetCertificateIssuerResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
 		return ClientSetCertificateIssuerResponse{}, err
 	}
@@ -3524,7 +3518,7 @@ func (client *Client) setSasDefinitionCreateRequest(ctx context.Context, vaultBa
 
 // setSasDefinitionHandleResponse handles the SetSasDefinition response.
 func (client *Client) setSasDefinitionHandleResponse(resp *http.Response) (ClientSetSasDefinitionResponse, error) {
-	result := ClientSetSasDefinitionResponse{RawResponse: resp}
+	result := ClientSetSasDefinitionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
 		return ClientSetSasDefinitionResponse{}, err
 	}
@@ -3575,7 +3569,7 @@ func (client *Client) setSecretCreateRequest(ctx context.Context, vaultBaseURL s
 
 // setSecretHandleResponse handles the SetSecret response.
 func (client *Client) setSecretHandleResponse(resp *http.Response) (ClientSetSecretResponse, error) {
-	result := ClientSetSecretResponse{RawResponse: resp}
+	result := ClientSetSecretResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return ClientSetSecretResponse{}, err
 	}
@@ -3625,7 +3619,7 @@ func (client *Client) setStorageAccountCreateRequest(ctx context.Context, vaultB
 
 // setStorageAccountHandleResponse handles the SetStorageAccount response.
 func (client *Client) setStorageAccountHandleResponse(resp *http.Response) (ClientSetStorageAccountResponse, error) {
-	result := ClientSetStorageAccountResponse{RawResponse: resp}
+	result := ClientSetStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return ClientSetStorageAccountResponse{}, err
 	}
@@ -3681,7 +3675,7 @@ func (client *Client) signCreateRequest(ctx context.Context, vaultBaseURL string
 
 // signHandleResponse handles the Sign response.
 func (client *Client) signHandleResponse(resp *http.Response) (ClientSignResponse, error) {
-	result := ClientSignResponse{RawResponse: resp}
+	result := ClientSignResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return ClientSignResponse{}, err
 	}
@@ -3739,7 +3733,7 @@ func (client *Client) unwrapKeyCreateRequest(ctx context.Context, vaultBaseURL s
 
 // unwrapKeyHandleResponse handles the UnwrapKey response.
 func (client *Client) unwrapKeyHandleResponse(resp *http.Response) (ClientUnwrapKeyResponse, error) {
-	result := ClientUnwrapKeyResponse{RawResponse: resp}
+	result := ClientUnwrapKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return ClientUnwrapKeyResponse{}, err
 	}
@@ -3796,7 +3790,7 @@ func (client *Client) updateCertificateCreateRequest(ctx context.Context, vaultB
 
 // updateCertificateHandleResponse handles the UpdateCertificate response.
 func (client *Client) updateCertificateHandleResponse(resp *http.Response) (ClientUpdateCertificateResponse, error) {
-	result := ClientUpdateCertificateResponse{RawResponse: resp}
+	result := ClientUpdateCertificateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
 		return ClientUpdateCertificateResponse{}, err
 	}
@@ -3848,7 +3842,7 @@ func (client *Client) updateCertificateIssuerCreateRequest(ctx context.Context, 
 
 // updateCertificateIssuerHandleResponse handles the UpdateCertificateIssuer response.
 func (client *Client) updateCertificateIssuerHandleResponse(resp *http.Response) (ClientUpdateCertificateIssuerResponse, error) {
-	result := ClientUpdateCertificateIssuerResponse{RawResponse: resp}
+	result := ClientUpdateCertificateIssuerResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
 		return ClientUpdateCertificateIssuerResponse{}, err
 	}
@@ -3900,7 +3894,7 @@ func (client *Client) updateCertificateOperationCreateRequest(ctx context.Contex
 
 // updateCertificateOperationHandleResponse handles the UpdateCertificateOperation response.
 func (client *Client) updateCertificateOperationHandleResponse(resp *http.Response) (ClientUpdateCertificateOperationResponse, error) {
-	result := ClientUpdateCertificateOperationResponse{RawResponse: resp}
+	result := ClientUpdateCertificateOperationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
 		return ClientUpdateCertificateOperationResponse{}, err
 	}
@@ -3952,7 +3946,7 @@ func (client *Client) updateCertificatePolicyCreateRequest(ctx context.Context, 
 
 // updateCertificatePolicyHandleResponse handles the UpdateCertificatePolicy response.
 func (client *Client) updateCertificatePolicyHandleResponse(resp *http.Response) (ClientUpdateCertificatePolicyResponse, error) {
-	result := ClientUpdateCertificatePolicyResponse{RawResponse: resp}
+	result := ClientUpdateCertificatePolicyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificatePolicy); err != nil {
 		return ClientUpdateCertificatePolicyResponse{}, err
 	}
@@ -4008,7 +4002,7 @@ func (client *Client) updateKeyCreateRequest(ctx context.Context, vaultBaseURL s
 
 // updateKeyHandleResponse handles the UpdateKey response.
 func (client *Client) updateKeyHandleResponse(resp *http.Response) (ClientUpdateKeyResponse, error) {
-	result := ClientUpdateKeyResponse{RawResponse: resp}
+	result := ClientUpdateKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
 		return ClientUpdateKeyResponse{}, err
 	}
@@ -4064,7 +4058,7 @@ func (client *Client) updateSasDefinitionCreateRequest(ctx context.Context, vaul
 
 // updateSasDefinitionHandleResponse handles the UpdateSasDefinition response.
 func (client *Client) updateSasDefinitionHandleResponse(resp *http.Response) (ClientUpdateSasDefinitionResponse, error) {
-	result := ClientUpdateSasDefinitionResponse{RawResponse: resp}
+	result := ClientUpdateSasDefinitionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
 		return ClientUpdateSasDefinitionResponse{}, err
 	}
@@ -4121,7 +4115,7 @@ func (client *Client) updateSecretCreateRequest(ctx context.Context, vaultBaseUR
 
 // updateSecretHandleResponse handles the UpdateSecret response.
 func (client *Client) updateSecretHandleResponse(resp *http.Response) (ClientUpdateSecretResponse, error) {
-	result := ClientUpdateSecretResponse{RawResponse: resp}
+	result := ClientUpdateSecretResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
 		return ClientUpdateSecretResponse{}, err
 	}
@@ -4172,7 +4166,7 @@ func (client *Client) updateStorageAccountCreateRequest(ctx context.Context, vau
 
 // updateStorageAccountHandleResponse handles the UpdateStorageAccount response.
 func (client *Client) updateStorageAccountHandleResponse(resp *http.Response) (ClientUpdateStorageAccountResponse, error) {
-	result := ClientUpdateStorageAccountResponse{RawResponse: resp}
+	result := ClientUpdateStorageAccountResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
 		return ClientUpdateStorageAccountResponse{}, err
 	}
@@ -4231,7 +4225,7 @@ func (client *Client) verifyCreateRequest(ctx context.Context, vaultBaseURL stri
 
 // verifyHandleResponse handles the Verify response.
 func (client *Client) verifyHandleResponse(resp *http.Response) (ClientVerifyResponse, error) {
-	result := ClientVerifyResponse{RawResponse: resp}
+	result := ClientVerifyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyVerifyResult); err != nil {
 		return ClientVerifyResponse{}, err
 	}
@@ -4291,7 +4285,7 @@ func (client *Client) wrapKeyCreateRequest(ctx context.Context, vaultBaseURL str
 
 // wrapKeyHandleResponse handles the WrapKey response.
 func (client *Client) wrapKeyHandleResponse(resp *http.Response) (ClientWrapKeyResponse, error) {
-	result := ClientWrapKeyResponse{RawResponse: resp}
+	result := ClientWrapKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
 		return ClientWrapKeyResponse{}, err
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
@@ -44,9 +44,7 @@ func (client *HSMSecurityDomainClient) BeginDownload(ctx context.Context, vaultB
 	if err != nil {
 		return HSMSecurityDomainClientDownloadPollerResponse{}, err
 	}
-	result := HSMSecurityDomainClientDownloadPollerResponse{
-		RawResponse: resp,
-	}
+	result := HSMSecurityDomainClientDownloadPollerResponse{}
 	pt, err := runtime.NewPoller("HSMSecurityDomainClient.Download", resp, client.pl)
 	if err != nil {
 		return HSMSecurityDomainClientDownloadPollerResponse{}, err
@@ -126,7 +124,7 @@ func (client *HSMSecurityDomainClient) downloadPendingCreateRequest(ctx context.
 
 // downloadPendingHandleResponse handles the DownloadPending response.
 func (client *HSMSecurityDomainClient) downloadPendingHandleResponse(resp *http.Response) (HSMSecurityDomainClientDownloadPendingResponse, error) {
-	result := HSMSecurityDomainClientDownloadPendingResponse{RawResponse: resp}
+	result := HSMSecurityDomainClientDownloadPendingResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityDomainOperationStatus); err != nil {
 		return HSMSecurityDomainClientDownloadPendingResponse{}, err
 	}
@@ -171,7 +169,7 @@ func (client *HSMSecurityDomainClient) transferKeyCreateRequest(ctx context.Cont
 
 // transferKeyHandleResponse handles the TransferKey response.
 func (client *HSMSecurityDomainClient) transferKeyHandleResponse(resp *http.Response) (HSMSecurityDomainClientTransferKeyResponse, error) {
-	result := HSMSecurityDomainClientTransferKeyResponse{RawResponse: resp}
+	result := HSMSecurityDomainClientTransferKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TransferKey); err != nil {
 		return HSMSecurityDomainClientTransferKeyResponse{}, err
 	}
@@ -189,9 +187,7 @@ func (client *HSMSecurityDomainClient) BeginUpload(ctx context.Context, vaultBas
 	if err != nil {
 		return HSMSecurityDomainClientUploadPollerResponse{}, err
 	}
-	result := HSMSecurityDomainClientUploadPollerResponse{
-		RawResponse: resp,
-	}
+	result := HSMSecurityDomainClientUploadPollerResponse{}
 	pt, err := runtime.NewPoller("HSMSecurityDomainClient.Upload", resp, client.pl)
 	if err != nil {
 		return HSMSecurityDomainClientUploadPollerResponse{}, err
@@ -267,7 +263,7 @@ func (client *HSMSecurityDomainClient) uploadPendingCreateRequest(ctx context.Co
 
 // uploadPendingHandleResponse handles the UploadPending response.
 func (client *HSMSecurityDomainClient) uploadPendingHandleResponse(resp *http.Response) (HSMSecurityDomainClientUploadPendingResponse, error) {
-	result := HSMSecurityDomainClientUploadPendingResponse{RawResponse: resp}
+	result := HSMSecurityDomainClientUploadPendingResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityDomainOperationStatus); err != nil {
 		return HSMSecurityDomainClientUploadPendingResponse{}, err
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_generated_pollers.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_pollers.go
@@ -43,11 +43,10 @@ func (p *ClientFullBackupPoller) Poll(ctx context.Context) (*http.Response, erro
 // If the final GET succeeded then the final ClientFullBackupResponse will be returned.
 func (p *ClientFullBackupPoller) FinalResponse(ctx context.Context) (ClientFullBackupResponse, error) {
 	respType := ClientFullBackupResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.FullBackupOperation)
+	_, err := p.pt.FinalResponse(ctx, &respType.FullBackupOperation)
 	if err != nil {
 		return ClientFullBackupResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -86,11 +85,10 @@ func (p *ClientFullRestoreOperationPoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final ClientFullRestoreOperationResponse will be returned.
 func (p *ClientFullRestoreOperationPoller) FinalResponse(ctx context.Context) (ClientFullRestoreOperationResponse, error) {
 	respType := ClientFullRestoreOperationResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.RestoreOperation)
+	_, err := p.pt.FinalResponse(ctx, &respType.RestoreOperation)
 	if err != nil {
 		return ClientFullRestoreOperationResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -129,11 +127,10 @@ func (p *ClientSelectiveKeyRestoreOperationPoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final ClientSelectiveKeyRestoreOperationResponse will be returned.
 func (p *ClientSelectiveKeyRestoreOperationPoller) FinalResponse(ctx context.Context) (ClientSelectiveKeyRestoreOperationResponse, error) {
 	respType := ClientSelectiveKeyRestoreOperationResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SelectiveKeyRestoreOperation)
+	_, err := p.pt.FinalResponse(ctx, &respType.SelectiveKeyRestoreOperation)
 	if err != nil {
 		return ClientSelectiveKeyRestoreOperationResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -172,11 +169,10 @@ func (p *HSMSecurityDomainClientDownloadPoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final HSMSecurityDomainClientDownloadResponse will be returned.
 func (p *HSMSecurityDomainClientDownloadPoller) FinalResponse(ctx context.Context) (HSMSecurityDomainClientDownloadResponse, error) {
 	respType := HSMSecurityDomainClientDownloadResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SecurityDomainObject)
+	_, err := p.pt.FinalResponse(ctx, &respType.SecurityDomainObject)
 	if err != nil {
 		return HSMSecurityDomainClientDownloadResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -215,11 +211,10 @@ func (p *HSMSecurityDomainClientUploadPoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final HSMSecurityDomainClientUploadResponse will be returned.
 func (p *HSMSecurityDomainClientUploadPoller) FinalResponse(ctx context.Context) (HSMSecurityDomainClientUploadResponse, error) {
 	respType := HSMSecurityDomainClientUploadResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SecurityDomainOperationStatus)
+	_, err := p.pt.FinalResponse(ctx, &respType.SecurityDomainOperationStatus)
 	if err != nil {
 		return HSMSecurityDomainClientUploadResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 

--- a/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
@@ -11,140 +11,103 @@ package azkeyvault
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"net/http"
 	"time"
 )
 
 // ClientBackupCertificateResponse contains the response from method Client.BackupCertificate.
 type ClientBackupCertificateResponse struct {
 	BackupCertificateResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientBackupKeyResponse contains the response from method Client.BackupKey.
 type ClientBackupKeyResponse struct {
 	BackupKeyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientBackupSecretResponse contains the response from method Client.BackupSecret.
 type ClientBackupSecretResponse struct {
 	BackupSecretResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientBackupStorageAccountResponse contains the response from method Client.BackupStorageAccount.
 type ClientBackupStorageAccountResponse struct {
 	BackupStorageResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientCreateCertificateResponse contains the response from method Client.CreateCertificate.
 type ClientCreateCertificateResponse struct {
 	CertificateOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientCreateKeyResponse contains the response from method Client.CreateKey.
 type ClientCreateKeyResponse struct {
 	KeyBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDecryptResponse contains the response from method Client.Decrypt.
 type ClientDecryptResponse struct {
 	KeyOperationResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDeleteCertificateContactsResponse contains the response from method Client.DeleteCertificateContacts.
 type ClientDeleteCertificateContactsResponse struct {
 	Contacts
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDeleteCertificateIssuerResponse contains the response from method Client.DeleteCertificateIssuer.
 type ClientDeleteCertificateIssuerResponse struct {
 	IssuerBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDeleteCertificateOperationResponse contains the response from method Client.DeleteCertificateOperation.
 type ClientDeleteCertificateOperationResponse struct {
 	CertificateOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDeleteCertificateResponse contains the response from method Client.DeleteCertificate.
 type ClientDeleteCertificateResponse struct {
 	DeletedCertificateBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDeleteKeyResponse contains the response from method Client.DeleteKey.
 type ClientDeleteKeyResponse struct {
 	DeletedKeyBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDeleteSasDefinitionResponse contains the response from method Client.DeleteSasDefinition.
 type ClientDeleteSasDefinitionResponse struct {
 	DeletedSasDefinitionBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDeleteSecretResponse contains the response from method Client.DeleteSecret.
 type ClientDeleteSecretResponse struct {
 	DeletedSecretBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientDeleteStorageAccountResponse contains the response from method Client.DeleteStorageAccount.
 type ClientDeleteStorageAccountResponse struct {
 	DeletedStorageBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientEncryptResponse contains the response from method Client.Encrypt.
 type ClientEncryptResponse struct {
 	KeyOperationResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientFullBackupPollerResponse contains the response from method Client.FullBackup.
 type ClientFullBackupPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ClientFullBackupPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l ClientFullBackupPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ClientFullBackupResponse, error) {
 	respType := ClientFullBackupResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FullBackupOperation)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FullBackupOperation)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -157,47 +120,38 @@ func (l *ClientFullBackupPollerResponse) Resume(ctx context.Context, client *Cli
 	poller := &ClientFullBackupPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ClientFullBackupResponse contains the response from method Client.FullBackup.
 type ClientFullBackupResponse struct {
 	FullBackupOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientFullBackupStatusResponse contains the response from method Client.FullBackupStatus.
 type ClientFullBackupStatusResponse struct {
 	FullBackupOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientFullRestoreOperationPollerResponse contains the response from method Client.FullRestoreOperation.
 type ClientFullRestoreOperationPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ClientFullRestoreOperationPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l ClientFullRestoreOperationPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ClientFullRestoreOperationResponse, error) {
 	respType := ClientFullRestoreOperationResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RestoreOperation)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RestoreOperation)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -210,358 +164,263 @@ func (l *ClientFullRestoreOperationPollerResponse) Resume(ctx context.Context, c
 	poller := &ClientFullRestoreOperationPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ClientFullRestoreOperationResponse contains the response from method Client.FullRestoreOperation.
 type ClientFullRestoreOperationResponse struct {
 	RestoreOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetCertificateContactsResponse contains the response from method Client.GetCertificateContacts.
 type ClientGetCertificateContactsResponse struct {
 	Contacts
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetCertificateIssuerResponse contains the response from method Client.GetCertificateIssuer.
 type ClientGetCertificateIssuerResponse struct {
 	IssuerBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetCertificateIssuersResponse contains the response from method Client.GetCertificateIssuers.
 type ClientGetCertificateIssuersResponse struct {
 	CertificateIssuerListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetCertificateOperationResponse contains the response from method Client.GetCertificateOperation.
 type ClientGetCertificateOperationResponse struct {
 	CertificateOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetCertificatePolicyResponse contains the response from method Client.GetCertificatePolicy.
 type ClientGetCertificatePolicyResponse struct {
 	CertificatePolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetCertificateResponse contains the response from method Client.GetCertificate.
 type ClientGetCertificateResponse struct {
 	CertificateBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetCertificateVersionsResponse contains the response from method Client.GetCertificateVersions.
 type ClientGetCertificateVersionsResponse struct {
 	CertificateListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetCertificatesResponse contains the response from method Client.GetCertificates.
 type ClientGetCertificatesResponse struct {
 	CertificateListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedCertificateResponse contains the response from method Client.GetDeletedCertificate.
 type ClientGetDeletedCertificateResponse struct {
 	DeletedCertificateBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedCertificatesResponse contains the response from method Client.GetDeletedCertificates.
 type ClientGetDeletedCertificatesResponse struct {
 	DeletedCertificateListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedKeyResponse contains the response from method Client.GetDeletedKey.
 type ClientGetDeletedKeyResponse struct {
 	DeletedKeyBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedKeysResponse contains the response from method Client.GetDeletedKeys.
 type ClientGetDeletedKeysResponse struct {
 	DeletedKeyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedSasDefinitionResponse contains the response from method Client.GetDeletedSasDefinition.
 type ClientGetDeletedSasDefinitionResponse struct {
 	DeletedSasDefinitionBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedSasDefinitionsResponse contains the response from method Client.GetDeletedSasDefinitions.
 type ClientGetDeletedSasDefinitionsResponse struct {
 	DeletedSasDefinitionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedSecretResponse contains the response from method Client.GetDeletedSecret.
 type ClientGetDeletedSecretResponse struct {
 	DeletedSecretBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedSecretsResponse contains the response from method Client.GetDeletedSecrets.
 type ClientGetDeletedSecretsResponse struct {
 	DeletedSecretListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedStorageAccountResponse contains the response from method Client.GetDeletedStorageAccount.
 type ClientGetDeletedStorageAccountResponse struct {
 	DeletedStorageBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetDeletedStorageAccountsResponse contains the response from method Client.GetDeletedStorageAccounts.
 type ClientGetDeletedStorageAccountsResponse struct {
 	DeletedStorageListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetKeyResponse contains the response from method Client.GetKey.
 type ClientGetKeyResponse struct {
 	KeyBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetKeyVersionsResponse contains the response from method Client.GetKeyVersions.
 type ClientGetKeyVersionsResponse struct {
 	KeyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetKeysResponse contains the response from method Client.GetKeys.
 type ClientGetKeysResponse struct {
 	KeyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetSasDefinitionResponse contains the response from method Client.GetSasDefinition.
 type ClientGetSasDefinitionResponse struct {
 	SasDefinitionBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetSasDefinitionsResponse contains the response from method Client.GetSasDefinitions.
 type ClientGetSasDefinitionsResponse struct {
 	SasDefinitionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetSecretResponse contains the response from method Client.GetSecret.
 type ClientGetSecretResponse struct {
 	SecretBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetSecretVersionsResponse contains the response from method Client.GetSecretVersions.
 type ClientGetSecretVersionsResponse struct {
 	SecretListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetSecretsResponse contains the response from method Client.GetSecrets.
 type ClientGetSecretsResponse struct {
 	SecretListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetStorageAccountResponse contains the response from method Client.GetStorageAccount.
 type ClientGetStorageAccountResponse struct {
 	StorageBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientGetStorageAccountsResponse contains the response from method Client.GetStorageAccounts.
 type ClientGetStorageAccountsResponse struct {
 	StorageListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientImportCertificateResponse contains the response from method Client.ImportCertificate.
 type ClientImportCertificateResponse struct {
 	CertificateBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientImportKeyResponse contains the response from method Client.ImportKey.
 type ClientImportKeyResponse struct {
 	KeyBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientMergeCertificateResponse contains the response from method Client.MergeCertificate.
 type ClientMergeCertificateResponse struct {
 	CertificateBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientPurgeDeletedCertificateResponse contains the response from method Client.PurgeDeletedCertificate.
 type ClientPurgeDeletedCertificateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ClientPurgeDeletedKeyResponse contains the response from method Client.PurgeDeletedKey.
 type ClientPurgeDeletedKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ClientPurgeDeletedSecretResponse contains the response from method Client.PurgeDeletedSecret.
 type ClientPurgeDeletedSecretResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ClientPurgeDeletedStorageAccountResponse contains the response from method Client.PurgeDeletedStorageAccount.
 type ClientPurgeDeletedStorageAccountResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ClientRecoverDeletedCertificateResponse contains the response from method Client.RecoverDeletedCertificate.
 type ClientRecoverDeletedCertificateResponse struct {
 	CertificateBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRecoverDeletedKeyResponse contains the response from method Client.RecoverDeletedKey.
 type ClientRecoverDeletedKeyResponse struct {
 	KeyBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRecoverDeletedSasDefinitionResponse contains the response from method Client.RecoverDeletedSasDefinition.
 type ClientRecoverDeletedSasDefinitionResponse struct {
 	SasDefinitionBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRecoverDeletedSecretResponse contains the response from method Client.RecoverDeletedSecret.
 type ClientRecoverDeletedSecretResponse struct {
 	SecretBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRecoverDeletedStorageAccountResponse contains the response from method Client.RecoverDeletedStorageAccount.
 type ClientRecoverDeletedStorageAccountResponse struct {
 	StorageBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRegenerateStorageAccountKeyResponse contains the response from method Client.RegenerateStorageAccountKey.
 type ClientRegenerateStorageAccountKeyResponse struct {
 	StorageBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRestoreCertificateResponse contains the response from method Client.RestoreCertificate.
 type ClientRestoreCertificateResponse struct {
 	CertificateBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRestoreKeyResponse contains the response from method Client.RestoreKey.
 type ClientRestoreKeyResponse struct {
 	KeyBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRestoreSecretResponse contains the response from method Client.RestoreSecret.
 type ClientRestoreSecretResponse struct {
 	SecretBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRestoreStatusResponse contains the response from method Client.RestoreStatus.
 type ClientRestoreStatusResponse struct {
 	RestoreOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientRestoreStorageAccountResponse contains the response from method Client.RestoreStorageAccount.
 type ClientRestoreStorageAccountResponse struct {
 	StorageBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientSelectiveKeyRestoreOperationPollerResponse contains the response from method Client.SelectiveKeyRestoreOperation.
 type ClientSelectiveKeyRestoreOperationPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ClientSelectiveKeyRestoreOperationPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l ClientSelectiveKeyRestoreOperationPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ClientSelectiveKeyRestoreOperationResponse, error) {
 	respType := ClientSelectiveKeyRestoreOperationResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SelectiveKeyRestoreOperation)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SelectiveKeyRestoreOperation)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -574,166 +433,123 @@ func (l *ClientSelectiveKeyRestoreOperationPollerResponse) Resume(ctx context.Co
 	poller := &ClientSelectiveKeyRestoreOperationPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ClientSelectiveKeyRestoreOperationResponse contains the response from method Client.SelectiveKeyRestoreOperation.
 type ClientSelectiveKeyRestoreOperationResponse struct {
 	SelectiveKeyRestoreOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientSetCertificateContactsResponse contains the response from method Client.SetCertificateContacts.
 type ClientSetCertificateContactsResponse struct {
 	Contacts
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientSetCertificateIssuerResponse contains the response from method Client.SetCertificateIssuer.
 type ClientSetCertificateIssuerResponse struct {
 	IssuerBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientSetSasDefinitionResponse contains the response from method Client.SetSasDefinition.
 type ClientSetSasDefinitionResponse struct {
 	SasDefinitionBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientSetSecretResponse contains the response from method Client.SetSecret.
 type ClientSetSecretResponse struct {
 	SecretBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientSetStorageAccountResponse contains the response from method Client.SetStorageAccount.
 type ClientSetStorageAccountResponse struct {
 	StorageBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientSignResponse contains the response from method Client.Sign.
 type ClientSignResponse struct {
 	KeyOperationResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUnwrapKeyResponse contains the response from method Client.UnwrapKey.
 type ClientUnwrapKeyResponse struct {
 	KeyOperationResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUpdateCertificateIssuerResponse contains the response from method Client.UpdateCertificateIssuer.
 type ClientUpdateCertificateIssuerResponse struct {
 	IssuerBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUpdateCertificateOperationResponse contains the response from method Client.UpdateCertificateOperation.
 type ClientUpdateCertificateOperationResponse struct {
 	CertificateOperation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUpdateCertificatePolicyResponse contains the response from method Client.UpdateCertificatePolicy.
 type ClientUpdateCertificatePolicyResponse struct {
 	CertificatePolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUpdateCertificateResponse contains the response from method Client.UpdateCertificate.
 type ClientUpdateCertificateResponse struct {
 	CertificateBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUpdateKeyResponse contains the response from method Client.UpdateKey.
 type ClientUpdateKeyResponse struct {
 	KeyBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUpdateSasDefinitionResponse contains the response from method Client.UpdateSasDefinition.
 type ClientUpdateSasDefinitionResponse struct {
 	SasDefinitionBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUpdateSecretResponse contains the response from method Client.UpdateSecret.
 type ClientUpdateSecretResponse struct {
 	SecretBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientUpdateStorageAccountResponse contains the response from method Client.UpdateStorageAccount.
 type ClientUpdateStorageAccountResponse struct {
 	StorageBundle
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientVerifyResponse contains the response from method Client.Verify.
 type ClientVerifyResponse struct {
 	KeyVerifyResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ClientWrapKeyResponse contains the response from method Client.WrapKey.
 type ClientWrapKeyResponse struct {
 	KeyOperationResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HSMSecurityDomainClientDownloadPendingResponse contains the response from method HSMSecurityDomainClient.DownloadPending.
 type HSMSecurityDomainClientDownloadPendingResponse struct {
 	SecurityDomainOperationStatus
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HSMSecurityDomainClientDownloadPollerResponse contains the response from method HSMSecurityDomainClient.Download.
 type HSMSecurityDomainClientDownloadPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *HSMSecurityDomainClientDownloadPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l HSMSecurityDomainClientDownloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (HSMSecurityDomainClientDownloadResponse, error) {
 	respType := HSMSecurityDomainClientDownloadResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityDomainObject)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityDomainObject)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -746,54 +562,43 @@ func (l *HSMSecurityDomainClientDownloadPollerResponse) Resume(ctx context.Conte
 	poller := &HSMSecurityDomainClientDownloadPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // HSMSecurityDomainClientDownloadResponse contains the response from method HSMSecurityDomainClient.Download.
 type HSMSecurityDomainClientDownloadResponse struct {
 	SecurityDomainObject
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HSMSecurityDomainClientTransferKeyResponse contains the response from method HSMSecurityDomainClient.TransferKey.
 type HSMSecurityDomainClientTransferKeyResponse struct {
 	TransferKey
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HSMSecurityDomainClientUploadPendingResponse contains the response from method HSMSecurityDomainClient.UploadPending.
 type HSMSecurityDomainClientUploadPendingResponse struct {
 	SecurityDomainOperationStatus
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HSMSecurityDomainClientUploadPollerResponse contains the response from method HSMSecurityDomainClient.Upload.
 type HSMSecurityDomainClientUploadPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *HSMSecurityDomainClientUploadPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l HSMSecurityDomainClientUploadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (HSMSecurityDomainClientUploadResponse, error) {
 	respType := HSMSecurityDomainClientUploadResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityDomainOperationStatus)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityDomainOperationStatus)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -806,74 +611,55 @@ func (l *HSMSecurityDomainClientUploadPollerResponse) Resume(ctx context.Context
 	poller := &HSMSecurityDomainClientUploadPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // HSMSecurityDomainClientUploadResponse contains the response from method HSMSecurityDomainClient.Upload.
 type HSMSecurityDomainClientUploadResponse struct {
 	SecurityDomainOperationStatus
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoleAssignmentsClientCreateResponse contains the response from method RoleAssignmentsClient.Create.
 type RoleAssignmentsClientCreateResponse struct {
 	RoleAssignment
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoleAssignmentsClientDeleteResponse contains the response from method RoleAssignmentsClient.Delete.
 type RoleAssignmentsClientDeleteResponse struct {
 	RoleAssignment
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoleAssignmentsClientGetResponse contains the response from method RoleAssignmentsClient.Get.
 type RoleAssignmentsClientGetResponse struct {
 	RoleAssignment
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoleAssignmentsClientListForScopeResponse contains the response from method RoleAssignmentsClient.ListForScope.
 type RoleAssignmentsClientListForScopeResponse struct {
 	RoleAssignmentListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoleDefinitionsClientCreateOrUpdateResponse contains the response from method RoleDefinitionsClient.CreateOrUpdate.
 type RoleDefinitionsClientCreateOrUpdateResponse struct {
 	RoleDefinition
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoleDefinitionsClientDeleteResponse contains the response from method RoleDefinitionsClient.Delete.
 type RoleDefinitionsClientDeleteResponse struct {
 	RoleDefinition
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoleDefinitionsClientGetResponse contains the response from method RoleDefinitionsClient.Get.
 type RoleDefinitionsClientGetResponse struct {
 	RoleDefinition
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoleDefinitionsClientListResponse contains the response from method RoleDefinitionsClient.List.
 type RoleDefinitionsClientListResponse struct {
 	RoleDefinitionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
@@ -78,7 +78,7 @@ func (client *RoleAssignmentsClient) createCreateRequest(ctx context.Context, va
 
 // createHandleResponse handles the Create response.
 func (client *RoleAssignmentsClient) createHandleResponse(resp *http.Response) (RoleAssignmentsClientCreateResponse, error) {
-	result := RoleAssignmentsClientCreateResponse{RawResponse: resp}
+	result := RoleAssignmentsClientCreateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleAssignment); err != nil {
 		return RoleAssignmentsClientCreateResponse{}, err
 	}
@@ -129,7 +129,7 @@ func (client *RoleAssignmentsClient) deleteCreateRequest(ctx context.Context, va
 
 // deleteHandleResponse handles the Delete response.
 func (client *RoleAssignmentsClient) deleteHandleResponse(resp *http.Response) (RoleAssignmentsClientDeleteResponse, error) {
-	result := RoleAssignmentsClientDeleteResponse{RawResponse: resp}
+	result := RoleAssignmentsClientDeleteResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleAssignment); err != nil {
 		return RoleAssignmentsClientDeleteResponse{}, err
 	}
@@ -180,7 +180,7 @@ func (client *RoleAssignmentsClient) getCreateRequest(ctx context.Context, vault
 
 // getHandleResponse handles the Get response.
 func (client *RoleAssignmentsClient) getHandleResponse(resp *http.Response) (RoleAssignmentsClientGetResponse, error) {
-	result := RoleAssignmentsClientGetResponse{RawResponse: resp}
+	result := RoleAssignmentsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleAssignment); err != nil {
 		return RoleAssignmentsClientGetResponse{}, err
 	}
@@ -227,7 +227,7 @@ func (client *RoleAssignmentsClient) listForScopeCreateRequest(ctx context.Conte
 
 // listForScopeHandleResponse handles the ListForScope response.
 func (client *RoleAssignmentsClient) listForScopeHandleResponse(resp *http.Response) (RoleAssignmentsClientListForScopeResponse, error) {
-	result := RoleAssignmentsClientListForScopeResponse{RawResponse: resp}
+	result := RoleAssignmentsClientListForScopeResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleAssignmentListResult); err != nil {
 		return RoleAssignmentsClientListForScopeResponse{}, err
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
@@ -79,7 +79,7 @@ func (client *RoleDefinitionsClient) createOrUpdateCreateRequest(ctx context.Con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *RoleDefinitionsClient) createOrUpdateHandleResponse(resp *http.Response) (RoleDefinitionsClientCreateOrUpdateResponse, error) {
-	result := RoleDefinitionsClientCreateOrUpdateResponse{RawResponse: resp}
+	result := RoleDefinitionsClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleDefinition); err != nil {
 		return RoleDefinitionsClientCreateOrUpdateResponse{}, err
 	}
@@ -130,7 +130,7 @@ func (client *RoleDefinitionsClient) deleteCreateRequest(ctx context.Context, va
 
 // deleteHandleResponse handles the Delete response.
 func (client *RoleDefinitionsClient) deleteHandleResponse(resp *http.Response) (RoleDefinitionsClientDeleteResponse, error) {
-	result := RoleDefinitionsClientDeleteResponse{RawResponse: resp}
+	result := RoleDefinitionsClientDeleteResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleDefinition); err != nil {
 		return RoleDefinitionsClientDeleteResponse{}, err
 	}
@@ -181,7 +181,7 @@ func (client *RoleDefinitionsClient) getCreateRequest(ctx context.Context, vault
 
 // getHandleResponse handles the Get response.
 func (client *RoleDefinitionsClient) getHandleResponse(resp *http.Response) (RoleDefinitionsClientGetResponse, error) {
-	result := RoleDefinitionsClientGetResponse{RawResponse: resp}
+	result := RoleDefinitionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleDefinition); err != nil {
 		return RoleDefinitionsClientGetResponse{}, err
 	}
@@ -227,7 +227,7 @@ func (client *RoleDefinitionsClient) listCreateRequest(ctx context.Context, vaul
 
 // listHandleResponse handles the List response.
 func (client *RoleDefinitionsClient) listHandleResponse(resp *http.Response) (RoleDefinitionsClientListResponse, error) {
-	result := RoleDefinitionsClientListResponse{RawResponse: resp}
+	result := RoleDefinitionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleDefinitionListResult); err != nil {
 		return RoleDefinitionsClientListResponse{}, err
 	}

--- a/test/maps/azalias/zz_generated_client.go
+++ b/test/maps/azalias/zz_generated_client.go
@@ -117,7 +117,7 @@ func (client *client) createCreateRequest(ctx context.Context, options *clientCr
 
 // createHandleResponse handles the Create response.
 func (client *client) createHandleResponse(resp *http.Response) (clientCreateResponse, error) {
-	result := clientCreateResponse{RawResponse: resp}
+	result := clientCreateResponse{}
 	if val := resp.Header.Get("Access-Control-Expose-Headers"); val != "" {
 		result.AccessControlExposeHeaders = &val
 	}
@@ -158,7 +158,7 @@ func (client *client) getScriptCreateRequest(ctx context.Context, props GeoJSONO
 
 // getScriptHandleResponse handles the GetScript response.
 func (client *client) getScriptHandleResponse(resp *http.Response) (clientGetScriptResponse, error) {
-	result := clientGetScriptResponse{RawResponse: resp}
+	result := clientGetScriptResponse{}
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return clientGetScriptResponse{}, err
@@ -221,7 +221,7 @@ func (client *client) listCreateRequest(ctx context.Context, options *clientList
 
 // listHandleResponse handles the List response.
 func (client *client) listHandleResponse(resp *http.Response) (clientListResponse, error) {
-	result := clientListResponse{RawResponse: resp}
+	result := clientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListResponse); err != nil {
 		return clientListResponse{}, err
 	}
@@ -259,7 +259,7 @@ func (client *client) policyAssignmentCreateRequest(ctx context.Context, props S
 
 // policyAssignmentHandleResponse handles the PolicyAssignment response.
 func (client *client) policyAssignmentHandleResponse(resp *http.Response) (clientPolicyAssignmentResponse, error) {
-	result := clientPolicyAssignmentResponse{RawResponse: resp}
+	result := clientPolicyAssignmentResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PolicyAssignmentProperties); err != nil {
 		return clientPolicyAssignmentResponse{}, err
 	}

--- a/test/maps/azalias/zz_generated_response_types.go
+++ b/test/maps/azalias/zz_generated_response_types.go
@@ -8,35 +8,24 @@
 
 package azalias
 
-import "net/http"
-
 // clientCreateResponse contains the response from method client.Create.
 type clientCreateResponse struct {
 	AliasesCreateResponse
 	// AccessControlExposeHeaders contains the information returned from the Access-Control-Expose-Headers header response.
 	AccessControlExposeHeaders *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // clientGetScriptResponse contains the response from method client.GetScript.
 type clientGetScriptResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // clientListResponse contains the response from method client.List.
 type clientListResponse struct {
 	ListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // clientPolicyAssignmentResponse contains the response from method client.PolicyAssignment.
 type clientPolicyAssignmentResponse struct {
 	PolicyAssignmentProperties
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
@@ -61,9 +61,7 @@ func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context,
 	if err != nil {
 		return ApplicationGatewaysClientBackendHealthPollerResponse{}, err
 	}
-	result := ApplicationGatewaysClientBackendHealthPollerResponse{
-		RawResponse: resp,
-	}
+	result := ApplicationGatewaysClientBackendHealthPollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.BackendHealth", "location", resp, client.pl)
 	if err != nil {
 		return ApplicationGatewaysClientBackendHealthPollerResponse{}, err
@@ -133,9 +131,7 @@ func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.
 	if err != nil {
 		return ApplicationGatewaysClientBackendHealthOnDemandPollerResponse{}, err
 	}
-	result := ApplicationGatewaysClientBackendHealthOnDemandPollerResponse{
-		RawResponse: resp,
-	}
+	result := ApplicationGatewaysClientBackendHealthOnDemandPollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.BackendHealthOnDemand", "location", resp, client.pl)
 	if err != nil {
 		return ApplicationGatewaysClientBackendHealthOnDemandPollerResponse{}, err
@@ -205,9 +201,7 @@ func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context
 	if err != nil {
 		return ApplicationGatewaysClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ApplicationGatewaysClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ApplicationGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ApplicationGatewaysClientCreateOrUpdatePollerResponse{}, err
@@ -272,9 +266,7 @@ func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resour
 	if err != nil {
 		return ApplicationGatewaysClientDeletePollerResponse{}, err
 	}
-	result := ApplicationGatewaysClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ApplicationGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ApplicationGatewaysClientDeletePollerResponse{}, err
@@ -376,7 +368,7 @@ func (client *ApplicationGatewaysClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client *ApplicationGatewaysClient) getHandleResponse(resp *http.Response) (ApplicationGatewaysClientGetResponse, error) {
-	result := ApplicationGatewaysClientGetResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGateway); err != nil {
 		return ApplicationGatewaysClientGetResponse{}, err
 	}
@@ -427,7 +419,7 @@ func (client *ApplicationGatewaysClient) getSSLPredefinedPolicyCreateRequest(ctx
 
 // getSSLPredefinedPolicyHandleResponse handles the GetSSLPredefinedPolicy response.
 func (client *ApplicationGatewaysClient) getSSLPredefinedPolicyHandleResponse(resp *http.Response) (ApplicationGatewaysClientGetSSLPredefinedPolicyResponse, error) {
-	result := ApplicationGatewaysClientGetSSLPredefinedPolicyResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientGetSSLPredefinedPolicyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewaySSLPredefinedPolicy); err != nil {
 		return ApplicationGatewaysClientGetSSLPredefinedPolicyResponse{}, err
 	}
@@ -475,7 +467,7 @@ func (client *ApplicationGatewaysClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client *ApplicationGatewaysClient) listHandleResponse(resp *http.Response) (ApplicationGatewaysClientListResponse, error) {
-	result := ApplicationGatewaysClientListResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayListResult); err != nil {
 		return ApplicationGatewaysClientListResponse{}, err
 	}
@@ -518,7 +510,7 @@ func (client *ApplicationGatewaysClient) listAllCreateRequest(ctx context.Contex
 
 // listAllHandleResponse handles the ListAll response.
 func (client *ApplicationGatewaysClient) listAllHandleResponse(resp *http.Response) (ApplicationGatewaysClientListAllResponse, error) {
-	result := ApplicationGatewaysClientListAllResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayListResult); err != nil {
 		return ApplicationGatewaysClientListAllResponse{}, err
 	}
@@ -564,7 +556,7 @@ func (client *ApplicationGatewaysClient) listAvailableRequestHeadersCreateReques
 
 // listAvailableRequestHeadersHandleResponse handles the ListAvailableRequestHeaders response.
 func (client *ApplicationGatewaysClient) listAvailableRequestHeadersHandleResponse(resp *http.Response) (ApplicationGatewaysClientListAvailableRequestHeadersResponse, error) {
-	result := ApplicationGatewaysClientListAvailableRequestHeadersResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientListAvailableRequestHeadersResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ApplicationGatewaysClientListAvailableRequestHeadersResponse{}, err
 	}
@@ -610,7 +602,7 @@ func (client *ApplicationGatewaysClient) listAvailableResponseHeadersCreateReque
 
 // listAvailableResponseHeadersHandleResponse handles the ListAvailableResponseHeaders response.
 func (client *ApplicationGatewaysClient) listAvailableResponseHeadersHandleResponse(resp *http.Response) (ApplicationGatewaysClientListAvailableResponseHeadersResponse, error) {
-	result := ApplicationGatewaysClientListAvailableResponseHeadersResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientListAvailableResponseHeadersResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ApplicationGatewaysClientListAvailableResponseHeadersResponse{}, err
 	}
@@ -656,7 +648,7 @@ func (client *ApplicationGatewaysClient) listAvailableSSLOptionsCreateRequest(ct
 
 // listAvailableSSLOptionsHandleResponse handles the ListAvailableSSLOptions response.
 func (client *ApplicationGatewaysClient) listAvailableSSLOptionsHandleResponse(resp *http.Response) (ApplicationGatewaysClientListAvailableSSLOptionsResponse, error) {
-	result := ApplicationGatewaysClientListAvailableSSLOptionsResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientListAvailableSSLOptionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayAvailableSSLOptions); err != nil {
 		return ApplicationGatewaysClientListAvailableSSLOptionsResponse{}, err
 	}
@@ -699,7 +691,7 @@ func (client *ApplicationGatewaysClient) listAvailableSSLPredefinedPoliciesCreat
 
 // listAvailableSSLPredefinedPoliciesHandleResponse handles the ListAvailableSSLPredefinedPolicies response.
 func (client *ApplicationGatewaysClient) listAvailableSSLPredefinedPoliciesHandleResponse(resp *http.Response) (ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse, error) {
-	result := ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayAvailableSSLPredefinedPolicies); err != nil {
 		return ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}, err
 	}
@@ -745,7 +737,7 @@ func (client *ApplicationGatewaysClient) listAvailableServerVariablesCreateReque
 
 // listAvailableServerVariablesHandleResponse handles the ListAvailableServerVariables response.
 func (client *ApplicationGatewaysClient) listAvailableServerVariablesHandleResponse(resp *http.Response) (ApplicationGatewaysClientListAvailableServerVariablesResponse, error) {
-	result := ApplicationGatewaysClientListAvailableServerVariablesResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientListAvailableServerVariablesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ApplicationGatewaysClientListAvailableServerVariablesResponse{}, err
 	}
@@ -791,7 +783,7 @@ func (client *ApplicationGatewaysClient) listAvailableWafRuleSetsCreateRequest(c
 
 // listAvailableWafRuleSetsHandleResponse handles the ListAvailableWafRuleSets response.
 func (client *ApplicationGatewaysClient) listAvailableWafRuleSetsHandleResponse(resp *http.Response) (ApplicationGatewaysClientListAvailableWafRuleSetsResponse, error) {
-	result := ApplicationGatewaysClientListAvailableWafRuleSetsResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientListAvailableWafRuleSetsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayAvailableWafRuleSetsResult); err != nil {
 		return ApplicationGatewaysClientListAvailableWafRuleSetsResponse{}, err
 	}
@@ -809,9 +801,7 @@ func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourc
 	if err != nil {
 		return ApplicationGatewaysClientStartPollerResponse{}, err
 	}
-	result := ApplicationGatewaysClientStartPollerResponse{
-		RawResponse: resp,
-	}
+	result := ApplicationGatewaysClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.Start", "location", resp, client.pl)
 	if err != nil {
 		return ApplicationGatewaysClientStartPollerResponse{}, err
@@ -876,9 +866,7 @@ func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resource
 	if err != nil {
 		return ApplicationGatewaysClientStopPollerResponse{}, err
 	}
-	result := ApplicationGatewaysClientStopPollerResponse{
-		RawResponse: resp,
-	}
+	result := ApplicationGatewaysClientStopPollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.Stop", "location", resp, client.pl)
 	if err != nil {
 		return ApplicationGatewaysClientStopPollerResponse{}, err
@@ -982,7 +970,7 @@ func (client *ApplicationGatewaysClient) updateTagsCreateRequest(ctx context.Con
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *ApplicationGatewaysClient) updateTagsHandleResponse(resp *http.Response) (ApplicationGatewaysClientUpdateTagsResponse, error) {
-	result := ApplicationGatewaysClientUpdateTagsResponse{RawResponse: resp}
+	result := ApplicationGatewaysClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGateway); err != nil {
 		return ApplicationGatewaysClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
@@ -62,9 +62,7 @@ func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.C
 	if err != nil {
 		return ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationSecurityGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, 
 	if err != nil {
 		return ApplicationSecurityGroupsClientDeletePollerResponse{}, err
 	}
-	result := ApplicationSecurityGroupsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ApplicationSecurityGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationSecurityGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ApplicationSecurityGroupsClientDeletePollerResponse{}, err
@@ -234,7 +230,7 @@ func (client *ApplicationSecurityGroupsClient) getCreateRequest(ctx context.Cont
 
 // getHandleResponse handles the Get response.
 func (client *ApplicationSecurityGroupsClient) getHandleResponse(resp *http.Response) (ApplicationSecurityGroupsClientGetResponse, error) {
-	result := ApplicationSecurityGroupsClientGetResponse{RawResponse: resp}
+	result := ApplicationSecurityGroupsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationSecurityGroup); err != nil {
 		return ApplicationSecurityGroupsClientGetResponse{}, err
 	}
@@ -282,7 +278,7 @@ func (client *ApplicationSecurityGroupsClient) listCreateRequest(ctx context.Con
 
 // listHandleResponse handles the List response.
 func (client *ApplicationSecurityGroupsClient) listHandleResponse(resp *http.Response) (ApplicationSecurityGroupsClientListResponse, error) {
-	result := ApplicationSecurityGroupsClientListResponse{RawResponse: resp}
+	result := ApplicationSecurityGroupsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationSecurityGroupListResult); err != nil {
 		return ApplicationSecurityGroupsClientListResponse{}, err
 	}
@@ -325,7 +321,7 @@ func (client *ApplicationSecurityGroupsClient) listAllCreateRequest(ctx context.
 
 // listAllHandleResponse handles the ListAll response.
 func (client *ApplicationSecurityGroupsClient) listAllHandleResponse(resp *http.Response) (ApplicationSecurityGroupsClientListAllResponse, error) {
-	result := ApplicationSecurityGroupsClientListAllResponse{RawResponse: resp}
+	result := ApplicationSecurityGroupsClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationSecurityGroupListResult); err != nil {
 		return ApplicationSecurityGroupsClientListAllResponse{}, err
 	}
@@ -382,7 +378,7 @@ func (client *ApplicationSecurityGroupsClient) updateTagsCreateRequest(ctx conte
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *ApplicationSecurityGroupsClient) updateTagsHandleResponse(resp *http.Response) (ApplicationSecurityGroupsClientUpdateTagsResponse, error) {
-	result := ApplicationSecurityGroupsClientUpdateTagsResponse{RawResponse: resp}
+	result := ApplicationSecurityGroupsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationSecurityGroup); err != nil {
 		return ApplicationSecurityGroupsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations_client.go
@@ -91,7 +91,7 @@ func (client *AvailableDelegationsClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client *AvailableDelegationsClient) listHandleResponse(resp *http.Response) (AvailableDelegationsClientListResponse, error) {
-	result := AvailableDelegationsClientListResponse{RawResponse: resp}
+	result := AvailableDelegationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailableDelegationsResult); err != nil {
 		return AvailableDelegationsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices_client.go
@@ -91,7 +91,7 @@ func (client *AvailableEndpointServicesClient) listCreateRequest(ctx context.Con
 
 // listHandleResponse handles the List response.
 func (client *AvailableEndpointServicesClient) listHandleResponse(resp *http.Response) (AvailableEndpointServicesClientListResponse, error) {
-	result := AvailableEndpointServicesClientListResponse{RawResponse: resp}
+	result := AvailableEndpointServicesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EndpointServicesListResult); err != nil {
 		return AvailableEndpointServicesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes_client.go
@@ -91,7 +91,7 @@ func (client *AvailablePrivateEndpointTypesClient) listCreateRequest(ctx context
 
 // listHandleResponse handles the List response.
 func (client *AvailablePrivateEndpointTypesClient) listHandleResponse(resp *http.Response) (AvailablePrivateEndpointTypesClientListResponse, error) {
-	result := AvailablePrivateEndpointTypesClientListResponse{RawResponse: resp}
+	result := AvailablePrivateEndpointTypesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailablePrivateEndpointTypesResult); err != nil {
 		return AvailablePrivateEndpointTypesClientListResponse{}, err
 	}
@@ -145,7 +145,7 @@ func (client *AvailablePrivateEndpointTypesClient) listByResourceGroupCreateRequ
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *AvailablePrivateEndpointTypesClient) listByResourceGroupHandleResponse(resp *http.Response) (AvailablePrivateEndpointTypesClientListByResourceGroupResponse, error) {
-	result := AvailablePrivateEndpointTypesClientListByResourceGroupResponse{RawResponse: resp}
+	result := AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailablePrivateEndpointTypesResult); err != nil {
 		return AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations_client.go
@@ -96,7 +96,7 @@ func (client *AvailableResourceGroupDelegationsClient) listCreateRequest(ctx con
 
 // listHandleResponse handles the List response.
 func (client *AvailableResourceGroupDelegationsClient) listHandleResponse(resp *http.Response) (AvailableResourceGroupDelegationsClientListResponse, error) {
-	result := AvailableResourceGroupDelegationsClientListResponse{RawResponse: resp}
+	result := AvailableResourceGroupDelegationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailableDelegationsResult); err != nil {
 		return AvailableResourceGroupDelegationsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases_client.go
@@ -91,7 +91,7 @@ func (client *AvailableServiceAliasesClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *AvailableServiceAliasesClient) listHandleResponse(resp *http.Response) (AvailableServiceAliasesClientListResponse, error) {
-	result := AvailableServiceAliasesClientListResponse{RawResponse: resp}
+	result := AvailableServiceAliasesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailableServiceAliasesResult); err != nil {
 		return AvailableServiceAliasesClientListResponse{}, err
 	}
@@ -144,7 +144,7 @@ func (client *AvailableServiceAliasesClient) listByResourceGroupCreateRequest(ct
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *AvailableServiceAliasesClient) listByResourceGroupHandleResponse(resp *http.Response) (AvailableServiceAliasesClientListByResourceGroupResponse, error) {
-	result := AvailableServiceAliasesClientListByResourceGroupResponse{RawResponse: resp}
+	result := AvailableServiceAliasesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailableServiceAliasesResult); err != nil {
 		return AvailableServiceAliasesClientListByResourceGroupResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags_client.go
@@ -86,7 +86,7 @@ func (client *AzureFirewallFqdnTagsClient) listAllCreateRequest(ctx context.Cont
 
 // listAllHandleResponse handles the ListAll response.
 func (client *AzureFirewallFqdnTagsClient) listAllHandleResponse(resp *http.Response) (AzureFirewallFqdnTagsClientListAllResponse, error) {
-	result := AzureFirewallFqdnTagsClientListAllResponse{RawResponse: resp}
+	result := AzureFirewallFqdnTagsClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureFirewallFqdnTagListResult); err != nil {
 		return AzureFirewallFqdnTagsClientListAllResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
@@ -62,9 +62,7 @@ func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return AzureFirewallsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := AzureFirewallsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := AzureFirewallsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("AzureFirewallsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return AzureFirewallsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return AzureFirewallsClientDeletePollerResponse{}, err
 	}
-	result := AzureFirewallsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := AzureFirewallsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("AzureFirewallsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return AzureFirewallsClientDeletePollerResponse{}, err
@@ -233,7 +229,7 @@ func (client *AzureFirewallsClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client *AzureFirewallsClient) getHandleResponse(resp *http.Response) (AzureFirewallsClientGetResponse, error) {
-	result := AzureFirewallsClientGetResponse{RawResponse: resp}
+	result := AzureFirewallsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureFirewall); err != nil {
 		return AzureFirewallsClientGetResponse{}, err
 	}
@@ -280,7 +276,7 @@ func (client *AzureFirewallsClient) listCreateRequest(ctx context.Context, resou
 
 // listHandleResponse handles the List response.
 func (client *AzureFirewallsClient) listHandleResponse(resp *http.Response) (AzureFirewallsClientListResponse, error) {
-	result := AzureFirewallsClientListResponse{RawResponse: resp}
+	result := AzureFirewallsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureFirewallListResult); err != nil {
 		return AzureFirewallsClientListResponse{}, err
 	}
@@ -322,7 +318,7 @@ func (client *AzureFirewallsClient) listAllCreateRequest(ctx context.Context, op
 
 // listAllHandleResponse handles the ListAll response.
 func (client *AzureFirewallsClient) listAllHandleResponse(resp *http.Response) (AzureFirewallsClientListAllResponse, error) {
-	result := AzureFirewallsClientListAllResponse{RawResponse: resp}
+	result := AzureFirewallsClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureFirewallListResult); err != nil {
 		return AzureFirewallsClientListAllResponse{}, err
 	}
@@ -341,9 +337,7 @@ func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourc
 	if err != nil {
 		return AzureFirewallsClientUpdateTagsPollerResponse{}, err
 	}
-	result := AzureFirewallsClientUpdateTagsPollerResponse{
-		RawResponse: resp,
-	}
+	result := AzureFirewallsClientUpdateTagsPollerResponse{}
 	pt, err := armruntime.NewPoller("AzureFirewallsClient.UpdateTags", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return AzureFirewallsClientUpdateTagsPollerResponse{}, err

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
@@ -62,9 +62,7 @@ func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return BastionHostsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := BastionHostsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := BastionHostsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("BastionHostsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return BastionHostsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroup
 	if err != nil {
 		return BastionHostsClientDeletePollerResponse{}, err
 	}
-	result := BastionHostsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := BastionHostsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("BastionHostsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return BastionHostsClientDeletePollerResponse{}, err
@@ -233,7 +229,7 @@ func (client *BastionHostsClient) getCreateRequest(ctx context.Context, resource
 
 // getHandleResponse handles the Get response.
 func (client *BastionHostsClient) getHandleResponse(resp *http.Response) (BastionHostsClientGetResponse, error) {
-	result := BastionHostsClientGetResponse{RawResponse: resp}
+	result := BastionHostsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionHost); err != nil {
 		return BastionHostsClientGetResponse{}, err
 	}
@@ -275,7 +271,7 @@ func (client *BastionHostsClient) listCreateRequest(ctx context.Context, options
 
 // listHandleResponse handles the List response.
 func (client *BastionHostsClient) listHandleResponse(resp *http.Response) (BastionHostsClientListResponse, error) {
-	result := BastionHostsClientListResponse{RawResponse: resp}
+	result := BastionHostsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionHostListResult); err != nil {
 		return BastionHostsClientListResponse{}, err
 	}
@@ -323,7 +319,7 @@ func (client *BastionHostsClient) listByResourceGroupCreateRequest(ctx context.C
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *BastionHostsClient) listByResourceGroupHandleResponse(resp *http.Response) (BastionHostsClientListByResourceGroupResponse, error) {
-	result := BastionHostsClientListByResourceGroupResponse{RawResponse: resp}
+	result := BastionHostsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionHostListResult); err != nil {
 		return BastionHostsClientListByResourceGroupResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities_client.go
@@ -86,7 +86,7 @@ func (client *BgpServiceCommunitiesClient) listCreateRequest(ctx context.Context
 
 // listHandleResponse handles the List response.
 func (client *BgpServiceCommunitiesClient) listHandleResponse(resp *http.Response) (BgpServiceCommunitiesClientListResponse, error) {
-	result := BgpServiceCommunitiesClientListResponse{RawResponse: resp}
+	result := BgpServiceCommunitiesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BgpServiceCommunityListResult); err != nil {
 		return BgpServiceCommunitiesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
@@ -63,9 +63,7 @@ func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return ConnectionMonitorsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ConnectionMonitorsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ConnectionMonitorsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ConnectionMonitorsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourc
 	if err != nil {
 		return ConnectionMonitorsClientDeletePollerResponse{}, err
 	}
-	result := ConnectionMonitorsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ConnectionMonitorsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ConnectionMonitorsClientDeletePollerResponse{}, err
@@ -248,7 +244,7 @@ func (client *ConnectionMonitorsClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client *ConnectionMonitorsClient) getHandleResponse(resp *http.Response) (ConnectionMonitorsClientGetResponse, error) {
-	result := ConnectionMonitorsClientGetResponse{RawResponse: resp}
+	result := ConnectionMonitorsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ConnectionMonitorResult); err != nil {
 		return ConnectionMonitorsClientGetResponse{}, err
 	}
@@ -297,7 +293,7 @@ func (client *ConnectionMonitorsClient) listCreateRequest(ctx context.Context, r
 
 // listHandleResponse handles the List response.
 func (client *ConnectionMonitorsClient) listHandleResponse(resp *http.Response) (ConnectionMonitorsClientListResponse, error) {
-	result := ConnectionMonitorsClientListResponse{RawResponse: resp}
+	result := ConnectionMonitorsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ConnectionMonitorListResult); err != nil {
 		return ConnectionMonitorsClientListResponse{}, err
 	}
@@ -316,9 +312,7 @@ func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resource
 	if err != nil {
 		return ConnectionMonitorsClientQueryPollerResponse{}, err
 	}
-	result := ConnectionMonitorsClientQueryPollerResponse{
-		RawResponse: resp,
-	}
+	result := ConnectionMonitorsClientQueryPollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.Query", "location", resp, client.pl)
 	if err != nil {
 		return ConnectionMonitorsClientQueryPollerResponse{}, err
@@ -388,9 +382,7 @@ func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resource
 	if err != nil {
 		return ConnectionMonitorsClientStartPollerResponse{}, err
 	}
-	result := ConnectionMonitorsClientStartPollerResponse{
-		RawResponse: resp,
-	}
+	result := ConnectionMonitorsClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.Start", "location", resp, client.pl)
 	if err != nil {
 		return ConnectionMonitorsClientStartPollerResponse{}, err
@@ -460,9 +452,7 @@ func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceG
 	if err != nil {
 		return ConnectionMonitorsClientStopPollerResponse{}, err
 	}
-	result := ConnectionMonitorsClientStopPollerResponse{
-		RawResponse: resp,
-	}
+	result := ConnectionMonitorsClientStopPollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.Stop", "location", resp, client.pl)
 	if err != nil {
 		return ConnectionMonitorsClientStopPollerResponse{}, err
@@ -575,7 +565,7 @@ func (client *ConnectionMonitorsClient) updateTagsCreateRequest(ctx context.Cont
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *ConnectionMonitorsClient) updateTagsHandleResponse(resp *http.Response) (ConnectionMonitorsClientUpdateTagsResponse, error) {
-	result := ConnectionMonitorsClientUpdateTagsResponse{RawResponse: resp}
+	result := ConnectionMonitorsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ConnectionMonitorResult); err != nil {
 		return ConnectionMonitorsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
@@ -62,9 +62,7 @@ func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return DdosCustomPoliciesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := DdosCustomPoliciesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := DdosCustomPoliciesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DdosCustomPoliciesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return DdosCustomPoliciesClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourc
 	if err != nil {
 		return DdosCustomPoliciesClientDeletePollerResponse{}, err
 	}
-	result := DdosCustomPoliciesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := DdosCustomPoliciesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DdosCustomPoliciesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return DdosCustomPoliciesClientDeletePollerResponse{}, err
@@ -233,7 +229,7 @@ func (client *DdosCustomPoliciesClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client *DdosCustomPoliciesClient) getHandleResponse(resp *http.Response) (DdosCustomPoliciesClientGetResponse, error) {
-	result := DdosCustomPoliciesClientGetResponse{RawResponse: resp}
+	result := DdosCustomPoliciesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosCustomPolicy); err != nil {
 		return DdosCustomPoliciesClientGetResponse{}, err
 	}
@@ -290,7 +286,7 @@ func (client *DdosCustomPoliciesClient) updateTagsCreateRequest(ctx context.Cont
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *DdosCustomPoliciesClient) updateTagsHandleResponse(resp *http.Response) (DdosCustomPoliciesClientUpdateTagsResponse, error) {
-	result := DdosCustomPoliciesClientUpdateTagsResponse{RawResponse: resp}
+	result := DdosCustomPoliciesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosCustomPolicy); err != nil {
 		return DdosCustomPoliciesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
@@ -62,9 +62,7 @@ func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context
 	if err != nil {
 		return DdosProtectionPlansClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := DdosProtectionPlansClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := DdosProtectionPlansClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DdosProtectionPlansClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return DdosProtectionPlansClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resour
 	if err != nil {
 		return DdosProtectionPlansClientDeletePollerResponse{}, err
 	}
-	result := DdosProtectionPlansClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := DdosProtectionPlansClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DdosProtectionPlansClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return DdosProtectionPlansClientDeletePollerResponse{}, err
@@ -233,7 +229,7 @@ func (client *DdosProtectionPlansClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client *DdosProtectionPlansClient) getHandleResponse(resp *http.Response) (DdosProtectionPlansClientGetResponse, error) {
-	result := DdosProtectionPlansClientGetResponse{RawResponse: resp}
+	result := DdosProtectionPlansClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosProtectionPlan); err != nil {
 		return DdosProtectionPlansClientGetResponse{}, err
 	}
@@ -276,7 +272,7 @@ func (client *DdosProtectionPlansClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client *DdosProtectionPlansClient) listHandleResponse(resp *http.Response) (DdosProtectionPlansClientListResponse, error) {
-	result := DdosProtectionPlansClientListResponse{RawResponse: resp}
+	result := DdosProtectionPlansClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosProtectionPlanListResult); err != nil {
 		return DdosProtectionPlansClientListResponse{}, err
 	}
@@ -324,7 +320,7 @@ func (client *DdosProtectionPlansClient) listByResourceGroupCreateRequest(ctx co
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *DdosProtectionPlansClient) listByResourceGroupHandleResponse(resp *http.Response) (DdosProtectionPlansClientListByResourceGroupResponse, error) {
-	result := DdosProtectionPlansClientListByResourceGroupResponse{RawResponse: resp}
+	result := DdosProtectionPlansClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosProtectionPlanListResult); err != nil {
 		return DdosProtectionPlansClientListByResourceGroupResponse{}, err
 	}
@@ -381,7 +377,7 @@ func (client *DdosProtectionPlansClient) updateTagsCreateRequest(ctx context.Con
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *DdosProtectionPlansClient) updateTagsHandleResponse(resp *http.Response) (DdosProtectionPlansClientUpdateTagsResponse, error) {
-	result := DdosProtectionPlansClientUpdateTagsResponse{RawResponse: resp}
+	result := DdosProtectionPlansClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosProtectionPlan); err != nil {
 		return DdosProtectionPlansClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules_client.go
@@ -104,7 +104,7 @@ func (client *DefaultSecurityRulesClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client *DefaultSecurityRulesClient) getHandleResponse(resp *http.Response) (DefaultSecurityRulesClientGetResponse, error) {
-	result := DefaultSecurityRulesClientGetResponse{RawResponse: resp}
+	result := DefaultSecurityRulesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityRule); err != nil {
 		return DefaultSecurityRulesClientGetResponse{}, err
 	}
@@ -157,7 +157,7 @@ func (client *DefaultSecurityRulesClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client *DefaultSecurityRulesClient) listHandleResponse(resp *http.Response) (DefaultSecurityRulesClientListResponse, error) {
-	result := DefaultSecurityRulesClientListResponse{RawResponse: resp}
+	result := DefaultSecurityRulesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityRuleListResult); err != nil {
 		return DefaultSecurityRulesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
@@ -63,9 +63,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx c
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.C
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationsClientDeletePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitAuthorizationsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitAuthorizationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitAuthorizationsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) getCreateRequest(ctx cont
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteCircuitAuthorizationsClient) getHandleResponse(resp *http.Response) (ExpressRouteCircuitAuthorizationsClientGetResponse, error) {
-	result := ExpressRouteCircuitAuthorizationsClientGetResponse{RawResponse: resp}
+	result := ExpressRouteCircuitAuthorizationsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitAuthorization); err != nil {
 		return ExpressRouteCircuitAuthorizationsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) listCreateRequest(ctx con
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteCircuitAuthorizationsClient) listHandleResponse(resp *http.Response) (ExpressRouteCircuitAuthorizationsClientListResponse, error) {
-	result := ExpressRouteCircuitAuthorizationsClientListResponse{RawResponse: resp}
+	result := ExpressRouteCircuitAuthorizationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AuthorizationListResult); err != nil {
 		return ExpressRouteCircuitAuthorizationsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
@@ -65,9 +65,7 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx cont
 	if err != nil {
 		return ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse{}, err
@@ -142,9 +140,7 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Cont
 	if err != nil {
 		return ExpressRouteCircuitConnectionsClientDeletePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitConnectionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitConnectionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitConnectionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitConnectionsClientDeletePollerResponse{}, err
@@ -265,7 +261,7 @@ func (client *ExpressRouteCircuitConnectionsClient) getCreateRequest(ctx context
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteCircuitConnectionsClient) getHandleResponse(resp *http.Response) (ExpressRouteCircuitConnectionsClientGetResponse, error) {
-	result := ExpressRouteCircuitConnectionsClientGetResponse{RawResponse: resp}
+	result := ExpressRouteCircuitConnectionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitConnection); err != nil {
 		return ExpressRouteCircuitConnectionsClientGetResponse{}, err
 	}
@@ -323,7 +319,7 @@ func (client *ExpressRouteCircuitConnectionsClient) listCreateRequest(ctx contex
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteCircuitConnectionsClient) listHandleResponse(resp *http.Response) (ExpressRouteCircuitConnectionsClientListResponse, error) {
-	result := ExpressRouteCircuitConnectionsClientListResponse{RawResponse: resp}
+	result := ExpressRouteCircuitConnectionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitConnectionListResult); err != nil {
 		return ExpressRouteCircuitConnectionsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
@@ -63,9 +63,7 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context
 	if err != nil {
 		return ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitPeeringsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context
 	if err != nil {
 		return ExpressRouteCircuitPeeringsClientDeletePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitPeeringsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitPeeringsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitPeeringsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitPeeringsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *ExpressRouteCircuitPeeringsClient) getCreateRequest(ctx context.Co
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteCircuitPeeringsClient) getHandleResponse(resp *http.Response) (ExpressRouteCircuitPeeringsClientGetResponse, error) {
-	result := ExpressRouteCircuitPeeringsClientGetResponse{RawResponse: resp}
+	result := ExpressRouteCircuitPeeringsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitPeering); err != nil {
 		return ExpressRouteCircuitPeeringsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *ExpressRouteCircuitPeeringsClient) listCreateRequest(ctx context.C
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteCircuitPeeringsClient) listHandleResponse(resp *http.Response) (ExpressRouteCircuitPeeringsClientListResponse, error) {
-	result := ExpressRouteCircuitPeeringsClientListResponse{RawResponse: resp}
+	result := ExpressRouteCircuitPeeringsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitPeeringListResult); err != nil {
 		return ExpressRouteCircuitPeeringsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
@@ -62,9 +62,7 @@ func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return ExpressRouteCircuitsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return ExpressRouteCircuitsClientDeletePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitsClientDeletePollerResponse{}, err
@@ -234,7 +230,7 @@ func (client *ExpressRouteCircuitsClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteCircuitsClient) getHandleResponse(resp *http.Response) (ExpressRouteCircuitsClientGetResponse, error) {
-	result := ExpressRouteCircuitsClientGetResponse{RawResponse: resp}
+	result := ExpressRouteCircuitsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuit); err != nil {
 		return ExpressRouteCircuitsClientGetResponse{}, err
 	}
@@ -295,7 +291,7 @@ func (client *ExpressRouteCircuitsClient) getPeeringStatsCreateRequest(ctx conte
 
 // getPeeringStatsHandleResponse handles the GetPeeringStats response.
 func (client *ExpressRouteCircuitsClient) getPeeringStatsHandleResponse(resp *http.Response) (ExpressRouteCircuitsClientGetPeeringStatsResponse, error) {
-	result := ExpressRouteCircuitsClientGetPeeringStatsResponse{RawResponse: resp}
+	result := ExpressRouteCircuitsClientGetPeeringStatsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitStats); err != nil {
 		return ExpressRouteCircuitsClientGetPeeringStatsResponse{}, err
 	}
@@ -351,7 +347,7 @@ func (client *ExpressRouteCircuitsClient) getStatsCreateRequest(ctx context.Cont
 
 // getStatsHandleResponse handles the GetStats response.
 func (client *ExpressRouteCircuitsClient) getStatsHandleResponse(resp *http.Response) (ExpressRouteCircuitsClientGetStatsResponse, error) {
-	result := ExpressRouteCircuitsClientGetStatsResponse{RawResponse: resp}
+	result := ExpressRouteCircuitsClientGetStatsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitStats); err != nil {
 		return ExpressRouteCircuitsClientGetStatsResponse{}, err
 	}
@@ -399,7 +395,7 @@ func (client *ExpressRouteCircuitsClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteCircuitsClient) listHandleResponse(resp *http.Response) (ExpressRouteCircuitsClientListResponse, error) {
-	result := ExpressRouteCircuitsClientListResponse{RawResponse: resp}
+	result := ExpressRouteCircuitsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitListResult); err != nil {
 		return ExpressRouteCircuitsClientListResponse{}, err
 	}
@@ -442,7 +438,7 @@ func (client *ExpressRouteCircuitsClient) listAllCreateRequest(ctx context.Conte
 
 // listAllHandleResponse handles the ListAll response.
 func (client *ExpressRouteCircuitsClient) listAllHandleResponse(resp *http.Response) (ExpressRouteCircuitsClientListAllResponse, error) {
-	result := ExpressRouteCircuitsClientListAllResponse{RawResponse: resp}
+	result := ExpressRouteCircuitsClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitListResult); err != nil {
 		return ExpressRouteCircuitsClientListAllResponse{}, err
 	}
@@ -462,9 +458,7 @@ func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context,
 	if err != nil {
 		return ExpressRouteCircuitsClientListArpTablePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitsClientListArpTablePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitsClientListArpTablePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.ListArpTable", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitsClientListArpTablePollerResponse{}, err
@@ -540,9 +534,7 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Conte
 	if err != nil {
 		return ExpressRouteCircuitsClientListRoutesTablePollerResponse{}, err
 	}
-	result := ExpressRouteCircuitsClientListRoutesTablePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitsClientListRoutesTablePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.ListRoutesTable", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitsClientListRoutesTablePollerResponse{}, err
@@ -618,9 +610,7 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx contex
 	if err != nil {
 		return ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse{}, err
 	}
-	result := ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.ListRoutesTableSummary", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse{}, err
@@ -733,7 +723,7 @@ func (client *ExpressRouteCircuitsClient) updateTagsCreateRequest(ctx context.Co
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *ExpressRouteCircuitsClient) updateTagsHandleResponse(resp *http.Response) (ExpressRouteCircuitsClientUpdateTagsResponse, error) {
-	result := ExpressRouteCircuitsClientUpdateTagsResponse{RawResponse: resp}
+	result := ExpressRouteCircuitsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuit); err != nil {
 		return ExpressRouteCircuitsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
@@ -63,9 +63,7 @@ func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return ExpressRouteConnectionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRouteConnectionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRouteConnectionsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return ExpressRouteConnectionsClientDeletePollerResponse{}, err
 	}
-	result := ExpressRouteConnectionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteConnectionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteConnectionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteConnectionsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *ExpressRouteConnectionsClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteConnectionsClient) getHandleResponse(resp *http.Response) (ExpressRouteConnectionsClientGetResponse, error) {
-	result := ExpressRouteConnectionsClientGetResponse{RawResponse: resp}
+	result := ExpressRouteConnectionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteConnection); err != nil {
 		return ExpressRouteConnectionsClientGetResponse{}, err
 	}
@@ -305,7 +301,7 @@ func (client *ExpressRouteConnectionsClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteConnectionsClient) listHandleResponse(resp *http.Response) (ExpressRouteConnectionsClientListResponse, error) {
-	result := ExpressRouteConnectionsClientListResponse{RawResponse: resp}
+	result := ExpressRouteConnectionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteConnectionList); err != nil {
 		return ExpressRouteConnectionsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
@@ -63,9 +63,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse{}, err
 	}
-	result := ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionPeeringsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) getCreateRequest(ctx co
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) getHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionPeeringsClientGetResponse, error) {
-	result := ExpressRouteCrossConnectionPeeringsClientGetResponse{RawResponse: resp}
+	result := ExpressRouteCrossConnectionPeeringsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnectionPeering); err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) listCreateRequest(ctx c
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) listHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionPeeringsClientListResponse, error) {
-	result := ExpressRouteCrossConnectionPeeringsClientListResponse{RawResponse: resp}
+	result := ExpressRouteCrossConnectionPeeringsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnectionPeeringList); err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
@@ -62,9 +62,7 @@ func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx contex
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse{}, err
@@ -167,7 +165,7 @@ func (client *ExpressRouteCrossConnectionsClient) getCreateRequest(ctx context.C
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteCrossConnectionsClient) getHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionsClientGetResponse, error) {
-	result := ExpressRouteCrossConnectionsClientGetResponse{RawResponse: resp}
+	result := ExpressRouteCrossConnectionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnection); err != nil {
 		return ExpressRouteCrossConnectionsClientGetResponse{}, err
 	}
@@ -210,7 +208,7 @@ func (client *ExpressRouteCrossConnectionsClient) listCreateRequest(ctx context.
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteCrossConnectionsClient) listHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionsClientListResponse, error) {
-	result := ExpressRouteCrossConnectionsClientListResponse{RawResponse: resp}
+	result := ExpressRouteCrossConnectionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnectionListResult); err != nil {
 		return ExpressRouteCrossConnectionsClientListResponse{}, err
 	}
@@ -231,9 +229,7 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListArpTablePollerResponse{}, err
 	}
-	result := ExpressRouteCrossConnectionsClientListArpTablePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCrossConnectionsClientListArpTablePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionsClient.ListArpTable", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListArpTablePollerResponse{}, err
@@ -337,7 +333,7 @@ func (client *ExpressRouteCrossConnectionsClient) listByResourceGroupCreateReque
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ExpressRouteCrossConnectionsClient) listByResourceGroupHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionsClientListByResourceGroupResponse, error) {
-	result := ExpressRouteCrossConnectionsClientListByResourceGroupResponse{RawResponse: resp}
+	result := ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnectionListResult); err != nil {
 		return ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}, err
 	}
@@ -358,9 +354,7 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx conte
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse{}, err
 	}
-	result := ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionsClient.ListRoutesTable", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse{}, err
@@ -437,9 +431,7 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ct
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse{}, err
 	}
-	result := ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionsClient.ListRoutesTableSummary", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse{}, err
@@ -552,7 +544,7 @@ func (client *ExpressRouteCrossConnectionsClient) updateTagsCreateRequest(ctx co
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *ExpressRouteCrossConnectionsClient) updateTagsHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionsClientUpdateTagsResponse, error) {
-	result := ExpressRouteCrossConnectionsClientUpdateTagsResponse{RawResponse: resp}
+	result := ExpressRouteCrossConnectionsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnection); err != nil {
 		return ExpressRouteCrossConnectionsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
@@ -62,9 +62,7 @@ func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return ExpressRouteGatewaysClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRouteGatewaysClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRouteGatewaysClientCreateOrUpdatePollerResponse{}, err
@@ -130,9 +128,7 @@ func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return ExpressRouteGatewaysClientDeletePollerResponse{}, err
 	}
-	result := ExpressRouteGatewaysClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRouteGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRouteGatewaysClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *ExpressRouteGatewaysClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteGatewaysClient) getHandleResponse(resp *http.Response) (ExpressRouteGatewaysClientGetResponse, error) {
-	result := ExpressRouteGatewaysClientGetResponse{RawResponse: resp}
+	result := ExpressRouteGatewaysClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteGateway); err != nil {
 		return ExpressRouteGatewaysClientGetResponse{}, err
 	}
@@ -287,7 +283,7 @@ func (client *ExpressRouteGatewaysClient) listByResourceGroupCreateRequest(ctx c
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ExpressRouteGatewaysClient) listByResourceGroupHandleResponse(resp *http.Response) (ExpressRouteGatewaysClientListByResourceGroupResponse, error) {
-	result := ExpressRouteGatewaysClientListByResourceGroupResponse{RawResponse: resp}
+	result := ExpressRouteGatewaysClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteGatewayList); err != nil {
 		return ExpressRouteGatewaysClientListByResourceGroupResponse{}, err
 	}
@@ -333,7 +329,7 @@ func (client *ExpressRouteGatewaysClient) listBySubscriptionCreateRequest(ctx co
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *ExpressRouteGatewaysClient) listBySubscriptionHandleResponse(resp *http.Response) (ExpressRouteGatewaysClientListBySubscriptionResponse, error) {
-	result := ExpressRouteGatewaysClientListBySubscriptionResponse{RawResponse: resp}
+	result := ExpressRouteGatewaysClientListBySubscriptionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteGatewayList); err != nil {
 		return ExpressRouteGatewaysClientListBySubscriptionResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks_client.go
@@ -103,7 +103,7 @@ func (client *ExpressRouteLinksClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRouteLinksClient) getHandleResponse(resp *http.Response) (ExpressRouteLinksClientGetResponse, error) {
-	result := ExpressRouteLinksClientGetResponse{RawResponse: resp}
+	result := ExpressRouteLinksClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteLink); err != nil {
 		return ExpressRouteLinksClientGetResponse{}, err
 	}
@@ -155,7 +155,7 @@ func (client *ExpressRouteLinksClient) listCreateRequest(ctx context.Context, re
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteLinksClient) listHandleResponse(resp *http.Response) (ExpressRouteLinksClientListResponse, error) {
-	result := ExpressRouteLinksClientListResponse{RawResponse: resp}
+	result := ExpressRouteLinksClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteLinkListResult); err != nil {
 		return ExpressRouteLinksClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
@@ -62,9 +62,7 @@ func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return ExpressRoutePortsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ExpressRoutePortsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRoutePortsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRoutePortsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ExpressRoutePortsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resource
 	if err != nil {
 		return ExpressRoutePortsClientDeletePollerResponse{}, err
 	}
-	result := ExpressRoutePortsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ExpressRoutePortsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRoutePortsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ExpressRoutePortsClientDeletePollerResponse{}, err
@@ -233,7 +229,7 @@ func (client *ExpressRoutePortsClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRoutePortsClient) getHandleResponse(resp *http.Response) (ExpressRoutePortsClientGetResponse, error) {
-	result := ExpressRoutePortsClientGetResponse{RawResponse: resp}
+	result := ExpressRoutePortsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePort); err != nil {
 		return ExpressRoutePortsClientGetResponse{}, err
 	}
@@ -275,7 +271,7 @@ func (client *ExpressRoutePortsClient) listCreateRequest(ctx context.Context, op
 
 // listHandleResponse handles the List response.
 func (client *ExpressRoutePortsClient) listHandleResponse(resp *http.Response) (ExpressRoutePortsClientListResponse, error) {
-	result := ExpressRoutePortsClientListResponse{RawResponse: resp}
+	result := ExpressRoutePortsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePortListResult); err != nil {
 		return ExpressRoutePortsClientListResponse{}, err
 	}
@@ -323,7 +319,7 @@ func (client *ExpressRoutePortsClient) listByResourceGroupCreateRequest(ctx cont
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ExpressRoutePortsClient) listByResourceGroupHandleResponse(resp *http.Response) (ExpressRoutePortsClientListByResourceGroupResponse, error) {
-	result := ExpressRoutePortsClientListByResourceGroupResponse{RawResponse: resp}
+	result := ExpressRoutePortsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePortListResult); err != nil {
 		return ExpressRoutePortsClientListByResourceGroupResponse{}, err
 	}
@@ -380,7 +376,7 @@ func (client *ExpressRoutePortsClient) updateTagsCreateRequest(ctx context.Conte
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *ExpressRoutePortsClient) updateTagsHandleResponse(resp *http.Response) (ExpressRoutePortsClientUpdateTagsResponse, error) {
-	result := ExpressRoutePortsClientUpdateTagsResponse{RawResponse: resp}
+	result := ExpressRoutePortsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePort); err != nil {
 		return ExpressRoutePortsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations_client.go
@@ -95,7 +95,7 @@ func (client *ExpressRoutePortsLocationsClient) getCreateRequest(ctx context.Con
 
 // getHandleResponse handles the Get response.
 func (client *ExpressRoutePortsLocationsClient) getHandleResponse(resp *http.Response) (ExpressRoutePortsLocationsClientGetResponse, error) {
-	result := ExpressRoutePortsLocationsClientGetResponse{RawResponse: resp}
+	result := ExpressRoutePortsLocationsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePortsLocation); err != nil {
 		return ExpressRoutePortsLocationsClientGetResponse{}, err
 	}
@@ -139,7 +139,7 @@ func (client *ExpressRoutePortsLocationsClient) listCreateRequest(ctx context.Co
 
 // listHandleResponse handles the List response.
 func (client *ExpressRoutePortsLocationsClient) listHandleResponse(resp *http.Response) (ExpressRoutePortsLocationsClientListResponse, error) {
-	result := ExpressRoutePortsLocationsClientListResponse{RawResponse: resp}
+	result := ExpressRoutePortsLocationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePortsLocationListResult); err != nil {
 		return ExpressRoutePortsLocationsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders_client.go
@@ -86,7 +86,7 @@ func (client *ExpressRouteServiceProvidersClient) listCreateRequest(ctx context.
 
 // listHandleResponse handles the List response.
 func (client *ExpressRouteServiceProvidersClient) listHandleResponse(resp *http.Response) (ExpressRouteServiceProvidersClientListResponse, error) {
-	result := ExpressRouteServiceProvidersClientListResponse{RawResponse: resp}
+	result := ExpressRouteServiceProvidersClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteServiceProviderListResult); err != nil {
 		return ExpressRouteServiceProvidersClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
@@ -62,9 +62,7 @@ func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return FirewallPoliciesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := FirewallPoliciesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := FirewallPoliciesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("FirewallPoliciesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return FirewallPoliciesClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceG
 	if err != nil {
 		return FirewallPoliciesClientDeletePollerResponse{}, err
 	}
-	result := FirewallPoliciesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := FirewallPoliciesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("FirewallPoliciesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return FirewallPoliciesClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *FirewallPoliciesClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client *FirewallPoliciesClient) getHandleResponse(resp *http.Response) (FirewallPoliciesClientGetResponse, error) {
-	result := FirewallPoliciesClientGetResponse{RawResponse: resp}
+	result := FirewallPoliciesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicy); err != nil {
 		return FirewallPoliciesClientGetResponse{}, err
 	}
@@ -283,7 +279,7 @@ func (client *FirewallPoliciesClient) listCreateRequest(ctx context.Context, res
 
 // listHandleResponse handles the List response.
 func (client *FirewallPoliciesClient) listHandleResponse(resp *http.Response) (FirewallPoliciesClientListResponse, error) {
-	result := FirewallPoliciesClientListResponse{RawResponse: resp}
+	result := FirewallPoliciesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicyListResult); err != nil {
 		return FirewallPoliciesClientListResponse{}, err
 	}
@@ -326,7 +322,7 @@ func (client *FirewallPoliciesClient) listAllCreateRequest(ctx context.Context, 
 
 // listAllHandleResponse handles the ListAll response.
 func (client *FirewallPoliciesClient) listAllHandleResponse(resp *http.Response) (FirewallPoliciesClientListAllResponse, error) {
-	result := FirewallPoliciesClientListAllResponse{RawResponse: resp}
+	result := FirewallPoliciesClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicyListResult); err != nil {
 		return FirewallPoliciesClientListAllResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
@@ -63,9 +63,7 @@ func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("FirewallPolicyRuleGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, r
 	if err != nil {
 		return FirewallPolicyRuleGroupsClientDeletePollerResponse{}, err
 	}
-	result := FirewallPolicyRuleGroupsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := FirewallPolicyRuleGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("FirewallPolicyRuleGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return FirewallPolicyRuleGroupsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *FirewallPolicyRuleGroupsClient) getCreateRequest(ctx context.Conte
 
 // getHandleResponse handles the Get response.
 func (client *FirewallPolicyRuleGroupsClient) getHandleResponse(resp *http.Response) (FirewallPolicyRuleGroupsClientGetResponse, error) {
-	result := FirewallPolicyRuleGroupsClientGetResponse{RawResponse: resp}
+	result := FirewallPolicyRuleGroupsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicyRuleGroup); err != nil {
 		return FirewallPolicyRuleGroupsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *FirewallPolicyRuleGroupsClient) listCreateRequest(ctx context.Cont
 
 // listHandleResponse handles the List response.
 func (client *FirewallPolicyRuleGroupsClient) listHandleResponse(resp *http.Response) (FirewallPolicyRuleGroupsClientListResponse, error) {
-	result := FirewallPolicyRuleGroupsClientListResponse{RawResponse: resp}
+	result := FirewallPolicyRuleGroupsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicyRuleGroupListResult); err != nil {
 		return FirewallPolicyRuleGroupsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
@@ -63,9 +63,7 @@ func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return FlowLogsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := FlowLogsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := FlowLogsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("FlowLogsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return FlowLogsClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName
 	if err != nil {
 		return FlowLogsClientDeletePollerResponse{}, err
 	}
-	result := FlowLogsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := FlowLogsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("FlowLogsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return FlowLogsClientDeletePollerResponse{}, err
@@ -247,7 +243,7 @@ func (client *FlowLogsClient) getCreateRequest(ctx context.Context, resourceGrou
 
 // getHandleResponse handles the Get response.
 func (client *FlowLogsClient) getHandleResponse(resp *http.Response) (FlowLogsClientGetResponse, error) {
-	result := FlowLogsClientGetResponse{RawResponse: resp}
+	result := FlowLogsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FlowLog); err != nil {
 		return FlowLogsClientGetResponse{}, err
 	}
@@ -299,7 +295,7 @@ func (client *FlowLogsClient) listCreateRequest(ctx context.Context, resourceGro
 
 // listHandleResponse handles the List response.
 func (client *FlowLogsClient) listHandleResponse(resp *http.Response) (FlowLogsClientListResponse, error) {
-	result := FlowLogsClientListResponse{RawResponse: resp}
+	result := FlowLogsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FlowLogListResult); err != nil {
 		return FlowLogsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections_client.go
@@ -104,7 +104,7 @@ func (client *HubVirtualNetworkConnectionsClient) getCreateRequest(ctx context.C
 
 // getHandleResponse handles the Get response.
 func (client *HubVirtualNetworkConnectionsClient) getHandleResponse(resp *http.Response) (HubVirtualNetworkConnectionsClientGetResponse, error) {
-	result := HubVirtualNetworkConnectionsClientGetResponse{RawResponse: resp}
+	result := HubVirtualNetworkConnectionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.HubVirtualNetworkConnection); err != nil {
 		return HubVirtualNetworkConnectionsClientGetResponse{}, err
 	}
@@ -157,7 +157,7 @@ func (client *HubVirtualNetworkConnectionsClient) listCreateRequest(ctx context.
 
 // listHandleResponse handles the List response.
 func (client *HubVirtualNetworkConnectionsClient) listHandleResponse(resp *http.Response) (HubVirtualNetworkConnectionsClientListResponse, error) {
-	result := HubVirtualNetworkConnectionsClientListResponse{RawResponse: resp}
+	result := HubVirtualNetworkConnectionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListHubVirtualNetworkConnectionsResult); err != nil {
 		return HubVirtualNetworkConnectionsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
@@ -63,9 +63,7 @@ func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, re
 	if err != nil {
 		return InboundNatRulesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := InboundNatRulesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := InboundNatRulesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("InboundNatRulesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return InboundNatRulesClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGr
 	if err != nil {
 		return InboundNatRulesClientDeletePollerResponse{}, err
 	}
-	result := InboundNatRulesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := InboundNatRulesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("InboundNatRulesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return InboundNatRulesClientDeletePollerResponse{}, err
@@ -251,7 +247,7 @@ func (client *InboundNatRulesClient) getCreateRequest(ctx context.Context, resou
 
 // getHandleResponse handles the Get response.
 func (client *InboundNatRulesClient) getHandleResponse(resp *http.Response) (InboundNatRulesClientGetResponse, error) {
-	result := InboundNatRulesClientGetResponse{RawResponse: resp}
+	result := InboundNatRulesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InboundNatRule); err != nil {
 		return InboundNatRulesClientGetResponse{}, err
 	}
@@ -303,7 +299,7 @@ func (client *InboundNatRulesClient) listCreateRequest(ctx context.Context, reso
 
 // listHandleResponse handles the List response.
 func (client *InboundNatRulesClient) listHandleResponse(resp *http.Response) (InboundNatRulesClientListResponse, error) {
-	result := InboundNatRulesClientListResponse{RawResponse: resp}
+	result := InboundNatRulesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InboundNatRuleListResult); err != nil {
 		return InboundNatRulesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaceipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaceipconfigurations_client.go
@@ -104,7 +104,7 @@ func (client *InterfaceIPConfigurationsClient) getCreateRequest(ctx context.Cont
 
 // getHandleResponse handles the Get response.
 func (client *InterfaceIPConfigurationsClient) getHandleResponse(resp *http.Response) (InterfaceIPConfigurationsClientGetResponse, error) {
-	result := InterfaceIPConfigurationsClientGetResponse{RawResponse: resp}
+	result := InterfaceIPConfigurationsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceIPConfiguration); err != nil {
 		return InterfaceIPConfigurationsClientGetResponse{}, err
 	}
@@ -157,7 +157,7 @@ func (client *InterfaceIPConfigurationsClient) listCreateRequest(ctx context.Con
 
 // listHandleResponse handles the List response.
 func (client *InterfaceIPConfigurationsClient) listHandleResponse(resp *http.Response) (InterfaceIPConfigurationsClientListResponse, error) {
-	result := InterfaceIPConfigurationsClientListResponse{RawResponse: resp}
+	result := InterfaceIPConfigurationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceIPConfigurationListResult); err != nil {
 		return InterfaceIPConfigurationsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaceloadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaceloadbalancers_client.go
@@ -96,7 +96,7 @@ func (client *InterfaceLoadBalancersClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client *InterfaceLoadBalancersClient) listHandleResponse(resp *http.Response) (InterfaceLoadBalancersClientListResponse, error) {
-	result := InterfaceLoadBalancersClientListResponse{RawResponse: resp}
+	result := InterfaceLoadBalancersClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceLoadBalancerListResult); err != nil {
 		return InterfaceLoadBalancersClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaces_client.go
@@ -62,9 +62,7 @@ func (client *InterfacesClient) BeginCreateOrUpdate(ctx context.Context, resourc
 	if err != nil {
 		return InterfacesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := InterfacesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := InterfacesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfacesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return InterfacesClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *InterfacesClient) BeginDelete(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return InterfacesClientDeletePollerResponse{}, err
 	}
-	result := InterfacesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := InterfacesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfacesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return InterfacesClientDeletePollerResponse{}, err
@@ -235,7 +231,7 @@ func (client *InterfacesClient) getCreateRequest(ctx context.Context, resourceGr
 
 // getHandleResponse handles the Get response.
 func (client *InterfacesClient) getHandleResponse(resp *http.Response) (InterfacesClientGetResponse, error) {
-	result := InterfacesClientGetResponse{RawResponse: resp}
+	result := InterfacesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
 		return InterfacesClientGetResponse{}, err
 	}
@@ -253,9 +249,7 @@ func (client *InterfacesClient) BeginGetEffectiveRouteTable(ctx context.Context,
 	if err != nil {
 		return InterfacesClientGetEffectiveRouteTablePollerResponse{}, err
 	}
-	result := InterfacesClientGetEffectiveRouteTablePollerResponse{
-		RawResponse: resp,
-	}
+	result := InterfacesClientGetEffectiveRouteTablePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfacesClient.GetEffectiveRouteTable", "location", resp, client.pl)
 	if err != nil {
 		return InterfacesClientGetEffectiveRouteTablePollerResponse{}, err
@@ -377,7 +371,7 @@ func (client *InterfacesClient) getVirtualMachineScaleSetIPConfigurationCreateRe
 
 // getVirtualMachineScaleSetIPConfigurationHandleResponse handles the GetVirtualMachineScaleSetIPConfiguration response.
 func (client *InterfacesClient) getVirtualMachineScaleSetIPConfigurationHandleResponse(resp *http.Response) (InterfacesClientGetVirtualMachineScaleSetIPConfigurationResponse, error) {
-	result := InterfacesClientGetVirtualMachineScaleSetIPConfigurationResponse{RawResponse: resp}
+	result := InterfacesClientGetVirtualMachineScaleSetIPConfigurationResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceIPConfiguration); err != nil {
 		return InterfacesClientGetVirtualMachineScaleSetIPConfigurationResponse{}, err
 	}
@@ -446,7 +440,7 @@ func (client *InterfacesClient) getVirtualMachineScaleSetNetworkInterfaceCreateR
 
 // getVirtualMachineScaleSetNetworkInterfaceHandleResponse handles the GetVirtualMachineScaleSetNetworkInterface response.
 func (client *InterfacesClient) getVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp *http.Response) (InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse, error) {
-	result := InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse{RawResponse: resp}
+	result := InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
 		return InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse{}, err
 	}
@@ -493,7 +487,7 @@ func (client *InterfacesClient) listCreateRequest(ctx context.Context, resourceG
 
 // listHandleResponse handles the List response.
 func (client *InterfacesClient) listHandleResponse(resp *http.Response) (InterfacesClientListResponse, error) {
-	result := InterfacesClientListResponse{RawResponse: resp}
+	result := InterfacesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return InterfacesClientListResponse{}, err
 	}
@@ -535,7 +529,7 @@ func (client *InterfacesClient) listAllCreateRequest(ctx context.Context, option
 
 // listAllHandleResponse handles the ListAll response.
 func (client *InterfacesClient) listAllHandleResponse(resp *http.Response) (InterfacesClientListAllResponse, error) {
-	result := InterfacesClientListAllResponse{RawResponse: resp}
+	result := InterfacesClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return InterfacesClientListAllResponse{}, err
 	}
@@ -553,9 +547,7 @@ func (client *InterfacesClient) BeginListEffectiveNetworkSecurityGroups(ctx cont
 	if err != nil {
 		return InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse{}, err
 	}
-	result := InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse{
-		RawResponse: resp,
-	}
+	result := InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse{}
 	pt, err := armruntime.NewPoller("InterfacesClient.ListEffectiveNetworkSecurityGroups", "location", resp, client.pl)
 	if err != nil {
 		return InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse{}, err
@@ -669,7 +661,7 @@ func (client *InterfacesClient) listVirtualMachineScaleSetIPConfigurationsCreate
 
 // listVirtualMachineScaleSetIPConfigurationsHandleResponse handles the ListVirtualMachineScaleSetIPConfigurations response.
 func (client *InterfacesClient) listVirtualMachineScaleSetIPConfigurationsHandleResponse(resp *http.Response) (InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse, error) {
-	result := InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse{RawResponse: resp}
+	result := InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceIPConfigurationListResult); err != nil {
 		return InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse{}, err
 	}
@@ -722,7 +714,7 @@ func (client *InterfacesClient) listVirtualMachineScaleSetNetworkInterfacesCreat
 
 // listVirtualMachineScaleSetNetworkInterfacesHandleResponse handles the ListVirtualMachineScaleSetNetworkInterfaces response.
 func (client *InterfacesClient) listVirtualMachineScaleSetNetworkInterfacesHandleResponse(resp *http.Response) (InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse, error) {
-	result := InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{RawResponse: resp}
+	result := InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{}, err
 	}
@@ -781,7 +773,7 @@ func (client *InterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesCre
 
 // listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse handles the ListVirtualMachineScaleSetVMNetworkInterfaces response.
 func (client *InterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse(resp *http.Response) (InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse, error) {
-	result := InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse{RawResponse: resp}
+	result := InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, err
 	}
@@ -837,7 +829,7 @@ func (client *InterfacesClient) updateTagsCreateRequest(ctx context.Context, res
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *InterfacesClient) updateTagsHandleResponse(resp *http.Response) (InterfacesClientUpdateTagsResponse, error) {
-	result := InterfacesClientUpdateTagsResponse{RawResponse: resp}
+	result := InterfacesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
 		return InterfacesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfacetapconfigurations_client.go
@@ -63,9 +63,7 @@ func (client *InterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx context.
 	if err != nil {
 		return InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfaceTapConfigurationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *InterfaceTapConfigurationsClient) BeginDelete(ctx context.Context,
 	if err != nil {
 		return InterfaceTapConfigurationsClientDeletePollerResponse{}, err
 	}
-	result := InterfaceTapConfigurationsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := InterfaceTapConfigurationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfaceTapConfigurationsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return InterfaceTapConfigurationsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *InterfaceTapConfigurationsClient) getCreateRequest(ctx context.Con
 
 // getHandleResponse handles the Get response.
 func (client *InterfaceTapConfigurationsClient) getHandleResponse(resp *http.Response) (InterfaceTapConfigurationsClientGetResponse, error) {
-	result := InterfaceTapConfigurationsClientGetResponse{RawResponse: resp}
+	result := InterfaceTapConfigurationsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceTapConfiguration); err != nil {
 		return InterfaceTapConfigurationsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *InterfaceTapConfigurationsClient) listCreateRequest(ctx context.Co
 
 // listHandleResponse handles the List response.
 func (client *InterfaceTapConfigurationsClient) listHandleResponse(resp *http.Response) (InterfaceTapConfigurationsClientListResponse, error) {
-	result := InterfaceTapConfigurationsClientListResponse{RawResponse: resp}
+	result := InterfaceTapConfigurationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceTapConfigurationListResult); err != nil {
 		return InterfaceTapConfigurationsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
@@ -62,9 +62,7 @@ func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return IPAllocationsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := IPAllocationsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := IPAllocationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("IPAllocationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return IPAllocationsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGrou
 	if err != nil {
 		return IPAllocationsClientDeletePollerResponse{}, err
 	}
-	result := IPAllocationsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := IPAllocationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("IPAllocationsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return IPAllocationsClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *IPAllocationsClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client *IPAllocationsClient) getHandleResponse(resp *http.Response) (IPAllocationsClientGetResponse, error) {
-	result := IPAllocationsClientGetResponse{RawResponse: resp}
+	result := IPAllocationsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAllocation); err != nil {
 		return IPAllocationsClientGetResponse{}, err
 	}
@@ -278,7 +274,7 @@ func (client *IPAllocationsClient) listCreateRequest(ctx context.Context, option
 
 // listHandleResponse handles the List response.
 func (client *IPAllocationsClient) listHandleResponse(resp *http.Response) (IPAllocationsClientListResponse, error) {
-	result := IPAllocationsClientListResponse{RawResponse: resp}
+	result := IPAllocationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAllocationListResult); err != nil {
 		return IPAllocationsClientListResponse{}, err
 	}
@@ -326,7 +322,7 @@ func (client *IPAllocationsClient) listByResourceGroupCreateRequest(ctx context.
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *IPAllocationsClient) listByResourceGroupHandleResponse(resp *http.Response) (IPAllocationsClientListByResourceGroupResponse, error) {
-	result := IPAllocationsClientListByResourceGroupResponse{RawResponse: resp}
+	result := IPAllocationsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAllocationListResult); err != nil {
 		return IPAllocationsClientListByResourceGroupResponse{}, err
 	}
@@ -383,7 +379,7 @@ func (client *IPAllocationsClient) updateTagsCreateRequest(ctx context.Context, 
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *IPAllocationsClient) updateTagsHandleResponse(resp *http.Response) (IPAllocationsClientUpdateTagsResponse, error) {
-	result := IPAllocationsClientUpdateTagsResponse{RawResponse: resp}
+	result := IPAllocationsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAllocation); err != nil {
 		return IPAllocationsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
@@ -62,9 +62,7 @@ func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return IPGroupsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := IPGroupsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := IPGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("IPGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return IPGroupsClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName
 	if err != nil {
 		return IPGroupsClientDeletePollerResponse{}, err
 	}
-	result := IPGroupsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := IPGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("IPGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return IPGroupsClientDeletePollerResponse{}, err
@@ -235,7 +231,7 @@ func (client *IPGroupsClient) getCreateRequest(ctx context.Context, resourceGrou
 
 // getHandleResponse handles the Get response.
 func (client *IPGroupsClient) getHandleResponse(resp *http.Response) (IPGroupsClientGetResponse, error) {
-	result := IPGroupsClientGetResponse{RawResponse: resp}
+	result := IPGroupsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPGroup); err != nil {
 		return IPGroupsClientGetResponse{}, err
 	}
@@ -277,7 +273,7 @@ func (client *IPGroupsClient) listCreateRequest(ctx context.Context, options *IP
 
 // listHandleResponse handles the List response.
 func (client *IPGroupsClient) listHandleResponse(resp *http.Response) (IPGroupsClientListResponse, error) {
-	result := IPGroupsClientListResponse{RawResponse: resp}
+	result := IPGroupsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPGroupListResult); err != nil {
 		return IPGroupsClientListResponse{}, err
 	}
@@ -325,7 +321,7 @@ func (client *IPGroupsClient) listByResourceGroupCreateRequest(ctx context.Conte
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *IPGroupsClient) listByResourceGroupHandleResponse(resp *http.Response) (IPGroupsClientListByResourceGroupResponse, error) {
-	result := IPGroupsClientListByResourceGroupResponse{RawResponse: resp}
+	result := IPGroupsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPGroupListResult); err != nil {
 		return IPGroupsClientListByResourceGroupResponse{}, err
 	}
@@ -381,7 +377,7 @@ func (client *IPGroupsClient) updateGroupsCreateRequest(ctx context.Context, res
 
 // updateGroupsHandleResponse handles the UpdateGroups response.
 func (client *IPGroupsClient) updateGroupsHandleResponse(resp *http.Response) (IPGroupsClientUpdateGroupsResponse, error) {
-	result := IPGroupsClientUpdateGroupsResponse{RawResponse: resp}
+	result := IPGroupsClientUpdateGroupsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPGroup); err != nil {
 		return IPGroupsClientUpdateGroupsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools_client.go
@@ -104,7 +104,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) getCreateRequest(ctx contex
 
 // getHandleResponse handles the Get response.
 func (client *LoadBalancerBackendAddressPoolsClient) getHandleResponse(resp *http.Response) (LoadBalancerBackendAddressPoolsClientGetResponse, error) {
-	result := LoadBalancerBackendAddressPoolsClientGetResponse{RawResponse: resp}
+	result := LoadBalancerBackendAddressPoolsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackendAddressPool); err != nil {
 		return LoadBalancerBackendAddressPoolsClientGetResponse{}, err
 	}
@@ -157,7 +157,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) listCreateRequest(ctx conte
 
 // listHandleResponse handles the List response.
 func (client *LoadBalancerBackendAddressPoolsClient) listHandleResponse(resp *http.Response) (LoadBalancerBackendAddressPoolsClientListResponse, error) {
-	result := LoadBalancerBackendAddressPoolsClientListResponse{RawResponse: resp}
+	result := LoadBalancerBackendAddressPoolsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerBackendAddressPoolListResult); err != nil {
 		return LoadBalancerBackendAddressPoolsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations_client.go
@@ -104,7 +104,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) getCreateRequest(ctx c
 
 // getHandleResponse handles the Get response.
 func (client *LoadBalancerFrontendIPConfigurationsClient) getHandleResponse(resp *http.Response) (LoadBalancerFrontendIPConfigurationsClientGetResponse, error) {
-	result := LoadBalancerFrontendIPConfigurationsClientGetResponse{RawResponse: resp}
+	result := LoadBalancerFrontendIPConfigurationsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FrontendIPConfiguration); err != nil {
 		return LoadBalancerFrontendIPConfigurationsClientGetResponse{}, err
 	}
@@ -157,7 +157,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) listCreateRequest(ctx 
 
 // listHandleResponse handles the List response.
 func (client *LoadBalancerFrontendIPConfigurationsClient) listHandleResponse(resp *http.Response) (LoadBalancerFrontendIPConfigurationsClientListResponse, error) {
-	result := LoadBalancerFrontendIPConfigurationsClientListResponse{RawResponse: resp}
+	result := LoadBalancerFrontendIPConfigurationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerFrontendIPConfigurationListResult); err != nil {
 		return LoadBalancerFrontendIPConfigurationsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules_client.go
@@ -104,7 +104,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) getCreateRequest(ctx context
 
 // getHandleResponse handles the Get response.
 func (client *LoadBalancerLoadBalancingRulesClient) getHandleResponse(resp *http.Response) (LoadBalancerLoadBalancingRulesClientGetResponse, error) {
-	result := LoadBalancerLoadBalancingRulesClientGetResponse{RawResponse: resp}
+	result := LoadBalancerLoadBalancingRulesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancingRule); err != nil {
 		return LoadBalancerLoadBalancingRulesClientGetResponse{}, err
 	}
@@ -157,7 +157,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) listCreateRequest(ctx contex
 
 // listHandleResponse handles the List response.
 func (client *LoadBalancerLoadBalancingRulesClient) listHandleResponse(resp *http.Response) (LoadBalancerLoadBalancingRulesClientListResponse, error) {
-	result := LoadBalancerLoadBalancingRulesClientListResponse{RawResponse: resp}
+	result := LoadBalancerLoadBalancingRulesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerLoadBalancingRuleListResult); err != nil {
 		return LoadBalancerLoadBalancingRulesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
@@ -96,7 +96,7 @@ func (client *LoadBalancerNetworkInterfacesClient) listCreateRequest(ctx context
 
 // listHandleResponse handles the List response.
 func (client *LoadBalancerNetworkInterfacesClient) listHandleResponse(resp *http.Response) (LoadBalancerNetworkInterfacesClientListResponse, error) {
-	result := LoadBalancerNetworkInterfacesClientListResponse{RawResponse: resp}
+	result := LoadBalancerNetworkInterfacesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceListResult); err != nil {
 		return LoadBalancerNetworkInterfacesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules_client.go
@@ -104,7 +104,7 @@ func (client *LoadBalancerOutboundRulesClient) getCreateRequest(ctx context.Cont
 
 // getHandleResponse handles the Get response.
 func (client *LoadBalancerOutboundRulesClient) getHandleResponse(resp *http.Response) (LoadBalancerOutboundRulesClientGetResponse, error) {
-	result := LoadBalancerOutboundRulesClientGetResponse{RawResponse: resp}
+	result := LoadBalancerOutboundRulesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OutboundRule); err != nil {
 		return LoadBalancerOutboundRulesClientGetResponse{}, err
 	}
@@ -157,7 +157,7 @@ func (client *LoadBalancerOutboundRulesClient) listCreateRequest(ctx context.Con
 
 // listHandleResponse handles the List response.
 func (client *LoadBalancerOutboundRulesClient) listHandleResponse(resp *http.Response) (LoadBalancerOutboundRulesClientListResponse, error) {
-	result := LoadBalancerOutboundRulesClientListResponse{RawResponse: resp}
+	result := LoadBalancerOutboundRulesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerOutboundRuleListResult); err != nil {
 		return LoadBalancerOutboundRulesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes_client.go
@@ -103,7 +103,7 @@ func (client *LoadBalancerProbesClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client *LoadBalancerProbesClient) getHandleResponse(resp *http.Response) (LoadBalancerProbesClientGetResponse, error) {
-	result := LoadBalancerProbesClientGetResponse{RawResponse: resp}
+	result := LoadBalancerProbesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Probe); err != nil {
 		return LoadBalancerProbesClientGetResponse{}, err
 	}
@@ -155,7 +155,7 @@ func (client *LoadBalancerProbesClient) listCreateRequest(ctx context.Context, r
 
 // listHandleResponse handles the List response.
 func (client *LoadBalancerProbesClient) listHandleResponse(resp *http.Response) (LoadBalancerProbesClientListResponse, error) {
-	result := LoadBalancerProbesClientListResponse{RawResponse: resp}
+	result := LoadBalancerProbesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerProbeListResult); err != nil {
 		return LoadBalancerProbesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
@@ -62,9 +62,7 @@ func (client *LoadBalancersClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return LoadBalancersClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := LoadBalancersClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := LoadBalancersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("LoadBalancersClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return LoadBalancersClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGrou
 	if err != nil {
 		return LoadBalancersClientDeletePollerResponse{}, err
 	}
-	result := LoadBalancersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := LoadBalancersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("LoadBalancersClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return LoadBalancersClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *LoadBalancersClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client *LoadBalancersClient) getHandleResponse(resp *http.Response) (LoadBalancersClientGetResponse, error) {
-	result := LoadBalancersClientGetResponse{RawResponse: resp}
+	result := LoadBalancersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancer); err != nil {
 		return LoadBalancersClientGetResponse{}, err
 	}
@@ -283,7 +279,7 @@ func (client *LoadBalancersClient) listCreateRequest(ctx context.Context, resour
 
 // listHandleResponse handles the List response.
 func (client *LoadBalancersClient) listHandleResponse(resp *http.Response) (LoadBalancersClientListResponse, error) {
-	result := LoadBalancersClientListResponse{RawResponse: resp}
+	result := LoadBalancersClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerListResult); err != nil {
 		return LoadBalancersClientListResponse{}, err
 	}
@@ -325,7 +321,7 @@ func (client *LoadBalancersClient) listAllCreateRequest(ctx context.Context, opt
 
 // listAllHandleResponse handles the ListAll response.
 func (client *LoadBalancersClient) listAllHandleResponse(resp *http.Response) (LoadBalancersClientListAllResponse, error) {
-	result := LoadBalancersClientListAllResponse{RawResponse: resp}
+	result := LoadBalancersClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerListResult); err != nil {
 		return LoadBalancersClientListAllResponse{}, err
 	}
@@ -382,7 +378,7 @@ func (client *LoadBalancersClient) updateTagsCreateRequest(ctx context.Context, 
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *LoadBalancersClient) updateTagsHandleResponse(resp *http.Response) (LoadBalancersClientUpdateTagsResponse, error) {
-	result := LoadBalancersClientUpdateTagsResponse{RawResponse: resp}
+	result := LoadBalancersClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancer); err != nil {
 		return LoadBalancersClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
@@ -62,9 +62,7 @@ func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return LocalNetworkGatewaysClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := LocalNetworkGatewaysClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := LocalNetworkGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("LocalNetworkGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return LocalNetworkGatewaysClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return LocalNetworkGatewaysClientDeletePollerResponse{}, err
 	}
-	result := LocalNetworkGatewaysClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := LocalNetworkGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("LocalNetworkGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return LocalNetworkGatewaysClientDeletePollerResponse{}, err
@@ -234,7 +230,7 @@ func (client *LocalNetworkGatewaysClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client *LocalNetworkGatewaysClient) getHandleResponse(resp *http.Response) (LocalNetworkGatewaysClientGetResponse, error) {
-	result := LocalNetworkGatewaysClientGetResponse{RawResponse: resp}
+	result := LocalNetworkGatewaysClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LocalNetworkGateway); err != nil {
 		return LocalNetworkGatewaysClientGetResponse{}, err
 	}
@@ -282,7 +278,7 @@ func (client *LocalNetworkGatewaysClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client *LocalNetworkGatewaysClient) listHandleResponse(resp *http.Response) (LocalNetworkGatewaysClientListResponse, error) {
-	result := LocalNetworkGatewaysClientListResponse{RawResponse: resp}
+	result := LocalNetworkGatewaysClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LocalNetworkGatewayListResult); err != nil {
 		return LocalNetworkGatewaysClientListResponse{}, err
 	}
@@ -339,7 +335,7 @@ func (client *LocalNetworkGatewaysClient) updateTagsCreateRequest(ctx context.Co
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *LocalNetworkGatewaysClient) updateTagsHandleResponse(resp *http.Response) (LocalNetworkGatewaysClientUpdateTagsResponse, error) {
-	result := LocalNetworkGatewaysClientUpdateTagsResponse{RawResponse: resp}
+	result := LocalNetworkGatewaysClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LocalNetworkGateway); err != nil {
 		return LocalNetworkGatewaysClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_management_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_management_client.go
@@ -96,7 +96,7 @@ func (client *ManagementClient) checkDNSNameAvailabilityCreateRequest(ctx contex
 
 // checkDNSNameAvailabilityHandleResponse handles the CheckDNSNameAvailability response.
 func (client *ManagementClient) checkDNSNameAvailabilityHandleResponse(resp *http.Response) (ManagementClientCheckDNSNameAvailabilityResponse, error) {
-	result := ManagementClientCheckDNSNameAvailabilityResponse{RawResponse: resp}
+	result := ManagementClientCheckDNSNameAvailabilityResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DNSNameAvailabilityResult); err != nil {
 		return ManagementClientCheckDNSNameAvailabilityResponse{}, err
 	}
@@ -115,9 +115,7 @@ func (client *ManagementClient) BeginDeleteBastionShareableLink(ctx context.Cont
 	if err != nil {
 		return ManagementClientDeleteBastionShareableLinkPollerResponse{}, err
 	}
-	result := ManagementClientDeleteBastionShareableLinkPollerResponse{
-		RawResponse: resp,
-	}
+	result := ManagementClientDeleteBastionShareableLinkPollerResponse{}
 	pt, err := armruntime.NewPoller("ManagementClient.DeleteBastionShareableLink", "location", resp, client.pl)
 	if err != nil {
 		return ManagementClientDeleteBastionShareableLinkPollerResponse{}, err
@@ -218,7 +216,7 @@ func (client *ManagementClient) disconnectActiveSessionsCreateRequest(ctx contex
 
 // disconnectActiveSessionsHandleResponse handles the DisconnectActiveSessions response.
 func (client *ManagementClient) disconnectActiveSessionsHandleResponse(resp *http.Response) (ManagementClientDisconnectActiveSessionsResponse, error) {
-	result := ManagementClientDisconnectActiveSessionsResponse{RawResponse: resp}
+	result := ManagementClientDisconnectActiveSessionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionSessionDeleteResult); err != nil {
 		return ManagementClientDisconnectActiveSessionsResponse{}, err
 	}
@@ -238,9 +236,7 @@ func (client *ManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpn
 	if err != nil {
 		return ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{}, err
 	}
-	result := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{
-		RawResponse: resp,
-	}
+	result := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{}
 	pt, err := armruntime.NewPoller("ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", "location", resp, client.pl)
 	if err != nil {
 		return ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{}, err
@@ -306,9 +302,7 @@ func (client *ManagementClient) BeginGetActiveSessions(ctx context.Context, reso
 	if err != nil {
 		return ManagementClientGetActiveSessionsPollerResponse{}, err
 	}
-	result := ManagementClientGetActiveSessionsPollerResponse{
-		RawResponse: resp,
-	}
+	result := ManagementClientGetActiveSessionsPollerResponse{}
 	pt, err := armruntime.NewPoller("ManagementClient.GetActiveSessions", "location", resp, client.pl)
 	if err != nil {
 		return ManagementClientGetActiveSessionsPollerResponse{}, err
@@ -365,7 +359,7 @@ func (client *ManagementClient) getActiveSessionsCreateRequest(ctx context.Conte
 
 // getActiveSessionsHandleResponse handles the GetActiveSessions response.
 func (client *ManagementClient) getActiveSessionsHandleResponse(resp *http.Response) (ManagementClientGetActiveSessionsResponse, error) {
-	result := ManagementClientGetActiveSessionsResponse{RawResponse: resp}
+	result := ManagementClientGetActiveSessionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionActiveSessionListResult); err != nil {
 		return ManagementClientGetActiveSessionsResponse{}, err
 	}
@@ -419,7 +413,7 @@ func (client *ManagementClient) getBastionShareableLinkCreateRequest(ctx context
 
 // getBastionShareableLinkHandleResponse handles the GetBastionShareableLink response.
 func (client *ManagementClient) getBastionShareableLinkHandleResponse(resp *http.Response) (ManagementClientGetBastionShareableLinkResponse, error) {
-	result := ManagementClientGetBastionShareableLinkResponse{RawResponse: resp}
+	result := ManagementClientGetBastionShareableLinkResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionShareableLinkListResult); err != nil {
 		return ManagementClientGetBastionShareableLinkResponse{}, err
 	}
@@ -438,9 +432,7 @@ func (client *ManagementClient) BeginPutBastionShareableLink(ctx context.Context
 	if err != nil {
 		return ManagementClientPutBastionShareableLinkPollerResponse{}, err
 	}
-	result := ManagementClientPutBastionShareableLinkPollerResponse{
-		RawResponse: resp,
-	}
+	result := ManagementClientPutBastionShareableLinkPollerResponse{}
 	pt, err := armruntime.NewPoller("ManagementClient.PutBastionShareableLink", "location", resp, client.pl)
 	if err != nil {
 		return ManagementClientPutBastionShareableLinkPollerResponse{}, err
@@ -497,7 +489,7 @@ func (client *ManagementClient) putBastionShareableLinkCreateRequest(ctx context
 
 // putBastionShareableLinkHandleResponse handles the PutBastionShareableLink response.
 func (client *ManagementClient) putBastionShareableLinkHandleResponse(resp *http.Response) (ManagementClientPutBastionShareableLinkResponse, error) {
-	result := ManagementClientPutBastionShareableLinkResponse{RawResponse: resp}
+	result := ManagementClientPutBastionShareableLinkResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionShareableLinkListResult); err != nil {
 		return ManagementClientPutBastionShareableLinkResponse{}, err
 	}
@@ -553,7 +545,7 @@ func (client *ManagementClient) supportedSecurityProvidersCreateRequest(ctx cont
 
 // supportedSecurityProvidersHandleResponse handles the SupportedSecurityProviders response.
 func (client *ManagementClient) supportedSecurityProvidersHandleResponse(resp *http.Response) (ManagementClientSupportedSecurityProvidersResponse, error) {
-	result := ManagementClientSupportedSecurityProvidersResponse{RawResponse: resp}
+	result := ManagementClientSupportedSecurityProvidersResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualWanSecurityProviders); err != nil {
 		return ManagementClientSupportedSecurityProvidersResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
@@ -62,9 +62,7 @@ func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return NatGatewaysClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := NatGatewaysClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := NatGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("NatGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return NatGatewaysClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return NatGatewaysClientDeletePollerResponse{}, err
 	}
-	result := NatGatewaysClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := NatGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("NatGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return NatGatewaysClientDeletePollerResponse{}, err
@@ -235,7 +231,7 @@ func (client *NatGatewaysClient) getCreateRequest(ctx context.Context, resourceG
 
 // getHandleResponse handles the Get response.
 func (client *NatGatewaysClient) getHandleResponse(resp *http.Response) (NatGatewaysClientGetResponse, error) {
-	result := NatGatewaysClientGetResponse{RawResponse: resp}
+	result := NatGatewaysClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NatGateway); err != nil {
 		return NatGatewaysClientGetResponse{}, err
 	}
@@ -282,7 +278,7 @@ func (client *NatGatewaysClient) listCreateRequest(ctx context.Context, resource
 
 // listHandleResponse handles the List response.
 func (client *NatGatewaysClient) listHandleResponse(resp *http.Response) (NatGatewaysClientListResponse, error) {
-	result := NatGatewaysClientListResponse{RawResponse: resp}
+	result := NatGatewaysClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NatGatewayListResult); err != nil {
 		return NatGatewaysClientListResponse{}, err
 	}
@@ -324,7 +320,7 @@ func (client *NatGatewaysClient) listAllCreateRequest(ctx context.Context, optio
 
 // listAllHandleResponse handles the ListAll response.
 func (client *NatGatewaysClient) listAllHandleResponse(resp *http.Response) (NatGatewaysClientListAllResponse, error) {
-	result := NatGatewaysClientListAllResponse{RawResponse: resp}
+	result := NatGatewaysClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NatGatewayListResult); err != nil {
 		return NatGatewaysClientListAllResponse{}, err
 	}
@@ -380,7 +376,7 @@ func (client *NatGatewaysClient) updateTagsCreateRequest(ctx context.Context, re
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *NatGatewaysClient) updateTagsHandleResponse(resp *http.Response) (NatGatewaysClientUpdateTagsResponse, error) {
-	result := NatGatewaysClientUpdateTagsResponse{RawResponse: resp}
+	result := NatGatewaysClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NatGateway); err != nil {
 		return NatGatewaysClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations_client.go
@@ -74,7 +74,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 
 // listHandleResponse handles the List response.
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
-	result := OperationsClientListResponse{RawResponse: resp}
+	result := OperationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
@@ -62,9 +62,7 @@ func (client *P2SVPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return P2SVPNGatewaysClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := P2SVPNGatewaysClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := P2SVPNGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return P2SVPNGatewaysClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *P2SVPNGatewaysClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return P2SVPNGatewaysClientDeletePollerResponse{}, err
 	}
-	result := P2SVPNGatewaysClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := P2SVPNGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return P2SVPNGatewaysClientDeletePollerResponse{}, err
@@ -198,9 +194,7 @@ func (client *P2SVPNGatewaysClient) BeginDisconnectP2SVPNConnections(ctx context
 	if err != nil {
 		return P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse{}, err
 	}
-	result := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse{
-		RawResponse: resp,
-	}
+	result := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.DisconnectP2SVPNConnections", "location", resp, client.pl)
 	if err != nil {
 		return P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse{}, err
@@ -267,9 +261,7 @@ func (client *P2SVPNGatewaysClient) BeginGenerateVPNProfile(ctx context.Context,
 	if err != nil {
 		return P2SVPNGatewaysClientGenerateVPNProfilePollerResponse{}, err
 	}
-	result := P2SVPNGatewaysClientGenerateVPNProfilePollerResponse{
-		RawResponse: resp,
-	}
+	result := P2SVPNGatewaysClientGenerateVPNProfilePollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.GenerateVPNProfile", "location", resp, client.pl)
 	if err != nil {
 		return P2SVPNGatewaysClientGenerateVPNProfilePollerResponse{}, err
@@ -371,7 +363,7 @@ func (client *P2SVPNGatewaysClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client *P2SVPNGatewaysClient) getHandleResponse(resp *http.Response) (P2SVPNGatewaysClientGetResponse, error) {
-	result := P2SVPNGatewaysClientGetResponse{RawResponse: resp}
+	result := P2SVPNGatewaysClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.P2SVPNGateway); err != nil {
 		return P2SVPNGatewaysClientGetResponse{}, err
 	}
@@ -390,9 +382,7 @@ func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealth(ctx context.C
 	if err != nil {
 		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse{}, err
 	}
-	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse{
-		RawResponse: resp,
-	}
+	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.GetP2SVPNConnectionHealth", "location", resp, client.pl)
 	if err != nil {
 		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse{}, err
@@ -460,9 +450,7 @@ func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealthDetailed(ctx c
 	if err != nil {
 		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse{}, err
 	}
-	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse{
-		RawResponse: resp,
-	}
+	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed", "location", resp, client.pl)
 	if err != nil {
 		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse{}, err
@@ -552,7 +540,7 @@ func (client *P2SVPNGatewaysClient) listCreateRequest(ctx context.Context, optio
 
 // listHandleResponse handles the List response.
 func (client *P2SVPNGatewaysClient) listHandleResponse(resp *http.Response) (P2SVPNGatewaysClientListResponse, error) {
-	result := P2SVPNGatewaysClientListResponse{RawResponse: resp}
+	result := P2SVPNGatewaysClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListP2SVPNGatewaysResult); err != nil {
 		return P2SVPNGatewaysClientListResponse{}, err
 	}
@@ -600,7 +588,7 @@ func (client *P2SVPNGatewaysClient) listByResourceGroupCreateRequest(ctx context
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *P2SVPNGatewaysClient) listByResourceGroupHandleResponse(resp *http.Response) (P2SVPNGatewaysClientListByResourceGroupResponse, error) {
-	result := P2SVPNGatewaysClientListByResourceGroupResponse{RawResponse: resp}
+	result := P2SVPNGatewaysClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListP2SVPNGatewaysResult); err != nil {
 		return P2SVPNGatewaysClientListByResourceGroupResponse{}, err
 	}
@@ -657,7 +645,7 @@ func (client *P2SVPNGatewaysClient) updateTagsCreateRequest(ctx context.Context,
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *P2SVPNGatewaysClient) updateTagsHandleResponse(resp *http.Response) (P2SVPNGatewaysClientUpdateTagsResponse, error) {
-	result := P2SVPNGatewaysClientUpdateTagsResponse{RawResponse: resp}
+	result := P2SVPNGatewaysClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.P2SVPNGateway); err != nil {
 		return P2SVPNGatewaysClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
@@ -63,9 +63,7 @@ func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGro
 	if err != nil {
 		return PacketCapturesClientCreatePollerResponse{}, err
 	}
-	result := PacketCapturesClientCreatePollerResponse{
-		RawResponse: resp,
-	}
+	result := PacketCapturesClientCreatePollerResponse{}
 	pt, err := armruntime.NewPoller("PacketCapturesClient.Create", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return PacketCapturesClientCreatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return PacketCapturesClientDeletePollerResponse{}, err
 	}
-	result := PacketCapturesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := PacketCapturesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PacketCapturesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return PacketCapturesClientDeletePollerResponse{}, err
@@ -248,7 +244,7 @@ func (client *PacketCapturesClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client *PacketCapturesClient) getHandleResponse(resp *http.Response) (PacketCapturesClientGetResponse, error) {
-	result := PacketCapturesClientGetResponse{RawResponse: resp}
+	result := PacketCapturesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PacketCaptureResult); err != nil {
 		return PacketCapturesClientGetResponse{}, err
 	}
@@ -267,9 +263,7 @@ func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resource
 	if err != nil {
 		return PacketCapturesClientGetStatusPollerResponse{}, err
 	}
-	result := PacketCapturesClientGetStatusPollerResponse{
-		RawResponse: resp,
-	}
+	result := PacketCapturesClientGetStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("PacketCapturesClient.GetStatus", "location", resp, client.pl)
 	if err != nil {
 		return PacketCapturesClientGetStatusPollerResponse{}, err
@@ -369,7 +363,7 @@ func (client *PacketCapturesClient) listCreateRequest(ctx context.Context, resou
 
 // listHandleResponse handles the List response.
 func (client *PacketCapturesClient) listHandleResponse(resp *http.Response) (PacketCapturesClientListResponse, error) {
-	result := PacketCapturesClientListResponse{RawResponse: resp}
+	result := PacketCapturesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PacketCaptureListResult); err != nil {
 		return PacketCapturesClientListResponse{}, err
 	}
@@ -388,9 +382,7 @@ func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroup
 	if err != nil {
 		return PacketCapturesClientStopPollerResponse{}, err
 	}
-	result := PacketCapturesClientStopPollerResponse{
-		RawResponse: resp,
-	}
+	result := PacketCapturesClientStopPollerResponse{}
 	pt, err := armruntime.NewPoller("PacketCapturesClient.Stop", "location", resp, client.pl)
 	if err != nil {
 		return PacketCapturesClientStopPollerResponse{}, err

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections_client.go
@@ -109,7 +109,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) getCreateRequest(ctx con
 
 // getHandleResponse handles the Get response.
 func (client *PeerExpressRouteCircuitConnectionsClient) getHandleResponse(resp *http.Response) (PeerExpressRouteCircuitConnectionsClientGetResponse, error) {
-	result := PeerExpressRouteCircuitConnectionsClientGetResponse{RawResponse: resp}
+	result := PeerExpressRouteCircuitConnectionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PeerExpressRouteCircuitConnection); err != nil {
 		return PeerExpressRouteCircuitConnectionsClientGetResponse{}, err
 	}
@@ -167,7 +167,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) listCreateRequest(ctx co
 
 // listHandleResponse handles the List response.
 func (client *PeerExpressRouteCircuitConnectionsClient) listHandleResponse(resp *http.Response) (PeerExpressRouteCircuitConnectionsClientListResponse, error) {
-	result := PeerExpressRouteCircuitConnectionsClientListResponse{RawResponse: resp}
+	result := PeerExpressRouteCircuitConnectionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PeerExpressRouteCircuitConnectionListResult); err != nil {
 		return PeerExpressRouteCircuitConnectionsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -43,11 +43,10 @@ func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Poll(ctx context.
 // If the final GET succeeded then the final ApplicationGatewaysClientBackendHealthOnDemandResponse will be returned.
 func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
 	respType := ApplicationGatewaysClientBackendHealthOnDemandResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ApplicationGatewayBackendHealthOnDemand)
+	_, err := p.pt.FinalResponse(ctx, &respType.ApplicationGatewayBackendHealthOnDemand)
 	if err != nil {
 		return ApplicationGatewaysClientBackendHealthOnDemandResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -86,11 +85,10 @@ func (p *ApplicationGatewaysClientBackendHealthPoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final ApplicationGatewaysClientBackendHealthResponse will be returned.
 func (p *ApplicationGatewaysClientBackendHealthPoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientBackendHealthResponse, error) {
 	respType := ApplicationGatewaysClientBackendHealthResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ApplicationGatewayBackendHealth)
+	_, err := p.pt.FinalResponse(ctx, &respType.ApplicationGatewayBackendHealth)
 	if err != nil {
 		return ApplicationGatewaysClientBackendHealthResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -129,11 +127,10 @@ func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context
 // If the final GET succeeded then the final ApplicationGatewaysClientCreateOrUpdateResponse will be returned.
 func (p *ApplicationGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
 	respType := ApplicationGatewaysClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ApplicationGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.ApplicationGateway)
 	if err != nil {
 		return ApplicationGatewaysClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -172,11 +169,10 @@ func (p *ApplicationGatewaysClientDeletePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final ApplicationGatewaysClientDeleteResponse will be returned.
 func (p *ApplicationGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientDeleteResponse, error) {
 	respType := ApplicationGatewaysClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ApplicationGatewaysClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -215,11 +211,10 @@ func (p *ApplicationGatewaysClientStartPoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final ApplicationGatewaysClientStartResponse will be returned.
 func (p *ApplicationGatewaysClientStartPoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientStartResponse, error) {
 	respType := ApplicationGatewaysClientStartResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ApplicationGatewaysClientStartResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -258,11 +253,10 @@ func (p *ApplicationGatewaysClientStopPoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final ApplicationGatewaysClientStopResponse will be returned.
 func (p *ApplicationGatewaysClientStopPoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientStopResponse, error) {
 	respType := ApplicationGatewaysClientStopResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ApplicationGatewaysClientStopResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -301,11 +295,10 @@ func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.C
 // If the final GET succeeded then the final ApplicationSecurityGroupsClientCreateOrUpdateResponse will be returned.
 func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
 	respType := ApplicationSecurityGroupsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ApplicationSecurityGroup)
+	_, err := p.pt.FinalResponse(ctx, &respType.ApplicationSecurityGroup)
 	if err != nil {
 		return ApplicationSecurityGroupsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -344,11 +337,10 @@ func (p *ApplicationSecurityGroupsClientDeletePoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final ApplicationSecurityGroupsClientDeleteResponse will be returned.
 func (p *ApplicationSecurityGroupsClientDeletePoller) FinalResponse(ctx context.Context) (ApplicationSecurityGroupsClientDeleteResponse, error) {
 	respType := ApplicationSecurityGroupsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ApplicationSecurityGroupsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -387,11 +379,10 @@ func (p *AzureFirewallsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final AzureFirewallsClientCreateOrUpdateResponse will be returned.
 func (p *AzureFirewallsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (AzureFirewallsClientCreateOrUpdateResponse, error) {
 	respType := AzureFirewallsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.AzureFirewall)
+	_, err := p.pt.FinalResponse(ctx, &respType.AzureFirewall)
 	if err != nil {
 		return AzureFirewallsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -430,11 +421,10 @@ func (p *AzureFirewallsClientDeletePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final AzureFirewallsClientDeleteResponse will be returned.
 func (p *AzureFirewallsClientDeletePoller) FinalResponse(ctx context.Context) (AzureFirewallsClientDeleteResponse, error) {
 	respType := AzureFirewallsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return AzureFirewallsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -473,11 +463,10 @@ func (p *AzureFirewallsClientUpdateTagsPoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final AzureFirewallsClientUpdateTagsResponse will be returned.
 func (p *AzureFirewallsClientUpdateTagsPoller) FinalResponse(ctx context.Context) (AzureFirewallsClientUpdateTagsResponse, error) {
 	respType := AzureFirewallsClientUpdateTagsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.AzureFirewall)
+	_, err := p.pt.FinalResponse(ctx, &respType.AzureFirewall)
 	if err != nil {
 		return AzureFirewallsClientUpdateTagsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -516,11 +505,10 @@ func (p *BastionHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final BastionHostsClientCreateOrUpdateResponse will be returned.
 func (p *BastionHostsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (BastionHostsClientCreateOrUpdateResponse, error) {
 	respType := BastionHostsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.BastionHost)
+	_, err := p.pt.FinalResponse(ctx, &respType.BastionHost)
 	if err != nil {
 		return BastionHostsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -559,11 +547,10 @@ func (p *BastionHostsClientDeletePoller) Poll(ctx context.Context) (*http.Respon
 // If the final GET succeeded then the final BastionHostsClientDeleteResponse will be returned.
 func (p *BastionHostsClientDeletePoller) FinalResponse(ctx context.Context) (BastionHostsClientDeleteResponse, error) {
 	respType := BastionHostsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return BastionHostsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -602,11 +589,10 @@ func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final ConnectionMonitorsClientCreateOrUpdateResponse will be returned.
 func (p *ConnectionMonitorsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
 	respType := ConnectionMonitorsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ConnectionMonitorResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.ConnectionMonitorResult)
 	if err != nil {
 		return ConnectionMonitorsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -645,11 +631,10 @@ func (p *ConnectionMonitorsClientDeletePoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final ConnectionMonitorsClientDeleteResponse will be returned.
 func (p *ConnectionMonitorsClientDeletePoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientDeleteResponse, error) {
 	respType := ConnectionMonitorsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ConnectionMonitorsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -688,11 +673,10 @@ func (p *ConnectionMonitorsClientQueryPoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final ConnectionMonitorsClientQueryResponse will be returned.
 func (p *ConnectionMonitorsClientQueryPoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientQueryResponse, error) {
 	respType := ConnectionMonitorsClientQueryResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ConnectionMonitorQueryResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.ConnectionMonitorQueryResult)
 	if err != nil {
 		return ConnectionMonitorsClientQueryResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -731,11 +715,10 @@ func (p *ConnectionMonitorsClientStartPoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final ConnectionMonitorsClientStartResponse will be returned.
 func (p *ConnectionMonitorsClientStartPoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientStartResponse, error) {
 	respType := ConnectionMonitorsClientStartResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ConnectionMonitorsClientStartResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -774,11 +757,10 @@ func (p *ConnectionMonitorsClientStopPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final ConnectionMonitorsClientStopResponse will be returned.
 func (p *ConnectionMonitorsClientStopPoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientStopResponse, error) {
 	respType := ConnectionMonitorsClientStopResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ConnectionMonitorsClientStopResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -817,11 +799,10 @@ func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final DdosCustomPoliciesClientCreateOrUpdateResponse will be returned.
 func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
 	respType := DdosCustomPoliciesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DdosCustomPolicy)
+	_, err := p.pt.FinalResponse(ctx, &respType.DdosCustomPolicy)
 	if err != nil {
 		return DdosCustomPoliciesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -860,11 +841,10 @@ func (p *DdosCustomPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final DdosCustomPoliciesClientDeleteResponse will be returned.
 func (p *DdosCustomPoliciesClientDeletePoller) FinalResponse(ctx context.Context) (DdosCustomPoliciesClientDeleteResponse, error) {
 	respType := DdosCustomPoliciesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DdosCustomPoliciesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -903,11 +883,10 @@ func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Poll(ctx context.Context
 // If the final GET succeeded then the final DdosProtectionPlansClientCreateOrUpdateResponse will be returned.
 func (p *DdosProtectionPlansClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
 	respType := DdosProtectionPlansClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DdosProtectionPlan)
+	_, err := p.pt.FinalResponse(ctx, &respType.DdosProtectionPlan)
 	if err != nil {
 		return DdosProtectionPlansClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -946,11 +925,10 @@ func (p *DdosProtectionPlansClientDeletePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final DdosProtectionPlansClientDeleteResponse will be returned.
 func (p *DdosProtectionPlansClientDeletePoller) FinalResponse(ctx context.Context) (DdosProtectionPlansClientDeleteResponse, error) {
 	respType := DdosProtectionPlansClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return DdosProtectionPlansClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -989,11 +967,10 @@ func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Poll(ctx c
 // If the final GET succeeded then the final ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitAuthorization)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitAuthorization)
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1032,11 +1009,10 @@ func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Poll(ctx context.C
 // If the final GET succeeded then the final ExpressRouteCircuitAuthorizationsClientDeleteResponse will be returned.
 func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
 	respType := ExpressRouteCircuitAuthorizationsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1075,11 +1051,10 @@ func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Poll(ctx cont
 // If the final GET succeeded then the final ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitConnection)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitConnection)
 	if err != nil {
 		return ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1118,11 +1093,10 @@ func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Poll(ctx context.Cont
 // If the final GET succeeded then the final ExpressRouteCircuitConnectionsClientDeleteResponse will be returned.
 func (p *ExpressRouteCircuitConnectionsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
 	respType := ExpressRouteCircuitConnectionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ExpressRouteCircuitConnectionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1161,11 +1135,10 @@ func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Poll(ctx context
 // If the final GET succeeded then the final ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitPeering)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitPeering)
 	if err != nil {
 		return ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1204,11 +1177,10 @@ func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Poll(ctx context.Context
 // If the final GET succeeded then the final ExpressRouteCircuitPeeringsClientDeleteResponse will be returned.
 func (p *ExpressRouteCircuitPeeringsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
 	respType := ExpressRouteCircuitPeeringsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ExpressRouteCircuitPeeringsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1247,11 +1219,10 @@ func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final ExpressRouteCircuitsClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCircuitsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuit)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuit)
 	if err != nil {
 		return ExpressRouteCircuitsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1290,11 +1261,10 @@ func (p *ExpressRouteCircuitsClientDeletePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final ExpressRouteCircuitsClientDeleteResponse will be returned.
 func (p *ExpressRouteCircuitsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientDeleteResponse, error) {
 	respType := ExpressRouteCircuitsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ExpressRouteCircuitsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1333,11 +1303,10 @@ func (p *ExpressRouteCircuitsClientListArpTablePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final ExpressRouteCircuitsClientListArpTableResponse will be returned.
 func (p *ExpressRouteCircuitsClientListArpTablePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientListArpTableResponse, error) {
 	respType := ExpressRouteCircuitsClientListArpTableResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsArpTableListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsArpTableListResult)
 	if err != nil {
 		return ExpressRouteCircuitsClientListArpTableResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1376,11 +1345,10 @@ func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Poll(ctx context.Conte
 // If the final GET succeeded then the final ExpressRouteCircuitsClientListRoutesTableResponse will be returned.
 func (p *ExpressRouteCircuitsClientListRoutesTablePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
 	respType := ExpressRouteCircuitsClientListRoutesTableResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableListResult)
 	if err != nil {
 		return ExpressRouteCircuitsClientListRoutesTableResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1419,11 +1387,10 @@ func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Poll(ctx contex
 // If the final GET succeeded then the final ExpressRouteCircuitsClientListRoutesTableSummaryResponse will be returned.
 func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
 	respType := ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableSummaryListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableSummaryListResult)
 	if err != nil {
 		return ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1462,11 +1429,10 @@ func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Con
 // If the final GET succeeded then the final ExpressRouteConnectionsClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteConnectionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteConnection)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteConnection)
 	if err != nil {
 		return ExpressRouteConnectionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1505,11 +1471,10 @@ func (p *ExpressRouteConnectionsClientDeletePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final ExpressRouteConnectionsClientDeleteResponse will be returned.
 func (p *ExpressRouteConnectionsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteConnectionsClientDeleteResponse, error) {
 	respType := ExpressRouteConnectionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ExpressRouteConnectionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1548,11 +1513,10 @@ func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Poll(ctx
 // If the final GET succeeded then the final ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnectionPeering)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnectionPeering)
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1591,11 +1555,10 @@ func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Poll(ctx context
 // If the final GET succeeded then the final ExpressRouteCrossConnectionPeeringsClientDeleteResponse will be returned.
 func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
 	respType := ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1634,11 +1597,10 @@ func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Poll(ctx contex
 // If the final GET succeeded then the final ExpressRouteCrossConnectionsClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnection)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnection)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1677,11 +1639,10 @@ func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Poll(ctx context.
 // If the final GET succeeded then the final ExpressRouteCrossConnectionsClientListArpTableResponse will be returned.
 func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
 	respType := ExpressRouteCrossConnectionsClientListArpTableResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsArpTableListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsArpTableListResult)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListArpTableResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1720,11 +1681,10 @@ func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Poll(ctx conte
 // If the final GET succeeded then the final ExpressRouteCrossConnectionsClientListRoutesTableResponse will be returned.
 func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
 	respType := ExpressRouteCrossConnectionsClientListRoutesTableResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableListResult)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListRoutesTableResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1763,11 +1723,10 @@ func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Poll(ct
 // If the final GET succeeded then the final ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse will be returned.
 func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
 	respType := ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1806,11 +1765,10 @@ func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final ExpressRouteGatewaysClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteGatewaysClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteGateway)
 	if err != nil {
 		return ExpressRouteGatewaysClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1849,11 +1807,10 @@ func (p *ExpressRouteGatewaysClientDeletePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final ExpressRouteGatewaysClientDeleteResponse will be returned.
 func (p *ExpressRouteGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteGatewaysClientDeleteResponse, error) {
 	respType := ExpressRouteGatewaysClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ExpressRouteGatewaysClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1892,11 +1849,10 @@ func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final ExpressRoutePortsClientCreateOrUpdateResponse will be returned.
 func (p *ExpressRoutePortsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRoutePortsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ExpressRoutePort)
+	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRoutePort)
 	if err != nil {
 		return ExpressRoutePortsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1935,11 +1891,10 @@ func (p *ExpressRoutePortsClientDeletePoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final ExpressRoutePortsClientDeleteResponse will be returned.
 func (p *ExpressRoutePortsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRoutePortsClientDeleteResponse, error) {
 	respType := ExpressRoutePortsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ExpressRoutePortsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1978,11 +1933,10 @@ func (p *FirewallPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final FirewallPoliciesClientCreateOrUpdateResponse will be returned.
 func (p *FirewallPoliciesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
 	respType := FirewallPoliciesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.FirewallPolicy)
+	_, err := p.pt.FinalResponse(ctx, &respType.FirewallPolicy)
 	if err != nil {
 		return FirewallPoliciesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2021,11 +1975,10 @@ func (p *FirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final FirewallPoliciesClientDeleteResponse will be returned.
 func (p *FirewallPoliciesClientDeletePoller) FinalResponse(ctx context.Context) (FirewallPoliciesClientDeleteResponse, error) {
 	respType := FirewallPoliciesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return FirewallPoliciesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2064,11 +2017,10 @@ func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Poll(ctx context.Co
 // If the final GET succeeded then the final FirewallPolicyRuleGroupsClientCreateOrUpdateResponse will be returned.
 func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
 	respType := FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.FirewallPolicyRuleGroup)
+	_, err := p.pt.FinalResponse(ctx, &respType.FirewallPolicyRuleGroup)
 	if err != nil {
 		return FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2107,11 +2059,10 @@ func (p *FirewallPolicyRuleGroupsClientDeletePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final FirewallPolicyRuleGroupsClientDeleteResponse will be returned.
 func (p *FirewallPolicyRuleGroupsClientDeletePoller) FinalResponse(ctx context.Context) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
 	respType := FirewallPolicyRuleGroupsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return FirewallPolicyRuleGroupsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2150,11 +2101,10 @@ func (p *FlowLogsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final FlowLogsClientCreateOrUpdateResponse will be returned.
 func (p *FlowLogsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (FlowLogsClientCreateOrUpdateResponse, error) {
 	respType := FlowLogsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.FlowLog)
+	_, err := p.pt.FinalResponse(ctx, &respType.FlowLog)
 	if err != nil {
 		return FlowLogsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2193,11 +2143,10 @@ func (p *FlowLogsClientDeletePoller) Poll(ctx context.Context) (*http.Response, 
 // If the final GET succeeded then the final FlowLogsClientDeleteResponse will be returned.
 func (p *FlowLogsClientDeletePoller) FinalResponse(ctx context.Context) (FlowLogsClientDeleteResponse, error) {
 	respType := FlowLogsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return FlowLogsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2236,11 +2185,10 @@ func (p *IPAllocationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final IPAllocationsClientCreateOrUpdateResponse will be returned.
 func (p *IPAllocationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (IPAllocationsClientCreateOrUpdateResponse, error) {
 	respType := IPAllocationsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.IPAllocation)
+	_, err := p.pt.FinalResponse(ctx, &respType.IPAllocation)
 	if err != nil {
 		return IPAllocationsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2279,11 +2227,10 @@ func (p *IPAllocationsClientDeletePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final IPAllocationsClientDeleteResponse will be returned.
 func (p *IPAllocationsClientDeletePoller) FinalResponse(ctx context.Context) (IPAllocationsClientDeleteResponse, error) {
 	respType := IPAllocationsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return IPAllocationsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2322,11 +2269,10 @@ func (p *IPGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final IPGroupsClientCreateOrUpdateResponse will be returned.
 func (p *IPGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (IPGroupsClientCreateOrUpdateResponse, error) {
 	respType := IPGroupsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.IPGroup)
+	_, err := p.pt.FinalResponse(ctx, &respType.IPGroup)
 	if err != nil {
 		return IPGroupsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2365,11 +2311,10 @@ func (p *IPGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, 
 // If the final GET succeeded then the final IPGroupsClientDeleteResponse will be returned.
 func (p *IPGroupsClientDeletePoller) FinalResponse(ctx context.Context) (IPGroupsClientDeleteResponse, error) {
 	respType := IPGroupsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return IPGroupsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2408,11 +2353,10 @@ func (p *InboundNatRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final InboundNatRulesClientCreateOrUpdateResponse will be returned.
 func (p *InboundNatRulesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (InboundNatRulesClientCreateOrUpdateResponse, error) {
 	respType := InboundNatRulesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.InboundNatRule)
+	_, err := p.pt.FinalResponse(ctx, &respType.InboundNatRule)
 	if err != nil {
 		return InboundNatRulesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2451,11 +2395,10 @@ func (p *InboundNatRulesClientDeletePoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final InboundNatRulesClientDeleteResponse will be returned.
 func (p *InboundNatRulesClientDeletePoller) FinalResponse(ctx context.Context) (InboundNatRulesClientDeleteResponse, error) {
 	respType := InboundNatRulesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return InboundNatRulesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2494,11 +2437,10 @@ func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.
 // If the final GET succeeded then the final InterfaceTapConfigurationsClientCreateOrUpdateResponse will be returned.
 func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
 	respType := InterfaceTapConfigurationsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.InterfaceTapConfiguration)
+	_, err := p.pt.FinalResponse(ctx, &respType.InterfaceTapConfiguration)
 	if err != nil {
 		return InterfaceTapConfigurationsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2537,11 +2479,10 @@ func (p *InterfaceTapConfigurationsClientDeletePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final InterfaceTapConfigurationsClientDeleteResponse will be returned.
 func (p *InterfaceTapConfigurationsClientDeletePoller) FinalResponse(ctx context.Context) (InterfaceTapConfigurationsClientDeleteResponse, error) {
 	respType := InterfaceTapConfigurationsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return InterfaceTapConfigurationsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2580,11 +2521,10 @@ func (p *InterfacesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final InterfacesClientCreateOrUpdateResponse will be returned.
 func (p *InterfacesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (InterfacesClientCreateOrUpdateResponse, error) {
 	respType := InterfacesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Interface)
+	_, err := p.pt.FinalResponse(ctx, &respType.Interface)
 	if err != nil {
 		return InterfacesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2623,11 +2563,10 @@ func (p *InterfacesClientDeletePoller) Poll(ctx context.Context) (*http.Response
 // If the final GET succeeded then the final InterfacesClientDeleteResponse will be returned.
 func (p *InterfacesClientDeletePoller) FinalResponse(ctx context.Context) (InterfacesClientDeleteResponse, error) {
 	respType := InterfacesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return InterfacesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2666,11 +2605,10 @@ func (p *InterfacesClientGetEffectiveRouteTablePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final InterfacesClientGetEffectiveRouteTableResponse will be returned.
 func (p *InterfacesClientGetEffectiveRouteTablePoller) FinalResponse(ctx context.Context) (InterfacesClientGetEffectiveRouteTableResponse, error) {
 	respType := InterfacesClientGetEffectiveRouteTableResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.EffectiveRouteListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.EffectiveRouteListResult)
 	if err != nil {
 		return InterfacesClientGetEffectiveRouteTableResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2709,11 +2647,10 @@ func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Poll(ctx cont
 // If the final GET succeeded then the final InterfacesClientListEffectiveNetworkSecurityGroupsResponse will be returned.
 func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) FinalResponse(ctx context.Context) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
 	respType := InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.EffectiveNetworkSecurityGroupListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.EffectiveNetworkSecurityGroupListResult)
 	if err != nil {
 		return InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2752,11 +2689,10 @@ func (p *LoadBalancersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final LoadBalancersClientCreateOrUpdateResponse will be returned.
 func (p *LoadBalancersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (LoadBalancersClientCreateOrUpdateResponse, error) {
 	respType := LoadBalancersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.LoadBalancer)
+	_, err := p.pt.FinalResponse(ctx, &respType.LoadBalancer)
 	if err != nil {
 		return LoadBalancersClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2795,11 +2731,10 @@ func (p *LoadBalancersClientDeletePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final LoadBalancersClientDeleteResponse will be returned.
 func (p *LoadBalancersClientDeletePoller) FinalResponse(ctx context.Context) (LoadBalancersClientDeleteResponse, error) {
 	respType := LoadBalancersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LoadBalancersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2838,11 +2773,10 @@ func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final LocalNetworkGatewaysClientCreateOrUpdateResponse will be returned.
 func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
 	respType := LocalNetworkGatewaysClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.LocalNetworkGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.LocalNetworkGateway)
 	if err != nil {
 		return LocalNetworkGatewaysClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2881,11 +2815,10 @@ func (p *LocalNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final LocalNetworkGatewaysClientDeleteResponse will be returned.
 func (p *LocalNetworkGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (LocalNetworkGatewaysClientDeleteResponse, error) {
 	respType := LocalNetworkGatewaysClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return LocalNetworkGatewaysClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2924,11 +2857,10 @@ func (p *ManagementClientDeleteBastionShareableLinkPoller) Poll(ctx context.Cont
 // If the final GET succeeded then the final ManagementClientDeleteBastionShareableLinkResponse will be returned.
 func (p *ManagementClientDeleteBastionShareableLinkPoller) FinalResponse(ctx context.Context) (ManagementClientDeleteBastionShareableLinkResponse, error) {
 	respType := ManagementClientDeleteBastionShareableLinkResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ManagementClientDeleteBastionShareableLinkResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2967,11 +2899,10 @@ func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePolle
 // If the final GET succeeded then the final ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse will be returned.
 func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) FinalResponse(ctx context.Context) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
 	respType := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNProfileResponse)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNProfileResponse)
 	if err != nil {
 		return ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3094,11 +3025,10 @@ func (p *NatGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final NatGatewaysClientCreateOrUpdateResponse will be returned.
 func (p *NatGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (NatGatewaysClientCreateOrUpdateResponse, error) {
 	respType := NatGatewaysClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.NatGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.NatGateway)
 	if err != nil {
 		return NatGatewaysClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3137,11 +3067,10 @@ func (p *NatGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Respons
 // If the final GET succeeded then the final NatGatewaysClientDeleteResponse will be returned.
 func (p *NatGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (NatGatewaysClientDeleteResponse, error) {
 	respType := NatGatewaysClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return NatGatewaysClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3180,11 +3109,10 @@ func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final P2SVPNGatewaysClientCreateOrUpdateResponse will be returned.
 func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
 	respType := P2SVPNGatewaysClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.P2SVPNGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.P2SVPNGateway)
 	if err != nil {
 		return P2SVPNGatewaysClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3223,11 +3151,10 @@ func (p *P2SVPNGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final P2SVPNGatewaysClientDeleteResponse will be returned.
 func (p *P2SVPNGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientDeleteResponse, error) {
 	respType := P2SVPNGatewaysClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return P2SVPNGatewaysClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3266,11 +3193,10 @@ func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Poll(ctx context
 // If the final GET succeeded then the final P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse will be returned.
 func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
 	respType := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3309,11 +3235,10 @@ func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final P2SVPNGatewaysClientGenerateVPNProfileResponse will be returned.
 func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
 	respType := P2SVPNGatewaysClientGenerateVPNProfileResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNProfileResponse)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNProfileResponse)
 	if err != nil {
 		return P2SVPNGatewaysClientGenerateVPNProfileResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3352,11 +3277,10 @@ func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Poll(ctx c
 // If the final GET succeeded then the final P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse will be returned.
 func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
 	respType := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.P2SVPNConnectionHealth)
+	_, err := p.pt.FinalResponse(ctx, &respType.P2SVPNConnectionHealth)
 	if err != nil {
 		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3395,11 +3319,10 @@ func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Poll(ctx context.C
 // If the final GET succeeded then the final P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse will be returned.
 func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
 	respType := P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.P2SVPNGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.P2SVPNGateway)
 	if err != nil {
 		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3438,11 +3361,10 @@ func (p *PacketCapturesClientCreatePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final PacketCapturesClientCreateResponse will be returned.
 func (p *PacketCapturesClientCreatePoller) FinalResponse(ctx context.Context) (PacketCapturesClientCreateResponse, error) {
 	respType := PacketCapturesClientCreateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PacketCaptureResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.PacketCaptureResult)
 	if err != nil {
 		return PacketCapturesClientCreateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3481,11 +3403,10 @@ func (p *PacketCapturesClientDeletePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final PacketCapturesClientDeleteResponse will be returned.
 func (p *PacketCapturesClientDeletePoller) FinalResponse(ctx context.Context) (PacketCapturesClientDeleteResponse, error) {
 	respType := PacketCapturesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return PacketCapturesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3524,11 +3445,10 @@ func (p *PacketCapturesClientGetStatusPoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final PacketCapturesClientGetStatusResponse will be returned.
 func (p *PacketCapturesClientGetStatusPoller) FinalResponse(ctx context.Context) (PacketCapturesClientGetStatusResponse, error) {
 	respType := PacketCapturesClientGetStatusResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PacketCaptureQueryStatusResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.PacketCaptureQueryStatusResult)
 	if err != nil {
 		return PacketCapturesClientGetStatusResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3567,11 +3487,10 @@ func (p *PacketCapturesClientStopPoller) Poll(ctx context.Context) (*http.Respon
 // If the final GET succeeded then the final PacketCapturesClientStopResponse will be returned.
 func (p *PacketCapturesClientStopPoller) FinalResponse(ctx context.Context) (PacketCapturesClientStopResponse, error) {
 	respType := PacketCapturesClientStopResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return PacketCapturesClientStopResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3610,11 +3529,10 @@ func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final PrivateDNSZoneGroupsClientCreateOrUpdateResponse will be returned.
 func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
 	respType := PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PrivateDNSZoneGroup)
+	_, err := p.pt.FinalResponse(ctx, &respType.PrivateDNSZoneGroup)
 	if err != nil {
 		return PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3653,11 +3571,10 @@ func (p *PrivateDNSZoneGroupsClientDeletePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final PrivateDNSZoneGroupsClientDeleteResponse will be returned.
 func (p *PrivateDNSZoneGroupsClientDeletePoller) FinalResponse(ctx context.Context) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
 	respType := PrivateDNSZoneGroupsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return PrivateDNSZoneGroupsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3696,11 +3613,10 @@ func (p *PrivateEndpointsClientCreateOrUpdatePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final PrivateEndpointsClientCreateOrUpdateResponse will be returned.
 func (p *PrivateEndpointsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
 	respType := PrivateEndpointsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PrivateEndpoint)
+	_, err := p.pt.FinalResponse(ctx, &respType.PrivateEndpoint)
 	if err != nil {
 		return PrivateEndpointsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3739,11 +3655,10 @@ func (p *PrivateEndpointsClientDeletePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final PrivateEndpointsClientDeleteResponse will be returned.
 func (p *PrivateEndpointsClientDeletePoller) FinalResponse(ctx context.Context) (PrivateEndpointsClientDeleteResponse, error) {
 	respType := PrivateEndpointsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return PrivateEndpointsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3782,11 +3697,10 @@ func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGro
 // If the final GET succeeded then the final PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse will be returned.
 func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
 	respType := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkServiceVisibility)
+	_, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkServiceVisibility)
 	if err != nil {
 		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3825,11 +3739,10 @@ func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Poll(
 // If the final GET succeeded then the final PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse will be returned.
 func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
 	respType := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkServiceVisibility)
+	_, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkServiceVisibility)
 	if err != nil {
 		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3868,11 +3781,10 @@ func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Poll(ctx context.Context
 // If the final GET succeeded then the final PrivateLinkServicesClientCreateOrUpdateResponse will be returned.
 func (p *PrivateLinkServicesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
 	respType := PrivateLinkServicesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkService)
+	_, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkService)
 	if err != nil {
 		return PrivateLinkServicesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3911,11 +3823,10 @@ func (p *PrivateLinkServicesClientDeletePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final PrivateLinkServicesClientDeleteResponse will be returned.
 func (p *PrivateLinkServicesClientDeletePoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientDeleteResponse, error) {
 	respType := PrivateLinkServicesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return PrivateLinkServicesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3954,11 +3865,10 @@ func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Poll(ct
 // If the final GET succeeded then the final PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse will be returned.
 func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
 	respType := PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3997,11 +3907,10 @@ func (p *ProfilesClientDeletePoller) Poll(ctx context.Context) (*http.Response, 
 // If the final GET succeeded then the final ProfilesClientDeleteResponse will be returned.
 func (p *ProfilesClientDeletePoller) FinalResponse(ctx context.Context) (ProfilesClientDeleteResponse, error) {
 	respType := ProfilesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ProfilesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4040,11 +3949,10 @@ func (p *PublicIPAddressesClientCreateOrUpdatePoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final PublicIPAddressesClientCreateOrUpdateResponse will be returned.
 func (p *PublicIPAddressesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
 	respType := PublicIPAddressesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PublicIPAddress)
+	_, err := p.pt.FinalResponse(ctx, &respType.PublicIPAddress)
 	if err != nil {
 		return PublicIPAddressesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4083,11 +3991,10 @@ func (p *PublicIPAddressesClientDeletePoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final PublicIPAddressesClientDeleteResponse will be returned.
 func (p *PublicIPAddressesClientDeletePoller) FinalResponse(ctx context.Context) (PublicIPAddressesClientDeleteResponse, error) {
 	respType := PublicIPAddressesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return PublicIPAddressesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4126,11 +4033,10 @@ func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final PublicIPPrefixesClientCreateOrUpdateResponse will be returned.
 func (p *PublicIPPrefixesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
 	respType := PublicIPPrefixesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PublicIPPrefix)
+	_, err := p.pt.FinalResponse(ctx, &respType.PublicIPPrefix)
 	if err != nil {
 		return PublicIPPrefixesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4169,11 +4075,10 @@ func (p *PublicIPPrefixesClientDeletePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final PublicIPPrefixesClientDeleteResponse will be returned.
 func (p *PublicIPPrefixesClientDeletePoller) FinalResponse(ctx context.Context) (PublicIPPrefixesClientDeleteResponse, error) {
 	respType := PublicIPPrefixesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return PublicIPPrefixesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4212,11 +4117,10 @@ func (p *RouteFilterRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final RouteFilterRulesClientCreateOrUpdateResponse will be returned.
 func (p *RouteFilterRulesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
 	respType := RouteFilterRulesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.RouteFilterRule)
+	_, err := p.pt.FinalResponse(ctx, &respType.RouteFilterRule)
 	if err != nil {
 		return RouteFilterRulesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4255,11 +4159,10 @@ func (p *RouteFilterRulesClientDeletePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final RouteFilterRulesClientDeleteResponse will be returned.
 func (p *RouteFilterRulesClientDeletePoller) FinalResponse(ctx context.Context) (RouteFilterRulesClientDeleteResponse, error) {
 	respType := RouteFilterRulesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return RouteFilterRulesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4298,11 +4201,10 @@ func (p *RouteFiltersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final RouteFiltersClientCreateOrUpdateResponse will be returned.
 func (p *RouteFiltersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RouteFiltersClientCreateOrUpdateResponse, error) {
 	respType := RouteFiltersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.RouteFilter)
+	_, err := p.pt.FinalResponse(ctx, &respType.RouteFilter)
 	if err != nil {
 		return RouteFiltersClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4341,11 +4243,10 @@ func (p *RouteFiltersClientDeletePoller) Poll(ctx context.Context) (*http.Respon
 // If the final GET succeeded then the final RouteFiltersClientDeleteResponse will be returned.
 func (p *RouteFiltersClientDeletePoller) FinalResponse(ctx context.Context) (RouteFiltersClientDeleteResponse, error) {
 	respType := RouteFiltersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return RouteFiltersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4384,11 +4285,10 @@ func (p *RouteTablesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final RouteTablesClientCreateOrUpdateResponse will be returned.
 func (p *RouteTablesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RouteTablesClientCreateOrUpdateResponse, error) {
 	respType := RouteTablesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.RouteTable)
+	_, err := p.pt.FinalResponse(ctx, &respType.RouteTable)
 	if err != nil {
 		return RouteTablesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4427,11 +4327,10 @@ func (p *RouteTablesClientDeletePoller) Poll(ctx context.Context) (*http.Respons
 // If the final GET succeeded then the final RouteTablesClientDeleteResponse will be returned.
 func (p *RouteTablesClientDeletePoller) FinalResponse(ctx context.Context) (RouteTablesClientDeleteResponse, error) {
 	respType := RouteTablesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return RouteTablesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4470,11 +4369,10 @@ func (p *RoutesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final RoutesClientCreateOrUpdateResponse will be returned.
 func (p *RoutesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RoutesClientCreateOrUpdateResponse, error) {
 	respType := RoutesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Route)
+	_, err := p.pt.FinalResponse(ctx, &respType.Route)
 	if err != nil {
 		return RoutesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4513,11 +4411,10 @@ func (p *RoutesClientDeletePoller) Poll(ctx context.Context) (*http.Response, er
 // If the final GET succeeded then the final RoutesClientDeleteResponse will be returned.
 func (p *RoutesClientDeletePoller) FinalResponse(ctx context.Context) (RoutesClientDeleteResponse, error) {
 	respType := RoutesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return RoutesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4556,11 +4453,10 @@ func (p *SecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final SecurityGroupsClientCreateOrUpdateResponse will be returned.
 func (p *SecurityGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SecurityGroupsClientCreateOrUpdateResponse, error) {
 	respType := SecurityGroupsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SecurityGroup)
+	_, err := p.pt.FinalResponse(ctx, &respType.SecurityGroup)
 	if err != nil {
 		return SecurityGroupsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4599,11 +4495,10 @@ func (p *SecurityGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final SecurityGroupsClientDeleteResponse will be returned.
 func (p *SecurityGroupsClientDeletePoller) FinalResponse(ctx context.Context) (SecurityGroupsClientDeleteResponse, error) {
 	respType := SecurityGroupsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SecurityGroupsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4642,11 +4537,10 @@ func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Poll(ctx context.Co
 // If the final GET succeeded then the final SecurityPartnerProvidersClientCreateOrUpdateResponse will be returned.
 func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
 	respType := SecurityPartnerProvidersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SecurityPartnerProvider)
+	_, err := p.pt.FinalResponse(ctx, &respType.SecurityPartnerProvider)
 	if err != nil {
 		return SecurityPartnerProvidersClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4685,11 +4579,10 @@ func (p *SecurityPartnerProvidersClientDeletePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final SecurityPartnerProvidersClientDeleteResponse will be returned.
 func (p *SecurityPartnerProvidersClientDeletePoller) FinalResponse(ctx context.Context) (SecurityPartnerProvidersClientDeleteResponse, error) {
 	respType := SecurityPartnerProvidersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SecurityPartnerProvidersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4728,11 +4621,10 @@ func (p *SecurityRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final SecurityRulesClientCreateOrUpdateResponse will be returned.
 func (p *SecurityRulesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SecurityRulesClientCreateOrUpdateResponse, error) {
 	respType := SecurityRulesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SecurityRule)
+	_, err := p.pt.FinalResponse(ctx, &respType.SecurityRule)
 	if err != nil {
 		return SecurityRulesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4771,11 +4663,10 @@ func (p *SecurityRulesClientDeletePoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final SecurityRulesClientDeleteResponse will be returned.
 func (p *SecurityRulesClientDeletePoller) FinalResponse(ctx context.Context) (SecurityRulesClientDeleteResponse, error) {
 	respType := SecurityRulesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SecurityRulesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4814,11 +4705,10 @@ func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Con
 // If the final GET succeeded then the final ServiceEndpointPoliciesClientCreateOrUpdateResponse will be returned.
 func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
 	respType := ServiceEndpointPoliciesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ServiceEndpointPolicy)
+	_, err := p.pt.FinalResponse(ctx, &respType.ServiceEndpointPolicy)
 	if err != nil {
 		return ServiceEndpointPoliciesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4857,11 +4747,10 @@ func (p *ServiceEndpointPoliciesClientDeletePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final ServiceEndpointPoliciesClientDeleteResponse will be returned.
 func (p *ServiceEndpointPoliciesClientDeletePoller) FinalResponse(ctx context.Context) (ServiceEndpointPoliciesClientDeleteResponse, error) {
 	respType := ServiceEndpointPoliciesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ServiceEndpointPoliciesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4900,11 +4789,10 @@ func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Poll(ctx co
 // If the final GET succeeded then the final ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse will be returned.
 func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
 	respType := ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ServiceEndpointPolicyDefinition)
+	_, err := p.pt.FinalResponse(ctx, &respType.ServiceEndpointPolicyDefinition)
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4943,11 +4831,10 @@ func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Poll(ctx context.Co
 // If the final GET succeeded then the final ServiceEndpointPolicyDefinitionsClientDeleteResponse will be returned.
 func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) FinalResponse(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
 	respType := ServiceEndpointPolicyDefinitionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4986,11 +4873,10 @@ func (p *SubnetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final SubnetsClientCreateOrUpdateResponse will be returned.
 func (p *SubnetsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SubnetsClientCreateOrUpdateResponse, error) {
 	respType := SubnetsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Subnet)
+	_, err := p.pt.FinalResponse(ctx, &respType.Subnet)
 	if err != nil {
 		return SubnetsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5029,11 +4915,10 @@ func (p *SubnetsClientDeletePoller) Poll(ctx context.Context) (*http.Response, e
 // If the final GET succeeded then the final SubnetsClientDeleteResponse will be returned.
 func (p *SubnetsClientDeletePoller) FinalResponse(ctx context.Context) (SubnetsClientDeleteResponse, error) {
 	respType := SubnetsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SubnetsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5072,11 +4957,10 @@ func (p *SubnetsClientPrepareNetworkPoliciesPoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final SubnetsClientPrepareNetworkPoliciesResponse will be returned.
 func (p *SubnetsClientPrepareNetworkPoliciesPoller) FinalResponse(ctx context.Context) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
 	respType := SubnetsClientPrepareNetworkPoliciesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SubnetsClientPrepareNetworkPoliciesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5115,11 +4999,10 @@ func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final SubnetsClientUnprepareNetworkPoliciesResponse will be returned.
 func (p *SubnetsClientUnprepareNetworkPoliciesPoller) FinalResponse(ctx context.Context) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
 	respType := SubnetsClientUnprepareNetworkPoliciesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return SubnetsClientUnprepareNetworkPoliciesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5158,11 +5041,10 @@ func (p *VPNConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final VPNConnectionsClientCreateOrUpdateResponse will be returned.
 func (p *VPNConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VPNConnectionsClientCreateOrUpdateResponse, error) {
 	respType := VPNConnectionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNConnection)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNConnection)
 	if err != nil {
 		return VPNConnectionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5201,11 +5083,10 @@ func (p *VPNConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final VPNConnectionsClientDeleteResponse will be returned.
 func (p *VPNConnectionsClientDeletePoller) FinalResponse(ctx context.Context) (VPNConnectionsClientDeleteResponse, error) {
 	respType := VPNConnectionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VPNConnectionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5244,11 +5125,10 @@ func (p *VPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final VPNGatewaysClientCreateOrUpdateResponse will be returned.
 func (p *VPNGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VPNGatewaysClientCreateOrUpdateResponse, error) {
 	respType := VPNGatewaysClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNGateway)
 	if err != nil {
 		return VPNGatewaysClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5287,11 +5167,10 @@ func (p *VPNGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Respons
 // If the final GET succeeded then the final VPNGatewaysClientDeleteResponse will be returned.
 func (p *VPNGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (VPNGatewaysClientDeleteResponse, error) {
 	respType := VPNGatewaysClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VPNGatewaysClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5330,11 +5209,10 @@ func (p *VPNGatewaysClientResetPoller) Poll(ctx context.Context) (*http.Response
 // If the final GET succeeded then the final VPNGatewaysClientResetResponse will be returned.
 func (p *VPNGatewaysClientResetPoller) FinalResponse(ctx context.Context) (VPNGatewaysClientResetResponse, error) {
 	respType := VPNGatewaysClientResetResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNGateway)
 	if err != nil {
 		return VPNGatewaysClientResetResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5373,11 +5251,10 @@ func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Poll(c
 // If the final GET succeeded then the final VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse will be returned.
 func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) FinalResponse(ctx context.Context) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
 	respType := VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNServerConfigurationsResponse)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNServerConfigurationsResponse)
 	if err != nil {
 		return VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5416,11 +5293,10 @@ func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Con
 // If the final GET succeeded then the final VPNServerConfigurationsClientCreateOrUpdateResponse will be returned.
 func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
 	respType := VPNServerConfigurationsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNServerConfiguration)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNServerConfiguration)
 	if err != nil {
 		return VPNServerConfigurationsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5459,11 +5335,10 @@ func (p *VPNServerConfigurationsClientDeletePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final VPNServerConfigurationsClientDeleteResponse will be returned.
 func (p *VPNServerConfigurationsClientDeletePoller) FinalResponse(ctx context.Context) (VPNServerConfigurationsClientDeleteResponse, error) {
 	respType := VPNServerConfigurationsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VPNServerConfigurationsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5502,11 +5377,10 @@ func (p *VPNSitesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final VPNSitesClientCreateOrUpdateResponse will be returned.
 func (p *VPNSitesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VPNSitesClientCreateOrUpdateResponse, error) {
 	respType := VPNSitesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNSite)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNSite)
 	if err != nil {
 		return VPNSitesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5545,11 +5419,10 @@ func (p *VPNSitesClientDeletePoller) Poll(ctx context.Context) (*http.Response, 
 // If the final GET succeeded then the final VPNSitesClientDeleteResponse will be returned.
 func (p *VPNSitesClientDeletePoller) FinalResponse(ctx context.Context) (VPNSitesClientDeleteResponse, error) {
 	respType := VPNSitesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VPNSitesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5588,11 +5461,10 @@ func (p *VPNSitesConfigurationClientDownloadPoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final VPNSitesConfigurationClientDownloadResponse will be returned.
 func (p *VPNSitesConfigurationClientDownloadPoller) FinalResponse(ctx context.Context) (VPNSitesConfigurationClientDownloadResponse, error) {
 	respType := VPNSitesConfigurationClientDownloadResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VPNSitesConfigurationClientDownloadResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5631,11 +5503,10 @@ func (p *VirtualAppliancesClientCreateOrUpdatePoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final VirtualAppliancesClientCreateOrUpdateResponse will be returned.
 func (p *VirtualAppliancesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
 	respType := VirtualAppliancesClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualAppliance)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualAppliance)
 	if err != nil {
 		return VirtualAppliancesClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5674,11 +5545,10 @@ func (p *VirtualAppliancesClientDeletePoller) Poll(ctx context.Context) (*http.R
 // If the final GET succeeded then the final VirtualAppliancesClientDeleteResponse will be returned.
 func (p *VirtualAppliancesClientDeletePoller) FinalResponse(ctx context.Context) (VirtualAppliancesClientDeleteResponse, error) {
 	respType := VirtualAppliancesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualAppliancesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5717,11 +5587,10 @@ func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Poll(ctx context.Con
 // If the final GET succeeded then the final VirtualHubRouteTableV2SClientCreateOrUpdateResponse will be returned.
 func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
 	respType := VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualHubRouteTableV2)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualHubRouteTableV2)
 	if err != nil {
 		return VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5760,11 +5629,10 @@ func (p *VirtualHubRouteTableV2SClientDeletePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final VirtualHubRouteTableV2SClientDeleteResponse will be returned.
 func (p *VirtualHubRouteTableV2SClientDeletePoller) FinalResponse(ctx context.Context) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
 	respType := VirtualHubRouteTableV2SClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualHubRouteTableV2SClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5803,11 +5671,10 @@ func (p *VirtualHubsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final VirtualHubsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualHubsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualHubsClientCreateOrUpdateResponse, error) {
 	respType := VirtualHubsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualHub)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualHub)
 	if err != nil {
 		return VirtualHubsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5846,11 +5713,10 @@ func (p *VirtualHubsClientDeletePoller) Poll(ctx context.Context) (*http.Respons
 // If the final GET succeeded then the final VirtualHubsClientDeleteResponse will be returned.
 func (p *VirtualHubsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualHubsClientDeleteResponse, error) {
 	respType := VirtualHubsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualHubsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5889,11 +5755,10 @@ func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Poll(ctx co
 // If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGatewayConnection)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGatewayConnection)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5932,11 +5797,10 @@ func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Poll(ctx context.Co
 // If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientDeleteResponse will be returned.
 func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5975,11 +5839,10 @@ func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Poll(ctx co
 // If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse will be returned.
 func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ConnectionResetSharedKey)
+	_, err := p.pt.FinalResponse(ctx, &respType.ConnectionResetSharedKey)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6018,11 +5881,10 @@ func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Poll(ctx cont
 // If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse will be returned.
 func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ConnectionSharedKey)
+	_, err := p.pt.FinalResponse(ctx, &respType.ConnectionSharedKey)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6061,11 +5923,10 @@ func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Poll(ct
 // If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse will be returned.
 func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Value)
+	_, err := p.pt.FinalResponse(ctx, &respType.Value)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6104,11 +5965,10 @@ func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Poll(ctx
 // If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse will be returned.
 func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Value)
+	_, err := p.pt.FinalResponse(ctx, &respType.Value)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6147,11 +6007,10 @@ func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Poll(ctx contex
 // If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientUpdateTagsResponse will be returned.
 func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGatewayConnection)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGatewayConnection)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6190,11 +6049,10 @@ func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Cont
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientCreateOrUpdateResponse will be returned.
 func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworkGatewaysClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
 	if err != nil {
 		return VirtualNetworkGatewaysClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6233,11 +6091,10 @@ func (p *VirtualNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientDeleteResponse will be returned.
 func (p *VirtualNetworkGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientDeleteResponse, error) {
 	respType := VirtualNetworkGatewaysClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualNetworkGatewaysClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6276,11 +6133,10 @@ func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectio
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse will be returned.
 func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
 	respType := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6319,11 +6175,10 @@ func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientGenerateVPNProfileResponse will be returned.
 func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
 	respType := VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Value)
+	_, err := p.pt.FinalResponse(ctx, &respType.Value)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6362,11 +6217,10 @@ func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Poll(ctx co
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse will be returned.
 func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
 	respType := VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Value)
+	_, err := p.pt.FinalResponse(ctx, &respType.Value)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6405,11 +6259,10 @@ func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Poll(ctx context
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse will be returned.
 func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GatewayRouteListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.GatewayRouteListResult)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6448,11 +6301,10 @@ func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Poll(ctx context.Co
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientGetBgpPeerStatusResponse will be returned.
 func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.BgpPeerStatusListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.BgpPeerStatusListResult)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6491,11 +6343,10 @@ func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Poll(ctx context.Co
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientGetLearnedRoutesResponse will be returned.
 func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.GatewayRouteListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.GatewayRouteListResult)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6534,11 +6385,10 @@ func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Poll(ctx con
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse will be returned.
 func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Value)
+	_, err := p.pt.FinalResponse(ctx, &respType.Value)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6577,11 +6427,10 @@ func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Poll(ct
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse will be returned.
 func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNClientConnectionHealthDetailListResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNClientConnectionHealthDetailListResult)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6620,11 +6469,10 @@ func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Poll(ctx
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse will be returned.
 func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNClientIPsecParameters)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNClientIPsecParameters)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6663,11 +6511,10 @@ func (p *VirtualNetworkGatewaysClientResetPoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientResetResponse will be returned.
 func (p *VirtualNetworkGatewaysClientResetPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientResetResponse, error) {
 	respType := VirtualNetworkGatewaysClientResetResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
 	if err != nil {
 		return VirtualNetworkGatewaysClientResetResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6706,11 +6553,10 @@ func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Poll(ctx con
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse will be returned.
 func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
 	respType := VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6749,11 +6595,10 @@ func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Poll(ctx
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse will be returned.
 func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
 	respType := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VPNClientIPsecParameters)
+	_, err := p.pt.FinalResponse(ctx, &respType.VPNClientIPsecParameters)
 	if err != nil {
 		return VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6792,11 +6637,10 @@ func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Poll(ctx context.
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientStartPacketCaptureResponse will be returned.
 func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
 	respType := VirtualNetworkGatewaysClientStartPacketCaptureResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Value)
+	_, err := p.pt.FinalResponse(ctx, &respType.Value)
 	if err != nil {
 		return VirtualNetworkGatewaysClientStartPacketCaptureResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6835,11 +6679,10 @@ func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Poll(ctx context.C
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientStopPacketCaptureResponse will be returned.
 func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
 	respType := VirtualNetworkGatewaysClientStopPacketCaptureResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.Value)
+	_, err := p.pt.FinalResponse(ctx, &respType.Value)
 	if err != nil {
 		return VirtualNetworkGatewaysClientStopPacketCaptureResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6878,11 +6721,10 @@ func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final VirtualNetworkGatewaysClientUpdateTagsResponse will be returned.
 func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
 	respType := VirtualNetworkGatewaysClientUpdateTagsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
 	if err != nil {
 		return VirtualNetworkGatewaysClientUpdateTagsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6921,11 +6763,10 @@ func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Cont
 // If the final GET succeeded then the final VirtualNetworkPeeringsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworkPeeringsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkPeering)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkPeering)
 	if err != nil {
 		return VirtualNetworkPeeringsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6964,11 +6805,10 @@ func (p *VirtualNetworkPeeringsClientDeletePoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final VirtualNetworkPeeringsClientDeleteResponse will be returned.
 func (p *VirtualNetworkPeeringsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworkPeeringsClientDeleteResponse, error) {
 	respType := VirtualNetworkPeeringsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualNetworkPeeringsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7007,11 +6847,10 @@ func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final VirtualNetworkTapsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworkTapsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkTap)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkTap)
 	if err != nil {
 		return VirtualNetworkTapsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7050,11 +6889,10 @@ func (p *VirtualNetworkTapsClientDeletePoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final VirtualNetworkTapsClientDeleteResponse will be returned.
 func (p *VirtualNetworkTapsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworkTapsClientDeleteResponse, error) {
 	respType := VirtualNetworkTapsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualNetworkTapsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7093,11 +6931,10 @@ func (p *VirtualNetworksClientCreateOrUpdatePoller) Poll(ctx context.Context) (*
 // If the final GET succeeded then the final VirtualNetworksClientCreateOrUpdateResponse will be returned.
 func (p *VirtualNetworksClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworksClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworksClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualNetwork)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetwork)
 	if err != nil {
 		return VirtualNetworksClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7136,11 +6973,10 @@ func (p *VirtualNetworksClientDeletePoller) Poll(ctx context.Context) (*http.Res
 // If the final GET succeeded then the final VirtualNetworksClientDeleteResponse will be returned.
 func (p *VirtualNetworksClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworksClientDeleteResponse, error) {
 	respType := VirtualNetworksClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualNetworksClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7179,11 +7015,10 @@ func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Conte
 // If the final GET succeeded then the final VirtualRouterPeeringsClientCreateOrUpdateResponse will be returned.
 func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
 	respType := VirtualRouterPeeringsClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualRouterPeering)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualRouterPeering)
 	if err != nil {
 		return VirtualRouterPeeringsClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7222,11 +7057,10 @@ func (p *VirtualRouterPeeringsClientDeletePoller) Poll(ctx context.Context) (*ht
 // If the final GET succeeded then the final VirtualRouterPeeringsClientDeleteResponse will be returned.
 func (p *VirtualRouterPeeringsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualRouterPeeringsClientDeleteResponse, error) {
 	respType := VirtualRouterPeeringsClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualRouterPeeringsClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7265,11 +7099,10 @@ func (p *VirtualRoutersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final VirtualRoutersClientCreateOrUpdateResponse will be returned.
 func (p *VirtualRoutersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualRoutersClientCreateOrUpdateResponse, error) {
 	respType := VirtualRoutersClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualRouter)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualRouter)
 	if err != nil {
 		return VirtualRoutersClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7308,11 +7141,10 @@ func (p *VirtualRoutersClientDeletePoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final VirtualRoutersClientDeleteResponse will be returned.
 func (p *VirtualRoutersClientDeletePoller) FinalResponse(ctx context.Context) (VirtualRoutersClientDeleteResponse, error) {
 	respType := VirtualRoutersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualRoutersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7351,11 +7183,10 @@ func (p *VirtualWansClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final VirtualWansClientCreateOrUpdateResponse will be returned.
 func (p *VirtualWansClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualWansClientCreateOrUpdateResponse, error) {
 	respType := VirtualWansClientCreateOrUpdateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VirtualWAN)
+	_, err := p.pt.FinalResponse(ctx, &respType.VirtualWAN)
 	if err != nil {
 		return VirtualWansClientCreateOrUpdateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7394,11 +7225,10 @@ func (p *VirtualWansClientDeletePoller) Poll(ctx context.Context) (*http.Respons
 // If the final GET succeeded then the final VirtualWansClientDeleteResponse will be returned.
 func (p *VirtualWansClientDeletePoller) FinalResponse(ctx context.Context) (VirtualWansClientDeleteResponse, error) {
 	respType := VirtualWansClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return VirtualWansClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7437,11 +7267,10 @@ func (p *WatchersClientCheckConnectivityPoller) Poll(ctx context.Context) (*http
 // If the final GET succeeded then the final WatchersClientCheckConnectivityResponse will be returned.
 func (p *WatchersClientCheckConnectivityPoller) FinalResponse(ctx context.Context) (WatchersClientCheckConnectivityResponse, error) {
 	respType := WatchersClientCheckConnectivityResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ConnectivityInformation)
+	_, err := p.pt.FinalResponse(ctx, &respType.ConnectivityInformation)
 	if err != nil {
 		return WatchersClientCheckConnectivityResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7480,11 +7309,10 @@ func (p *WatchersClientDeletePoller) Poll(ctx context.Context) (*http.Response, 
 // If the final GET succeeded then the final WatchersClientDeleteResponse will be returned.
 func (p *WatchersClientDeletePoller) FinalResponse(ctx context.Context) (WatchersClientDeleteResponse, error) {
 	respType := WatchersClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return WatchersClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7523,11 +7351,10 @@ func (p *WatchersClientGetAzureReachabilityReportPoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final WatchersClientGetAzureReachabilityReportResponse will be returned.
 func (p *WatchersClientGetAzureReachabilityReportPoller) FinalResponse(ctx context.Context) (WatchersClientGetAzureReachabilityReportResponse, error) {
 	respType := WatchersClientGetAzureReachabilityReportResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.AzureReachabilityReport)
+	_, err := p.pt.FinalResponse(ctx, &respType.AzureReachabilityReport)
 	if err != nil {
 		return WatchersClientGetAzureReachabilityReportResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7566,11 +7393,10 @@ func (p *WatchersClientGetFlowLogStatusPoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final WatchersClientGetFlowLogStatusResponse will be returned.
 func (p *WatchersClientGetFlowLogStatusPoller) FinalResponse(ctx context.Context) (WatchersClientGetFlowLogStatusResponse, error) {
 	respType := WatchersClientGetFlowLogStatusResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.FlowLogInformation)
+	_, err := p.pt.FinalResponse(ctx, &respType.FlowLogInformation)
 	if err != nil {
 		return WatchersClientGetFlowLogStatusResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7609,11 +7435,10 @@ func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Poll(ctx context
 // If the final GET succeeded then the final WatchersClientGetNetworkConfigurationDiagnosticResponse will be returned.
 func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) FinalResponse(ctx context.Context) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
 	respType := WatchersClientGetNetworkConfigurationDiagnosticResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.ConfigurationDiagnosticResponse)
+	_, err := p.pt.FinalResponse(ctx, &respType.ConfigurationDiagnosticResponse)
 	if err != nil {
 		return WatchersClientGetNetworkConfigurationDiagnosticResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7652,11 +7477,10 @@ func (p *WatchersClientGetNextHopPoller) Poll(ctx context.Context) (*http.Respon
 // If the final GET succeeded then the final WatchersClientGetNextHopResponse will be returned.
 func (p *WatchersClientGetNextHopPoller) FinalResponse(ctx context.Context) (WatchersClientGetNextHopResponse, error) {
 	respType := WatchersClientGetNextHopResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.NextHopResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.NextHopResult)
 	if err != nil {
 		return WatchersClientGetNextHopResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7695,11 +7519,10 @@ func (p *WatchersClientGetTroubleshootingPoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final WatchersClientGetTroubleshootingResponse will be returned.
 func (p *WatchersClientGetTroubleshootingPoller) FinalResponse(ctx context.Context) (WatchersClientGetTroubleshootingResponse, error) {
 	respType := WatchersClientGetTroubleshootingResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.TroubleshootingResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.TroubleshootingResult)
 	if err != nil {
 		return WatchersClientGetTroubleshootingResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7738,11 +7561,10 @@ func (p *WatchersClientGetTroubleshootingResultPoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final WatchersClientGetTroubleshootingResultResponse will be returned.
 func (p *WatchersClientGetTroubleshootingResultPoller) FinalResponse(ctx context.Context) (WatchersClientGetTroubleshootingResultResponse, error) {
 	respType := WatchersClientGetTroubleshootingResultResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.TroubleshootingResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.TroubleshootingResult)
 	if err != nil {
 		return WatchersClientGetTroubleshootingResultResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7781,11 +7603,10 @@ func (p *WatchersClientGetVMSecurityRulesPoller) Poll(ctx context.Context) (*htt
 // If the final GET succeeded then the final WatchersClientGetVMSecurityRulesResponse will be returned.
 func (p *WatchersClientGetVMSecurityRulesPoller) FinalResponse(ctx context.Context) (WatchersClientGetVMSecurityRulesResponse, error) {
 	respType := WatchersClientGetVMSecurityRulesResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SecurityGroupViewResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.SecurityGroupViewResult)
 	if err != nil {
 		return WatchersClientGetVMSecurityRulesResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7824,11 +7645,10 @@ func (p *WatchersClientListAvailableProvidersPoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final WatchersClientListAvailableProvidersResponse will be returned.
 func (p *WatchersClientListAvailableProvidersPoller) FinalResponse(ctx context.Context) (WatchersClientListAvailableProvidersResponse, error) {
 	respType := WatchersClientListAvailableProvidersResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.AvailableProvidersList)
+	_, err := p.pt.FinalResponse(ctx, &respType.AvailableProvidersList)
 	if err != nil {
 		return WatchersClientListAvailableProvidersResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7867,11 +7687,10 @@ func (p *WatchersClientSetFlowLogConfigurationPoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final WatchersClientSetFlowLogConfigurationResponse will be returned.
 func (p *WatchersClientSetFlowLogConfigurationPoller) FinalResponse(ctx context.Context) (WatchersClientSetFlowLogConfigurationResponse, error) {
 	respType := WatchersClientSetFlowLogConfigurationResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.FlowLogInformation)
+	_, err := p.pt.FinalResponse(ctx, &respType.FlowLogInformation)
 	if err != nil {
 		return WatchersClientSetFlowLogConfigurationResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7910,11 +7729,10 @@ func (p *WatchersClientVerifyIPFlowPoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final WatchersClientVerifyIPFlowResponse will be returned.
 func (p *WatchersClientVerifyIPFlowPoller) FinalResponse(ctx context.Context) (WatchersClientVerifyIPFlowResponse, error) {
 	respType := WatchersClientVerifyIPFlowResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.VerificationIPFlowResult)
+	_, err := p.pt.FinalResponse(ctx, &respType.VerificationIPFlowResult)
 	if err != nil {
 		return WatchersClientVerifyIPFlowResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7953,11 +7771,10 @@ func (p *WebApplicationFirewallPoliciesClientDeletePoller) Poll(ctx context.Cont
 // If the final GET succeeded then the final WebApplicationFirewallPoliciesClientDeleteResponse will be returned.
 func (p *WebApplicationFirewallPoliciesClientDeletePoller) FinalResponse(ctx context.Context) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
 	respType := WebApplicationFirewallPoliciesClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return WebApplicationFirewallPoliciesClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
@@ -63,9 +63,7 @@ func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateDNSZoneGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return PrivateDNSZoneGroupsClientDeletePollerResponse{}, err
 	}
-	result := PrivateDNSZoneGroupsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateDNSZoneGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateDNSZoneGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return PrivateDNSZoneGroupsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *PrivateDNSZoneGroupsClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client *PrivateDNSZoneGroupsClient) getHandleResponse(resp *http.Response) (PrivateDNSZoneGroupsClientGetResponse, error) {
-	result := PrivateDNSZoneGroupsClientGetResponse{RawResponse: resp}
+	result := PrivateDNSZoneGroupsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateDNSZoneGroup); err != nil {
 		return PrivateDNSZoneGroupsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *PrivateDNSZoneGroupsClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client *PrivateDNSZoneGroupsClient) listHandleResponse(resp *http.Response) (PrivateDNSZoneGroupsClientListResponse, error) {
-	result := PrivateDNSZoneGroupsClientListResponse{RawResponse: resp}
+	result := PrivateDNSZoneGroupsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateDNSZoneGroupListResult); err != nil {
 		return PrivateDNSZoneGroupsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
@@ -62,9 +62,7 @@ func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return PrivateEndpointsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := PrivateEndpointsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateEndpointsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateEndpointsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return PrivateEndpointsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceG
 	if err != nil {
 		return PrivateEndpointsClientDeletePollerResponse{}, err
 	}
-	result := PrivateEndpointsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateEndpointsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateEndpointsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return PrivateEndpointsClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *PrivateEndpointsClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client *PrivateEndpointsClient) getHandleResponse(resp *http.Response) (PrivateEndpointsClientGetResponse, error) {
-	result := PrivateEndpointsClientGetResponse{RawResponse: resp}
+	result := PrivateEndpointsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpoint); err != nil {
 		return PrivateEndpointsClientGetResponse{}, err
 	}
@@ -283,7 +279,7 @@ func (client *PrivateEndpointsClient) listCreateRequest(ctx context.Context, res
 
 // listHandleResponse handles the List response.
 func (client *PrivateEndpointsClient) listHandleResponse(resp *http.Response) (PrivateEndpointsClientListResponse, error) {
-	result := PrivateEndpointsClientListResponse{RawResponse: resp}
+	result := PrivateEndpointsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointListResult); err != nil {
 		return PrivateEndpointsClientListResponse{}, err
 	}
@@ -326,7 +322,7 @@ func (client *PrivateEndpointsClient) listBySubscriptionCreateRequest(ctx contex
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *PrivateEndpointsClient) listBySubscriptionHandleResponse(resp *http.Response) (PrivateEndpointsClientListBySubscriptionResponse, error) {
-	result := PrivateEndpointsClientListBySubscriptionResponse{RawResponse: resp}
+	result := PrivateEndpointsClientListBySubscriptionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointListResult); err != nil {
 		return PrivateEndpointsClientListBySubscriptionResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
@@ -61,9 +61,7 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(
 	if err != nil {
 		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse{}, err
 	}
-	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility", "location", resp, client.pl)
 	if err != nil {
 		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse{}, err
@@ -126,9 +124,7 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityB
 	if err != nil {
 		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse{}, err
 	}
-	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup", "location", resp, client.pl)
 	if err != nil {
 		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse{}, err
@@ -195,9 +191,7 @@ func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context
 	if err != nil {
 		return PrivateLinkServicesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := PrivateLinkServicesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateLinkServicesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return PrivateLinkServicesClientCreateOrUpdatePollerResponse{}, err
@@ -262,9 +256,7 @@ func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resour
 	if err != nil {
 		return PrivateLinkServicesClientDeletePollerResponse{}, err
 	}
-	result := PrivateLinkServicesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateLinkServicesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return PrivateLinkServicesClientDeletePollerResponse{}, err
@@ -330,9 +322,7 @@ func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ct
 	if err != nil {
 		return PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse{}, err
 	}
-	result := PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse{
-		RawResponse: resp,
-	}
+	result := PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.DeletePrivateEndpointConnection", "location", resp, client.pl)
 	if err != nil {
 		return PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse{}, err
@@ -441,7 +431,7 @@ func (client *PrivateLinkServicesClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client *PrivateLinkServicesClient) getHandleResponse(resp *http.Response) (PrivateLinkServicesClientGetResponse, error) {
-	result := PrivateLinkServicesClientGetResponse{RawResponse: resp}
+	result := PrivateLinkServicesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateLinkService); err != nil {
 		return PrivateLinkServicesClientGetResponse{}, err
 	}
@@ -506,7 +496,7 @@ func (client *PrivateLinkServicesClient) getPrivateEndpointConnectionCreateReque
 
 // getPrivateEndpointConnectionHandleResponse handles the GetPrivateEndpointConnection response.
 func (client *PrivateLinkServicesClient) getPrivateEndpointConnectionHandleResponse(resp *http.Response) (PrivateLinkServicesClientGetPrivateEndpointConnectionResponse, error) {
-	result := PrivateLinkServicesClientGetPrivateEndpointConnectionResponse{RawResponse: resp}
+	result := PrivateLinkServicesClientGetPrivateEndpointConnectionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointConnection); err != nil {
 		return PrivateLinkServicesClientGetPrivateEndpointConnectionResponse{}, err
 	}
@@ -554,7 +544,7 @@ func (client *PrivateLinkServicesClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client *PrivateLinkServicesClient) listHandleResponse(resp *http.Response) (PrivateLinkServicesClientListResponse, error) {
-	result := PrivateLinkServicesClientListResponse{RawResponse: resp}
+	result := PrivateLinkServicesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateLinkServiceListResult); err != nil {
 		return PrivateLinkServicesClientListResponse{}, err
 	}
@@ -603,7 +593,7 @@ func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesCrea
 
 // listAutoApprovedPrivateLinkServicesHandleResponse handles the ListAutoApprovedPrivateLinkServices response.
 func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesHandleResponse(resp *http.Response) (PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse, error) {
-	result := PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{RawResponse: resp}
+	result := PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AutoApprovedPrivateLinkServicesResult); err != nil {
 		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}, err
 	}
@@ -657,7 +647,7 @@ func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesByRe
 
 // listAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse handles the ListAutoApprovedPrivateLinkServicesByResourceGroup response.
 func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse(resp *http.Response) (PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse, error) {
-	result := PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{RawResponse: resp}
+	result := PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AutoApprovedPrivateLinkServicesResult); err != nil {
 		return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, err
 	}
@@ -700,7 +690,7 @@ func (client *PrivateLinkServicesClient) listBySubscriptionCreateRequest(ctx con
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *PrivateLinkServicesClient) listBySubscriptionHandleResponse(resp *http.Response) (PrivateLinkServicesClientListBySubscriptionResponse, error) {
-	result := PrivateLinkServicesClientListBySubscriptionResponse{RawResponse: resp}
+	result := PrivateLinkServicesClientListBySubscriptionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateLinkServiceListResult); err != nil {
 		return PrivateLinkServicesClientListBySubscriptionResponse{}, err
 	}
@@ -753,7 +743,7 @@ func (client *PrivateLinkServicesClient) listPrivateEndpointConnectionsCreateReq
 
 // listPrivateEndpointConnectionsHandleResponse handles the ListPrivateEndpointConnections response.
 func (client *PrivateLinkServicesClient) listPrivateEndpointConnectionsHandleResponse(resp *http.Response) (PrivateLinkServicesClientListPrivateEndpointConnectionsResponse, error) {
-	result := PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{RawResponse: resp}
+	result := PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointConnectionListResult); err != nil {
 		return PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}, err
 	}
@@ -815,7 +805,7 @@ func (client *PrivateLinkServicesClient) updatePrivateEndpointConnectionCreateRe
 
 // updatePrivateEndpointConnectionHandleResponse handles the UpdatePrivateEndpointConnection response.
 func (client *PrivateLinkServicesClient) updatePrivateEndpointConnectionHandleResponse(resp *http.Response) (PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse, error) {
-	result := PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse{RawResponse: resp}
+	result := PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointConnection); err != nil {
 		return PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_profiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_profiles_client.go
@@ -99,7 +99,7 @@ func (client *ProfilesClient) createOrUpdateCreateRequest(ctx context.Context, r
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ProfilesClient) createOrUpdateHandleResponse(resp *http.Response) (ProfilesClientCreateOrUpdateResponse, error) {
-	result := ProfilesClientCreateOrUpdateResponse{RawResponse: resp}
+	result := ProfilesClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Profile); err != nil {
 		return ProfilesClientCreateOrUpdateResponse{}, err
 	}
@@ -116,9 +116,7 @@ func (client *ProfilesClient) BeginDelete(ctx context.Context, resourceGroupName
 	if err != nil {
 		return ProfilesClientDeletePollerResponse{}, err
 	}
-	result := ProfilesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ProfilesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ProfilesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ProfilesClientDeletePollerResponse{}, err
@@ -223,7 +221,7 @@ func (client *ProfilesClient) getCreateRequest(ctx context.Context, resourceGrou
 
 // getHandleResponse handles the Get response.
 func (client *ProfilesClient) getHandleResponse(resp *http.Response) (ProfilesClientGetResponse, error) {
-	result := ProfilesClientGetResponse{RawResponse: resp}
+	result := ProfilesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Profile); err != nil {
 		return ProfilesClientGetResponse{}, err
 	}
@@ -270,7 +268,7 @@ func (client *ProfilesClient) listCreateRequest(ctx context.Context, resourceGro
 
 // listHandleResponse handles the List response.
 func (client *ProfilesClient) listHandleResponse(resp *http.Response) (ProfilesClientListResponse, error) {
-	result := ProfilesClientListResponse{RawResponse: resp}
+	result := ProfilesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProfileListResult); err != nil {
 		return ProfilesClientListResponse{}, err
 	}
@@ -312,7 +310,7 @@ func (client *ProfilesClient) listAllCreateRequest(ctx context.Context, options 
 
 // listAllHandleResponse handles the ListAll response.
 func (client *ProfilesClient) listAllHandleResponse(resp *http.Response) (ProfilesClientListAllResponse, error) {
-	result := ProfilesClientListAllResponse{RawResponse: resp}
+	result := ProfilesClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProfileListResult); err != nil {
 		return ProfilesClientListAllResponse{}, err
 	}
@@ -368,7 +366,7 @@ func (client *ProfilesClient) updateTagsCreateRequest(ctx context.Context, resou
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *ProfilesClient) updateTagsHandleResponse(resp *http.Response) (ProfilesClientUpdateTagsResponse, error) {
-	result := ProfilesClientUpdateTagsResponse{RawResponse: resp}
+	result := ProfilesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Profile); err != nil {
 		return ProfilesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
@@ -62,9 +62,7 @@ func (client *PublicIPAddressesClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return PublicIPAddressesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := PublicIPAddressesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := PublicIPAddressesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PublicIPAddressesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return PublicIPAddressesClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resource
 	if err != nil {
 		return PublicIPAddressesClientDeletePollerResponse{}, err
 	}
-	result := PublicIPAddressesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := PublicIPAddressesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PublicIPAddressesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return PublicIPAddressesClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *PublicIPAddressesClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client *PublicIPAddressesClient) getHandleResponse(resp *http.Response) (PublicIPAddressesClientGetResponse, error) {
-	result := PublicIPAddressesClientGetResponse{RawResponse: resp}
+	result := PublicIPAddressesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddress); err != nil {
 		return PublicIPAddressesClientGetResponse{}, err
 	}
@@ -315,7 +311,7 @@ func (client *PublicIPAddressesClient) getVirtualMachineScaleSetPublicIPAddressC
 
 // getVirtualMachineScaleSetPublicIPAddressHandleResponse handles the GetVirtualMachineScaleSetPublicIPAddress response.
 func (client *PublicIPAddressesClient) getVirtualMachineScaleSetPublicIPAddressHandleResponse(resp *http.Response) (PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse, error) {
-	result := PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse{RawResponse: resp}
+	result := PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddress); err != nil {
 		return PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse{}, err
 	}
@@ -362,7 +358,7 @@ func (client *PublicIPAddressesClient) listCreateRequest(ctx context.Context, re
 
 // listHandleResponse handles the List response.
 func (client *PublicIPAddressesClient) listHandleResponse(resp *http.Response) (PublicIPAddressesClientListResponse, error) {
-	result := PublicIPAddressesClientListResponse{RawResponse: resp}
+	result := PublicIPAddressesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddressListResult); err != nil {
 		return PublicIPAddressesClientListResponse{}, err
 	}
@@ -405,7 +401,7 @@ func (client *PublicIPAddressesClient) listAllCreateRequest(ctx context.Context,
 
 // listAllHandleResponse handles the ListAll response.
 func (client *PublicIPAddressesClient) listAllHandleResponse(resp *http.Response) (PublicIPAddressesClientListAllResponse, error) {
-	result := PublicIPAddressesClientListAllResponse{RawResponse: resp}
+	result := PublicIPAddressesClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddressListResult); err != nil {
 		return PublicIPAddressesClientListAllResponse{}, err
 	}
@@ -459,7 +455,7 @@ func (client *PublicIPAddressesClient) listVirtualMachineScaleSetPublicIPAddress
 
 // listVirtualMachineScaleSetPublicIPAddressesHandleResponse handles the ListVirtualMachineScaleSetPublicIPAddresses response.
 func (client *PublicIPAddressesClient) listVirtualMachineScaleSetPublicIPAddressesHandleResponse(resp *http.Response) (PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse, error) {
-	result := PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{RawResponse: resp}
+	result := PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddressListResult); err != nil {
 		return PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}, err
 	}
@@ -528,7 +524,7 @@ func (client *PublicIPAddressesClient) listVirtualMachineScaleSetVMPublicIPAddre
 
 // listVirtualMachineScaleSetVMPublicIPAddressesHandleResponse handles the ListVirtualMachineScaleSetVMPublicIPAddresses response.
 func (client *PublicIPAddressesClient) listVirtualMachineScaleSetVMPublicIPAddressesHandleResponse(resp *http.Response) (PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse, error) {
-	result := PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{RawResponse: resp}
+	result := PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddressListResult); err != nil {
 		return PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, err
 	}
@@ -585,7 +581,7 @@ func (client *PublicIPAddressesClient) updateTagsCreateRequest(ctx context.Conte
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *PublicIPAddressesClient) updateTagsHandleResponse(resp *http.Response) (PublicIPAddressesClientUpdateTagsResponse, error) {
-	result := PublicIPAddressesClientUpdateTagsResponse{RawResponse: resp}
+	result := PublicIPAddressesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddress); err != nil {
 		return PublicIPAddressesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
@@ -62,9 +62,7 @@ func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return PublicIPPrefixesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := PublicIPPrefixesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := PublicIPPrefixesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PublicIPPrefixesClient.CreateOrUpdate", "location", resp, client.pl)
 	if err != nil {
 		return PublicIPPrefixesClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceG
 	if err != nil {
 		return PublicIPPrefixesClientDeletePollerResponse{}, err
 	}
-	result := PublicIPPrefixesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := PublicIPPrefixesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PublicIPPrefixesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return PublicIPPrefixesClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *PublicIPPrefixesClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client *PublicIPPrefixesClient) getHandleResponse(resp *http.Response) (PublicIPPrefixesClientGetResponse, error) {
-	result := PublicIPPrefixesClientGetResponse{RawResponse: resp}
+	result := PublicIPPrefixesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPPrefix); err != nil {
 		return PublicIPPrefixesClientGetResponse{}, err
 	}
@@ -283,7 +279,7 @@ func (client *PublicIPPrefixesClient) listCreateRequest(ctx context.Context, res
 
 // listHandleResponse handles the List response.
 func (client *PublicIPPrefixesClient) listHandleResponse(resp *http.Response) (PublicIPPrefixesClientListResponse, error) {
-	result := PublicIPPrefixesClientListResponse{RawResponse: resp}
+	result := PublicIPPrefixesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPPrefixListResult); err != nil {
 		return PublicIPPrefixesClientListResponse{}, err
 	}
@@ -326,7 +322,7 @@ func (client *PublicIPPrefixesClient) listAllCreateRequest(ctx context.Context, 
 
 // listAllHandleResponse handles the ListAll response.
 func (client *PublicIPPrefixesClient) listAllHandleResponse(resp *http.Response) (PublicIPPrefixesClientListAllResponse, error) {
-	result := PublicIPPrefixesClientListAllResponse{RawResponse: resp}
+	result := PublicIPPrefixesClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPPrefixListResult); err != nil {
 		return PublicIPPrefixesClientListAllResponse{}, err
 	}
@@ -383,7 +379,7 @@ func (client *PublicIPPrefixesClient) updateTagsCreateRequest(ctx context.Contex
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *PublicIPPrefixesClient) updateTagsHandleResponse(resp *http.Response) (PublicIPPrefixesClientUpdateTagsResponse, error) {
-	result := PublicIPPrefixesClientUpdateTagsResponse{RawResponse: resp}
+	result := PublicIPPrefixesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPPrefix); err != nil {
 		return PublicIPPrefixesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks_client.go
@@ -104,7 +104,7 @@ func (client *ResourceNavigationLinksClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *ResourceNavigationLinksClient) listHandleResponse(resp *http.Response) (ResourceNavigationLinksClientListResponse, error) {
-	result := ResourceNavigationLinksClientListResponse{RawResponse: resp}
+	result := ResourceNavigationLinksClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceNavigationLinksListResult); err != nil {
 		return ResourceNavigationLinksClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
@@ -11,7 +11,6 @@ package armnetwork
 import (
 	"context"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"net/http"
 	"time"
 )
 
@@ -19,9 +18,6 @@ import (
 type ApplicationGatewaysClientBackendHealthOnDemandPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ApplicationGatewaysClientBackendHealthOnDemandPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -29,11 +25,10 @@ type ApplicationGatewaysClientBackendHealthOnDemandPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ApplicationGatewaysClientBackendHealthOnDemandPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
 	respType := ApplicationGatewaysClientBackendHealthOnDemandResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGatewayBackendHealthOnDemand)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGatewayBackendHealthOnDemand)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -46,29 +41,23 @@ func (l *ApplicationGatewaysClientBackendHealthOnDemandPollerResponse) Resume(ct
 	poller := &ApplicationGatewaysClientBackendHealthOnDemandPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ApplicationGatewaysClientBackendHealthOnDemandResponse contains the response from method ApplicationGatewaysClient.BackendHealthOnDemand.
 type ApplicationGatewaysClientBackendHealthOnDemandResponse struct {
 	ApplicationGatewayBackendHealthOnDemand
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientBackendHealthPollerResponse contains the response from method ApplicationGatewaysClient.BackendHealth.
 type ApplicationGatewaysClientBackendHealthPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ApplicationGatewaysClientBackendHealthPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -76,11 +65,10 @@ type ApplicationGatewaysClientBackendHealthPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ApplicationGatewaysClientBackendHealthPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientBackendHealthResponse, error) {
 	respType := ApplicationGatewaysClientBackendHealthResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGatewayBackendHealth)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGatewayBackendHealth)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -93,29 +81,23 @@ func (l *ApplicationGatewaysClientBackendHealthPollerResponse) Resume(ctx contex
 	poller := &ApplicationGatewaysClientBackendHealthPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ApplicationGatewaysClientBackendHealthResponse contains the response from method ApplicationGatewaysClient.BackendHealth.
 type ApplicationGatewaysClientBackendHealthResponse struct {
 	ApplicationGatewayBackendHealth
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientCreateOrUpdatePollerResponse contains the response from method ApplicationGatewaysClient.CreateOrUpdate.
 type ApplicationGatewaysClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ApplicationGatewaysClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -123,11 +105,10 @@ type ApplicationGatewaysClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ApplicationGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
 	respType := ApplicationGatewaysClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -140,29 +121,23 @@ func (l *ApplicationGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx conte
 	poller := &ApplicationGatewaysClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ApplicationGatewaysClientCreateOrUpdateResponse contains the response from method ApplicationGatewaysClient.CreateOrUpdate.
 type ApplicationGatewaysClientCreateOrUpdateResponse struct {
 	ApplicationGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientDeletePollerResponse contains the response from method ApplicationGatewaysClient.Delete.
 type ApplicationGatewaysClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ApplicationGatewaysClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -170,11 +145,10 @@ type ApplicationGatewaysClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ApplicationGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientDeleteResponse, error) {
 	respType := ApplicationGatewaysClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -187,56 +161,42 @@ func (l *ApplicationGatewaysClientDeletePollerResponse) Resume(ctx context.Conte
 	poller := &ApplicationGatewaysClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ApplicationGatewaysClientDeleteResponse contains the response from method ApplicationGatewaysClient.Delete.
 type ApplicationGatewaysClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ApplicationGatewaysClientGetResponse contains the response from method ApplicationGatewaysClient.Get.
 type ApplicationGatewaysClientGetResponse struct {
 	ApplicationGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientGetSSLPredefinedPolicyResponse contains the response from method ApplicationGatewaysClient.GetSSLPredefinedPolicy.
 type ApplicationGatewaysClientGetSSLPredefinedPolicyResponse struct {
 	ApplicationGatewaySSLPredefinedPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientListAllResponse contains the response from method ApplicationGatewaysClient.ListAll.
 type ApplicationGatewaysClientListAllResponse struct {
 	ApplicationGatewayListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientListAvailableRequestHeadersResponse contains the response from method ApplicationGatewaysClient.ListAvailableRequestHeaders.
 type ApplicationGatewaysClientListAvailableRequestHeadersResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Response for ApplicationGatewayAvailableRequestHeaders API service call.
 	StringArray []*string
 }
 
 // ApplicationGatewaysClientListAvailableResponseHeadersResponse contains the response from method ApplicationGatewaysClient.ListAvailableResponseHeaders.
 type ApplicationGatewaysClientListAvailableResponseHeadersResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Response for ApplicationGatewayAvailableResponseHeaders API service call.
 	StringArray []*string
 }
@@ -244,22 +204,15 @@ type ApplicationGatewaysClientListAvailableResponseHeadersResponse struct {
 // ApplicationGatewaysClientListAvailableSSLOptionsResponse contains the response from method ApplicationGatewaysClient.ListAvailableSSLOptions.
 type ApplicationGatewaysClientListAvailableSSLOptionsResponse struct {
 	ApplicationGatewayAvailableSSLOptions
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse contains the response from method ApplicationGatewaysClient.ListAvailableSSLPredefinedPolicies.
 type ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse struct {
 	ApplicationGatewayAvailableSSLPredefinedPolicies
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientListAvailableServerVariablesResponse contains the response from method ApplicationGatewaysClient.ListAvailableServerVariables.
 type ApplicationGatewaysClientListAvailableServerVariablesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// Response for ApplicationGatewayAvailableServerVariables API service call.
 	StringArray []*string
 }
@@ -267,24 +220,17 @@ type ApplicationGatewaysClientListAvailableServerVariablesResponse struct {
 // ApplicationGatewaysClientListAvailableWafRuleSetsResponse contains the response from method ApplicationGatewaysClient.ListAvailableWafRuleSets.
 type ApplicationGatewaysClientListAvailableWafRuleSetsResponse struct {
 	ApplicationGatewayAvailableWafRuleSetsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientListResponse contains the response from method ApplicationGatewaysClient.List.
 type ApplicationGatewaysClientListResponse struct {
 	ApplicationGatewayListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationGatewaysClientStartPollerResponse contains the response from method ApplicationGatewaysClient.Start.
 type ApplicationGatewaysClientStartPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ApplicationGatewaysClientStartPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -292,11 +238,10 @@ type ApplicationGatewaysClientStartPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ApplicationGatewaysClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientStartResponse, error) {
 	respType := ApplicationGatewaysClientStartResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -309,28 +254,23 @@ func (l *ApplicationGatewaysClientStartPollerResponse) Resume(ctx context.Contex
 	poller := &ApplicationGatewaysClientStartPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ApplicationGatewaysClientStartResponse contains the response from method ApplicationGatewaysClient.Start.
 type ApplicationGatewaysClientStartResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ApplicationGatewaysClientStopPollerResponse contains the response from method ApplicationGatewaysClient.Stop.
 type ApplicationGatewaysClientStopPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ApplicationGatewaysClientStopPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -338,11 +278,10 @@ type ApplicationGatewaysClientStopPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ApplicationGatewaysClientStopPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientStopResponse, error) {
 	respType := ApplicationGatewaysClientStopResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -355,35 +294,28 @@ func (l *ApplicationGatewaysClientStopPollerResponse) Resume(ctx context.Context
 	poller := &ApplicationGatewaysClientStopPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ApplicationGatewaysClientStopResponse contains the response from method ApplicationGatewaysClient.Stop.
 type ApplicationGatewaysClientStopResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ApplicationGatewaysClientUpdateTagsResponse contains the response from method ApplicationGatewaysClient.UpdateTags.
 type ApplicationGatewaysClientUpdateTagsResponse struct {
 	ApplicationGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse contains the response from method ApplicationSecurityGroupsClient.CreateOrUpdate.
 type ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ApplicationSecurityGroupsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -391,11 +323,10 @@ type ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
 	respType := ApplicationSecurityGroupsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationSecurityGroup)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationSecurityGroup)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -408,29 +339,23 @@ func (l *ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse) Resume(ctx
 	poller := &ApplicationSecurityGroupsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ApplicationSecurityGroupsClientCreateOrUpdateResponse contains the response from method ApplicationSecurityGroupsClient.CreateOrUpdate.
 type ApplicationSecurityGroupsClientCreateOrUpdateResponse struct {
 	ApplicationSecurityGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationSecurityGroupsClientDeletePollerResponse contains the response from method ApplicationSecurityGroupsClient.Delete.
 type ApplicationSecurityGroupsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ApplicationSecurityGroupsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -438,11 +363,10 @@ type ApplicationSecurityGroupsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ApplicationSecurityGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationSecurityGroupsClientDeleteResponse, error) {
 	respType := ApplicationSecurityGroupsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -455,112 +379,83 @@ func (l *ApplicationSecurityGroupsClientDeletePollerResponse) Resume(ctx context
 	poller := &ApplicationSecurityGroupsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ApplicationSecurityGroupsClientDeleteResponse contains the response from method ApplicationSecurityGroupsClient.Delete.
 type ApplicationSecurityGroupsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ApplicationSecurityGroupsClientGetResponse contains the response from method ApplicationSecurityGroupsClient.Get.
 type ApplicationSecurityGroupsClientGetResponse struct {
 	ApplicationSecurityGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationSecurityGroupsClientListAllResponse contains the response from method ApplicationSecurityGroupsClient.ListAll.
 type ApplicationSecurityGroupsClientListAllResponse struct {
 	ApplicationSecurityGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationSecurityGroupsClientListResponse contains the response from method ApplicationSecurityGroupsClient.List.
 type ApplicationSecurityGroupsClientListResponse struct {
 	ApplicationSecurityGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ApplicationSecurityGroupsClientUpdateTagsResponse contains the response from method ApplicationSecurityGroupsClient.UpdateTags.
 type ApplicationSecurityGroupsClientUpdateTagsResponse struct {
 	ApplicationSecurityGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailableDelegationsClientListResponse contains the response from method AvailableDelegationsClient.List.
 type AvailableDelegationsClientListResponse struct {
 	AvailableDelegationsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailableEndpointServicesClientListResponse contains the response from method AvailableEndpointServicesClient.List.
 type AvailableEndpointServicesClientListResponse struct {
 	EndpointServicesListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailablePrivateEndpointTypesClientListByResourceGroupResponse contains the response from method AvailablePrivateEndpointTypesClient.ListByResourceGroup.
 type AvailablePrivateEndpointTypesClientListByResourceGroupResponse struct {
 	AvailablePrivateEndpointTypesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailablePrivateEndpointTypesClientListResponse contains the response from method AvailablePrivateEndpointTypesClient.List.
 type AvailablePrivateEndpointTypesClientListResponse struct {
 	AvailablePrivateEndpointTypesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailableResourceGroupDelegationsClientListResponse contains the response from method AvailableResourceGroupDelegationsClient.List.
 type AvailableResourceGroupDelegationsClientListResponse struct {
 	AvailableDelegationsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailableServiceAliasesClientListByResourceGroupResponse contains the response from method AvailableServiceAliasesClient.ListByResourceGroup.
 type AvailableServiceAliasesClientListByResourceGroupResponse struct {
 	AvailableServiceAliasesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AvailableServiceAliasesClientListResponse contains the response from method AvailableServiceAliasesClient.List.
 type AvailableServiceAliasesClientListResponse struct {
 	AvailableServiceAliasesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AzureFirewallFqdnTagsClientListAllResponse contains the response from method AzureFirewallFqdnTagsClient.ListAll.
 type AzureFirewallFqdnTagsClientListAllResponse struct {
 	AzureFirewallFqdnTagListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AzureFirewallsClientCreateOrUpdatePollerResponse contains the response from method AzureFirewallsClient.CreateOrUpdate.
 type AzureFirewallsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *AzureFirewallsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -568,11 +463,10 @@ type AzureFirewallsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l AzureFirewallsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientCreateOrUpdateResponse, error) {
 	respType := AzureFirewallsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureFirewall)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureFirewall)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -585,29 +479,23 @@ func (l *AzureFirewallsClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 	poller := &AzureFirewallsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // AzureFirewallsClientCreateOrUpdateResponse contains the response from method AzureFirewallsClient.CreateOrUpdate.
 type AzureFirewallsClientCreateOrUpdateResponse struct {
 	AzureFirewall
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AzureFirewallsClientDeletePollerResponse contains the response from method AzureFirewallsClient.Delete.
 type AzureFirewallsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *AzureFirewallsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -615,11 +503,10 @@ type AzureFirewallsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l AzureFirewallsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientDeleteResponse, error) {
 	respType := AzureFirewallsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -632,49 +519,38 @@ func (l *AzureFirewallsClientDeletePollerResponse) Resume(ctx context.Context, c
 	poller := &AzureFirewallsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // AzureFirewallsClientDeleteResponse contains the response from method AzureFirewallsClient.Delete.
 type AzureFirewallsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // AzureFirewallsClientGetResponse contains the response from method AzureFirewallsClient.Get.
 type AzureFirewallsClientGetResponse struct {
 	AzureFirewall
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AzureFirewallsClientListAllResponse contains the response from method AzureFirewallsClient.ListAll.
 type AzureFirewallsClientListAllResponse struct {
 	AzureFirewallListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AzureFirewallsClientListResponse contains the response from method AzureFirewallsClient.List.
 type AzureFirewallsClientListResponse struct {
 	AzureFirewallListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // AzureFirewallsClientUpdateTagsPollerResponse contains the response from method AzureFirewallsClient.UpdateTags.
 type AzureFirewallsClientUpdateTagsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *AzureFirewallsClientUpdateTagsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -682,11 +558,10 @@ type AzureFirewallsClientUpdateTagsPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l AzureFirewallsClientUpdateTagsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientUpdateTagsResponse, error) {
 	respType := AzureFirewallsClientUpdateTagsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureFirewall)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureFirewall)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -699,29 +574,23 @@ func (l *AzureFirewallsClientUpdateTagsPollerResponse) Resume(ctx context.Contex
 	poller := &AzureFirewallsClientUpdateTagsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // AzureFirewallsClientUpdateTagsResponse contains the response from method AzureFirewallsClient.UpdateTags.
 type AzureFirewallsClientUpdateTagsResponse struct {
 	AzureFirewall
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BastionHostsClientCreateOrUpdatePollerResponse contains the response from method BastionHostsClient.CreateOrUpdate.
 type BastionHostsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *BastionHostsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -729,11 +598,10 @@ type BastionHostsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l BastionHostsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BastionHostsClientCreateOrUpdateResponse, error) {
 	respType := BastionHostsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BastionHost)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BastionHost)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -746,29 +614,23 @@ func (l *BastionHostsClientCreateOrUpdatePollerResponse) Resume(ctx context.Cont
 	poller := &BastionHostsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // BastionHostsClientCreateOrUpdateResponse contains the response from method BastionHostsClient.CreateOrUpdate.
 type BastionHostsClientCreateOrUpdateResponse struct {
 	BastionHost
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BastionHostsClientDeletePollerResponse contains the response from method BastionHostsClient.Delete.
 type BastionHostsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *BastionHostsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -776,11 +638,10 @@ type BastionHostsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l BastionHostsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BastionHostsClientDeleteResponse, error) {
 	respType := BastionHostsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -793,56 +654,43 @@ func (l *BastionHostsClientDeletePollerResponse) Resume(ctx context.Context, cli
 	poller := &BastionHostsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // BastionHostsClientDeleteResponse contains the response from method BastionHostsClient.Delete.
 type BastionHostsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // BastionHostsClientGetResponse contains the response from method BastionHostsClient.Get.
 type BastionHostsClientGetResponse struct {
 	BastionHost
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BastionHostsClientListByResourceGroupResponse contains the response from method BastionHostsClient.ListByResourceGroup.
 type BastionHostsClientListByResourceGroupResponse struct {
 	BastionHostListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BastionHostsClientListResponse contains the response from method BastionHostsClient.List.
 type BastionHostsClientListResponse struct {
 	BastionHostListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // BgpServiceCommunitiesClientListResponse contains the response from method BgpServiceCommunitiesClient.List.
 type BgpServiceCommunitiesClientListResponse struct {
 	BgpServiceCommunityListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ConnectionMonitorsClientCreateOrUpdatePollerResponse contains the response from method ConnectionMonitorsClient.CreateOrUpdate.
 type ConnectionMonitorsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ConnectionMonitorsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -850,11 +698,10 @@ type ConnectionMonitorsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ConnectionMonitorsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
 	respType := ConnectionMonitorsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionMonitorResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionMonitorResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -867,29 +714,23 @@ func (l *ConnectionMonitorsClientCreateOrUpdatePollerResponse) Resume(ctx contex
 	poller := &ConnectionMonitorsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ConnectionMonitorsClientCreateOrUpdateResponse contains the response from method ConnectionMonitorsClient.CreateOrUpdate.
 type ConnectionMonitorsClientCreateOrUpdateResponse struct {
 	ConnectionMonitorResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ConnectionMonitorsClientDeletePollerResponse contains the response from method ConnectionMonitorsClient.Delete.
 type ConnectionMonitorsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ConnectionMonitorsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -897,11 +738,10 @@ type ConnectionMonitorsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ConnectionMonitorsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientDeleteResponse, error) {
 	respType := ConnectionMonitorsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -914,42 +754,33 @@ func (l *ConnectionMonitorsClientDeletePollerResponse) Resume(ctx context.Contex
 	poller := &ConnectionMonitorsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ConnectionMonitorsClientDeleteResponse contains the response from method ConnectionMonitorsClient.Delete.
 type ConnectionMonitorsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ConnectionMonitorsClientGetResponse contains the response from method ConnectionMonitorsClient.Get.
 type ConnectionMonitorsClientGetResponse struct {
 	ConnectionMonitorResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ConnectionMonitorsClientListResponse contains the response from method ConnectionMonitorsClient.List.
 type ConnectionMonitorsClientListResponse struct {
 	ConnectionMonitorListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ConnectionMonitorsClientQueryPollerResponse contains the response from method ConnectionMonitorsClient.Query.
 type ConnectionMonitorsClientQueryPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ConnectionMonitorsClientQueryPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -957,11 +788,10 @@ type ConnectionMonitorsClientQueryPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ConnectionMonitorsClientQueryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientQueryResponse, error) {
 	respType := ConnectionMonitorsClientQueryResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionMonitorQueryResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionMonitorQueryResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -974,29 +804,23 @@ func (l *ConnectionMonitorsClientQueryPollerResponse) Resume(ctx context.Context
 	poller := &ConnectionMonitorsClientQueryPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ConnectionMonitorsClientQueryResponse contains the response from method ConnectionMonitorsClient.Query.
 type ConnectionMonitorsClientQueryResponse struct {
 	ConnectionMonitorQueryResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ConnectionMonitorsClientStartPollerResponse contains the response from method ConnectionMonitorsClient.Start.
 type ConnectionMonitorsClientStartPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ConnectionMonitorsClientStartPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1004,11 +828,10 @@ type ConnectionMonitorsClientStartPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ConnectionMonitorsClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientStartResponse, error) {
 	respType := ConnectionMonitorsClientStartResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1021,28 +844,23 @@ func (l *ConnectionMonitorsClientStartPollerResponse) Resume(ctx context.Context
 	poller := &ConnectionMonitorsClientStartPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ConnectionMonitorsClientStartResponse contains the response from method ConnectionMonitorsClient.Start.
 type ConnectionMonitorsClientStartResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ConnectionMonitorsClientStopPollerResponse contains the response from method ConnectionMonitorsClient.Stop.
 type ConnectionMonitorsClientStopPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ConnectionMonitorsClientStopPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1050,11 +868,10 @@ type ConnectionMonitorsClientStopPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ConnectionMonitorsClientStopPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientStopResponse, error) {
 	respType := ConnectionMonitorsClientStopResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1067,35 +884,28 @@ func (l *ConnectionMonitorsClientStopPollerResponse) Resume(ctx context.Context,
 	poller := &ConnectionMonitorsClientStopPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ConnectionMonitorsClientStopResponse contains the response from method ConnectionMonitorsClient.Stop.
 type ConnectionMonitorsClientStopResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ConnectionMonitorsClientUpdateTagsResponse contains the response from method ConnectionMonitorsClient.UpdateTags.
 type ConnectionMonitorsClientUpdateTagsResponse struct {
 	ConnectionMonitorResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DdosCustomPoliciesClientCreateOrUpdatePollerResponse contains the response from method DdosCustomPoliciesClient.CreateOrUpdate.
 type DdosCustomPoliciesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DdosCustomPoliciesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1103,11 +913,10 @@ type DdosCustomPoliciesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DdosCustomPoliciesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
 	respType := DdosCustomPoliciesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DdosCustomPolicy)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DdosCustomPolicy)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1120,29 +929,23 @@ func (l *DdosCustomPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx contex
 	poller := &DdosCustomPoliciesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DdosCustomPoliciesClientCreateOrUpdateResponse contains the response from method DdosCustomPoliciesClient.CreateOrUpdate.
 type DdosCustomPoliciesClientCreateOrUpdateResponse struct {
 	DdosCustomPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DdosCustomPoliciesClientDeletePollerResponse contains the response from method DdosCustomPoliciesClient.Delete.
 type DdosCustomPoliciesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DdosCustomPoliciesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1150,11 +953,10 @@ type DdosCustomPoliciesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DdosCustomPoliciesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DdosCustomPoliciesClientDeleteResponse, error) {
 	respType := DdosCustomPoliciesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1167,42 +969,33 @@ func (l *DdosCustomPoliciesClientDeletePollerResponse) Resume(ctx context.Contex
 	poller := &DdosCustomPoliciesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DdosCustomPoliciesClientDeleteResponse contains the response from method DdosCustomPoliciesClient.Delete.
 type DdosCustomPoliciesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DdosCustomPoliciesClientGetResponse contains the response from method DdosCustomPoliciesClient.Get.
 type DdosCustomPoliciesClientGetResponse struct {
 	DdosCustomPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DdosCustomPoliciesClientUpdateTagsResponse contains the response from method DdosCustomPoliciesClient.UpdateTags.
 type DdosCustomPoliciesClientUpdateTagsResponse struct {
 	DdosCustomPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DdosProtectionPlansClientCreateOrUpdatePollerResponse contains the response from method DdosProtectionPlansClient.CreateOrUpdate.
 type DdosProtectionPlansClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DdosProtectionPlansClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1210,11 +1003,10 @@ type DdosProtectionPlansClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DdosProtectionPlansClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
 	respType := DdosProtectionPlansClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DdosProtectionPlan)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DdosProtectionPlan)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1227,29 +1019,23 @@ func (l *DdosProtectionPlansClientCreateOrUpdatePollerResponse) Resume(ctx conte
 	poller := &DdosProtectionPlansClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DdosProtectionPlansClientCreateOrUpdateResponse contains the response from method DdosProtectionPlansClient.CreateOrUpdate.
 type DdosProtectionPlansClientCreateOrUpdateResponse struct {
 	DdosProtectionPlan
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DdosProtectionPlansClientDeletePollerResponse contains the response from method DdosProtectionPlansClient.Delete.
 type DdosProtectionPlansClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *DdosProtectionPlansClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1257,11 +1043,10 @@ type DdosProtectionPlansClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l DdosProtectionPlansClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DdosProtectionPlansClientDeleteResponse, error) {
 	respType := DdosProtectionPlansClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1274,70 +1059,53 @@ func (l *DdosProtectionPlansClientDeletePollerResponse) Resume(ctx context.Conte
 	poller := &DdosProtectionPlansClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // DdosProtectionPlansClientDeleteResponse contains the response from method DdosProtectionPlansClient.Delete.
 type DdosProtectionPlansClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // DdosProtectionPlansClientGetResponse contains the response from method DdosProtectionPlansClient.Get.
 type DdosProtectionPlansClientGetResponse struct {
 	DdosProtectionPlan
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DdosProtectionPlansClientListByResourceGroupResponse contains the response from method DdosProtectionPlansClient.ListByResourceGroup.
 type DdosProtectionPlansClientListByResourceGroupResponse struct {
 	DdosProtectionPlanListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DdosProtectionPlansClientListResponse contains the response from method DdosProtectionPlansClient.List.
 type DdosProtectionPlansClientListResponse struct {
 	DdosProtectionPlanListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DdosProtectionPlansClientUpdateTagsResponse contains the response from method DdosProtectionPlansClient.UpdateTags.
 type DdosProtectionPlansClientUpdateTagsResponse struct {
 	DdosProtectionPlan
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DefaultSecurityRulesClientGetResponse contains the response from method DefaultSecurityRulesClient.Get.
 type DefaultSecurityRulesClientGetResponse struct {
 	SecurityRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // DefaultSecurityRulesClientListResponse contains the response from method DefaultSecurityRulesClient.List.
 type DefaultSecurityRulesClientListResponse struct {
 	SecurityRuleListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate.
 type ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1345,11 +1113,10 @@ type ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse struct 
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitAuthorization)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitAuthorization)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1363,29 +1130,23 @@ func (l *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse) Re
 	poller := &ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate.
 type ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse struct {
 	ExpressRouteCircuitAuthorization
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitAuthorizationsClientDeletePollerResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.Delete.
 type ExpressRouteCircuitAuthorizationsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitAuthorizationsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1393,11 +1154,10 @@ type ExpressRouteCircuitAuthorizationsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitAuthorizationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
 	respType := ExpressRouteCircuitAuthorizationsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1410,42 +1170,33 @@ func (l *ExpressRouteCircuitAuthorizationsClientDeletePollerResponse) Resume(ctx
 	poller := &ExpressRouteCircuitAuthorizationsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitAuthorizationsClientDeleteResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.Delete.
 type ExpressRouteCircuitAuthorizationsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExpressRouteCircuitAuthorizationsClientGetResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.Get.
 type ExpressRouteCircuitAuthorizationsClientGetResponse struct {
 	ExpressRouteCircuitAuthorization
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitAuthorizationsClientListResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.List.
 type ExpressRouteCircuitAuthorizationsClientListResponse struct {
 	AuthorizationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitConnectionsClient.CreateOrUpdate.
 type ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1453,11 +1204,10 @@ type ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitConnection)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitConnection)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1471,29 +1221,23 @@ func (l *ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse) Resum
 	poller := &ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitConnectionsClient.CreateOrUpdate.
 type ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse struct {
 	ExpressRouteCircuitConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitConnectionsClientDeletePollerResponse contains the response from method ExpressRouteCircuitConnectionsClient.Delete.
 type ExpressRouteCircuitConnectionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitConnectionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1501,11 +1245,10 @@ type ExpressRouteCircuitConnectionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitConnectionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
 	respType := ExpressRouteCircuitConnectionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1518,42 +1261,33 @@ func (l *ExpressRouteCircuitConnectionsClientDeletePollerResponse) Resume(ctx co
 	poller := &ExpressRouteCircuitConnectionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitConnectionsClientDeleteResponse contains the response from method ExpressRouteCircuitConnectionsClient.Delete.
 type ExpressRouteCircuitConnectionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExpressRouteCircuitConnectionsClientGetResponse contains the response from method ExpressRouteCircuitConnectionsClient.Get.
 type ExpressRouteCircuitConnectionsClientGetResponse struct {
 	ExpressRouteCircuitConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitConnectionsClientListResponse contains the response from method ExpressRouteCircuitConnectionsClient.List.
 type ExpressRouteCircuitConnectionsClientListResponse struct {
 	ExpressRouteCircuitConnectionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitPeeringsClient.CreateOrUpdate.
 type ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1561,11 +1295,10 @@ type ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitPeering)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitPeering)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1578,29 +1311,23 @@ func (l *ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse) Resume(c
 	poller := &ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitPeeringsClient.CreateOrUpdate.
 type ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse struct {
 	ExpressRouteCircuitPeering
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitPeeringsClientDeletePollerResponse contains the response from method ExpressRouteCircuitPeeringsClient.Delete.
 type ExpressRouteCircuitPeeringsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitPeeringsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1608,11 +1335,10 @@ type ExpressRouteCircuitPeeringsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitPeeringsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
 	respType := ExpressRouteCircuitPeeringsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1625,42 +1351,33 @@ func (l *ExpressRouteCircuitPeeringsClientDeletePollerResponse) Resume(ctx conte
 	poller := &ExpressRouteCircuitPeeringsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitPeeringsClientDeleteResponse contains the response from method ExpressRouteCircuitPeeringsClient.Delete.
 type ExpressRouteCircuitPeeringsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExpressRouteCircuitPeeringsClientGetResponse contains the response from method ExpressRouteCircuitPeeringsClient.Get.
 type ExpressRouteCircuitPeeringsClientGetResponse struct {
 	ExpressRouteCircuitPeering
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitPeeringsClientListResponse contains the response from method ExpressRouteCircuitPeeringsClient.List.
 type ExpressRouteCircuitPeeringsClientListResponse struct {
 	ExpressRouteCircuitPeeringListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitsClient.CreateOrUpdate.
 type ExpressRouteCircuitsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1668,11 +1385,10 @@ type ExpressRouteCircuitsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCircuitsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuit)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuit)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1685,29 +1401,23 @@ func (l *ExpressRouteCircuitsClientCreateOrUpdatePollerResponse) Resume(ctx cont
 	poller := &ExpressRouteCircuitsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitsClient.CreateOrUpdate.
 type ExpressRouteCircuitsClientCreateOrUpdateResponse struct {
 	ExpressRouteCircuit
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientDeletePollerResponse contains the response from method ExpressRouteCircuitsClient.Delete.
 type ExpressRouteCircuitsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1715,11 +1425,10 @@ type ExpressRouteCircuitsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientDeleteResponse, error) {
 	respType := ExpressRouteCircuitsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1732,56 +1441,43 @@ func (l *ExpressRouteCircuitsClientDeletePollerResponse) Resume(ctx context.Cont
 	poller := &ExpressRouteCircuitsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitsClientDeleteResponse contains the response from method ExpressRouteCircuitsClient.Delete.
 type ExpressRouteCircuitsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExpressRouteCircuitsClientGetPeeringStatsResponse contains the response from method ExpressRouteCircuitsClient.GetPeeringStats.
 type ExpressRouteCircuitsClientGetPeeringStatsResponse struct {
 	ExpressRouteCircuitStats
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientGetResponse contains the response from method ExpressRouteCircuitsClient.Get.
 type ExpressRouteCircuitsClientGetResponse struct {
 	ExpressRouteCircuit
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientGetStatsResponse contains the response from method ExpressRouteCircuitsClient.GetStats.
 type ExpressRouteCircuitsClientGetStatsResponse struct {
 	ExpressRouteCircuitStats
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientListAllResponse contains the response from method ExpressRouteCircuitsClient.ListAll.
 type ExpressRouteCircuitsClientListAllResponse struct {
 	ExpressRouteCircuitListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientListArpTablePollerResponse contains the response from method ExpressRouteCircuitsClient.ListArpTable.
 type ExpressRouteCircuitsClientListArpTablePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitsClientListArpTablePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1789,11 +1485,10 @@ type ExpressRouteCircuitsClientListArpTablePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitsClientListArpTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListArpTableResponse, error) {
 	respType := ExpressRouteCircuitsClientListArpTableResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsArpTableListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsArpTableListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1806,36 +1501,28 @@ func (l *ExpressRouteCircuitsClientListArpTablePollerResponse) Resume(ctx contex
 	poller := &ExpressRouteCircuitsClientListArpTablePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitsClientListArpTableResponse contains the response from method ExpressRouteCircuitsClient.ListArpTable.
 type ExpressRouteCircuitsClientListArpTableResponse struct {
 	ExpressRouteCircuitsArpTableListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientListResponse contains the response from method ExpressRouteCircuitsClient.List.
 type ExpressRouteCircuitsClientListResponse struct {
 	ExpressRouteCircuitListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientListRoutesTablePollerResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTable.
 type ExpressRouteCircuitsClientListRoutesTablePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitsClientListRoutesTablePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1843,11 +1530,10 @@ type ExpressRouteCircuitsClientListRoutesTablePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitsClientListRoutesTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
 	respType := ExpressRouteCircuitsClientListRoutesTableResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1860,29 +1546,23 @@ func (l *ExpressRouteCircuitsClientListRoutesTablePollerResponse) Resume(ctx con
 	poller := &ExpressRouteCircuitsClientListRoutesTablePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitsClientListRoutesTableResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTable.
 type ExpressRouteCircuitsClientListRoutesTableResponse struct {
 	ExpressRouteCircuitsRoutesTableListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTableSummary.
 type ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCircuitsClientListRoutesTableSummaryPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1890,11 +1570,10 @@ type ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
 	respType := ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableSummaryListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableSummaryListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1908,36 +1587,28 @@ func (l *ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse) Resume(
 	poller := &ExpressRouteCircuitsClientListRoutesTableSummaryPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCircuitsClientListRoutesTableSummaryResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTableSummary.
 type ExpressRouteCircuitsClientListRoutesTableSummaryResponse struct {
 	ExpressRouteCircuitsRoutesTableSummaryListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCircuitsClientUpdateTagsResponse contains the response from method ExpressRouteCircuitsClient.UpdateTags.
 type ExpressRouteCircuitsClientUpdateTagsResponse struct {
 	ExpressRouteCircuit
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteConnectionsClient.CreateOrUpdate.
 type ExpressRouteConnectionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteConnectionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1945,11 +1616,10 @@ type ExpressRouteConnectionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteConnectionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteConnection)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteConnection)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1962,29 +1632,23 @@ func (l *ExpressRouteConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx c
 	poller := &ExpressRouteConnectionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteConnectionsClient.CreateOrUpdate.
 type ExpressRouteConnectionsClientCreateOrUpdateResponse struct {
 	ExpressRouteConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteConnectionsClientDeletePollerResponse contains the response from method ExpressRouteConnectionsClient.Delete.
 type ExpressRouteConnectionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteConnectionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1992,11 +1656,10 @@ type ExpressRouteConnectionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteConnectionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteConnectionsClientDeleteResponse, error) {
 	respType := ExpressRouteConnectionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2009,42 +1672,33 @@ func (l *ExpressRouteConnectionsClientDeletePollerResponse) Resume(ctx context.C
 	poller := &ExpressRouteConnectionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteConnectionsClientDeleteResponse contains the response from method ExpressRouteConnectionsClient.Delete.
 type ExpressRouteConnectionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExpressRouteConnectionsClientGetResponse contains the response from method ExpressRouteConnectionsClient.Get.
 type ExpressRouteConnectionsClientGetResponse struct {
 	ExpressRouteConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteConnectionsClientListResponse contains the response from method ExpressRouteConnectionsClient.List.
 type ExpressRouteConnectionsClientListResponse struct {
 	ExpressRouteConnectionList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate.
 type ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2052,11 +1706,10 @@ type ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse struc
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnectionPeering)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnectionPeering)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2070,29 +1723,23 @@ func (l *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse) 
 	poller := &ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate.
 type ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse struct {
 	ExpressRouteCrossConnectionPeering
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.Delete.
 type ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCrossConnectionPeeringsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2100,11 +1747,10 @@ type ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
 	respType := ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2117,42 +1763,33 @@ func (l *ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse) Resume(c
 	poller := &ExpressRouteCrossConnectionPeeringsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCrossConnectionPeeringsClientDeleteResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.Delete.
 type ExpressRouteCrossConnectionPeeringsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExpressRouteCrossConnectionPeeringsClientGetResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.Get.
 type ExpressRouteCrossConnectionPeeringsClientGetResponse struct {
 	ExpressRouteCrossConnectionPeering
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionPeeringsClientListResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.List.
 type ExpressRouteCrossConnectionPeeringsClientListResponse struct {
 	ExpressRouteCrossConnectionPeeringList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.CreateOrUpdate.
 type ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2160,11 +1797,10 @@ type ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnection)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnection)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2178,36 +1814,28 @@ func (l *ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse) Resume(
 	poller := &ExpressRouteCrossConnectionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCrossConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteCrossConnectionsClient.CreateOrUpdate.
 type ExpressRouteCrossConnectionsClientCreateOrUpdateResponse struct {
 	ExpressRouteCrossConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionsClientGetResponse contains the response from method ExpressRouteCrossConnectionsClient.Get.
 type ExpressRouteCrossConnectionsClientGetResponse struct {
 	ExpressRouteCrossConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionsClientListArpTablePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListArpTable.
 type ExpressRouteCrossConnectionsClientListArpTablePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCrossConnectionsClientListArpTablePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2215,11 +1843,10 @@ type ExpressRouteCrossConnectionsClientListArpTablePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCrossConnectionsClientListArpTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
 	respType := ExpressRouteCrossConnectionsClientListArpTableResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsArpTableListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsArpTableListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2232,43 +1859,33 @@ func (l *ExpressRouteCrossConnectionsClientListArpTablePollerResponse) Resume(ct
 	poller := &ExpressRouteCrossConnectionsClientListArpTablePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCrossConnectionsClientListArpTableResponse contains the response from method ExpressRouteCrossConnectionsClient.ListArpTable.
 type ExpressRouteCrossConnectionsClientListArpTableResponse struct {
 	ExpressRouteCircuitsArpTableListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionsClientListByResourceGroupResponse contains the response from method ExpressRouteCrossConnectionsClient.ListByResourceGroup.
 type ExpressRouteCrossConnectionsClientListByResourceGroupResponse struct {
 	ExpressRouteCrossConnectionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionsClientListResponse contains the response from method ExpressRouteCrossConnectionsClient.List.
 type ExpressRouteCrossConnectionsClientListResponse struct {
 	ExpressRouteCrossConnectionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTable.
 type ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCrossConnectionsClientListRoutesTablePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2276,11 +1893,10 @@ type ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
 	respType := ExpressRouteCrossConnectionsClientListRoutesTableResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2294,29 +1910,23 @@ func (l *ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse) Resume
 	poller := &ExpressRouteCrossConnectionsClientListRoutesTablePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTableResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTable.
 type ExpressRouteCrossConnectionsClientListRoutesTableResponse struct {
 	ExpressRouteCircuitsRoutesTableListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTableSummary.
 type ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2324,11 +1934,10 @@ type ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse stru
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
 	respType := ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2342,36 +1951,28 @@ func (l *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse)
 	poller := &ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTableSummary.
 type ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse struct {
 	ExpressRouteCrossConnectionsRoutesTableSummaryListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteCrossConnectionsClientUpdateTagsResponse contains the response from method ExpressRouteCrossConnectionsClient.UpdateTags.
 type ExpressRouteCrossConnectionsClientUpdateTagsResponse struct {
 	ExpressRouteCrossConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteGatewaysClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteGatewaysClient.CreateOrUpdate.
 type ExpressRouteGatewaysClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteGatewaysClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2379,11 +1980,10 @@ type ExpressRouteGatewaysClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
 	respType := ExpressRouteGatewaysClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2396,29 +1996,23 @@ func (l *ExpressRouteGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx cont
 	poller := &ExpressRouteGatewaysClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteGatewaysClientCreateOrUpdateResponse contains the response from method ExpressRouteGatewaysClient.CreateOrUpdate.
 type ExpressRouteGatewaysClientCreateOrUpdateResponse struct {
 	ExpressRouteGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteGatewaysClientDeletePollerResponse contains the response from method ExpressRouteGatewaysClient.Delete.
 type ExpressRouteGatewaysClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRouteGatewaysClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2426,11 +2020,10 @@ type ExpressRouteGatewaysClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRouteGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteGatewaysClientDeleteResponse, error) {
 	respType := ExpressRouteGatewaysClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2443,63 +2036,48 @@ func (l *ExpressRouteGatewaysClientDeletePollerResponse) Resume(ctx context.Cont
 	poller := &ExpressRouteGatewaysClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRouteGatewaysClientDeleteResponse contains the response from method ExpressRouteGatewaysClient.Delete.
 type ExpressRouteGatewaysClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExpressRouteGatewaysClientGetResponse contains the response from method ExpressRouteGatewaysClient.Get.
 type ExpressRouteGatewaysClientGetResponse struct {
 	ExpressRouteGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteGatewaysClientListByResourceGroupResponse contains the response from method ExpressRouteGatewaysClient.ListByResourceGroup.
 type ExpressRouteGatewaysClientListByResourceGroupResponse struct {
 	ExpressRouteGatewayList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteGatewaysClientListBySubscriptionResponse contains the response from method ExpressRouteGatewaysClient.ListBySubscription.
 type ExpressRouteGatewaysClientListBySubscriptionResponse struct {
 	ExpressRouteGatewayList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteLinksClientGetResponse contains the response from method ExpressRouteLinksClient.Get.
 type ExpressRouteLinksClientGetResponse struct {
 	ExpressRouteLink
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteLinksClientListResponse contains the response from method ExpressRouteLinksClient.List.
 type ExpressRouteLinksClientListResponse struct {
 	ExpressRouteLinkListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRoutePortsClientCreateOrUpdatePollerResponse contains the response from method ExpressRoutePortsClient.CreateOrUpdate.
 type ExpressRoutePortsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRoutePortsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2507,11 +2085,10 @@ type ExpressRoutePortsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRoutePortsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
 	respType := ExpressRoutePortsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRoutePort)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRoutePort)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2524,29 +2101,23 @@ func (l *ExpressRoutePortsClientCreateOrUpdatePollerResponse) Resume(ctx context
 	poller := &ExpressRoutePortsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRoutePortsClientCreateOrUpdateResponse contains the response from method ExpressRoutePortsClient.CreateOrUpdate.
 type ExpressRoutePortsClientCreateOrUpdateResponse struct {
 	ExpressRoutePort
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRoutePortsClientDeletePollerResponse contains the response from method ExpressRoutePortsClient.Delete.
 type ExpressRoutePortsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ExpressRoutePortsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2554,11 +2125,10 @@ type ExpressRoutePortsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ExpressRoutePortsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRoutePortsClientDeleteResponse, error) {
 	respType := ExpressRoutePortsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2571,77 +2141,58 @@ func (l *ExpressRoutePortsClientDeletePollerResponse) Resume(ctx context.Context
 	poller := &ExpressRoutePortsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ExpressRoutePortsClientDeleteResponse contains the response from method ExpressRoutePortsClient.Delete.
 type ExpressRoutePortsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ExpressRoutePortsClientGetResponse contains the response from method ExpressRoutePortsClient.Get.
 type ExpressRoutePortsClientGetResponse struct {
 	ExpressRoutePort
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRoutePortsClientListByResourceGroupResponse contains the response from method ExpressRoutePortsClient.ListByResourceGroup.
 type ExpressRoutePortsClientListByResourceGroupResponse struct {
 	ExpressRoutePortListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRoutePortsClientListResponse contains the response from method ExpressRoutePortsClient.List.
 type ExpressRoutePortsClientListResponse struct {
 	ExpressRoutePortListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRoutePortsClientUpdateTagsResponse contains the response from method ExpressRoutePortsClient.UpdateTags.
 type ExpressRoutePortsClientUpdateTagsResponse struct {
 	ExpressRoutePort
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRoutePortsLocationsClientGetResponse contains the response from method ExpressRoutePortsLocationsClient.Get.
 type ExpressRoutePortsLocationsClientGetResponse struct {
 	ExpressRoutePortsLocation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRoutePortsLocationsClientListResponse contains the response from method ExpressRoutePortsLocationsClient.List.
 type ExpressRoutePortsLocationsClientListResponse struct {
 	ExpressRoutePortsLocationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ExpressRouteServiceProvidersClientListResponse contains the response from method ExpressRouteServiceProvidersClient.List.
 type ExpressRouteServiceProvidersClientListResponse struct {
 	ExpressRouteServiceProviderListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FirewallPoliciesClientCreateOrUpdatePollerResponse contains the response from method FirewallPoliciesClient.CreateOrUpdate.
 type FirewallPoliciesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *FirewallPoliciesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2649,11 +2200,10 @@ type FirewallPoliciesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l FirewallPoliciesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
 	respType := FirewallPoliciesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FirewallPolicy)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FirewallPolicy)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2666,29 +2216,23 @@ func (l *FirewallPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx context.
 	poller := &FirewallPoliciesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // FirewallPoliciesClientCreateOrUpdateResponse contains the response from method FirewallPoliciesClient.CreateOrUpdate.
 type FirewallPoliciesClientCreateOrUpdateResponse struct {
 	FirewallPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FirewallPoliciesClientDeletePollerResponse contains the response from method FirewallPoliciesClient.Delete.
 type FirewallPoliciesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *FirewallPoliciesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2696,11 +2240,10 @@ type FirewallPoliciesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l FirewallPoliciesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPoliciesClientDeleteResponse, error) {
 	respType := FirewallPoliciesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2713,49 +2256,38 @@ func (l *FirewallPoliciesClientDeletePollerResponse) Resume(ctx context.Context,
 	poller := &FirewallPoliciesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // FirewallPoliciesClientDeleteResponse contains the response from method FirewallPoliciesClient.Delete.
 type FirewallPoliciesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // FirewallPoliciesClientGetResponse contains the response from method FirewallPoliciesClient.Get.
 type FirewallPoliciesClientGetResponse struct {
 	FirewallPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FirewallPoliciesClientListAllResponse contains the response from method FirewallPoliciesClient.ListAll.
 type FirewallPoliciesClientListAllResponse struct {
 	FirewallPolicyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FirewallPoliciesClientListResponse contains the response from method FirewallPoliciesClient.List.
 type FirewallPoliciesClientListResponse struct {
 	FirewallPolicyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse contains the response from method FirewallPolicyRuleGroupsClient.CreateOrUpdate.
 type FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2763,11 +2295,10 @@ type FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
 	respType := FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FirewallPolicyRuleGroup)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FirewallPolicyRuleGroup)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2780,29 +2311,23 @@ func (l *FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse) Resume(ctx 
 	poller := &FirewallPolicyRuleGroupsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // FirewallPolicyRuleGroupsClientCreateOrUpdateResponse contains the response from method FirewallPolicyRuleGroupsClient.CreateOrUpdate.
 type FirewallPolicyRuleGroupsClientCreateOrUpdateResponse struct {
 	FirewallPolicyRuleGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FirewallPolicyRuleGroupsClientDeletePollerResponse contains the response from method FirewallPolicyRuleGroupsClient.Delete.
 type FirewallPolicyRuleGroupsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *FirewallPolicyRuleGroupsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2810,11 +2335,10 @@ type FirewallPolicyRuleGroupsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l FirewallPolicyRuleGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
 	respType := FirewallPolicyRuleGroupsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2827,42 +2351,33 @@ func (l *FirewallPolicyRuleGroupsClientDeletePollerResponse) Resume(ctx context.
 	poller := &FirewallPolicyRuleGroupsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // FirewallPolicyRuleGroupsClientDeleteResponse contains the response from method FirewallPolicyRuleGroupsClient.Delete.
 type FirewallPolicyRuleGroupsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // FirewallPolicyRuleGroupsClientGetResponse contains the response from method FirewallPolicyRuleGroupsClient.Get.
 type FirewallPolicyRuleGroupsClientGetResponse struct {
 	FirewallPolicyRuleGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FirewallPolicyRuleGroupsClientListResponse contains the response from method FirewallPolicyRuleGroupsClient.List.
 type FirewallPolicyRuleGroupsClientListResponse struct {
 	FirewallPolicyRuleGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FlowLogsClientCreateOrUpdatePollerResponse contains the response from method FlowLogsClient.CreateOrUpdate.
 type FlowLogsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *FlowLogsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2870,11 +2385,10 @@ type FlowLogsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l FlowLogsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FlowLogsClientCreateOrUpdateResponse, error) {
 	respType := FlowLogsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLog)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLog)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2887,29 +2401,23 @@ func (l *FlowLogsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context,
 	poller := &FlowLogsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // FlowLogsClientCreateOrUpdateResponse contains the response from method FlowLogsClient.CreateOrUpdate.
 type FlowLogsClientCreateOrUpdateResponse struct {
 	FlowLog
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FlowLogsClientDeletePollerResponse contains the response from method FlowLogsClient.Delete.
 type FlowLogsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *FlowLogsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2917,11 +2425,10 @@ type FlowLogsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l FlowLogsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FlowLogsClientDeleteResponse, error) {
 	respType := FlowLogsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -2934,56 +2441,43 @@ func (l *FlowLogsClientDeletePollerResponse) Resume(ctx context.Context, client 
 	poller := &FlowLogsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // FlowLogsClientDeleteResponse contains the response from method FlowLogsClient.Delete.
 type FlowLogsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // FlowLogsClientGetResponse contains the response from method FlowLogsClient.Get.
 type FlowLogsClientGetResponse struct {
 	FlowLog
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // FlowLogsClientListResponse contains the response from method FlowLogsClient.List.
 type FlowLogsClientListResponse struct {
 	FlowLogListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HubVirtualNetworkConnectionsClientGetResponse contains the response from method HubVirtualNetworkConnectionsClient.Get.
 type HubVirtualNetworkConnectionsClientGetResponse struct {
 	HubVirtualNetworkConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HubVirtualNetworkConnectionsClientListResponse contains the response from method HubVirtualNetworkConnectionsClient.List.
 type HubVirtualNetworkConnectionsClientListResponse struct {
 	ListHubVirtualNetworkConnectionsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPAllocationsClientCreateOrUpdatePollerResponse contains the response from method IPAllocationsClient.CreateOrUpdate.
 type IPAllocationsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *IPAllocationsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2991,11 +2485,10 @@ type IPAllocationsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l IPAllocationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (IPAllocationsClientCreateOrUpdateResponse, error) {
 	respType := IPAllocationsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.IPAllocation)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.IPAllocation)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3008,29 +2501,23 @@ func (l *IPAllocationsClientCreateOrUpdatePollerResponse) Resume(ctx context.Con
 	poller := &IPAllocationsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // IPAllocationsClientCreateOrUpdateResponse contains the response from method IPAllocationsClient.CreateOrUpdate.
 type IPAllocationsClientCreateOrUpdateResponse struct {
 	IPAllocation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPAllocationsClientDeletePollerResponse contains the response from method IPAllocationsClient.Delete.
 type IPAllocationsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *IPAllocationsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3038,11 +2525,10 @@ type IPAllocationsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l IPAllocationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (IPAllocationsClientDeleteResponse, error) {
 	respType := IPAllocationsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3055,56 +2541,43 @@ func (l *IPAllocationsClientDeletePollerResponse) Resume(ctx context.Context, cl
 	poller := &IPAllocationsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // IPAllocationsClientDeleteResponse contains the response from method IPAllocationsClient.Delete.
 type IPAllocationsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // IPAllocationsClientGetResponse contains the response from method IPAllocationsClient.Get.
 type IPAllocationsClientGetResponse struct {
 	IPAllocation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPAllocationsClientListByResourceGroupResponse contains the response from method IPAllocationsClient.ListByResourceGroup.
 type IPAllocationsClientListByResourceGroupResponse struct {
 	IPAllocationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPAllocationsClientListResponse contains the response from method IPAllocationsClient.List.
 type IPAllocationsClientListResponse struct {
 	IPAllocationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPAllocationsClientUpdateTagsResponse contains the response from method IPAllocationsClient.UpdateTags.
 type IPAllocationsClientUpdateTagsResponse struct {
 	IPAllocation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPGroupsClientCreateOrUpdatePollerResponse contains the response from method IPGroupsClient.CreateOrUpdate.
 type IPGroupsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *IPGroupsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3112,11 +2585,10 @@ type IPGroupsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l IPGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (IPGroupsClientCreateOrUpdateResponse, error) {
 	respType := IPGroupsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.IPGroup)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.IPGroup)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3129,29 +2601,23 @@ func (l *IPGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context,
 	poller := &IPGroupsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // IPGroupsClientCreateOrUpdateResponse contains the response from method IPGroupsClient.CreateOrUpdate.
 type IPGroupsClientCreateOrUpdateResponse struct {
 	IPGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPGroupsClientDeletePollerResponse contains the response from method IPGroupsClient.Delete.
 type IPGroupsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *IPGroupsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3159,11 +2625,10 @@ type IPGroupsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l IPGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (IPGroupsClientDeleteResponse, error) {
 	respType := IPGroupsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3176,56 +2641,43 @@ func (l *IPGroupsClientDeletePollerResponse) Resume(ctx context.Context, client 
 	poller := &IPGroupsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // IPGroupsClientDeleteResponse contains the response from method IPGroupsClient.Delete.
 type IPGroupsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // IPGroupsClientGetResponse contains the response from method IPGroupsClient.Get.
 type IPGroupsClientGetResponse struct {
 	IPGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPGroupsClientListByResourceGroupResponse contains the response from method IPGroupsClient.ListByResourceGroup.
 type IPGroupsClientListByResourceGroupResponse struct {
 	IPGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPGroupsClientListResponse contains the response from method IPGroupsClient.List.
 type IPGroupsClientListResponse struct {
 	IPGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // IPGroupsClientUpdateGroupsResponse contains the response from method IPGroupsClient.UpdateGroups.
 type IPGroupsClientUpdateGroupsResponse struct {
 	IPGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InboundNatRulesClientCreateOrUpdatePollerResponse contains the response from method InboundNatRulesClient.CreateOrUpdate.
 type InboundNatRulesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *InboundNatRulesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3233,11 +2685,10 @@ type InboundNatRulesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l InboundNatRulesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InboundNatRulesClientCreateOrUpdateResponse, error) {
 	respType := InboundNatRulesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.InboundNatRule)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.InboundNatRule)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3250,29 +2701,23 @@ func (l *InboundNatRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.C
 	poller := &InboundNatRulesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // InboundNatRulesClientCreateOrUpdateResponse contains the response from method InboundNatRulesClient.CreateOrUpdate.
 type InboundNatRulesClientCreateOrUpdateResponse struct {
 	InboundNatRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InboundNatRulesClientDeletePollerResponse contains the response from method InboundNatRulesClient.Delete.
 type InboundNatRulesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *InboundNatRulesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3280,11 +2725,10 @@ type InboundNatRulesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l InboundNatRulesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InboundNatRulesClientDeleteResponse, error) {
 	respType := InboundNatRulesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3297,63 +2741,48 @@ func (l *InboundNatRulesClientDeletePollerResponse) Resume(ctx context.Context, 
 	poller := &InboundNatRulesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // InboundNatRulesClientDeleteResponse contains the response from method InboundNatRulesClient.Delete.
 type InboundNatRulesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // InboundNatRulesClientGetResponse contains the response from method InboundNatRulesClient.Get.
 type InboundNatRulesClientGetResponse struct {
 	InboundNatRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InboundNatRulesClientListResponse contains the response from method InboundNatRulesClient.List.
 type InboundNatRulesClientListResponse struct {
 	InboundNatRuleListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfaceIPConfigurationsClientGetResponse contains the response from method InterfaceIPConfigurationsClient.Get.
 type InterfaceIPConfigurationsClientGetResponse struct {
 	InterfaceIPConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfaceIPConfigurationsClientListResponse contains the response from method InterfaceIPConfigurationsClient.List.
 type InterfaceIPConfigurationsClientListResponse struct {
 	InterfaceIPConfigurationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfaceLoadBalancersClientListResponse contains the response from method InterfaceLoadBalancersClient.List.
 type InterfaceLoadBalancersClientListResponse struct {
 	InterfaceLoadBalancerListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse contains the response from method InterfaceTapConfigurationsClient.CreateOrUpdate.
 type InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *InterfaceTapConfigurationsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3361,11 +2790,10 @@ type InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
 	respType := InterfaceTapConfigurationsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.InterfaceTapConfiguration)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.InterfaceTapConfiguration)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3378,29 +2806,23 @@ func (l *InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse) Resume(ct
 	poller := &InterfaceTapConfigurationsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // InterfaceTapConfigurationsClientCreateOrUpdateResponse contains the response from method InterfaceTapConfigurationsClient.CreateOrUpdate.
 type InterfaceTapConfigurationsClientCreateOrUpdateResponse struct {
 	InterfaceTapConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfaceTapConfigurationsClientDeletePollerResponse contains the response from method InterfaceTapConfigurationsClient.Delete.
 type InterfaceTapConfigurationsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *InterfaceTapConfigurationsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3408,11 +2830,10 @@ type InterfaceTapConfigurationsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l InterfaceTapConfigurationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfaceTapConfigurationsClientDeleteResponse, error) {
 	respType := InterfaceTapConfigurationsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3425,42 +2846,33 @@ func (l *InterfaceTapConfigurationsClientDeletePollerResponse) Resume(ctx contex
 	poller := &InterfaceTapConfigurationsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // InterfaceTapConfigurationsClientDeleteResponse contains the response from method InterfaceTapConfigurationsClient.Delete.
 type InterfaceTapConfigurationsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // InterfaceTapConfigurationsClientGetResponse contains the response from method InterfaceTapConfigurationsClient.Get.
 type InterfaceTapConfigurationsClientGetResponse struct {
 	InterfaceTapConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfaceTapConfigurationsClientListResponse contains the response from method InterfaceTapConfigurationsClient.List.
 type InterfaceTapConfigurationsClientListResponse struct {
 	InterfaceTapConfigurationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientCreateOrUpdatePollerResponse contains the response from method InterfacesClient.CreateOrUpdate.
 type InterfacesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *InterfacesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3468,11 +2880,10 @@ type InterfacesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l InterfacesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientCreateOrUpdateResponse, error) {
 	respType := InterfacesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Interface)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Interface)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3485,29 +2896,23 @@ func (l *InterfacesClientCreateOrUpdatePollerResponse) Resume(ctx context.Contex
 	poller := &InterfacesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // InterfacesClientCreateOrUpdateResponse contains the response from method InterfacesClient.CreateOrUpdate.
 type InterfacesClientCreateOrUpdateResponse struct {
 	Interface
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientDeletePollerResponse contains the response from method InterfacesClient.Delete.
 type InterfacesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *InterfacesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3515,11 +2920,10 @@ type InterfacesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l InterfacesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientDeleteResponse, error) {
 	respType := InterfacesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3532,28 +2936,23 @@ func (l *InterfacesClientDeletePollerResponse) Resume(ctx context.Context, clien
 	poller := &InterfacesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // InterfacesClientDeleteResponse contains the response from method InterfacesClient.Delete.
 type InterfacesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // InterfacesClientGetEffectiveRouteTablePollerResponse contains the response from method InterfacesClient.GetEffectiveRouteTable.
 type InterfacesClientGetEffectiveRouteTablePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *InterfacesClientGetEffectiveRouteTablePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3561,11 +2960,10 @@ type InterfacesClientGetEffectiveRouteTablePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l InterfacesClientGetEffectiveRouteTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientGetEffectiveRouteTableResponse, error) {
 	respType := InterfacesClientGetEffectiveRouteTableResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.EffectiveRouteListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.EffectiveRouteListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3578,57 +2976,43 @@ func (l *InterfacesClientGetEffectiveRouteTablePollerResponse) Resume(ctx contex
 	poller := &InterfacesClientGetEffectiveRouteTablePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // InterfacesClientGetEffectiveRouteTableResponse contains the response from method InterfacesClient.GetEffectiveRouteTable.
 type InterfacesClientGetEffectiveRouteTableResponse struct {
 	EffectiveRouteListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientGetResponse contains the response from method InterfacesClient.Get.
 type InterfacesClientGetResponse struct {
 	Interface
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientGetVirtualMachineScaleSetIPConfigurationResponse contains the response from method InterfacesClient.GetVirtualMachineScaleSetIPConfiguration.
 type InterfacesClientGetVirtualMachineScaleSetIPConfigurationResponse struct {
 	InterfaceIPConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse contains the response from method InterfacesClient.GetVirtualMachineScaleSetNetworkInterface.
 type InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse struct {
 	Interface
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientListAllResponse contains the response from method InterfacesClient.ListAll.
 type InterfacesClientListAllResponse struct {
 	InterfaceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse contains the response from method InterfacesClient.ListEffectiveNetworkSecurityGroups.
 type InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *InterfacesClientListEffectiveNetworkSecurityGroupsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3636,11 +3020,10 @@ type InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
 	respType := InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.EffectiveNetworkSecurityGroupListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.EffectiveNetworkSecurityGroupListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3654,141 +3037,103 @@ func (l *InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse) Resum
 	poller := &InterfacesClientListEffectiveNetworkSecurityGroupsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // InterfacesClientListEffectiveNetworkSecurityGroupsResponse contains the response from method InterfacesClient.ListEffectiveNetworkSecurityGroups.
 type InterfacesClientListEffectiveNetworkSecurityGroupsResponse struct {
 	EffectiveNetworkSecurityGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientListResponse contains the response from method InterfacesClient.List.
 type InterfacesClientListResponse struct {
 	InterfaceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse contains the response from method InterfacesClient.ListVirtualMachineScaleSetIPConfigurations.
 type InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse struct {
 	InterfaceIPConfigurationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse contains the response from method InterfacesClient.ListVirtualMachineScaleSetNetworkInterfaces.
 type InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse struct {
 	InterfaceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse contains the response from method InterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfaces.
 type InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse struct {
 	InterfaceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // InterfacesClientUpdateTagsResponse contains the response from method InterfacesClient.UpdateTags.
 type InterfacesClientUpdateTagsResponse struct {
 	Interface
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerBackendAddressPoolsClientGetResponse contains the response from method LoadBalancerBackendAddressPoolsClient.Get.
 type LoadBalancerBackendAddressPoolsClientGetResponse struct {
 	BackendAddressPool
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerBackendAddressPoolsClientListResponse contains the response from method LoadBalancerBackendAddressPoolsClient.List.
 type LoadBalancerBackendAddressPoolsClientListResponse struct {
 	LoadBalancerBackendAddressPoolListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerFrontendIPConfigurationsClientGetResponse contains the response from method LoadBalancerFrontendIPConfigurationsClient.Get.
 type LoadBalancerFrontendIPConfigurationsClientGetResponse struct {
 	FrontendIPConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerFrontendIPConfigurationsClientListResponse contains the response from method LoadBalancerFrontendIPConfigurationsClient.List.
 type LoadBalancerFrontendIPConfigurationsClientListResponse struct {
 	LoadBalancerFrontendIPConfigurationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerLoadBalancingRulesClientGetResponse contains the response from method LoadBalancerLoadBalancingRulesClient.Get.
 type LoadBalancerLoadBalancingRulesClientGetResponse struct {
 	LoadBalancingRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerLoadBalancingRulesClientListResponse contains the response from method LoadBalancerLoadBalancingRulesClient.List.
 type LoadBalancerLoadBalancingRulesClientListResponse struct {
 	LoadBalancerLoadBalancingRuleListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerNetworkInterfacesClientListResponse contains the response from method LoadBalancerNetworkInterfacesClient.List.
 type LoadBalancerNetworkInterfacesClientListResponse struct {
 	InterfaceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerOutboundRulesClientGetResponse contains the response from method LoadBalancerOutboundRulesClient.Get.
 type LoadBalancerOutboundRulesClientGetResponse struct {
 	OutboundRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerOutboundRulesClientListResponse contains the response from method LoadBalancerOutboundRulesClient.List.
 type LoadBalancerOutboundRulesClientListResponse struct {
 	LoadBalancerOutboundRuleListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerProbesClientGetResponse contains the response from method LoadBalancerProbesClient.Get.
 type LoadBalancerProbesClientGetResponse struct {
 	Probe
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancerProbesClientListResponse contains the response from method LoadBalancerProbesClient.List.
 type LoadBalancerProbesClientListResponse struct {
 	LoadBalancerProbeListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancersClientCreateOrUpdatePollerResponse contains the response from method LoadBalancersClient.CreateOrUpdate.
 type LoadBalancersClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LoadBalancersClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3796,11 +3141,10 @@ type LoadBalancersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l LoadBalancersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LoadBalancersClientCreateOrUpdateResponse, error) {
 	respType := LoadBalancersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LoadBalancer)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LoadBalancer)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3813,29 +3157,23 @@ func (l *LoadBalancersClientCreateOrUpdatePollerResponse) Resume(ctx context.Con
 	poller := &LoadBalancersClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LoadBalancersClientCreateOrUpdateResponse contains the response from method LoadBalancersClient.CreateOrUpdate.
 type LoadBalancersClientCreateOrUpdateResponse struct {
 	LoadBalancer
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancersClientDeletePollerResponse contains the response from method LoadBalancersClient.Delete.
 type LoadBalancersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LoadBalancersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3843,11 +3181,10 @@ type LoadBalancersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l LoadBalancersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LoadBalancersClientDeleteResponse, error) {
 	respType := LoadBalancersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3860,56 +3197,43 @@ func (l *LoadBalancersClientDeletePollerResponse) Resume(ctx context.Context, cl
 	poller := &LoadBalancersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LoadBalancersClientDeleteResponse contains the response from method LoadBalancersClient.Delete.
 type LoadBalancersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LoadBalancersClientGetResponse contains the response from method LoadBalancersClient.Get.
 type LoadBalancersClientGetResponse struct {
 	LoadBalancer
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancersClientListAllResponse contains the response from method LoadBalancersClient.ListAll.
 type LoadBalancersClientListAllResponse struct {
 	LoadBalancerListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancersClientListResponse contains the response from method LoadBalancersClient.List.
 type LoadBalancersClientListResponse struct {
 	LoadBalancerListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LoadBalancersClientUpdateTagsResponse contains the response from method LoadBalancersClient.UpdateTags.
 type LoadBalancersClientUpdateTagsResponse struct {
 	LoadBalancer
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LocalNetworkGatewaysClientCreateOrUpdatePollerResponse contains the response from method LocalNetworkGatewaysClient.CreateOrUpdate.
 type LocalNetworkGatewaysClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LocalNetworkGatewaysClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3917,11 +3241,10 @@ type LocalNetworkGatewaysClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l LocalNetworkGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
 	respType := LocalNetworkGatewaysClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LocalNetworkGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LocalNetworkGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3934,29 +3257,23 @@ func (l *LocalNetworkGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx cont
 	poller := &LocalNetworkGatewaysClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LocalNetworkGatewaysClientCreateOrUpdateResponse contains the response from method LocalNetworkGatewaysClient.CreateOrUpdate.
 type LocalNetworkGatewaysClientCreateOrUpdateResponse struct {
 	LocalNetworkGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LocalNetworkGatewaysClientDeletePollerResponse contains the response from method LocalNetworkGatewaysClient.Delete.
 type LocalNetworkGatewaysClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *LocalNetworkGatewaysClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3964,11 +3281,10 @@ type LocalNetworkGatewaysClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l LocalNetworkGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LocalNetworkGatewaysClientDeleteResponse, error) {
 	respType := LocalNetworkGatewaysClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -3981,56 +3297,43 @@ func (l *LocalNetworkGatewaysClientDeletePollerResponse) Resume(ctx context.Cont
 	poller := &LocalNetworkGatewaysClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // LocalNetworkGatewaysClientDeleteResponse contains the response from method LocalNetworkGatewaysClient.Delete.
 type LocalNetworkGatewaysClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // LocalNetworkGatewaysClientGetResponse contains the response from method LocalNetworkGatewaysClient.Get.
 type LocalNetworkGatewaysClientGetResponse struct {
 	LocalNetworkGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LocalNetworkGatewaysClientListResponse contains the response from method LocalNetworkGatewaysClient.List.
 type LocalNetworkGatewaysClientListResponse struct {
 	LocalNetworkGatewayListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // LocalNetworkGatewaysClientUpdateTagsResponse contains the response from method LocalNetworkGatewaysClient.UpdateTags.
 type LocalNetworkGatewaysClientUpdateTagsResponse struct {
 	LocalNetworkGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ManagementClientCheckDNSNameAvailabilityResponse contains the response from method ManagementClient.CheckDNSNameAvailability.
 type ManagementClientCheckDNSNameAvailabilityResponse struct {
 	DNSNameAvailabilityResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ManagementClientDeleteBastionShareableLinkPollerResponse contains the response from method ManagementClient.DeleteBastionShareableLink.
 type ManagementClientDeleteBastionShareableLinkPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ManagementClientDeleteBastionShareableLinkPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4038,11 +3341,10 @@ type ManagementClientDeleteBastionShareableLinkPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ManagementClientDeleteBastionShareableLinkPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ManagementClientDeleteBastionShareableLinkResponse, error) {
 	respType := ManagementClientDeleteBastionShareableLinkResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4055,35 +3357,28 @@ func (l *ManagementClientDeleteBastionShareableLinkPollerResponse) Resume(ctx co
 	poller := &ManagementClientDeleteBastionShareableLinkPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ManagementClientDeleteBastionShareableLinkResponse contains the response from method ManagementClient.DeleteBastionShareableLink.
 type ManagementClientDeleteBastionShareableLinkResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ManagementClientDisconnectActiveSessionsResponse contains the response from method ManagementClient.DisconnectActiveSessions.
 type ManagementClientDisconnectActiveSessionsResponse struct {
 	BastionSessionDeleteResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse contains the response from method ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile.
 type ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4091,11 +3386,10 @@ type ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerRes
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
 	respType := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNProfileResponse)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNProfileResponse)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4109,29 +3403,23 @@ func (l *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePolle
 	poller := &ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse contains the response from method ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile.
 type ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse struct {
 	VPNProfileResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ManagementClientGetActiveSessionsPollerResponse contains the response from method ManagementClient.GetActiveSessions.
 type ManagementClientGetActiveSessionsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ManagementClientGetActiveSessionsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4139,11 +3427,10 @@ type ManagementClientGetActiveSessionsPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ManagementClientGetActiveSessionsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (*ManagementClientGetActiveSessionsPager, error) {
 	respType := &ManagementClientGetActiveSessionsPager{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.BastionActiveSessionListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.BastionActiveSessionListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.current.RawResponse = resp
 	respType.client = l.Poller.client
 	return respType, nil
 }
@@ -4158,36 +3445,28 @@ func (l *ManagementClientGetActiveSessionsPollerResponse) Resume(ctx context.Con
 		pt:     pt,
 		client: client,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ManagementClientGetActiveSessionsResponse contains the response from method ManagementClient.GetActiveSessions.
 type ManagementClientGetActiveSessionsResponse struct {
 	BastionActiveSessionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ManagementClientGetBastionShareableLinkResponse contains the response from method ManagementClient.GetBastionShareableLink.
 type ManagementClientGetBastionShareableLinkResponse struct {
 	BastionShareableLinkListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ManagementClientPutBastionShareableLinkPollerResponse contains the response from method ManagementClient.PutBastionShareableLink.
 type ManagementClientPutBastionShareableLinkPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ManagementClientPutBastionShareableLinkPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4195,11 +3474,10 @@ type ManagementClientPutBastionShareableLinkPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ManagementClientPutBastionShareableLinkPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (*ManagementClientPutBastionShareableLinkPager, error) {
 	respType := &ManagementClientPutBastionShareableLinkPager{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.BastionShareableLinkListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.BastionShareableLinkListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.current.RawResponse = resp
 	respType.client = l.Poller.client
 	return respType, nil
 }
@@ -4214,36 +3492,28 @@ func (l *ManagementClientPutBastionShareableLinkPollerResponse) Resume(ctx conte
 		pt:     pt,
 		client: client,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ManagementClientPutBastionShareableLinkResponse contains the response from method ManagementClient.PutBastionShareableLink.
 type ManagementClientPutBastionShareableLinkResponse struct {
 	BastionShareableLinkListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ManagementClientSupportedSecurityProvidersResponse contains the response from method ManagementClient.SupportedSecurityProviders.
 type ManagementClientSupportedSecurityProvidersResponse struct {
 	VirtualWanSecurityProviders
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // NatGatewaysClientCreateOrUpdatePollerResponse contains the response from method NatGatewaysClient.CreateOrUpdate.
 type NatGatewaysClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *NatGatewaysClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4251,11 +3521,10 @@ type NatGatewaysClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l NatGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NatGatewaysClientCreateOrUpdateResponse, error) {
 	respType := NatGatewaysClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NatGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NatGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4268,29 +3537,23 @@ func (l *NatGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 	poller := &NatGatewaysClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // NatGatewaysClientCreateOrUpdateResponse contains the response from method NatGatewaysClient.CreateOrUpdate.
 type NatGatewaysClientCreateOrUpdateResponse struct {
 	NatGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // NatGatewaysClientDeletePollerResponse contains the response from method NatGatewaysClient.Delete.
 type NatGatewaysClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *NatGatewaysClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4298,11 +3561,10 @@ type NatGatewaysClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l NatGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NatGatewaysClientDeleteResponse, error) {
 	respType := NatGatewaysClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4315,63 +3577,48 @@ func (l *NatGatewaysClientDeletePollerResponse) Resume(ctx context.Context, clie
 	poller := &NatGatewaysClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // NatGatewaysClientDeleteResponse contains the response from method NatGatewaysClient.Delete.
 type NatGatewaysClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // NatGatewaysClientGetResponse contains the response from method NatGatewaysClient.Get.
 type NatGatewaysClientGetResponse struct {
 	NatGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // NatGatewaysClientListAllResponse contains the response from method NatGatewaysClient.ListAll.
 type NatGatewaysClientListAllResponse struct {
 	NatGatewayListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // NatGatewaysClientListResponse contains the response from method NatGatewaysClient.List.
 type NatGatewaysClientListResponse struct {
 	NatGatewayListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // NatGatewaysClientUpdateTagsResponse contains the response from method NatGatewaysClient.UpdateTags.
 type NatGatewaysClientUpdateTagsResponse struct {
 	NatGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // OperationsClientListResponse contains the response from method OperationsClient.List.
 type OperationsClientListResponse struct {
 	OperationListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // P2SVPNGatewaysClientCreateOrUpdatePollerResponse contains the response from method P2SVPNGatewaysClient.CreateOrUpdate.
 type P2SVPNGatewaysClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *P2SVPNGatewaysClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4379,11 +3626,10 @@ type P2SVPNGatewaysClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l P2SVPNGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
 	respType := P2SVPNGatewaysClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4396,29 +3642,23 @@ func (l *P2SVPNGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 	poller := &P2SVPNGatewaysClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // P2SVPNGatewaysClientCreateOrUpdateResponse contains the response from method P2SVPNGatewaysClient.CreateOrUpdate.
 type P2SVPNGatewaysClientCreateOrUpdateResponse struct {
 	P2SVPNGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // P2SVPNGatewaysClientDeletePollerResponse contains the response from method P2SVPNGatewaysClient.Delete.
 type P2SVPNGatewaysClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *P2SVPNGatewaysClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4426,11 +3666,10 @@ type P2SVPNGatewaysClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l P2SVPNGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientDeleteResponse, error) {
 	respType := P2SVPNGatewaysClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4443,28 +3682,23 @@ func (l *P2SVPNGatewaysClientDeletePollerResponse) Resume(ctx context.Context, c
 	poller := &P2SVPNGatewaysClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // P2SVPNGatewaysClientDeleteResponse contains the response from method P2SVPNGatewaysClient.Delete.
 type P2SVPNGatewaysClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse contains the response from method P2SVPNGatewaysClient.DisconnectP2SVPNConnections.
 type P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4472,11 +3706,10 @@ type P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
 	respType := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4489,28 +3722,23 @@ func (l *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse) Resume(c
 	poller := &P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse contains the response from method P2SVPNGatewaysClient.DisconnectP2SVPNConnections.
 type P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // P2SVPNGatewaysClientGenerateVPNProfilePollerResponse contains the response from method P2SVPNGatewaysClient.GenerateVPNProfile.
 type P2SVPNGatewaysClientGenerateVPNProfilePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *P2SVPNGatewaysClientGenerateVPNProfilePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4518,11 +3746,10 @@ type P2SVPNGatewaysClientGenerateVPNProfilePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l P2SVPNGatewaysClientGenerateVPNProfilePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
 	respType := P2SVPNGatewaysClientGenerateVPNProfileResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNProfileResponse)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNProfileResponse)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4535,29 +3762,23 @@ func (l *P2SVPNGatewaysClientGenerateVPNProfilePollerResponse) Resume(ctx contex
 	poller := &P2SVPNGatewaysClientGenerateVPNProfilePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // P2SVPNGatewaysClientGenerateVPNProfileResponse contains the response from method P2SVPNGatewaysClient.GenerateVPNProfile.
 type P2SVPNGatewaysClientGenerateVPNProfileResponse struct {
 	VPNProfileResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed.
 type P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4565,11 +3786,10 @@ type P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse struct 
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
 	respType := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNConnectionHealth)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNConnectionHealth)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4583,29 +3803,23 @@ func (l *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse) Re
 	poller := &P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed.
 type P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse struct {
 	P2SVPNConnectionHealth
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealth.
 type P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4613,11 +3827,10 @@ type P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
 	respType := P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4630,57 +3843,43 @@ func (l *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse) Resume(ctx
 	poller := &P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealth.
 type P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse struct {
 	P2SVPNGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // P2SVPNGatewaysClientGetResponse contains the response from method P2SVPNGatewaysClient.Get.
 type P2SVPNGatewaysClientGetResponse struct {
 	P2SVPNGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // P2SVPNGatewaysClientListByResourceGroupResponse contains the response from method P2SVPNGatewaysClient.ListByResourceGroup.
 type P2SVPNGatewaysClientListByResourceGroupResponse struct {
 	ListP2SVPNGatewaysResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // P2SVPNGatewaysClientListResponse contains the response from method P2SVPNGatewaysClient.List.
 type P2SVPNGatewaysClientListResponse struct {
 	ListP2SVPNGatewaysResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // P2SVPNGatewaysClientUpdateTagsResponse contains the response from method P2SVPNGatewaysClient.UpdateTags.
 type P2SVPNGatewaysClientUpdateTagsResponse struct {
 	P2SVPNGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PacketCapturesClientCreatePollerResponse contains the response from method PacketCapturesClient.Create.
 type PacketCapturesClientCreatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PacketCapturesClientCreatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4688,11 +3887,10 @@ type PacketCapturesClientCreatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PacketCapturesClientCreatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientCreateResponse, error) {
 	respType := PacketCapturesClientCreateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PacketCaptureResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PacketCaptureResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4705,29 +3903,23 @@ func (l *PacketCapturesClientCreatePollerResponse) Resume(ctx context.Context, c
 	poller := &PacketCapturesClientCreatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PacketCapturesClientCreateResponse contains the response from method PacketCapturesClient.Create.
 type PacketCapturesClientCreateResponse struct {
 	PacketCaptureResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PacketCapturesClientDeletePollerResponse contains the response from method PacketCapturesClient.Delete.
 type PacketCapturesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PacketCapturesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4735,11 +3927,10 @@ type PacketCapturesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PacketCapturesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientDeleteResponse, error) {
 	respType := PacketCapturesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4752,35 +3943,28 @@ func (l *PacketCapturesClientDeletePollerResponse) Resume(ctx context.Context, c
 	poller := &PacketCapturesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PacketCapturesClientDeleteResponse contains the response from method PacketCapturesClient.Delete.
 type PacketCapturesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PacketCapturesClientGetResponse contains the response from method PacketCapturesClient.Get.
 type PacketCapturesClientGetResponse struct {
 	PacketCaptureResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PacketCapturesClientGetStatusPollerResponse contains the response from method PacketCapturesClient.GetStatus.
 type PacketCapturesClientGetStatusPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PacketCapturesClientGetStatusPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4788,11 +3972,10 @@ type PacketCapturesClientGetStatusPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PacketCapturesClientGetStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientGetStatusResponse, error) {
 	respType := PacketCapturesClientGetStatusResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PacketCaptureQueryStatusResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PacketCaptureQueryStatusResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4805,36 +3988,28 @@ func (l *PacketCapturesClientGetStatusPollerResponse) Resume(ctx context.Context
 	poller := &PacketCapturesClientGetStatusPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PacketCapturesClientGetStatusResponse contains the response from method PacketCapturesClient.GetStatus.
 type PacketCapturesClientGetStatusResponse struct {
 	PacketCaptureQueryStatusResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PacketCapturesClientListResponse contains the response from method PacketCapturesClient.List.
 type PacketCapturesClientListResponse struct {
 	PacketCaptureListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PacketCapturesClientStopPollerResponse contains the response from method PacketCapturesClient.Stop.
 type PacketCapturesClientStopPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PacketCapturesClientStopPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4842,11 +4017,10 @@ type PacketCapturesClientStopPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PacketCapturesClientStopPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientStopResponse, error) {
 	respType := PacketCapturesClientStopResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4859,42 +4033,33 @@ func (l *PacketCapturesClientStopPollerResponse) Resume(ctx context.Context, cli
 	poller := &PacketCapturesClientStopPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PacketCapturesClientStopResponse contains the response from method PacketCapturesClient.Stop.
 type PacketCapturesClientStopResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PeerExpressRouteCircuitConnectionsClientGetResponse contains the response from method PeerExpressRouteCircuitConnectionsClient.Get.
 type PeerExpressRouteCircuitConnectionsClientGetResponse struct {
 	PeerExpressRouteCircuitConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PeerExpressRouteCircuitConnectionsClientListResponse contains the response from method PeerExpressRouteCircuitConnectionsClient.List.
 type PeerExpressRouteCircuitConnectionsClientListResponse struct {
 	PeerExpressRouteCircuitConnectionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse contains the response from method PrivateDNSZoneGroupsClient.CreateOrUpdate.
 type PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateDNSZoneGroupsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4902,11 +4067,10 @@ type PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
 	respType := PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateDNSZoneGroup)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateDNSZoneGroup)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4919,29 +4083,23 @@ func (l *PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse) Resume(ctx cont
 	poller := &PrivateDNSZoneGroupsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PrivateDNSZoneGroupsClientCreateOrUpdateResponse contains the response from method PrivateDNSZoneGroupsClient.CreateOrUpdate.
 type PrivateDNSZoneGroupsClientCreateOrUpdateResponse struct {
 	PrivateDNSZoneGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateDNSZoneGroupsClientDeletePollerResponse contains the response from method PrivateDNSZoneGroupsClient.Delete.
 type PrivateDNSZoneGroupsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateDNSZoneGroupsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4949,11 +4107,10 @@ type PrivateDNSZoneGroupsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateDNSZoneGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
 	respType := PrivateDNSZoneGroupsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -4966,42 +4123,33 @@ func (l *PrivateDNSZoneGroupsClientDeletePollerResponse) Resume(ctx context.Cont
 	poller := &PrivateDNSZoneGroupsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PrivateDNSZoneGroupsClientDeleteResponse contains the response from method PrivateDNSZoneGroupsClient.Delete.
 type PrivateDNSZoneGroupsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrivateDNSZoneGroupsClientGetResponse contains the response from method PrivateDNSZoneGroupsClient.Get.
 type PrivateDNSZoneGroupsClientGetResponse struct {
 	PrivateDNSZoneGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateDNSZoneGroupsClientListResponse contains the response from method PrivateDNSZoneGroupsClient.List.
 type PrivateDNSZoneGroupsClientListResponse struct {
 	PrivateDNSZoneGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateEndpointsClientCreateOrUpdatePollerResponse contains the response from method PrivateEndpointsClient.CreateOrUpdate.
 type PrivateEndpointsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateEndpointsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5009,11 +4157,10 @@ type PrivateEndpointsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateEndpointsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
 	respType := PrivateEndpointsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateEndpoint)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateEndpoint)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5026,29 +4173,23 @@ func (l *PrivateEndpointsClientCreateOrUpdatePollerResponse) Resume(ctx context.
 	poller := &PrivateEndpointsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PrivateEndpointsClientCreateOrUpdateResponse contains the response from method PrivateEndpointsClient.CreateOrUpdate.
 type PrivateEndpointsClientCreateOrUpdateResponse struct {
 	PrivateEndpoint
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateEndpointsClientDeletePollerResponse contains the response from method PrivateEndpointsClient.Delete.
 type PrivateEndpointsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateEndpointsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5056,11 +4197,10 @@ type PrivateEndpointsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateEndpointsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateEndpointsClientDeleteResponse, error) {
 	respType := PrivateEndpointsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5073,40 +4213,32 @@ func (l *PrivateEndpointsClientDeletePollerResponse) Resume(ctx context.Context,
 	poller := &PrivateEndpointsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PrivateEndpointsClientDeleteResponse contains the response from method PrivateEndpointsClient.Delete.
 type PrivateEndpointsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrivateEndpointsClientGetResponse contains the response from method PrivateEndpointsClient.Get.
 type PrivateEndpointsClientGetResponse struct {
 	PrivateEndpoint
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateEndpointsClientListBySubscriptionResponse contains the response from method PrivateEndpointsClient.ListBySubscription.
 type PrivateEndpointsClientListBySubscriptionResponse struct {
 	PrivateEndpointListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateEndpointsClientListResponse contains the response from method PrivateEndpointsClient.List.
 type PrivateEndpointsClientListResponse struct {
 	PrivateEndpointListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse contains the response from method
@@ -5114,9 +4246,6 @@ type PrivateEndpointsClientListResponse struct {
 type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5124,11 +4253,10 @@ type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPo
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
 	respType := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkServiceVisibility)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkServiceVisibility)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5142,29 +4270,23 @@ func (l *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGro
 	poller := &PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup.
 type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse struct {
 	PrivateLinkServiceVisibility
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility.
 type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5172,11 +4294,10 @@ type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse st
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
 	respType := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkServiceVisibility)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkServiceVisibility)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5190,29 +4311,23 @@ func (l *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerRespons
 	poller := &PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility.
 type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse struct {
 	PrivateLinkServiceVisibility
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientCreateOrUpdatePollerResponse contains the response from method PrivateLinkServicesClient.CreateOrUpdate.
 type PrivateLinkServicesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateLinkServicesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5220,11 +4335,10 @@ type PrivateLinkServicesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateLinkServicesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
 	respType := PrivateLinkServicesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkService)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkService)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5237,29 +4351,23 @@ func (l *PrivateLinkServicesClientCreateOrUpdatePollerResponse) Resume(ctx conte
 	poller := &PrivateLinkServicesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PrivateLinkServicesClientCreateOrUpdateResponse contains the response from method PrivateLinkServicesClient.CreateOrUpdate.
 type PrivateLinkServicesClientCreateOrUpdateResponse struct {
 	PrivateLinkService
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientDeletePollerResponse contains the response from method PrivateLinkServicesClient.Delete.
 type PrivateLinkServicesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateLinkServicesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5267,11 +4375,10 @@ type PrivateLinkServicesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateLinkServicesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientDeleteResponse, error) {
 	respType := PrivateLinkServicesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5284,12 +4391,11 @@ func (l *PrivateLinkServicesClientDeletePollerResponse) Resume(ctx context.Conte
 	poller := &PrivateLinkServicesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
@@ -5297,9 +4403,6 @@ func (l *PrivateLinkServicesClientDeletePollerResponse) Resume(ctx context.Conte
 type PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5307,11 +4410,10 @@ type PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse stru
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
 	respType := PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5325,97 +4427,73 @@ func (l *PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse)
 	poller := &PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse contains the response from method PrivateLinkServicesClient.DeletePrivateEndpointConnection.
 type PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrivateLinkServicesClientDeleteResponse contains the response from method PrivateLinkServicesClient.Delete.
 type PrivateLinkServicesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PrivateLinkServicesClientGetPrivateEndpointConnectionResponse contains the response from method PrivateLinkServicesClient.GetPrivateEndpointConnection.
 type PrivateLinkServicesClientGetPrivateEndpointConnectionResponse struct {
 	PrivateEndpointConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientGetResponse contains the response from method PrivateLinkServicesClient.Get.
 type PrivateLinkServicesClientGetResponse struct {
 	PrivateLinkService
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse contains the response from method PrivateLinkServicesClient.ListAutoApprovedPrivateLinkServicesByResourceGroup.
 type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse struct {
 	AutoApprovedPrivateLinkServicesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse contains the response from method PrivateLinkServicesClient.ListAutoApprovedPrivateLinkServices.
 type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse struct {
 	AutoApprovedPrivateLinkServicesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientListBySubscriptionResponse contains the response from method PrivateLinkServicesClient.ListBySubscription.
 type PrivateLinkServicesClientListBySubscriptionResponse struct {
 	PrivateLinkServiceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientListPrivateEndpointConnectionsResponse contains the response from method PrivateLinkServicesClient.ListPrivateEndpointConnections.
 type PrivateLinkServicesClientListPrivateEndpointConnectionsResponse struct {
 	PrivateEndpointConnectionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientListResponse contains the response from method PrivateLinkServicesClient.List.
 type PrivateLinkServicesClientListResponse struct {
 	PrivateLinkServiceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse contains the response from method PrivateLinkServicesClient.UpdatePrivateEndpointConnection.
 type PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse struct {
 	PrivateEndpointConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProfilesClientCreateOrUpdateResponse contains the response from method ProfilesClient.CreateOrUpdate.
 type ProfilesClientCreateOrUpdateResponse struct {
 	Profile
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProfilesClientDeletePollerResponse contains the response from method ProfilesClient.Delete.
 type ProfilesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ProfilesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5423,11 +4501,10 @@ type ProfilesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ProfilesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ProfilesClientDeleteResponse, error) {
 	respType := ProfilesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5440,56 +4517,43 @@ func (l *ProfilesClientDeletePollerResponse) Resume(ctx context.Context, client 
 	poller := &ProfilesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ProfilesClientDeleteResponse contains the response from method ProfilesClient.Delete.
 type ProfilesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ProfilesClientGetResponse contains the response from method ProfilesClient.Get.
 type ProfilesClientGetResponse struct {
 	Profile
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProfilesClientListAllResponse contains the response from method ProfilesClient.ListAll.
 type ProfilesClientListAllResponse struct {
 	ProfileListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProfilesClientListResponse contains the response from method ProfilesClient.List.
 type ProfilesClientListResponse struct {
 	ProfileListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ProfilesClientUpdateTagsResponse contains the response from method ProfilesClient.UpdateTags.
 type ProfilesClientUpdateTagsResponse struct {
 	Profile
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPAddressesClientCreateOrUpdatePollerResponse contains the response from method PublicIPAddressesClient.CreateOrUpdate.
 type PublicIPAddressesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PublicIPAddressesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5497,11 +4561,10 @@ type PublicIPAddressesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PublicIPAddressesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
 	respType := PublicIPAddressesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PublicIPAddress)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PublicIPAddress)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5514,29 +4577,23 @@ func (l *PublicIPAddressesClientCreateOrUpdatePollerResponse) Resume(ctx context
 	poller := &PublicIPAddressesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PublicIPAddressesClientCreateOrUpdateResponse contains the response from method PublicIPAddressesClient.CreateOrUpdate.
 type PublicIPAddressesClientCreateOrUpdateResponse struct {
 	PublicIPAddress
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPAddressesClientDeletePollerResponse contains the response from method PublicIPAddressesClient.Delete.
 type PublicIPAddressesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PublicIPAddressesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5544,11 +4601,10 @@ type PublicIPAddressesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PublicIPAddressesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPAddressesClientDeleteResponse, error) {
 	respType := PublicIPAddressesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5561,77 +4617,58 @@ func (l *PublicIPAddressesClientDeletePollerResponse) Resume(ctx context.Context
 	poller := &PublicIPAddressesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PublicIPAddressesClientDeleteResponse contains the response from method PublicIPAddressesClient.Delete.
 type PublicIPAddressesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PublicIPAddressesClientGetResponse contains the response from method PublicIPAddressesClient.Get.
 type PublicIPAddressesClientGetResponse struct {
 	PublicIPAddress
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse contains the response from method PublicIPAddressesClient.GetVirtualMachineScaleSetPublicIPAddress.
 type PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse struct {
 	PublicIPAddress
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPAddressesClientListAllResponse contains the response from method PublicIPAddressesClient.ListAll.
 type PublicIPAddressesClientListAllResponse struct {
 	PublicIPAddressListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPAddressesClientListResponse contains the response from method PublicIPAddressesClient.List.
 type PublicIPAddressesClientListResponse struct {
 	PublicIPAddressListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse contains the response from method PublicIPAddressesClient.ListVirtualMachineScaleSetPublicIPAddresses.
 type PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse struct {
 	PublicIPAddressListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse contains the response from method PublicIPAddressesClient.ListVirtualMachineScaleSetVMPublicIPAddresses.
 type PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse struct {
 	PublicIPAddressListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPAddressesClientUpdateTagsResponse contains the response from method PublicIPAddressesClient.UpdateTags.
 type PublicIPAddressesClientUpdateTagsResponse struct {
 	PublicIPAddress
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPPrefixesClientCreateOrUpdatePollerResponse contains the response from method PublicIPPrefixesClient.CreateOrUpdate.
 type PublicIPPrefixesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PublicIPPrefixesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5639,11 +4676,10 @@ type PublicIPPrefixesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PublicIPPrefixesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
 	respType := PublicIPPrefixesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PublicIPPrefix)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PublicIPPrefix)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5656,29 +4692,23 @@ func (l *PublicIPPrefixesClientCreateOrUpdatePollerResponse) Resume(ctx context.
 	poller := &PublicIPPrefixesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PublicIPPrefixesClientCreateOrUpdateResponse contains the response from method PublicIPPrefixesClient.CreateOrUpdate.
 type PublicIPPrefixesClientCreateOrUpdateResponse struct {
 	PublicIPPrefix
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPPrefixesClientDeletePollerResponse contains the response from method PublicIPPrefixesClient.Delete.
 type PublicIPPrefixesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *PublicIPPrefixesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5686,11 +4716,10 @@ type PublicIPPrefixesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l PublicIPPrefixesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPPrefixesClientDeleteResponse, error) {
 	respType := PublicIPPrefixesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5703,63 +4732,48 @@ func (l *PublicIPPrefixesClientDeletePollerResponse) Resume(ctx context.Context,
 	poller := &PublicIPPrefixesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // PublicIPPrefixesClientDeleteResponse contains the response from method PublicIPPrefixesClient.Delete.
 type PublicIPPrefixesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // PublicIPPrefixesClientGetResponse contains the response from method PublicIPPrefixesClient.Get.
 type PublicIPPrefixesClientGetResponse struct {
 	PublicIPPrefix
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPPrefixesClientListAllResponse contains the response from method PublicIPPrefixesClient.ListAll.
 type PublicIPPrefixesClientListAllResponse struct {
 	PublicIPPrefixListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPPrefixesClientListResponse contains the response from method PublicIPPrefixesClient.List.
 type PublicIPPrefixesClientListResponse struct {
 	PublicIPPrefixListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PublicIPPrefixesClientUpdateTagsResponse contains the response from method PublicIPPrefixesClient.UpdateTags.
 type PublicIPPrefixesClientUpdateTagsResponse struct {
 	PublicIPPrefix
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ResourceNavigationLinksClientListResponse contains the response from method ResourceNavigationLinksClient.List.
 type ResourceNavigationLinksClientListResponse struct {
 	ResourceNavigationLinksListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteFilterRulesClientCreateOrUpdatePollerResponse contains the response from method RouteFilterRulesClient.CreateOrUpdate.
 type RouteFilterRulesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RouteFilterRulesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5767,11 +4781,10 @@ type RouteFilterRulesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RouteFilterRulesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
 	respType := RouteFilterRulesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteFilterRule)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteFilterRule)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5784,29 +4797,23 @@ func (l *RouteFilterRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.
 	poller := &RouteFilterRulesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RouteFilterRulesClientCreateOrUpdateResponse contains the response from method RouteFilterRulesClient.CreateOrUpdate.
 type RouteFilterRulesClientCreateOrUpdateResponse struct {
 	RouteFilterRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteFilterRulesClientDeletePollerResponse contains the response from method RouteFilterRulesClient.Delete.
 type RouteFilterRulesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RouteFilterRulesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5814,11 +4821,10 @@ type RouteFilterRulesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RouteFilterRulesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFilterRulesClientDeleteResponse, error) {
 	respType := RouteFilterRulesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5831,42 +4837,33 @@ func (l *RouteFilterRulesClientDeletePollerResponse) Resume(ctx context.Context,
 	poller := &RouteFilterRulesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RouteFilterRulesClientDeleteResponse contains the response from method RouteFilterRulesClient.Delete.
 type RouteFilterRulesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // RouteFilterRulesClientGetResponse contains the response from method RouteFilterRulesClient.Get.
 type RouteFilterRulesClientGetResponse struct {
 	RouteFilterRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteFilterRulesClientListByRouteFilterResponse contains the response from method RouteFilterRulesClient.ListByRouteFilter.
 type RouteFilterRulesClientListByRouteFilterResponse struct {
 	RouteFilterRuleListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteFiltersClientCreateOrUpdatePollerResponse contains the response from method RouteFiltersClient.CreateOrUpdate.
 type RouteFiltersClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RouteFiltersClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5874,11 +4871,10 @@ type RouteFiltersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RouteFiltersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFiltersClientCreateOrUpdateResponse, error) {
 	respType := RouteFiltersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteFilter)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteFilter)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5891,29 +4887,23 @@ func (l *RouteFiltersClientCreateOrUpdatePollerResponse) Resume(ctx context.Cont
 	poller := &RouteFiltersClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RouteFiltersClientCreateOrUpdateResponse contains the response from method RouteFiltersClient.CreateOrUpdate.
 type RouteFiltersClientCreateOrUpdateResponse struct {
 	RouteFilter
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteFiltersClientDeletePollerResponse contains the response from method RouteFiltersClient.Delete.
 type RouteFiltersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RouteFiltersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5921,11 +4911,10 @@ type RouteFiltersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RouteFiltersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFiltersClientDeleteResponse, error) {
 	respType := RouteFiltersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -5938,56 +4927,43 @@ func (l *RouteFiltersClientDeletePollerResponse) Resume(ctx context.Context, cli
 	poller := &RouteFiltersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RouteFiltersClientDeleteResponse contains the response from method RouteFiltersClient.Delete.
 type RouteFiltersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // RouteFiltersClientGetResponse contains the response from method RouteFiltersClient.Get.
 type RouteFiltersClientGetResponse struct {
 	RouteFilter
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteFiltersClientListByResourceGroupResponse contains the response from method RouteFiltersClient.ListByResourceGroup.
 type RouteFiltersClientListByResourceGroupResponse struct {
 	RouteFilterListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteFiltersClientListResponse contains the response from method RouteFiltersClient.List.
 type RouteFiltersClientListResponse struct {
 	RouteFilterListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteFiltersClientUpdateTagsResponse contains the response from method RouteFiltersClient.UpdateTags.
 type RouteFiltersClientUpdateTagsResponse struct {
 	RouteFilter
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteTablesClientCreateOrUpdatePollerResponse contains the response from method RouteTablesClient.CreateOrUpdate.
 type RouteTablesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RouteTablesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5995,11 +4971,10 @@ type RouteTablesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RouteTablesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteTablesClientCreateOrUpdateResponse, error) {
 	respType := RouteTablesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteTable)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteTable)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6012,29 +4987,23 @@ func (l *RouteTablesClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 	poller := &RouteTablesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RouteTablesClientCreateOrUpdateResponse contains the response from method RouteTablesClient.CreateOrUpdate.
 type RouteTablesClientCreateOrUpdateResponse struct {
 	RouteTable
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteTablesClientDeletePollerResponse contains the response from method RouteTablesClient.Delete.
 type RouteTablesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RouteTablesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6042,11 +5011,10 @@ type RouteTablesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RouteTablesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteTablesClientDeleteResponse, error) {
 	respType := RouteTablesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6059,56 +5027,43 @@ func (l *RouteTablesClientDeletePollerResponse) Resume(ctx context.Context, clie
 	poller := &RouteTablesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RouteTablesClientDeleteResponse contains the response from method RouteTablesClient.Delete.
 type RouteTablesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // RouteTablesClientGetResponse contains the response from method RouteTablesClient.Get.
 type RouteTablesClientGetResponse struct {
 	RouteTable
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteTablesClientListAllResponse contains the response from method RouteTablesClient.ListAll.
 type RouteTablesClientListAllResponse struct {
 	RouteTableListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteTablesClientListResponse contains the response from method RouteTablesClient.List.
 type RouteTablesClientListResponse struct {
 	RouteTableListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RouteTablesClientUpdateTagsResponse contains the response from method RouteTablesClient.UpdateTags.
 type RouteTablesClientUpdateTagsResponse struct {
 	RouteTable
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoutesClientCreateOrUpdatePollerResponse contains the response from method RoutesClient.CreateOrUpdate.
 type RoutesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RoutesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6116,11 +5071,10 @@ type RoutesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RoutesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RoutesClientCreateOrUpdateResponse, error) {
 	respType := RoutesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Route)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Route)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6133,29 +5087,23 @@ func (l *RoutesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, c
 	poller := &RoutesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RoutesClientCreateOrUpdateResponse contains the response from method RoutesClient.CreateOrUpdate.
 type RoutesClientCreateOrUpdateResponse struct {
 	Route
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoutesClientDeletePollerResponse contains the response from method RoutesClient.Delete.
 type RoutesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *RoutesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6163,11 +5111,10 @@ type RoutesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l RoutesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RoutesClientDeleteResponse, error) {
 	respType := RoutesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6180,42 +5127,33 @@ func (l *RoutesClientDeletePollerResponse) Resume(ctx context.Context, client *R
 	poller := &RoutesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // RoutesClientDeleteResponse contains the response from method RoutesClient.Delete.
 type RoutesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // RoutesClientGetResponse contains the response from method RoutesClient.Get.
 type RoutesClientGetResponse struct {
 	Route
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // RoutesClientListResponse contains the response from method RoutesClient.List.
 type RoutesClientListResponse struct {
 	RouteListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityGroupsClientCreateOrUpdatePollerResponse contains the response from method SecurityGroupsClient.CreateOrUpdate.
 type SecurityGroupsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SecurityGroupsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6223,11 +5161,10 @@ type SecurityGroupsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SecurityGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityGroupsClientCreateOrUpdateResponse, error) {
 	respType := SecurityGroupsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityGroup)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityGroup)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6240,29 +5177,23 @@ func (l *SecurityGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 	poller := &SecurityGroupsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SecurityGroupsClientCreateOrUpdateResponse contains the response from method SecurityGroupsClient.CreateOrUpdate.
 type SecurityGroupsClientCreateOrUpdateResponse struct {
 	SecurityGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityGroupsClientDeletePollerResponse contains the response from method SecurityGroupsClient.Delete.
 type SecurityGroupsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SecurityGroupsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6270,11 +5201,10 @@ type SecurityGroupsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SecurityGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityGroupsClientDeleteResponse, error) {
 	respType := SecurityGroupsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6287,56 +5217,43 @@ func (l *SecurityGroupsClientDeletePollerResponse) Resume(ctx context.Context, c
 	poller := &SecurityGroupsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SecurityGroupsClientDeleteResponse contains the response from method SecurityGroupsClient.Delete.
 type SecurityGroupsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SecurityGroupsClientGetResponse contains the response from method SecurityGroupsClient.Get.
 type SecurityGroupsClientGetResponse struct {
 	SecurityGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityGroupsClientListAllResponse contains the response from method SecurityGroupsClient.ListAll.
 type SecurityGroupsClientListAllResponse struct {
 	SecurityGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityGroupsClientListResponse contains the response from method SecurityGroupsClient.List.
 type SecurityGroupsClientListResponse struct {
 	SecurityGroupListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityGroupsClientUpdateTagsResponse contains the response from method SecurityGroupsClient.UpdateTags.
 type SecurityGroupsClientUpdateTagsResponse struct {
 	SecurityGroup
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityPartnerProvidersClientCreateOrUpdatePollerResponse contains the response from method SecurityPartnerProvidersClient.CreateOrUpdate.
 type SecurityPartnerProvidersClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SecurityPartnerProvidersClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6344,11 +5261,10 @@ type SecurityPartnerProvidersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SecurityPartnerProvidersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
 	respType := SecurityPartnerProvidersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityPartnerProvider)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityPartnerProvider)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6361,29 +5277,23 @@ func (l *SecurityPartnerProvidersClientCreateOrUpdatePollerResponse) Resume(ctx 
 	poller := &SecurityPartnerProvidersClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SecurityPartnerProvidersClientCreateOrUpdateResponse contains the response from method SecurityPartnerProvidersClient.CreateOrUpdate.
 type SecurityPartnerProvidersClientCreateOrUpdateResponse struct {
 	SecurityPartnerProvider
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityPartnerProvidersClientDeletePollerResponse contains the response from method SecurityPartnerProvidersClient.Delete.
 type SecurityPartnerProvidersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SecurityPartnerProvidersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6391,11 +5301,10 @@ type SecurityPartnerProvidersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SecurityPartnerProvidersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityPartnerProvidersClientDeleteResponse, error) {
 	respType := SecurityPartnerProvidersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6408,56 +5317,43 @@ func (l *SecurityPartnerProvidersClientDeletePollerResponse) Resume(ctx context.
 	poller := &SecurityPartnerProvidersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SecurityPartnerProvidersClientDeleteResponse contains the response from method SecurityPartnerProvidersClient.Delete.
 type SecurityPartnerProvidersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SecurityPartnerProvidersClientGetResponse contains the response from method SecurityPartnerProvidersClient.Get.
 type SecurityPartnerProvidersClientGetResponse struct {
 	SecurityPartnerProvider
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityPartnerProvidersClientListByResourceGroupResponse contains the response from method SecurityPartnerProvidersClient.ListByResourceGroup.
 type SecurityPartnerProvidersClientListByResourceGroupResponse struct {
 	SecurityPartnerProviderListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityPartnerProvidersClientListResponse contains the response from method SecurityPartnerProvidersClient.List.
 type SecurityPartnerProvidersClientListResponse struct {
 	SecurityPartnerProviderListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityPartnerProvidersClientUpdateTagsResponse contains the response from method SecurityPartnerProvidersClient.UpdateTags.
 type SecurityPartnerProvidersClientUpdateTagsResponse struct {
 	SecurityPartnerProvider
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityRulesClientCreateOrUpdatePollerResponse contains the response from method SecurityRulesClient.CreateOrUpdate.
 type SecurityRulesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SecurityRulesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6465,11 +5361,10 @@ type SecurityRulesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SecurityRulesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityRulesClientCreateOrUpdateResponse, error) {
 	respType := SecurityRulesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityRule)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityRule)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6482,29 +5377,23 @@ func (l *SecurityRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.Con
 	poller := &SecurityRulesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SecurityRulesClientCreateOrUpdateResponse contains the response from method SecurityRulesClient.CreateOrUpdate.
 type SecurityRulesClientCreateOrUpdateResponse struct {
 	SecurityRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityRulesClientDeletePollerResponse contains the response from method SecurityRulesClient.Delete.
 type SecurityRulesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SecurityRulesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6512,11 +5401,10 @@ type SecurityRulesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SecurityRulesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityRulesClientDeleteResponse, error) {
 	respType := SecurityRulesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6529,49 +5417,38 @@ func (l *SecurityRulesClientDeletePollerResponse) Resume(ctx context.Context, cl
 	poller := &SecurityRulesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SecurityRulesClientDeleteResponse contains the response from method SecurityRulesClient.Delete.
 type SecurityRulesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SecurityRulesClientGetResponse contains the response from method SecurityRulesClient.Get.
 type SecurityRulesClientGetResponse struct {
 	SecurityRule
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SecurityRulesClientListResponse contains the response from method SecurityRulesClient.List.
 type SecurityRulesClientListResponse struct {
 	SecurityRuleListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceAssociationLinksClientListResponse contains the response from method ServiceAssociationLinksClient.List.
 type ServiceAssociationLinksClientListResponse struct {
 	ServiceAssociationLinksListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse contains the response from method ServiceEndpointPoliciesClient.CreateOrUpdate.
 type ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ServiceEndpointPoliciesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6579,11 +5456,10 @@ type ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
 	respType := ServiceEndpointPoliciesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ServiceEndpointPolicy)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ServiceEndpointPolicy)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6596,29 +5472,23 @@ func (l *ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx c
 	poller := &ServiceEndpointPoliciesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ServiceEndpointPoliciesClientCreateOrUpdateResponse contains the response from method ServiceEndpointPoliciesClient.CreateOrUpdate.
 type ServiceEndpointPoliciesClientCreateOrUpdateResponse struct {
 	ServiceEndpointPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceEndpointPoliciesClientDeletePollerResponse contains the response from method ServiceEndpointPoliciesClient.Delete.
 type ServiceEndpointPoliciesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ServiceEndpointPoliciesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6626,11 +5496,10 @@ type ServiceEndpointPoliciesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ServiceEndpointPoliciesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPoliciesClientDeleteResponse, error) {
 	respType := ServiceEndpointPoliciesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6643,56 +5512,43 @@ func (l *ServiceEndpointPoliciesClientDeletePollerResponse) Resume(ctx context.C
 	poller := &ServiceEndpointPoliciesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ServiceEndpointPoliciesClientDeleteResponse contains the response from method ServiceEndpointPoliciesClient.Delete.
 type ServiceEndpointPoliciesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ServiceEndpointPoliciesClientGetResponse contains the response from method ServiceEndpointPoliciesClient.Get.
 type ServiceEndpointPoliciesClientGetResponse struct {
 	ServiceEndpointPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceEndpointPoliciesClientListByResourceGroupResponse contains the response from method ServiceEndpointPoliciesClient.ListByResourceGroup.
 type ServiceEndpointPoliciesClientListByResourceGroupResponse struct {
 	ServiceEndpointPolicyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceEndpointPoliciesClientListResponse contains the response from method ServiceEndpointPoliciesClient.List.
 type ServiceEndpointPoliciesClientListResponse struct {
 	ServiceEndpointPolicyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceEndpointPoliciesClientUpdateTagsResponse contains the response from method ServiceEndpointPoliciesClient.UpdateTags.
 type ServiceEndpointPoliciesClientUpdateTagsResponse struct {
 	ServiceEndpointPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate.
 type ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6700,11 +5556,10 @@ type ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
 	respType := ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ServiceEndpointPolicyDefinition)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ServiceEndpointPolicyDefinition)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6718,29 +5573,23 @@ func (l *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse) Res
 	poller := &ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate.
 type ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse struct {
 	ServiceEndpointPolicyDefinition
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceEndpointPolicyDefinitionsClientDeletePollerResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.Delete.
 type ServiceEndpointPolicyDefinitionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *ServiceEndpointPolicyDefinitionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6748,11 +5597,10 @@ type ServiceEndpointPolicyDefinitionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l ServiceEndpointPolicyDefinitionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
 	respType := ServiceEndpointPolicyDefinitionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6765,49 +5613,38 @@ func (l *ServiceEndpointPolicyDefinitionsClientDeletePollerResponse) Resume(ctx 
 	poller := &ServiceEndpointPolicyDefinitionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // ServiceEndpointPolicyDefinitionsClientDeleteResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.Delete.
 type ServiceEndpointPolicyDefinitionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // ServiceEndpointPolicyDefinitionsClientGetResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.Get.
 type ServiceEndpointPolicyDefinitionsClientGetResponse struct {
 	ServiceEndpointPolicyDefinition
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.ListByResourceGroup.
 type ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse struct {
 	ServiceEndpointPolicyDefinitionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // ServiceTagsClientListResponse contains the response from method ServiceTagsClient.List.
 type ServiceTagsClientListResponse struct {
 	ServiceTagsListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SubnetsClientCreateOrUpdatePollerResponse contains the response from method SubnetsClient.CreateOrUpdate.
 type SubnetsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SubnetsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6815,11 +5652,10 @@ type SubnetsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SubnetsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientCreateOrUpdateResponse, error) {
 	respType := SubnetsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Subnet)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Subnet)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6832,29 +5668,23 @@ func (l *SubnetsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, 
 	poller := &SubnetsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SubnetsClientCreateOrUpdateResponse contains the response from method SubnetsClient.CreateOrUpdate.
 type SubnetsClientCreateOrUpdateResponse struct {
 	Subnet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SubnetsClientDeletePollerResponse contains the response from method SubnetsClient.Delete.
 type SubnetsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SubnetsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6862,11 +5692,10 @@ type SubnetsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SubnetsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientDeleteResponse, error) {
 	respType := SubnetsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6879,42 +5708,33 @@ func (l *SubnetsClientDeletePollerResponse) Resume(ctx context.Context, client *
 	poller := &SubnetsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SubnetsClientDeleteResponse contains the response from method SubnetsClient.Delete.
 type SubnetsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubnetsClientGetResponse contains the response from method SubnetsClient.Get.
 type SubnetsClientGetResponse struct {
 	Subnet
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SubnetsClientListResponse contains the response from method SubnetsClient.List.
 type SubnetsClientListResponse struct {
 	SubnetListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // SubnetsClientPrepareNetworkPoliciesPollerResponse contains the response from method SubnetsClient.PrepareNetworkPolicies.
 type SubnetsClientPrepareNetworkPoliciesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SubnetsClientPrepareNetworkPoliciesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6922,11 +5742,10 @@ type SubnetsClientPrepareNetworkPoliciesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SubnetsClientPrepareNetworkPoliciesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
 	respType := SubnetsClientPrepareNetworkPoliciesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6939,28 +5758,23 @@ func (l *SubnetsClientPrepareNetworkPoliciesPollerResponse) Resume(ctx context.C
 	poller := &SubnetsClientPrepareNetworkPoliciesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SubnetsClientPrepareNetworkPoliciesResponse contains the response from method SubnetsClient.PrepareNetworkPolicies.
 type SubnetsClientPrepareNetworkPoliciesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // SubnetsClientUnprepareNetworkPoliciesPollerResponse contains the response from method SubnetsClient.UnprepareNetworkPolicies.
 type SubnetsClientUnprepareNetworkPoliciesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *SubnetsClientUnprepareNetworkPoliciesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6968,11 +5782,10 @@ type SubnetsClientUnprepareNetworkPoliciesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l SubnetsClientUnprepareNetworkPoliciesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
 	respType := SubnetsClientUnprepareNetworkPoliciesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -6985,35 +5798,28 @@ func (l *SubnetsClientUnprepareNetworkPoliciesPollerResponse) Resume(ctx context
 	poller := &SubnetsClientUnprepareNetworkPoliciesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // SubnetsClientUnprepareNetworkPoliciesResponse contains the response from method SubnetsClient.UnprepareNetworkPolicies.
 type SubnetsClientUnprepareNetworkPoliciesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // UsagesClientListResponse contains the response from method UsagesClient.List.
 type UsagesClientListResponse struct {
 	UsagesListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNConnectionsClientCreateOrUpdatePollerResponse contains the response from method VPNConnectionsClient.CreateOrUpdate.
 type VPNConnectionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNConnectionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7021,11 +5827,10 @@ type VPNConnectionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNConnectionsClientCreateOrUpdateResponse, error) {
 	respType := VPNConnectionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNConnection)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNConnection)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7038,29 +5843,23 @@ func (l *VPNConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 	poller := &VPNConnectionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNConnectionsClientCreateOrUpdateResponse contains the response from method VPNConnectionsClient.CreateOrUpdate.
 type VPNConnectionsClientCreateOrUpdateResponse struct {
 	VPNConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNConnectionsClientDeletePollerResponse contains the response from method VPNConnectionsClient.Delete.
 type VPNConnectionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNConnectionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7068,11 +5867,10 @@ type VPNConnectionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNConnectionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNConnectionsClientDeleteResponse, error) {
 	respType := VPNConnectionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7085,42 +5883,33 @@ func (l *VPNConnectionsClientDeletePollerResponse) Resume(ctx context.Context, c
 	poller := &VPNConnectionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNConnectionsClientDeleteResponse contains the response from method VPNConnectionsClient.Delete.
 type VPNConnectionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VPNConnectionsClientGetResponse contains the response from method VPNConnectionsClient.Get.
 type VPNConnectionsClientGetResponse struct {
 	VPNConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNConnectionsClientListByVPNGatewayResponse contains the response from method VPNConnectionsClient.ListByVPNGateway.
 type VPNConnectionsClientListByVPNGatewayResponse struct {
 	ListVPNConnectionsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNGatewaysClientCreateOrUpdatePollerResponse contains the response from method VPNGatewaysClient.CreateOrUpdate.
 type VPNGatewaysClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNGatewaysClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7128,11 +5917,10 @@ type VPNGatewaysClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientCreateOrUpdateResponse, error) {
 	respType := VPNGatewaysClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7145,29 +5933,23 @@ func (l *VPNGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 	poller := &VPNGatewaysClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNGatewaysClientCreateOrUpdateResponse contains the response from method VPNGatewaysClient.CreateOrUpdate.
 type VPNGatewaysClientCreateOrUpdateResponse struct {
 	VPNGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNGatewaysClientDeletePollerResponse contains the response from method VPNGatewaysClient.Delete.
 type VPNGatewaysClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNGatewaysClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7175,11 +5957,10 @@ type VPNGatewaysClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientDeleteResponse, error) {
 	respType := VPNGatewaysClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7192,49 +5973,38 @@ func (l *VPNGatewaysClientDeletePollerResponse) Resume(ctx context.Context, clie
 	poller := &VPNGatewaysClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNGatewaysClientDeleteResponse contains the response from method VPNGatewaysClient.Delete.
 type VPNGatewaysClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VPNGatewaysClientGetResponse contains the response from method VPNGatewaysClient.Get.
 type VPNGatewaysClientGetResponse struct {
 	VPNGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNGatewaysClientListByResourceGroupResponse contains the response from method VPNGatewaysClient.ListByResourceGroup.
 type VPNGatewaysClientListByResourceGroupResponse struct {
 	ListVPNGatewaysResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNGatewaysClientListResponse contains the response from method VPNGatewaysClient.List.
 type VPNGatewaysClientListResponse struct {
 	ListVPNGatewaysResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNGatewaysClientResetPollerResponse contains the response from method VPNGatewaysClient.Reset.
 type VPNGatewaysClientResetPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNGatewaysClientResetPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7242,11 +6012,10 @@ type VPNGatewaysClientResetPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNGatewaysClientResetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientResetResponse, error) {
 	respType := VPNGatewaysClientResetResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7259,43 +6028,33 @@ func (l *VPNGatewaysClientResetPollerResponse) Resume(ctx context.Context, clien
 	poller := &VPNGatewaysClientResetPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNGatewaysClientResetResponse contains the response from method VPNGatewaysClient.Reset.
 type VPNGatewaysClientResetResponse struct {
 	VPNGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNGatewaysClientUpdateTagsResponse contains the response from method VPNGatewaysClient.UpdateTags.
 type VPNGatewaysClientUpdateTagsResponse struct {
 	VPNGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNLinkConnectionsClientListByVPNConnectionResponse contains the response from method VPNLinkConnectionsClient.ListByVPNConnection.
 type VPNLinkConnectionsClientListByVPNConnectionResponse struct {
 	ListVPNSiteLinkConnectionsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse contains the response from method VPNServerConfigurationsAssociatedWithVirtualWanClient.List.
 type VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7303,11 +6062,10 @@ type VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse str
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
 	respType := VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNServerConfigurationsResponse)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNServerConfigurationsResponse)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7321,29 +6079,23 @@ func (l *VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse
 	poller := &VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse contains the response from method VPNServerConfigurationsAssociatedWithVirtualWanClient.List.
 type VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse struct {
 	VPNServerConfigurationsResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNServerConfigurationsClientCreateOrUpdatePollerResponse contains the response from method VPNServerConfigurationsClient.CreateOrUpdate.
 type VPNServerConfigurationsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNServerConfigurationsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7351,11 +6103,10 @@ type VPNServerConfigurationsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNServerConfigurationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
 	respType := VPNServerConfigurationsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNServerConfiguration)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNServerConfiguration)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7368,29 +6119,23 @@ func (l *VPNServerConfigurationsClientCreateOrUpdatePollerResponse) Resume(ctx c
 	poller := &VPNServerConfigurationsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNServerConfigurationsClientCreateOrUpdateResponse contains the response from method VPNServerConfigurationsClient.CreateOrUpdate.
 type VPNServerConfigurationsClientCreateOrUpdateResponse struct {
 	VPNServerConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNServerConfigurationsClientDeletePollerResponse contains the response from method VPNServerConfigurationsClient.Delete.
 type VPNServerConfigurationsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNServerConfigurationsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7398,11 +6143,10 @@ type VPNServerConfigurationsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNServerConfigurationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsClientDeleteResponse, error) {
 	respType := VPNServerConfigurationsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7415,77 +6159,58 @@ func (l *VPNServerConfigurationsClientDeletePollerResponse) Resume(ctx context.C
 	poller := &VPNServerConfigurationsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNServerConfigurationsClientDeleteResponse contains the response from method VPNServerConfigurationsClient.Delete.
 type VPNServerConfigurationsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VPNServerConfigurationsClientGetResponse contains the response from method VPNServerConfigurationsClient.Get.
 type VPNServerConfigurationsClientGetResponse struct {
 	VPNServerConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNServerConfigurationsClientListByResourceGroupResponse contains the response from method VPNServerConfigurationsClient.ListByResourceGroup.
 type VPNServerConfigurationsClientListByResourceGroupResponse struct {
 	ListVPNServerConfigurationsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNServerConfigurationsClientListResponse contains the response from method VPNServerConfigurationsClient.List.
 type VPNServerConfigurationsClientListResponse struct {
 	ListVPNServerConfigurationsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNServerConfigurationsClientUpdateTagsResponse contains the response from method VPNServerConfigurationsClient.UpdateTags.
 type VPNServerConfigurationsClientUpdateTagsResponse struct {
 	VPNServerConfiguration
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSiteLinkConnectionsClientGetResponse contains the response from method VPNSiteLinkConnectionsClient.Get.
 type VPNSiteLinkConnectionsClientGetResponse struct {
 	VPNSiteLinkConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSiteLinksClientGetResponse contains the response from method VPNSiteLinksClient.Get.
 type VPNSiteLinksClientGetResponse struct {
 	VPNSiteLink
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSiteLinksClientListByVPNSiteResponse contains the response from method VPNSiteLinksClient.ListByVPNSite.
 type VPNSiteLinksClientListByVPNSiteResponse struct {
 	ListVPNSiteLinksResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSitesClientCreateOrUpdatePollerResponse contains the response from method VPNSitesClient.CreateOrUpdate.
 type VPNSitesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNSitesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7493,11 +6218,10 @@ type VPNSitesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNSitesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesClientCreateOrUpdateResponse, error) {
 	respType := VPNSitesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNSite)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNSite)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7510,29 +6234,23 @@ func (l *VPNSitesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context,
 	poller := &VPNSitesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNSitesClientCreateOrUpdateResponse contains the response from method VPNSitesClient.CreateOrUpdate.
 type VPNSitesClientCreateOrUpdateResponse struct {
 	VPNSite
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSitesClientDeletePollerResponse contains the response from method VPNSitesClient.Delete.
 type VPNSitesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNSitesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7540,11 +6258,10 @@ type VPNSitesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNSitesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesClientDeleteResponse, error) {
 	respType := VPNSitesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7557,56 +6274,43 @@ func (l *VPNSitesClientDeletePollerResponse) Resume(ctx context.Context, client 
 	poller := &VPNSitesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNSitesClientDeleteResponse contains the response from method VPNSitesClient.Delete.
 type VPNSitesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VPNSitesClientGetResponse contains the response from method VPNSitesClient.Get.
 type VPNSitesClientGetResponse struct {
 	VPNSite
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSitesClientListByResourceGroupResponse contains the response from method VPNSitesClient.ListByResourceGroup.
 type VPNSitesClientListByResourceGroupResponse struct {
 	ListVPNSitesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSitesClientListResponse contains the response from method VPNSitesClient.List.
 type VPNSitesClientListResponse struct {
 	ListVPNSitesResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSitesClientUpdateTagsResponse contains the response from method VPNSitesClient.UpdateTags.
 type VPNSitesClientUpdateTagsResponse struct {
 	VPNSite
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VPNSitesConfigurationClientDownloadPollerResponse contains the response from method VPNSitesConfigurationClient.Download.
 type VPNSitesConfigurationClientDownloadPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VPNSitesConfigurationClientDownloadPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7614,11 +6318,10 @@ type VPNSitesConfigurationClientDownloadPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VPNSitesConfigurationClientDownloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesConfigurationClientDownloadResponse, error) {
 	respType := VPNSitesConfigurationClientDownloadResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7631,28 +6334,23 @@ func (l *VPNSitesConfigurationClientDownloadPollerResponse) Resume(ctx context.C
 	poller := &VPNSitesConfigurationClientDownloadPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VPNSitesConfigurationClientDownloadResponse contains the response from method VPNSitesConfigurationClient.Download.
 type VPNSitesConfigurationClientDownloadResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualAppliancesClientCreateOrUpdatePollerResponse contains the response from method VirtualAppliancesClient.CreateOrUpdate.
 type VirtualAppliancesClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualAppliancesClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7660,11 +6358,10 @@ type VirtualAppliancesClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualAppliancesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
 	respType := VirtualAppliancesClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualAppliance)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualAppliance)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7677,29 +6374,23 @@ func (l *VirtualAppliancesClientCreateOrUpdatePollerResponse) Resume(ctx context
 	poller := &VirtualAppliancesClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualAppliancesClientCreateOrUpdateResponse contains the response from method VirtualAppliancesClient.CreateOrUpdate.
 type VirtualAppliancesClientCreateOrUpdateResponse struct {
 	VirtualAppliance
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualAppliancesClientDeletePollerResponse contains the response from method VirtualAppliancesClient.Delete.
 type VirtualAppliancesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualAppliancesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7707,11 +6398,10 @@ type VirtualAppliancesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualAppliancesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualAppliancesClientDeleteResponse, error) {
 	respType := VirtualAppliancesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7724,56 +6414,43 @@ func (l *VirtualAppliancesClientDeletePollerResponse) Resume(ctx context.Context
 	poller := &VirtualAppliancesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualAppliancesClientDeleteResponse contains the response from method VirtualAppliancesClient.Delete.
 type VirtualAppliancesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualAppliancesClientGetResponse contains the response from method VirtualAppliancesClient.Get.
 type VirtualAppliancesClientGetResponse struct {
 	VirtualAppliance
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualAppliancesClientListByResourceGroupResponse contains the response from method VirtualAppliancesClient.ListByResourceGroup.
 type VirtualAppliancesClientListByResourceGroupResponse struct {
 	VirtualApplianceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualAppliancesClientListResponse contains the response from method VirtualAppliancesClient.List.
 type VirtualAppliancesClientListResponse struct {
 	VirtualApplianceListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualAppliancesClientUpdateTagsResponse contains the response from method VirtualAppliancesClient.UpdateTags.
 type VirtualAppliancesClientUpdateTagsResponse struct {
 	VirtualAppliance
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse contains the response from method VirtualHubRouteTableV2SClient.CreateOrUpdate.
 type VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualHubRouteTableV2SClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7781,11 +6458,10 @@ type VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
 	respType := VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualHubRouteTableV2)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualHubRouteTableV2)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7798,29 +6474,23 @@ func (l *VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse) Resume(ctx c
 	poller := &VirtualHubRouteTableV2SClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualHubRouteTableV2SClientCreateOrUpdateResponse contains the response from method VirtualHubRouteTableV2SClient.CreateOrUpdate.
 type VirtualHubRouteTableV2SClientCreateOrUpdateResponse struct {
 	VirtualHubRouteTableV2
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualHubRouteTableV2SClientDeletePollerResponse contains the response from method VirtualHubRouteTableV2SClient.Delete.
 type VirtualHubRouteTableV2SClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualHubRouteTableV2SClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7828,11 +6498,10 @@ type VirtualHubRouteTableV2SClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualHubRouteTableV2SClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
 	respType := VirtualHubRouteTableV2SClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7845,42 +6514,33 @@ func (l *VirtualHubRouteTableV2SClientDeletePollerResponse) Resume(ctx context.C
 	poller := &VirtualHubRouteTableV2SClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualHubRouteTableV2SClientDeleteResponse contains the response from method VirtualHubRouteTableV2SClient.Delete.
 type VirtualHubRouteTableV2SClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualHubRouteTableV2SClientGetResponse contains the response from method VirtualHubRouteTableV2SClient.Get.
 type VirtualHubRouteTableV2SClientGetResponse struct {
 	VirtualHubRouteTableV2
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualHubRouteTableV2SClientListResponse contains the response from method VirtualHubRouteTableV2SClient.List.
 type VirtualHubRouteTableV2SClientListResponse struct {
 	ListVirtualHubRouteTableV2SResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualHubsClientCreateOrUpdatePollerResponse contains the response from method VirtualHubsClient.CreateOrUpdate.
 type VirtualHubsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualHubsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7888,11 +6548,10 @@ type VirtualHubsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualHubsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubsClientCreateOrUpdateResponse, error) {
 	respType := VirtualHubsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualHub)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualHub)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7905,29 +6564,23 @@ func (l *VirtualHubsClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 	poller := &VirtualHubsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualHubsClientCreateOrUpdateResponse contains the response from method VirtualHubsClient.CreateOrUpdate.
 type VirtualHubsClientCreateOrUpdateResponse struct {
 	VirtualHub
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualHubsClientDeletePollerResponse contains the response from method VirtualHubsClient.Delete.
 type VirtualHubsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualHubsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7935,11 +6588,10 @@ type VirtualHubsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualHubsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubsClientDeleteResponse, error) {
 	respType := VirtualHubsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -7952,56 +6604,43 @@ func (l *VirtualHubsClientDeletePollerResponse) Resume(ctx context.Context, clie
 	poller := &VirtualHubsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualHubsClientDeleteResponse contains the response from method VirtualHubsClient.Delete.
 type VirtualHubsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualHubsClientGetResponse contains the response from method VirtualHubsClient.Get.
 type VirtualHubsClientGetResponse struct {
 	VirtualHub
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualHubsClientListByResourceGroupResponse contains the response from method VirtualHubsClient.ListByResourceGroup.
 type VirtualHubsClientListByResourceGroupResponse struct {
 	ListVirtualHubsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualHubsClientListResponse contains the response from method VirtualHubsClient.List.
 type VirtualHubsClientListResponse struct {
 	ListVirtualHubsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualHubsClientUpdateTagsResponse contains the response from method VirtualHubsClient.UpdateTags.
 type VirtualHubsClientUpdateTagsResponse struct {
 	VirtualHub
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.CreateOrUpdate.
 type VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8009,11 +6648,10 @@ type VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGatewayConnection)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGatewayConnection)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8027,29 +6665,23 @@ func (l *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse) Res
 	poller := &VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse contains the response from method VirtualNetworkGatewayConnectionsClient.CreateOrUpdate.
 type VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse struct {
 	VirtualNetworkGatewayConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewayConnectionsClientDeletePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.Delete.
 type VirtualNetworkGatewayConnectionsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewayConnectionsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8057,11 +6689,10 @@ type VirtualNetworkGatewayConnectionsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewayConnectionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8074,49 +6705,38 @@ func (l *VirtualNetworkGatewayConnectionsClientDeletePollerResponse) Resume(ctx 
 	poller := &VirtualNetworkGatewayConnectionsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientDeleteResponse contains the response from method VirtualNetworkGatewayConnectionsClient.Delete.
 type VirtualNetworkGatewayConnectionsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualNetworkGatewayConnectionsClientGetResponse contains the response from method VirtualNetworkGatewayConnectionsClient.Get.
 type VirtualNetworkGatewayConnectionsClientGetResponse struct {
 	VirtualNetworkGatewayConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse contains the response from method VirtualNetworkGatewayConnectionsClient.GetSharedKey.
 type VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse struct {
 	ConnectionSharedKey
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewayConnectionsClientListResponse contains the response from method VirtualNetworkGatewayConnectionsClient.List.
 type VirtualNetworkGatewayConnectionsClientListResponse struct {
 	VirtualNetworkGatewayConnectionListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.ResetSharedKey.
 type VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8124,11 +6744,10 @@ type VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionResetSharedKey)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionResetSharedKey)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8142,29 +6761,23 @@ func (l *VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse) Res
 	poller := &VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse contains the response from method VirtualNetworkGatewayConnectionsClient.ResetSharedKey.
 type VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse struct {
 	ConnectionResetSharedKey
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.SetSharedKey.
 type VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8172,11 +6785,10 @@ type VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionSharedKey)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionSharedKey)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8190,29 +6802,23 @@ func (l *VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse) Resum
 	poller := &VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse contains the response from method VirtualNetworkGatewayConnectionsClient.SetSharedKey.
 type VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse struct {
 	ConnectionSharedKey
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StartPacketCapture.
 type VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8220,11 +6826,10 @@ type VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse stru
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8238,29 +6843,23 @@ func (l *VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse)
 	poller := &VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StartPacketCapture.
 type VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StopPacketCapture.
 type VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8268,11 +6867,10 @@ type VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse struc
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8286,29 +6884,23 @@ func (l *VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse) 
 	poller := &VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StopPacketCapture.
 type VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.UpdateTags.
 type VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8316,11 +6908,10 @@ type VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
 	respType := VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGatewayConnection)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGatewayConnection)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8334,29 +6925,23 @@ func (l *VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse) Resume(
 	poller := &VirtualNetworkGatewayConnectionsClientUpdateTagsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientUpdateTagsResponse contains the response from method VirtualNetworkGatewayConnectionsClient.UpdateTags.
 type VirtualNetworkGatewayConnectionsClientUpdateTagsResponse struct {
 	VirtualNetworkGatewayConnection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkGatewaysClient.CreateOrUpdate.
 type VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8364,11 +6949,10 @@ type VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworkGatewaysClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8381,29 +6965,23 @@ func (l *VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx co
 	poller := &VirtualNetworkGatewaysClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientCreateOrUpdateResponse contains the response from method VirtualNetworkGatewaysClient.CreateOrUpdate.
 type VirtualNetworkGatewaysClientCreateOrUpdateResponse struct {
 	VirtualNetworkGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientDeletePollerResponse contains the response from method VirtualNetworkGatewaysClient.Delete.
 type VirtualNetworkGatewaysClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8411,11 +6989,10 @@ type VirtualNetworkGatewaysClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientDeleteResponse, error) {
 	respType := VirtualNetworkGatewaysClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8428,19 +7005,17 @@ func (l *VirtualNetworkGatewaysClientDeletePollerResponse) Resume(ctx context.Co
 	poller := &VirtualNetworkGatewaysClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientDeleteResponse contains the response from method VirtualNetworkGatewaysClient.Delete.
 type VirtualNetworkGatewaysClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse contains the response from method
@@ -8448,9 +7023,6 @@ type VirtualNetworkGatewaysClientDeleteResponse struct {
 type VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8458,11 +7030,10 @@ type VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPo
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
 	respType := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8476,28 +7047,23 @@ func (l *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectio
 	poller := &VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse contains the response from method VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections.
 type VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse contains the response from method VirtualNetworkGatewaysClient.GenerateVPNProfile.
 type VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientGenerateVPNProfilePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8505,11 +7071,10 @@ type VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
 	respType := VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8522,29 +7087,23 @@ func (l *VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse) Resume(ct
 	poller := &VirtualNetworkGatewaysClientGenerateVPNProfilePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientGenerateVPNProfileResponse contains the response from method VirtualNetworkGatewaysClient.GenerateVPNProfile.
 type VirtualNetworkGatewaysClientGenerateVPNProfileResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse contains the response from method VirtualNetworkGatewaysClient.Generatevpnclientpackage.
 type VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8552,11 +7111,10 @@ type VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
 	respType := VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8570,29 +7128,23 @@ func (l *VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse) Res
 	poller := &VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse contains the response from method VirtualNetworkGatewaysClient.Generatevpnclientpackage.
 type VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetAdvertisedRoutes.
 type VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8600,11 +7152,10 @@ type VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GatewayRouteListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GatewayRouteListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8617,29 +7168,23 @@ func (l *VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse) Resume(c
 	poller := &VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse contains the response from method VirtualNetworkGatewaysClient.GetAdvertisedRoutes.
 type VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse struct {
 	GatewayRouteListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetBgpPeerStatus.
 type VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8647,11 +7192,10 @@ type VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BgpPeerStatusListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BgpPeerStatusListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8664,29 +7208,23 @@ func (l *VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse) Resume(ctx 
 	poller := &VirtualNetworkGatewaysClientGetBgpPeerStatusPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientGetBgpPeerStatusResponse contains the response from method VirtualNetworkGatewaysClient.GetBgpPeerStatus.
 type VirtualNetworkGatewaysClientGetBgpPeerStatusResponse struct {
 	BgpPeerStatusListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetLearnedRoutes.
 type VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientGetLearnedRoutesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8694,11 +7232,10 @@ type VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GatewayRouteListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GatewayRouteListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8711,36 +7248,28 @@ func (l *VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse) Resume(ctx 
 	poller := &VirtualNetworkGatewaysClientGetLearnedRoutesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientGetLearnedRoutesResponse contains the response from method VirtualNetworkGatewaysClient.GetLearnedRoutes.
 type VirtualNetworkGatewaysClientGetLearnedRoutesResponse struct {
 	GatewayRouteListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientGetResponse contains the response from method VirtualNetworkGatewaysClient.Get.
 type VirtualNetworkGatewaysClientGetResponse struct {
 	VirtualNetworkGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVPNProfilePackageURL.
 type VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8748,11 +7277,10 @@ type VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8766,29 +7294,23 @@ func (l *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse) Resu
 	poller := &VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse contains the response from method VirtualNetworkGatewaysClient.GetVPNProfilePackageURL.
 type VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth.
 type VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8796,11 +7318,10 @@ type VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse stru
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientConnectionHealthDetailListResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientConnectionHealthDetailListResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8814,29 +7335,23 @@ func (l *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse)
 	poller := &VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth.
 type VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse struct {
 	VPNClientConnectionHealthDetailListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters.
 type VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8844,11 +7359,10 @@ type VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse struc
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
 	respType := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientIPsecParameters)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientIPsecParameters)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8862,43 +7376,33 @@ func (l *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse) 
 	poller := &VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters.
 type VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse struct {
 	VPNClientIPsecParameters
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientListConnectionsResponse contains the response from method VirtualNetworkGatewaysClient.ListConnections.
 type VirtualNetworkGatewaysClientListConnectionsResponse struct {
 	VirtualNetworkGatewayListConnectionsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientListResponse contains the response from method VirtualNetworkGatewaysClient.List.
 type VirtualNetworkGatewaysClientListResponse struct {
 	VirtualNetworkGatewayListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientResetPollerResponse contains the response from method VirtualNetworkGatewaysClient.Reset.
 type VirtualNetworkGatewaysClientResetPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientResetPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8906,11 +7410,10 @@ type VirtualNetworkGatewaysClientResetPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientResetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientResetResponse, error) {
 	respType := VirtualNetworkGatewaysClientResetResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8923,29 +7426,23 @@ func (l *VirtualNetworkGatewaysClientResetPollerResponse) Resume(ctx context.Con
 	poller := &VirtualNetworkGatewaysClientResetPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientResetResponse contains the response from method VirtualNetworkGatewaysClient.Reset.
 type VirtualNetworkGatewaysClientResetResponse struct {
 	VirtualNetworkGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse contains the response from method VirtualNetworkGatewaysClient.ResetVPNClientSharedKey.
 type VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8953,11 +7450,10 @@ type VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
 	respType := VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -8971,28 +7467,23 @@ func (l *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse) Resu
 	poller := &VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse contains the response from method VirtualNetworkGatewaysClient.ResetVPNClientSharedKey.
 type VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse contains the response from method VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters.
 type VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9000,11 +7491,10 @@ type VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse struc
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
 	respType := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientIPsecParameters)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientIPsecParameters)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9018,29 +7508,23 @@ func (l *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse) 
 	poller := &VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse contains the response from method VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters.
 type VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse struct {
 	VPNClientIPsecParameters
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientStartPacketCapturePollerResponse contains the response from method VirtualNetworkGatewaysClient.StartPacketCapture.
 type VirtualNetworkGatewaysClientStartPacketCapturePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientStartPacketCapturePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9048,11 +7532,10 @@ type VirtualNetworkGatewaysClientStartPacketCapturePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientStartPacketCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
 	respType := VirtualNetworkGatewaysClientStartPacketCaptureResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9065,29 +7548,23 @@ func (l *VirtualNetworkGatewaysClientStartPacketCapturePollerResponse) Resume(ct
 	poller := &VirtualNetworkGatewaysClientStartPacketCapturePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientStartPacketCaptureResponse contains the response from method VirtualNetworkGatewaysClient.StartPacketCapture.
 type VirtualNetworkGatewaysClientStartPacketCaptureResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkGatewaysClientStopPacketCapturePollerResponse contains the response from method VirtualNetworkGatewaysClient.StopPacketCapture.
 type VirtualNetworkGatewaysClientStopPacketCapturePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientStopPacketCapturePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9095,11 +7572,10 @@ type VirtualNetworkGatewaysClientStopPacketCapturePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientStopPacketCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
 	respType := VirtualNetworkGatewaysClientStopPacketCaptureResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9112,36 +7588,28 @@ func (l *VirtualNetworkGatewaysClientStopPacketCapturePollerResponse) Resume(ctx
 	poller := &VirtualNetworkGatewaysClientStopPacketCapturePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientStopPacketCaptureResponse contains the response from method VirtualNetworkGatewaysClient.StopPacketCapture.
 type VirtualNetworkGatewaysClientStopPacketCaptureResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkGatewaysClientSupportedVPNDevicesResponse contains the response from method VirtualNetworkGatewaysClient.SupportedVPNDevices.
 type VirtualNetworkGatewaysClientSupportedVPNDevicesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkGatewaysClientUpdateTagsPollerResponse contains the response from method VirtualNetworkGatewaysClient.UpdateTags.
 type VirtualNetworkGatewaysClientUpdateTagsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkGatewaysClientUpdateTagsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9149,11 +7617,10 @@ type VirtualNetworkGatewaysClientUpdateTagsPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkGatewaysClientUpdateTagsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
 	respType := VirtualNetworkGatewaysClientUpdateTagsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9166,36 +7633,28 @@ func (l *VirtualNetworkGatewaysClientUpdateTagsPollerResponse) Resume(ctx contex
 	poller := &VirtualNetworkGatewaysClientUpdateTagsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkGatewaysClientUpdateTagsResponse contains the response from method VirtualNetworkGatewaysClient.UpdateTags.
 type VirtualNetworkGatewaysClientUpdateTagsResponse struct {
 	VirtualNetworkGateway
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse contains the response from method VirtualNetworkGatewaysClient.VPNDeviceConfigurationScript.
 type VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
+	Value *string
 }
 
 // VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkPeeringsClient.CreateOrUpdate.
 type VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkPeeringsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9203,11 +7662,10 @@ type VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworkPeeringsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkPeering)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkPeering)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9220,29 +7678,23 @@ func (l *VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse) Resume(ctx co
 	poller := &VirtualNetworkPeeringsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkPeeringsClientCreateOrUpdateResponse contains the response from method VirtualNetworkPeeringsClient.CreateOrUpdate.
 type VirtualNetworkPeeringsClientCreateOrUpdateResponse struct {
 	VirtualNetworkPeering
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkPeeringsClientDeletePollerResponse contains the response from method VirtualNetworkPeeringsClient.Delete.
 type VirtualNetworkPeeringsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkPeeringsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9250,11 +7702,10 @@ type VirtualNetworkPeeringsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkPeeringsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkPeeringsClientDeleteResponse, error) {
 	respType := VirtualNetworkPeeringsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9267,42 +7718,33 @@ func (l *VirtualNetworkPeeringsClientDeletePollerResponse) Resume(ctx context.Co
 	poller := &VirtualNetworkPeeringsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkPeeringsClientDeleteResponse contains the response from method VirtualNetworkPeeringsClient.Delete.
 type VirtualNetworkPeeringsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualNetworkPeeringsClientGetResponse contains the response from method VirtualNetworkPeeringsClient.Get.
 type VirtualNetworkPeeringsClientGetResponse struct {
 	VirtualNetworkPeering
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkPeeringsClientListResponse contains the response from method VirtualNetworkPeeringsClient.List.
 type VirtualNetworkPeeringsClientListResponse struct {
 	VirtualNetworkPeeringListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkTapsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkTapsClient.CreateOrUpdate.
 type VirtualNetworkTapsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkTapsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9310,11 +7752,10 @@ type VirtualNetworkTapsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkTapsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworkTapsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkTap)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkTap)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9327,29 +7768,23 @@ func (l *VirtualNetworkTapsClientCreateOrUpdatePollerResponse) Resume(ctx contex
 	poller := &VirtualNetworkTapsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkTapsClientCreateOrUpdateResponse contains the response from method VirtualNetworkTapsClient.CreateOrUpdate.
 type VirtualNetworkTapsClientCreateOrUpdateResponse struct {
 	VirtualNetworkTap
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkTapsClientDeletePollerResponse contains the response from method VirtualNetworkTapsClient.Delete.
 type VirtualNetworkTapsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworkTapsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9357,11 +7792,10 @@ type VirtualNetworkTapsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworkTapsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkTapsClientDeleteResponse, error) {
 	respType := VirtualNetworkTapsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9374,63 +7808,48 @@ func (l *VirtualNetworkTapsClientDeletePollerResponse) Resume(ctx context.Contex
 	poller := &VirtualNetworkTapsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworkTapsClientDeleteResponse contains the response from method VirtualNetworkTapsClient.Delete.
 type VirtualNetworkTapsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualNetworkTapsClientGetResponse contains the response from method VirtualNetworkTapsClient.Get.
 type VirtualNetworkTapsClientGetResponse struct {
 	VirtualNetworkTap
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkTapsClientListAllResponse contains the response from method VirtualNetworkTapsClient.ListAll.
 type VirtualNetworkTapsClientListAllResponse struct {
 	VirtualNetworkTapListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkTapsClientListByResourceGroupResponse contains the response from method VirtualNetworkTapsClient.ListByResourceGroup.
 type VirtualNetworkTapsClientListByResourceGroupResponse struct {
 	VirtualNetworkTapListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworkTapsClientUpdateTagsResponse contains the response from method VirtualNetworkTapsClient.UpdateTags.
 type VirtualNetworkTapsClientUpdateTagsResponse struct {
 	VirtualNetworkTap
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworksClientCheckIPAddressAvailabilityResponse contains the response from method VirtualNetworksClient.CheckIPAddressAvailability.
 type VirtualNetworksClientCheckIPAddressAvailabilityResponse struct {
 	IPAddressAvailabilityResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworksClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworksClient.CreateOrUpdate.
 type VirtualNetworksClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworksClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9438,11 +7857,10 @@ type VirtualNetworksClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworksClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworksClientCreateOrUpdateResponse, error) {
 	respType := VirtualNetworksClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetwork)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetwork)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9455,29 +7873,23 @@ func (l *VirtualNetworksClientCreateOrUpdatePollerResponse) Resume(ctx context.C
 	poller := &VirtualNetworksClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworksClientCreateOrUpdateResponse contains the response from method VirtualNetworksClient.CreateOrUpdate.
 type VirtualNetworksClientCreateOrUpdateResponse struct {
 	VirtualNetwork
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworksClientDeletePollerResponse contains the response from method VirtualNetworksClient.Delete.
 type VirtualNetworksClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualNetworksClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9485,11 +7897,10 @@ type VirtualNetworksClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualNetworksClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworksClientDeleteResponse, error) {
 	respType := VirtualNetworksClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9502,63 +7913,48 @@ func (l *VirtualNetworksClientDeletePollerResponse) Resume(ctx context.Context, 
 	poller := &VirtualNetworksClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualNetworksClientDeleteResponse contains the response from method VirtualNetworksClient.Delete.
 type VirtualNetworksClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualNetworksClientGetResponse contains the response from method VirtualNetworksClient.Get.
 type VirtualNetworksClientGetResponse struct {
 	VirtualNetwork
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworksClientListAllResponse contains the response from method VirtualNetworksClient.ListAll.
 type VirtualNetworksClientListAllResponse struct {
 	VirtualNetworkListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworksClientListResponse contains the response from method VirtualNetworksClient.List.
 type VirtualNetworksClientListResponse struct {
 	VirtualNetworkListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworksClientListUsageResponse contains the response from method VirtualNetworksClient.ListUsage.
 type VirtualNetworksClientListUsageResponse struct {
 	VirtualNetworkListUsageResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualNetworksClientUpdateTagsResponse contains the response from method VirtualNetworksClient.UpdateTags.
 type VirtualNetworksClientUpdateTagsResponse struct {
 	VirtualNetwork
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualRouterPeeringsClientCreateOrUpdatePollerResponse contains the response from method VirtualRouterPeeringsClient.CreateOrUpdate.
 type VirtualRouterPeeringsClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualRouterPeeringsClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9566,11 +7962,10 @@ type VirtualRouterPeeringsClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualRouterPeeringsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
 	respType := VirtualRouterPeeringsClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualRouterPeering)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualRouterPeering)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9583,29 +7978,23 @@ func (l *VirtualRouterPeeringsClientCreateOrUpdatePollerResponse) Resume(ctx con
 	poller := &VirtualRouterPeeringsClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualRouterPeeringsClientCreateOrUpdateResponse contains the response from method VirtualRouterPeeringsClient.CreateOrUpdate.
 type VirtualRouterPeeringsClientCreateOrUpdateResponse struct {
 	VirtualRouterPeering
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualRouterPeeringsClientDeletePollerResponse contains the response from method VirtualRouterPeeringsClient.Delete.
 type VirtualRouterPeeringsClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualRouterPeeringsClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9613,11 +8002,10 @@ type VirtualRouterPeeringsClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualRouterPeeringsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRouterPeeringsClientDeleteResponse, error) {
 	respType := VirtualRouterPeeringsClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9630,42 +8018,33 @@ func (l *VirtualRouterPeeringsClientDeletePollerResponse) Resume(ctx context.Con
 	poller := &VirtualRouterPeeringsClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualRouterPeeringsClientDeleteResponse contains the response from method VirtualRouterPeeringsClient.Delete.
 type VirtualRouterPeeringsClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualRouterPeeringsClientGetResponse contains the response from method VirtualRouterPeeringsClient.Get.
 type VirtualRouterPeeringsClientGetResponse struct {
 	VirtualRouterPeering
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualRouterPeeringsClientListResponse contains the response from method VirtualRouterPeeringsClient.List.
 type VirtualRouterPeeringsClientListResponse struct {
 	VirtualRouterPeeringListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualRoutersClientCreateOrUpdatePollerResponse contains the response from method VirtualRoutersClient.CreateOrUpdate.
 type VirtualRoutersClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualRoutersClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9673,11 +8052,10 @@ type VirtualRoutersClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualRoutersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRoutersClientCreateOrUpdateResponse, error) {
 	respType := VirtualRoutersClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualRouter)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualRouter)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9690,29 +8068,23 @@ func (l *VirtualRoutersClientCreateOrUpdatePollerResponse) Resume(ctx context.Co
 	poller := &VirtualRoutersClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualRoutersClientCreateOrUpdateResponse contains the response from method VirtualRoutersClient.CreateOrUpdate.
 type VirtualRoutersClientCreateOrUpdateResponse struct {
 	VirtualRouter
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualRoutersClientDeletePollerResponse contains the response from method VirtualRoutersClient.Delete.
 type VirtualRoutersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualRoutersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9720,11 +8092,10 @@ type VirtualRoutersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualRoutersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRoutersClientDeleteResponse, error) {
 	respType := VirtualRoutersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9737,49 +8108,38 @@ func (l *VirtualRoutersClientDeletePollerResponse) Resume(ctx context.Context, c
 	poller := &VirtualRoutersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualRoutersClientDeleteResponse contains the response from method VirtualRoutersClient.Delete.
 type VirtualRoutersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualRoutersClientGetResponse contains the response from method VirtualRoutersClient.Get.
 type VirtualRoutersClientGetResponse struct {
 	VirtualRouter
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualRoutersClientListByResourceGroupResponse contains the response from method VirtualRoutersClient.ListByResourceGroup.
 type VirtualRoutersClientListByResourceGroupResponse struct {
 	VirtualRouterListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualRoutersClientListResponse contains the response from method VirtualRoutersClient.List.
 type VirtualRoutersClientListResponse struct {
 	VirtualRouterListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualWansClientCreateOrUpdatePollerResponse contains the response from method VirtualWansClient.CreateOrUpdate.
 type VirtualWansClientCreateOrUpdatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualWansClientCreateOrUpdatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9787,11 +8147,10 @@ type VirtualWansClientCreateOrUpdatePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualWansClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualWansClientCreateOrUpdateResponse, error) {
 	respType := VirtualWansClientCreateOrUpdateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualWAN)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualWAN)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9804,29 +8163,23 @@ func (l *VirtualWansClientCreateOrUpdatePollerResponse) Resume(ctx context.Conte
 	poller := &VirtualWansClientCreateOrUpdatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualWansClientCreateOrUpdateResponse contains the response from method VirtualWansClient.CreateOrUpdate.
 type VirtualWansClientCreateOrUpdateResponse struct {
 	VirtualWAN
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualWansClientDeletePollerResponse contains the response from method VirtualWansClient.Delete.
 type VirtualWansClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *VirtualWansClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9834,11 +8187,10 @@ type VirtualWansClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l VirtualWansClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualWansClientDeleteResponse, error) {
 	respType := VirtualWansClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9851,56 +8203,43 @@ func (l *VirtualWansClientDeletePollerResponse) Resume(ctx context.Context, clie
 	poller := &VirtualWansClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // VirtualWansClientDeleteResponse contains the response from method VirtualWansClient.Delete.
 type VirtualWansClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // VirtualWansClientGetResponse contains the response from method VirtualWansClient.Get.
 type VirtualWansClientGetResponse struct {
 	VirtualWAN
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualWansClientListByResourceGroupResponse contains the response from method VirtualWansClient.ListByResourceGroup.
 type VirtualWansClientListByResourceGroupResponse struct {
 	ListVirtualWANsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualWansClientListResponse contains the response from method VirtualWansClient.List.
 type VirtualWansClientListResponse struct {
 	ListVirtualWANsResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // VirtualWansClientUpdateTagsResponse contains the response from method VirtualWansClient.UpdateTags.
 type VirtualWansClientUpdateTagsResponse struct {
 	VirtualWAN
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientCheckConnectivityPollerResponse contains the response from method WatchersClient.CheckConnectivity.
 type WatchersClientCheckConnectivityPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientCheckConnectivityPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9908,11 +8247,10 @@ type WatchersClientCheckConnectivityPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientCheckConnectivityPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientCheckConnectivityResponse, error) {
 	respType := WatchersClientCheckConnectivityResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectivityInformation)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectivityInformation)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9925,36 +8263,28 @@ func (l *WatchersClientCheckConnectivityPollerResponse) Resume(ctx context.Conte
 	poller := &WatchersClientCheckConnectivityPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientCheckConnectivityResponse contains the response from method WatchersClient.CheckConnectivity.
 type WatchersClientCheckConnectivityResponse struct {
 	ConnectivityInformation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientCreateOrUpdateResponse contains the response from method WatchersClient.CreateOrUpdate.
 type WatchersClientCreateOrUpdateResponse struct {
 	Watcher
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientDeletePollerResponse contains the response from method WatchersClient.Delete.
 type WatchersClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9962,11 +8292,10 @@ type WatchersClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientDeleteResponse, error) {
 	respType := WatchersClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -9979,28 +8308,23 @@ func (l *WatchersClientDeletePollerResponse) Resume(ctx context.Context, client 
 	poller := &WatchersClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientDeleteResponse contains the response from method WatchersClient.Delete.
 type WatchersClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // WatchersClientGetAzureReachabilityReportPollerResponse contains the response from method WatchersClient.GetAzureReachabilityReport.
 type WatchersClientGetAzureReachabilityReportPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientGetAzureReachabilityReportPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10008,11 +8332,10 @@ type WatchersClientGetAzureReachabilityReportPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientGetAzureReachabilityReportPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetAzureReachabilityReportResponse, error) {
 	respType := WatchersClientGetAzureReachabilityReportResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureReachabilityReport)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureReachabilityReport)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10025,29 +8348,23 @@ func (l *WatchersClientGetAzureReachabilityReportPollerResponse) Resume(ctx cont
 	poller := &WatchersClientGetAzureReachabilityReportPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientGetAzureReachabilityReportResponse contains the response from method WatchersClient.GetAzureReachabilityReport.
 type WatchersClientGetAzureReachabilityReportResponse struct {
 	AzureReachabilityReport
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientGetFlowLogStatusPollerResponse contains the response from method WatchersClient.GetFlowLogStatus.
 type WatchersClientGetFlowLogStatusPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientGetFlowLogStatusPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10055,11 +8372,10 @@ type WatchersClientGetFlowLogStatusPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientGetFlowLogStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetFlowLogStatusResponse, error) {
 	respType := WatchersClientGetFlowLogStatusResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLogInformation)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLogInformation)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10072,29 +8388,23 @@ func (l *WatchersClientGetFlowLogStatusPollerResponse) Resume(ctx context.Contex
 	poller := &WatchersClientGetFlowLogStatusPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientGetFlowLogStatusResponse contains the response from method WatchersClient.GetFlowLogStatus.
 type WatchersClientGetFlowLogStatusResponse struct {
 	FlowLogInformation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientGetNetworkConfigurationDiagnosticPollerResponse contains the response from method WatchersClient.GetNetworkConfigurationDiagnostic.
 type WatchersClientGetNetworkConfigurationDiagnosticPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientGetNetworkConfigurationDiagnosticPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10102,11 +8412,10 @@ type WatchersClientGetNetworkConfigurationDiagnosticPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientGetNetworkConfigurationDiagnosticPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
 	respType := WatchersClientGetNetworkConfigurationDiagnosticResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConfigurationDiagnosticResponse)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConfigurationDiagnosticResponse)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10119,29 +8428,23 @@ func (l *WatchersClientGetNetworkConfigurationDiagnosticPollerResponse) Resume(c
 	poller := &WatchersClientGetNetworkConfigurationDiagnosticPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientGetNetworkConfigurationDiagnosticResponse contains the response from method WatchersClient.GetNetworkConfigurationDiagnostic.
 type WatchersClientGetNetworkConfigurationDiagnosticResponse struct {
 	ConfigurationDiagnosticResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientGetNextHopPollerResponse contains the response from method WatchersClient.GetNextHop.
 type WatchersClientGetNextHopPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientGetNextHopPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10149,11 +8452,10 @@ type WatchersClientGetNextHopPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientGetNextHopPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetNextHopResponse, error) {
 	respType := WatchersClientGetNextHopResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NextHopResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NextHopResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10166,43 +8468,33 @@ func (l *WatchersClientGetNextHopPollerResponse) Resume(ctx context.Context, cli
 	poller := &WatchersClientGetNextHopPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientGetNextHopResponse contains the response from method WatchersClient.GetNextHop.
 type WatchersClientGetNextHopResponse struct {
 	NextHopResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientGetResponse contains the response from method WatchersClient.Get.
 type WatchersClientGetResponse struct {
 	Watcher
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientGetTopologyResponse contains the response from method WatchersClient.GetTopology.
 type WatchersClientGetTopologyResponse struct {
 	Topology
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientGetTroubleshootingPollerResponse contains the response from method WatchersClient.GetTroubleshooting.
 type WatchersClientGetTroubleshootingPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientGetTroubleshootingPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10210,11 +8502,10 @@ type WatchersClientGetTroubleshootingPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientGetTroubleshootingPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetTroubleshootingResponse, error) {
 	respType := WatchersClientGetTroubleshootingResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TroubleshootingResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TroubleshootingResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10227,29 +8518,23 @@ func (l *WatchersClientGetTroubleshootingPollerResponse) Resume(ctx context.Cont
 	poller := &WatchersClientGetTroubleshootingPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientGetTroubleshootingResponse contains the response from method WatchersClient.GetTroubleshooting.
 type WatchersClientGetTroubleshootingResponse struct {
 	TroubleshootingResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientGetTroubleshootingResultPollerResponse contains the response from method WatchersClient.GetTroubleshootingResult.
 type WatchersClientGetTroubleshootingResultPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientGetTroubleshootingResultPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10257,11 +8542,10 @@ type WatchersClientGetTroubleshootingResultPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientGetTroubleshootingResultPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetTroubleshootingResultResponse, error) {
 	respType := WatchersClientGetTroubleshootingResultResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TroubleshootingResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TroubleshootingResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10274,29 +8558,23 @@ func (l *WatchersClientGetTroubleshootingResultPollerResponse) Resume(ctx contex
 	poller := &WatchersClientGetTroubleshootingResultPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientGetTroubleshootingResultResponse contains the response from method WatchersClient.GetTroubleshootingResult.
 type WatchersClientGetTroubleshootingResultResponse struct {
 	TroubleshootingResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientGetVMSecurityRulesPollerResponse contains the response from method WatchersClient.GetVMSecurityRules.
 type WatchersClientGetVMSecurityRulesPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientGetVMSecurityRulesPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10304,11 +8582,10 @@ type WatchersClientGetVMSecurityRulesPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientGetVMSecurityRulesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetVMSecurityRulesResponse, error) {
 	respType := WatchersClientGetVMSecurityRulesResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityGroupViewResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityGroupViewResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10321,36 +8598,28 @@ func (l *WatchersClientGetVMSecurityRulesPollerResponse) Resume(ctx context.Cont
 	poller := &WatchersClientGetVMSecurityRulesPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientGetVMSecurityRulesResponse contains the response from method WatchersClient.GetVMSecurityRules.
 type WatchersClientGetVMSecurityRulesResponse struct {
 	SecurityGroupViewResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientListAllResponse contains the response from method WatchersClient.ListAll.
 type WatchersClientListAllResponse struct {
 	WatcherListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientListAvailableProvidersPollerResponse contains the response from method WatchersClient.ListAvailableProviders.
 type WatchersClientListAvailableProvidersPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientListAvailableProvidersPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10358,11 +8627,10 @@ type WatchersClientListAvailableProvidersPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientListAvailableProvidersPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientListAvailableProvidersResponse, error) {
 	respType := WatchersClientListAvailableProvidersResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AvailableProvidersList)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AvailableProvidersList)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10375,36 +8643,28 @@ func (l *WatchersClientListAvailableProvidersPollerResponse) Resume(ctx context.
 	poller := &WatchersClientListAvailableProvidersPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientListAvailableProvidersResponse contains the response from method WatchersClient.ListAvailableProviders.
 type WatchersClientListAvailableProvidersResponse struct {
 	AvailableProvidersList
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientListResponse contains the response from method WatchersClient.List.
 type WatchersClientListResponse struct {
 	WatcherListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientSetFlowLogConfigurationPollerResponse contains the response from method WatchersClient.SetFlowLogConfiguration.
 type WatchersClientSetFlowLogConfigurationPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientSetFlowLogConfigurationPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10412,11 +8672,10 @@ type WatchersClientSetFlowLogConfigurationPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientSetFlowLogConfigurationPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientSetFlowLogConfigurationResponse, error) {
 	respType := WatchersClientSetFlowLogConfigurationResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLogInformation)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLogInformation)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10429,36 +8688,28 @@ func (l *WatchersClientSetFlowLogConfigurationPollerResponse) Resume(ctx context
 	poller := &WatchersClientSetFlowLogConfigurationPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientSetFlowLogConfigurationResponse contains the response from method WatchersClient.SetFlowLogConfiguration.
 type WatchersClientSetFlowLogConfigurationResponse struct {
 	FlowLogInformation
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientUpdateTagsResponse contains the response from method WatchersClient.UpdateTags.
 type WatchersClientUpdateTagsResponse struct {
 	Watcher
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WatchersClientVerifyIPFlowPollerResponse contains the response from method WatchersClient.VerifyIPFlow.
 type WatchersClientVerifyIPFlowPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WatchersClientVerifyIPFlowPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10466,11 +8717,10 @@ type WatchersClientVerifyIPFlowPollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WatchersClientVerifyIPFlowPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientVerifyIPFlowResponse, error) {
 	respType := WatchersClientVerifyIPFlowResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VerificationIPFlowResult)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VerificationIPFlowResult)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10483,36 +8733,28 @@ func (l *WatchersClientVerifyIPFlowPollerResponse) Resume(ctx context.Context, c
 	poller := &WatchersClientVerifyIPFlowPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WatchersClientVerifyIPFlowResponse contains the response from method WatchersClient.VerifyIPFlow.
 type WatchersClientVerifyIPFlowResponse struct {
 	VerificationIPFlowResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WebApplicationFirewallPoliciesClientCreateOrUpdateResponse contains the response from method WebApplicationFirewallPoliciesClient.CreateOrUpdate.
 type WebApplicationFirewallPoliciesClientCreateOrUpdateResponse struct {
 	WebApplicationFirewallPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WebApplicationFirewallPoliciesClientDeletePollerResponse contains the response from method WebApplicationFirewallPoliciesClient.Delete.
 type WebApplicationFirewallPoliciesClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *WebApplicationFirewallPoliciesClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10520,11 +8762,10 @@ type WebApplicationFirewallPoliciesClientDeletePollerResponse struct {
 // A good starting value is 30 seconds. Note that some resources might benefit from a different value.
 func (l WebApplicationFirewallPoliciesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
 	respType := WebApplicationFirewallPoliciesClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -10537,38 +8778,30 @@ func (l *WebApplicationFirewallPoliciesClientDeletePollerResponse) Resume(ctx co
 	poller := &WebApplicationFirewallPoliciesClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // WebApplicationFirewallPoliciesClientDeleteResponse contains the response from method WebApplicationFirewallPoliciesClient.Delete.
 type WebApplicationFirewallPoliciesClientDeleteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // WebApplicationFirewallPoliciesClientGetResponse contains the response from method WebApplicationFirewallPoliciesClient.Get.
 type WebApplicationFirewallPoliciesClientGetResponse struct {
 	WebApplicationFirewallPolicy
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WebApplicationFirewallPoliciesClientListAllResponse contains the response from method WebApplicationFirewallPoliciesClient.ListAll.
 type WebApplicationFirewallPoliciesClientListAllResponse struct {
 	WebApplicationFirewallPolicyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // WebApplicationFirewallPoliciesClientListResponse contains the response from method WebApplicationFirewallPoliciesClient.List.
 type WebApplicationFirewallPoliciesClientListResponse struct {
 	WebApplicationFirewallPolicyListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
@@ -63,9 +63,7 @@ func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return RouteFilterRulesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := RouteFilterRulesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := RouteFilterRulesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteFilterRulesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return RouteFilterRulesClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceG
 	if err != nil {
 		return RouteFilterRulesClientDeletePollerResponse{}, err
 	}
-	result := RouteFilterRulesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := RouteFilterRulesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteFilterRulesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return RouteFilterRulesClientDeletePollerResponse{}, err
@@ -248,7 +244,7 @@ func (client *RouteFilterRulesClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client *RouteFilterRulesClient) getHandleResponse(resp *http.Response) (RouteFilterRulesClientGetResponse, error) {
-	result := RouteFilterRulesClientGetResponse{RawResponse: resp}
+	result := RouteFilterRulesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilterRule); err != nil {
 		return RouteFilterRulesClientGetResponse{}, err
 	}
@@ -301,7 +297,7 @@ func (client *RouteFilterRulesClient) listByRouteFilterCreateRequest(ctx context
 
 // listByRouteFilterHandleResponse handles the ListByRouteFilter response.
 func (client *RouteFilterRulesClient) listByRouteFilterHandleResponse(resp *http.Response) (RouteFilterRulesClientListByRouteFilterResponse, error) {
-	result := RouteFilterRulesClientListByRouteFilterResponse{RawResponse: resp}
+	result := RouteFilterRulesClientListByRouteFilterResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilterRuleListResult); err != nil {
 		return RouteFilterRulesClientListByRouteFilterResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
@@ -62,9 +62,7 @@ func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return RouteFiltersClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := RouteFiltersClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := RouteFiltersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteFiltersClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return RouteFiltersClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroup
 	if err != nil {
 		return RouteFiltersClientDeletePollerResponse{}, err
 	}
-	result := RouteFiltersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := RouteFiltersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteFiltersClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return RouteFiltersClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *RouteFiltersClient) getCreateRequest(ctx context.Context, resource
 
 // getHandleResponse handles the Get response.
 func (client *RouteFiltersClient) getHandleResponse(resp *http.Response) (RouteFiltersClientGetResponse, error) {
-	result := RouteFiltersClientGetResponse{RawResponse: resp}
+	result := RouteFiltersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilter); err != nil {
 		return RouteFiltersClientGetResponse{}, err
 	}
@@ -278,7 +274,7 @@ func (client *RouteFiltersClient) listCreateRequest(ctx context.Context, options
 
 // listHandleResponse handles the List response.
 func (client *RouteFiltersClient) listHandleResponse(resp *http.Response) (RouteFiltersClientListResponse, error) {
-	result := RouteFiltersClientListResponse{RawResponse: resp}
+	result := RouteFiltersClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilterListResult); err != nil {
 		return RouteFiltersClientListResponse{}, err
 	}
@@ -326,7 +322,7 @@ func (client *RouteFiltersClient) listByResourceGroupCreateRequest(ctx context.C
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *RouteFiltersClient) listByResourceGroupHandleResponse(resp *http.Response) (RouteFiltersClientListByResourceGroupResponse, error) {
-	result := RouteFiltersClientListByResourceGroupResponse{RawResponse: resp}
+	result := RouteFiltersClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilterListResult); err != nil {
 		return RouteFiltersClientListByResourceGroupResponse{}, err
 	}
@@ -382,7 +378,7 @@ func (client *RouteFiltersClient) updateTagsCreateRequest(ctx context.Context, r
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *RouteFiltersClient) updateTagsHandleResponse(resp *http.Response) (RouteFiltersClientUpdateTagsResponse, error) {
-	result := RouteFiltersClientUpdateTagsResponse{RawResponse: resp}
+	result := RouteFiltersClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilter); err != nil {
 		return RouteFiltersClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
@@ -63,9 +63,7 @@ func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return RoutesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := RoutesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := RoutesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RoutesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return RoutesClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return RoutesClientDeletePollerResponse{}, err
 	}
-	result := RoutesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := RoutesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RoutesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return RoutesClientDeletePollerResponse{}, err
@@ -247,7 +243,7 @@ func (client *RoutesClient) getCreateRequest(ctx context.Context, resourceGroupN
 
 // getHandleResponse handles the Get response.
 func (client *RoutesClient) getHandleResponse(resp *http.Response) (RoutesClientGetResponse, error) {
-	result := RoutesClientGetResponse{RawResponse: resp}
+	result := RoutesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Route); err != nil {
 		return RoutesClientGetResponse{}, err
 	}
@@ -299,7 +295,7 @@ func (client *RoutesClient) listCreateRequest(ctx context.Context, resourceGroup
 
 // listHandleResponse handles the List response.
 func (client *RoutesClient) listHandleResponse(resp *http.Response) (RoutesClientListResponse, error) {
-	result := RoutesClientListResponse{RawResponse: resp}
+	result := RoutesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteListResult); err != nil {
 		return RoutesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
@@ -62,9 +62,7 @@ func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return RouteTablesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := RouteTablesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := RouteTablesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteTablesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return RouteTablesClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return RouteTablesClientDeletePollerResponse{}, err
 	}
-	result := RouteTablesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := RouteTablesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteTablesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return RouteTablesClientDeletePollerResponse{}, err
@@ -235,7 +231,7 @@ func (client *RouteTablesClient) getCreateRequest(ctx context.Context, resourceG
 
 // getHandleResponse handles the Get response.
 func (client *RouteTablesClient) getHandleResponse(resp *http.Response) (RouteTablesClientGetResponse, error) {
-	result := RouteTablesClientGetResponse{RawResponse: resp}
+	result := RouteTablesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteTable); err != nil {
 		return RouteTablesClientGetResponse{}, err
 	}
@@ -282,7 +278,7 @@ func (client *RouteTablesClient) listCreateRequest(ctx context.Context, resource
 
 // listHandleResponse handles the List response.
 func (client *RouteTablesClient) listHandleResponse(resp *http.Response) (RouteTablesClientListResponse, error) {
-	result := RouteTablesClientListResponse{RawResponse: resp}
+	result := RouteTablesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteTableListResult); err != nil {
 		return RouteTablesClientListResponse{}, err
 	}
@@ -324,7 +320,7 @@ func (client *RouteTablesClient) listAllCreateRequest(ctx context.Context, optio
 
 // listAllHandleResponse handles the ListAll response.
 func (client *RouteTablesClient) listAllHandleResponse(resp *http.Response) (RouteTablesClientListAllResponse, error) {
-	result := RouteTablesClientListAllResponse{RawResponse: resp}
+	result := RouteTablesClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteTableListResult); err != nil {
 		return RouteTablesClientListAllResponse{}, err
 	}
@@ -380,7 +376,7 @@ func (client *RouteTablesClient) updateTagsCreateRequest(ctx context.Context, re
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *RouteTablesClient) updateTagsHandleResponse(resp *http.Response) (RouteTablesClientUpdateTagsResponse, error) {
-	result := RouteTablesClientUpdateTagsResponse{RawResponse: resp}
+	result := RouteTablesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteTable); err != nil {
 		return RouteTablesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitygroups_client.go
@@ -62,9 +62,7 @@ func (client *SecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return SecurityGroupsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := SecurityGroupsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := SecurityGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return SecurityGroupsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *SecurityGroupsClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return SecurityGroupsClientDeletePollerResponse{}, err
 	}
-	result := SecurityGroupsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := SecurityGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return SecurityGroupsClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *SecurityGroupsClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client *SecurityGroupsClient) getHandleResponse(resp *http.Response) (SecurityGroupsClientGetResponse, error) {
-	result := SecurityGroupsClientGetResponse{RawResponse: resp}
+	result := SecurityGroupsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityGroup); err != nil {
 		return SecurityGroupsClientGetResponse{}, err
 	}
@@ -283,7 +279,7 @@ func (client *SecurityGroupsClient) listCreateRequest(ctx context.Context, resou
 
 // listHandleResponse handles the List response.
 func (client *SecurityGroupsClient) listHandleResponse(resp *http.Response) (SecurityGroupsClientListResponse, error) {
-	result := SecurityGroupsClientListResponse{RawResponse: resp}
+	result := SecurityGroupsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityGroupListResult); err != nil {
 		return SecurityGroupsClientListResponse{}, err
 	}
@@ -325,7 +321,7 @@ func (client *SecurityGroupsClient) listAllCreateRequest(ctx context.Context, op
 
 // listAllHandleResponse handles the ListAll response.
 func (client *SecurityGroupsClient) listAllHandleResponse(resp *http.Response) (SecurityGroupsClientListAllResponse, error) {
-	result := SecurityGroupsClientListAllResponse{RawResponse: resp}
+	result := SecurityGroupsClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityGroupListResult); err != nil {
 		return SecurityGroupsClientListAllResponse{}, err
 	}
@@ -382,7 +378,7 @@ func (client *SecurityGroupsClient) updateTagsCreateRequest(ctx context.Context,
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *SecurityGroupsClient) updateTagsHandleResponse(resp *http.Response) (SecurityGroupsClientUpdateTagsResponse, error) {
-	result := SecurityGroupsClientUpdateTagsResponse{RawResponse: resp}
+	result := SecurityGroupsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityGroup); err != nil {
 		return SecurityGroupsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
@@ -62,9 +62,7 @@ func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return SecurityPartnerProvidersClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := SecurityPartnerProvidersClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := SecurityPartnerProvidersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityPartnerProvidersClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return SecurityPartnerProvidersClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, r
 	if err != nil {
 		return SecurityPartnerProvidersClientDeletePollerResponse{}, err
 	}
-	result := SecurityPartnerProvidersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := SecurityPartnerProvidersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityPartnerProvidersClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return SecurityPartnerProvidersClientDeletePollerResponse{}, err
@@ -234,7 +230,7 @@ func (client *SecurityPartnerProvidersClient) getCreateRequest(ctx context.Conte
 
 // getHandleResponse handles the Get response.
 func (client *SecurityPartnerProvidersClient) getHandleResponse(resp *http.Response) (SecurityPartnerProvidersClientGetResponse, error) {
-	result := SecurityPartnerProvidersClientGetResponse{RawResponse: resp}
+	result := SecurityPartnerProvidersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityPartnerProvider); err != nil {
 		return SecurityPartnerProvidersClientGetResponse{}, err
 	}
@@ -277,7 +273,7 @@ func (client *SecurityPartnerProvidersClient) listCreateRequest(ctx context.Cont
 
 // listHandleResponse handles the List response.
 func (client *SecurityPartnerProvidersClient) listHandleResponse(resp *http.Response) (SecurityPartnerProvidersClientListResponse, error) {
-	result := SecurityPartnerProvidersClientListResponse{RawResponse: resp}
+	result := SecurityPartnerProvidersClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityPartnerProviderListResult); err != nil {
 		return SecurityPartnerProvidersClientListResponse{}, err
 	}
@@ -325,7 +321,7 @@ func (client *SecurityPartnerProvidersClient) listByResourceGroupCreateRequest(c
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *SecurityPartnerProvidersClient) listByResourceGroupHandleResponse(resp *http.Response) (SecurityPartnerProvidersClientListByResourceGroupResponse, error) {
-	result := SecurityPartnerProvidersClientListByResourceGroupResponse{RawResponse: resp}
+	result := SecurityPartnerProvidersClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityPartnerProviderListResult); err != nil {
 		return SecurityPartnerProvidersClientListByResourceGroupResponse{}, err
 	}
@@ -382,7 +378,7 @@ func (client *SecurityPartnerProvidersClient) updateTagsCreateRequest(ctx contex
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *SecurityPartnerProvidersClient) updateTagsHandleResponse(resp *http.Response) (SecurityPartnerProvidersClientUpdateTagsResponse, error) {
-	result := SecurityPartnerProvidersClientUpdateTagsResponse{RawResponse: resp}
+	result := SecurityPartnerProvidersClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityPartnerProvider); err != nil {
 		return SecurityPartnerProvidersClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
@@ -63,9 +63,7 @@ func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return SecurityRulesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := SecurityRulesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := SecurityRulesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityRulesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return SecurityRulesClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGrou
 	if err != nil {
 		return SecurityRulesClientDeletePollerResponse{}, err
 	}
-	result := SecurityRulesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := SecurityRulesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityRulesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return SecurityRulesClientDeletePollerResponse{}, err
@@ -248,7 +244,7 @@ func (client *SecurityRulesClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client *SecurityRulesClient) getHandleResponse(resp *http.Response) (SecurityRulesClientGetResponse, error) {
-	result := SecurityRulesClientGetResponse{RawResponse: resp}
+	result := SecurityRulesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityRule); err != nil {
 		return SecurityRulesClientGetResponse{}, err
 	}
@@ -300,7 +296,7 @@ func (client *SecurityRulesClient) listCreateRequest(ctx context.Context, resour
 
 // listHandleResponse handles the List response.
 func (client *SecurityRulesClient) listHandleResponse(resp *http.Response) (SecurityRulesClientListResponse, error) {
-	result := SecurityRulesClientListResponse{RawResponse: resp}
+	result := SecurityRulesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityRuleListResult); err != nil {
 		return SecurityRulesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks_client.go
@@ -104,7 +104,7 @@ func (client *ServiceAssociationLinksClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *ServiceAssociationLinksClient) listHandleResponse(resp *http.Response) (ServiceAssociationLinksClientListResponse, error) {
-	result := ServiceAssociationLinksClientListResponse{RawResponse: resp}
+	result := ServiceAssociationLinksClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceAssociationLinksListResult); err != nil {
 		return ServiceAssociationLinksClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
@@ -62,9 +62,7 @@ func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ServiceEndpointPoliciesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return ServiceEndpointPoliciesClientDeletePollerResponse{}, err
 	}
-	result := ServiceEndpointPoliciesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ServiceEndpointPoliciesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ServiceEndpointPoliciesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ServiceEndpointPoliciesClientDeletePollerResponse{}, err
@@ -237,7 +233,7 @@ func (client *ServiceEndpointPoliciesClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client *ServiceEndpointPoliciesClient) getHandleResponse(resp *http.Response) (ServiceEndpointPoliciesClientGetResponse, error) {
-	result := ServiceEndpointPoliciesClientGetResponse{RawResponse: resp}
+	result := ServiceEndpointPoliciesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicy); err != nil {
 		return ServiceEndpointPoliciesClientGetResponse{}, err
 	}
@@ -280,7 +276,7 @@ func (client *ServiceEndpointPoliciesClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *ServiceEndpointPoliciesClient) listHandleResponse(resp *http.Response) (ServiceEndpointPoliciesClientListResponse, error) {
-	result := ServiceEndpointPoliciesClientListResponse{RawResponse: resp}
+	result := ServiceEndpointPoliciesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicyListResult); err != nil {
 		return ServiceEndpointPoliciesClientListResponse{}, err
 	}
@@ -328,7 +324,7 @@ func (client *ServiceEndpointPoliciesClient) listByResourceGroupCreateRequest(ct
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ServiceEndpointPoliciesClient) listByResourceGroupHandleResponse(resp *http.Response) (ServiceEndpointPoliciesClientListByResourceGroupResponse, error) {
-	result := ServiceEndpointPoliciesClientListByResourceGroupResponse{RawResponse: resp}
+	result := ServiceEndpointPoliciesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicyListResult); err != nil {
 		return ServiceEndpointPoliciesClientListByResourceGroupResponse{}, err
 	}
@@ -385,7 +381,7 @@ func (client *ServiceEndpointPoliciesClient) updateTagsCreateRequest(ctx context
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *ServiceEndpointPoliciesClient) updateTagsHandleResponse(resp *http.Response) (ServiceEndpointPoliciesClientUpdateTagsResponse, error) {
-	result := ServiceEndpointPoliciesClientUpdateTagsResponse{RawResponse: resp}
+	result := ServiceEndpointPoliciesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicy); err != nil {
 		return ServiceEndpointPoliciesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
@@ -63,9 +63,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx co
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Co
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionsClientDeletePollerResponse{}, err
 	}
-	result := ServiceEndpointPolicyDefinitionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := ServiceEndpointPolicyDefinitionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ServiceEndpointPolicyDefinitionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) getCreateRequest(ctx conte
 
 // getHandleResponse handles the Get response.
 func (client *ServiceEndpointPolicyDefinitionsClient) getHandleResponse(resp *http.Response) (ServiceEndpointPolicyDefinitionsClientGetResponse, error) {
-	result := ServiceEndpointPolicyDefinitionsClientGetResponse{RawResponse: resp}
+	result := ServiceEndpointPolicyDefinitionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicyDefinition); err != nil {
 		return ServiceEndpointPolicyDefinitionsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) listByResourceGroupCreateR
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ServiceEndpointPolicyDefinitionsClient) listByResourceGroupHandleResponse(resp *http.Response) (ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse, error) {
-	result := ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{RawResponse: resp}
+	result := ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicyDefinitionListResult); err != nil {
 		return ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags_client.go
@@ -95,7 +95,7 @@ func (client *ServiceTagsClient) listCreateRequest(ctx context.Context, location
 
 // listHandleResponse handles the List response.
 func (client *ServiceTagsClient) listHandleResponse(resp *http.Response) (ServiceTagsClientListResponse, error) {
-	result := ServiceTagsClientListResponse{RawResponse: resp}
+	result := ServiceTagsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceTagsListResult); err != nil {
 		return ServiceTagsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
@@ -63,9 +63,7 @@ func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return SubnetsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := SubnetsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := SubnetsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SubnetsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return SubnetsClientCreateOrUpdatePollerResponse{}, err
@@ -134,9 +132,7 @@ func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return SubnetsClientDeletePollerResponse{}, err
 	}
-	result := SubnetsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := SubnetsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SubnetsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return SubnetsClientDeletePollerResponse{}, err
@@ -250,7 +246,7 @@ func (client *SubnetsClient) getCreateRequest(ctx context.Context, resourceGroup
 
 // getHandleResponse handles the Get response.
 func (client *SubnetsClient) getHandleResponse(resp *http.Response) (SubnetsClientGetResponse, error) {
-	result := SubnetsClientGetResponse{RawResponse: resp}
+	result := SubnetsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Subnet); err != nil {
 		return SubnetsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *SubnetsClient) listCreateRequest(ctx context.Context, resourceGrou
 
 // listHandleResponse handles the List response.
 func (client *SubnetsClient) listHandleResponse(resp *http.Response) (SubnetsClientListResponse, error) {
-	result := SubnetsClientListResponse{RawResponse: resp}
+	result := SubnetsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SubnetListResult); err != nil {
 		return SubnetsClientListResponse{}, err
 	}
@@ -322,9 +318,7 @@ func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, re
 	if err != nil {
 		return SubnetsClientPrepareNetworkPoliciesPollerResponse{}, err
 	}
-	result := SubnetsClientPrepareNetworkPoliciesPollerResponse{
-		RawResponse: resp,
-	}
+	result := SubnetsClientPrepareNetworkPoliciesPollerResponse{}
 	pt, err := armruntime.NewPoller("SubnetsClient.PrepareNetworkPolicies", "location", resp, client.pl)
 	if err != nil {
 		return SubnetsClientPrepareNetworkPoliciesPollerResponse{}, err
@@ -395,9 +389,7 @@ func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, 
 	if err != nil {
 		return SubnetsClientUnprepareNetworkPoliciesPollerResponse{}, err
 	}
-	result := SubnetsClientUnprepareNetworkPoliciesPollerResponse{
-		RawResponse: resp,
-	}
+	result := SubnetsClientUnprepareNetworkPoliciesPollerResponse{}
 	pt, err := armruntime.NewPoller("SubnetsClient.UnprepareNetworkPolicies", "location", resp, client.pl)
 	if err != nil {
 		return SubnetsClientUnprepareNetworkPoliciesPollerResponse{}, err

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages_client.go
@@ -90,7 +90,7 @@ func (client *UsagesClient) listCreateRequest(ctx context.Context, location stri
 
 // listHandleResponse handles the List response.
 func (client *UsagesClient) listHandleResponse(resp *http.Response) (UsagesClientListResponse, error) {
-	result := UsagesClientListResponse{RawResponse: resp}
+	result := UsagesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UsagesListResult); err != nil {
 		return UsagesClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualappliances_client.go
@@ -62,9 +62,7 @@ func (client *VirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return VirtualAppliancesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualAppliancesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualAppliancesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualAppliancesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualAppliancesClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *VirtualAppliancesClient) BeginDelete(ctx context.Context, resource
 	if err != nil {
 		return VirtualAppliancesClientDeletePollerResponse{}, err
 	}
-	result := VirtualAppliancesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualAppliancesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualAppliancesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualAppliancesClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *VirtualAppliancesClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client *VirtualAppliancesClient) getHandleResponse(resp *http.Response) (VirtualAppliancesClientGetResponse, error) {
-	result := VirtualAppliancesClientGetResponse{RawResponse: resp}
+	result := VirtualAppliancesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualAppliance); err != nil {
 		return VirtualAppliancesClientGetResponse{}, err
 	}
@@ -278,7 +274,7 @@ func (client *VirtualAppliancesClient) listCreateRequest(ctx context.Context, op
 
 // listHandleResponse handles the List response.
 func (client *VirtualAppliancesClient) listHandleResponse(resp *http.Response) (VirtualAppliancesClientListResponse, error) {
-	result := VirtualAppliancesClientListResponse{RawResponse: resp}
+	result := VirtualAppliancesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualApplianceListResult); err != nil {
 		return VirtualAppliancesClientListResponse{}, err
 	}
@@ -326,7 +322,7 @@ func (client *VirtualAppliancesClient) listByResourceGroupCreateRequest(ctx cont
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualAppliancesClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualAppliancesClientListByResourceGroupResponse, error) {
-	result := VirtualAppliancesClientListByResourceGroupResponse{RawResponse: resp}
+	result := VirtualAppliancesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualApplianceListResult); err != nil {
 		return VirtualAppliancesClientListByResourceGroupResponse{}, err
 	}
@@ -383,7 +379,7 @@ func (client *VirtualAppliancesClient) updateTagsCreateRequest(ctx context.Conte
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualAppliancesClient) updateTagsHandleResponse(resp *http.Response) (VirtualAppliancesClientUpdateTagsResponse, error) {
-	result := VirtualAppliancesClientUpdateTagsResponse{RawResponse: resp}
+	result := VirtualAppliancesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualAppliance); err != nil {
 		return VirtualAppliancesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
@@ -63,9 +63,7 @@ func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualHubRouteTableV2SClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return VirtualHubRouteTableV2SClientDeletePollerResponse{}, err
 	}
-	result := VirtualHubRouteTableV2SClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualHubRouteTableV2SClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualHubRouteTableV2SClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualHubRouteTableV2SClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *VirtualHubRouteTableV2SClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client *VirtualHubRouteTableV2SClient) getHandleResponse(resp *http.Response) (VirtualHubRouteTableV2SClientGetResponse, error) {
-	result := VirtualHubRouteTableV2SClientGetResponse{RawResponse: resp}
+	result := VirtualHubRouteTableV2SClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualHubRouteTableV2); err != nil {
 		return VirtualHubRouteTableV2SClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *VirtualHubRouteTableV2SClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *VirtualHubRouteTableV2SClient) listHandleResponse(resp *http.Response) (VirtualHubRouteTableV2SClientListResponse, error) {
-	result := VirtualHubRouteTableV2SClientListResponse{RawResponse: resp}
+	result := VirtualHubRouteTableV2SClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualHubRouteTableV2SResult); err != nil {
 		return VirtualHubRouteTableV2SClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
@@ -62,9 +62,7 @@ func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return VirtualHubsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualHubsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualHubsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualHubsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualHubsClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return VirtualHubsClientDeletePollerResponse{}, err
 	}
-	result := VirtualHubsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualHubsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualHubsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualHubsClientDeletePollerResponse{}, err
@@ -232,7 +228,7 @@ func (client *VirtualHubsClient) getCreateRequest(ctx context.Context, resourceG
 
 // getHandleResponse handles the Get response.
 func (client *VirtualHubsClient) getHandleResponse(resp *http.Response) (VirtualHubsClientGetResponse, error) {
-	result := VirtualHubsClientGetResponse{RawResponse: resp}
+	result := VirtualHubsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualHub); err != nil {
 		return VirtualHubsClientGetResponse{}, err
 	}
@@ -274,7 +270,7 @@ func (client *VirtualHubsClient) listCreateRequest(ctx context.Context, options 
 
 // listHandleResponse handles the List response.
 func (client *VirtualHubsClient) listHandleResponse(resp *http.Response) (VirtualHubsClientListResponse, error) {
-	result := VirtualHubsClientListResponse{RawResponse: resp}
+	result := VirtualHubsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualHubsResult); err != nil {
 		return VirtualHubsClientListResponse{}, err
 	}
@@ -322,7 +318,7 @@ func (client *VirtualHubsClient) listByResourceGroupCreateRequest(ctx context.Co
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualHubsClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualHubsClientListByResourceGroupResponse, error) {
-	result := VirtualHubsClientListByResourceGroupResponse{RawResponse: resp}
+	result := VirtualHubsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualHubsResult); err != nil {
 		return VirtualHubsClientListByResourceGroupResponse{}, err
 	}
@@ -378,7 +374,7 @@ func (client *VirtualHubsClient) updateTagsCreateRequest(ctx context.Context, re
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualHubsClient) updateTagsHandleResponse(resp *http.Response) (VirtualHubsClientUpdateTagsResponse, error) {
-	result := VirtualHubsClientUpdateTagsResponse{RawResponse: resp}
+	result := VirtualHubsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualHub); err != nil {
 		return VirtualHubsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
@@ -62,9 +62,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx co
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Co
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientDeletePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewayConnectionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientDeletePollerResponse{}, err
@@ -234,7 +230,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) getCreateRequest(ctx conte
 
 // getHandleResponse handles the Get response.
 func (client *VirtualNetworkGatewayConnectionsClient) getHandleResponse(resp *http.Response) (VirtualNetworkGatewayConnectionsClientGetResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientGetResponse{RawResponse: resp}
+	result := VirtualNetworkGatewayConnectionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGatewayConnection); err != nil {
 		return VirtualNetworkGatewayConnectionsClientGetResponse{}, err
 	}
@@ -291,7 +287,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) getSharedKeyCreateRequest(
 
 // getSharedKeyHandleResponse handles the GetSharedKey response.
 func (client *VirtualNetworkGatewayConnectionsClient) getSharedKeyHandleResponse(resp *http.Response) (VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse{RawResponse: resp}
+	result := VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ConnectionSharedKey); err != nil {
 		return VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse{}, err
 	}
@@ -339,7 +335,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) listCreateRequest(ctx cont
 
 // listHandleResponse handles the List response.
 func (client *VirtualNetworkGatewayConnectionsClient) listHandleResponse(resp *http.Response) (VirtualNetworkGatewayConnectionsClientListResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientListResponse{RawResponse: resp}
+	result := VirtualNetworkGatewayConnectionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGatewayConnectionListResult); err != nil {
 		return VirtualNetworkGatewayConnectionsClientListResponse{}, err
 	}
@@ -361,9 +357,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx co
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.ResetSharedKey", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse{}, err
@@ -434,9 +428,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx cont
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.SetSharedKey", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse{}, err
@@ -503,9 +495,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ct
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.StartPacketCapture", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse{}, err
@@ -574,9 +564,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.StopPacketCapture", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse{}, err
@@ -642,9 +630,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx contex
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.UpdateTags", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse{}, err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
@@ -62,9 +62,7 @@ func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Cont
 	if err != nil {
 		return VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, res
 	if err != nil {
 		return VirtualNetworkGatewaysClientDeletePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientDeletePollerResponse{}, err
@@ -198,9 +194,7 @@ func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGateway
 	if err != nil {
 		return VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse{}, err
@@ -268,9 +262,7 @@ func (client *VirtualNetworkGatewaysClient) BeginGenerateVPNProfile(ctx context.
 	if err != nil {
 		return VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GenerateVPNProfile", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse{}, err
@@ -338,9 +330,7 @@ func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx co
 	if err != nil {
 		return VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.Generatevpnclientpackage", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse{}, err
@@ -444,7 +434,7 @@ func (client *VirtualNetworkGatewaysClient) getCreateRequest(ctx context.Context
 
 // getHandleResponse handles the Get response.
 func (client *VirtualNetworkGatewaysClient) getHandleResponse(resp *http.Response) (VirtualNetworkGatewaysClientGetResponse, error) {
-	result := VirtualNetworkGatewaysClientGetResponse{RawResponse: resp}
+	result := VirtualNetworkGatewaysClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGateway); err != nil {
 		return VirtualNetworkGatewaysClientGetResponse{}, err
 	}
@@ -464,9 +454,7 @@ func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetAdvertisedRoutes", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse{}, err
@@ -533,9 +521,7 @@ func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Co
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetBgpPeerStatus", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse{}, err
@@ -604,9 +590,7 @@ func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Co
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetLearnedRoutes", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse{}, err
@@ -673,9 +657,7 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVPNProfilePackageURL(ctx con
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetVPNProfilePackageURL", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse{}, err
@@ -742,9 +724,7 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ct
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse{}, err
@@ -812,9 +792,7 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPSecParameters(ctx
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse{}, err
@@ -911,7 +889,7 @@ func (client *VirtualNetworkGatewaysClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client *VirtualNetworkGatewaysClient) listHandleResponse(resp *http.Response) (VirtualNetworkGatewaysClientListResponse, error) {
-	result := VirtualNetworkGatewaysClientListResponse{RawResponse: resp}
+	result := VirtualNetworkGatewaysClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGatewayListResult); err != nil {
 		return VirtualNetworkGatewaysClientListResponse{}, err
 	}
@@ -964,7 +942,7 @@ func (client *VirtualNetworkGatewaysClient) listConnectionsCreateRequest(ctx con
 
 // listConnectionsHandleResponse handles the ListConnections response.
 func (client *VirtualNetworkGatewaysClient) listConnectionsHandleResponse(resp *http.Response) (VirtualNetworkGatewaysClientListConnectionsResponse, error) {
-	result := VirtualNetworkGatewaysClientListConnectionsResponse{RawResponse: resp}
+	result := VirtualNetworkGatewaysClientListConnectionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGatewayListConnectionsResult); err != nil {
 		return VirtualNetworkGatewaysClientListConnectionsResponse{}, err
 	}
@@ -982,9 +960,7 @@ func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, reso
 	if err != nil {
 		return VirtualNetworkGatewaysClientResetPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientResetPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientResetPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.Reset", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientResetPollerResponse{}, err
@@ -1053,9 +1029,7 @@ func (client *VirtualNetworkGatewaysClient) BeginResetVPNClientSharedKey(ctx con
 	if err != nil {
 		return VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.ResetVPNClientSharedKey", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse{}, err
@@ -1123,9 +1097,7 @@ func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPSecParameters(ctx
 	if err != nil {
 		return VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse{}, err
@@ -1191,9 +1163,7 @@ func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.
 	if err != nil {
 		return VirtualNetworkGatewaysClientStartPacketCapturePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientStartPacketCapturePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientStartPacketCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.StartPacketCapture", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientStartPacketCapturePollerResponse{}, err
@@ -1262,9 +1232,7 @@ func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.C
 	if err != nil {
 		return VirtualNetworkGatewaysClientStopPacketCapturePollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientStopPacketCapturePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientStopPacketCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.StopPacketCapture", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientStopPacketCapturePollerResponse{}, err
@@ -1367,7 +1335,7 @@ func (client *VirtualNetworkGatewaysClient) supportedVPNDevicesCreateRequest(ctx
 
 // supportedVPNDevicesHandleResponse handles the SupportedVPNDevices response.
 func (client *VirtualNetworkGatewaysClient) supportedVPNDevicesHandleResponse(resp *http.Response) (VirtualNetworkGatewaysClientSupportedVPNDevicesResponse, error) {
-	result := VirtualNetworkGatewaysClientSupportedVPNDevicesResponse{RawResponse: resp}
+	result := VirtualNetworkGatewaysClientSupportedVPNDevicesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return VirtualNetworkGatewaysClientSupportedVPNDevicesResponse{}, err
 	}
@@ -1386,9 +1354,7 @@ func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context,
 	if err != nil {
 		return VirtualNetworkGatewaysClientUpdateTagsPollerResponse{}, err
 	}
-	result := VirtualNetworkGatewaysClientUpdateTagsPollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkGatewaysClientUpdateTagsPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.UpdateTags", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkGatewaysClientUpdateTagsPollerResponse{}, err
@@ -1493,7 +1459,7 @@ func (client *VirtualNetworkGatewaysClient) vpnDeviceConfigurationScriptCreateRe
 
 // vpnDeviceConfigurationScriptHandleResponse handles the VPNDeviceConfigurationScript response.
 func (client *VirtualNetworkGatewaysClient) vpnDeviceConfigurationScriptHandleResponse(resp *http.Response) (VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse, error) {
-	result := VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse{RawResponse: resp}
+	result := VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
@@ -63,9 +63,7 @@ func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Cont
 	if err != nil {
 		return VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkPeeringsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, res
 	if err != nil {
 		return VirtualNetworkPeeringsClientDeletePollerResponse{}, err
 	}
-	result := VirtualNetworkPeeringsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkPeeringsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkPeeringsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkPeeringsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *VirtualNetworkPeeringsClient) getCreateRequest(ctx context.Context
 
 // getHandleResponse handles the Get response.
 func (client *VirtualNetworkPeeringsClient) getHandleResponse(resp *http.Response) (VirtualNetworkPeeringsClientGetResponse, error) {
-	result := VirtualNetworkPeeringsClientGetResponse{RawResponse: resp}
+	result := VirtualNetworkPeeringsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkPeering); err != nil {
 		return VirtualNetworkPeeringsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *VirtualNetworkPeeringsClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client *VirtualNetworkPeeringsClient) listHandleResponse(resp *http.Response) (VirtualNetworkPeeringsClientListResponse, error) {
-	result := VirtualNetworkPeeringsClientListResponse{RawResponse: resp}
+	result := VirtualNetworkPeeringsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkPeeringListResult); err != nil {
 		return VirtualNetworkPeeringsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
@@ -101,7 +101,7 @@ func (client *VirtualNetworksClient) checkIPAddressAvailabilityCreateRequest(ctx
 
 // checkIPAddressAvailabilityHandleResponse handles the CheckIPAddressAvailability response.
 func (client *VirtualNetworksClient) checkIPAddressAvailabilityHandleResponse(resp *http.Response) (VirtualNetworksClientCheckIPAddressAvailabilityResponse, error) {
-	result := VirtualNetworksClientCheckIPAddressAvailabilityResponse{RawResponse: resp}
+	result := VirtualNetworksClientCheckIPAddressAvailabilityResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAddressAvailabilityResult); err != nil {
 		return VirtualNetworksClientCheckIPAddressAvailabilityResponse{}, err
 	}
@@ -120,9 +120,7 @@ func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, re
 	if err != nil {
 		return VirtualNetworksClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualNetworksClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworksClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworksClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualNetworksClientCreateOrUpdatePollerResponse{}, err
@@ -187,9 +185,7 @@ func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGr
 	if err != nil {
 		return VirtualNetworksClientDeletePollerResponse{}, err
 	}
-	result := VirtualNetworksClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworksClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworksClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworksClientDeletePollerResponse{}, err
@@ -294,7 +290,7 @@ func (client *VirtualNetworksClient) getCreateRequest(ctx context.Context, resou
 
 // getHandleResponse handles the Get response.
 func (client *VirtualNetworksClient) getHandleResponse(resp *http.Response) (VirtualNetworksClientGetResponse, error) {
-	result := VirtualNetworksClientGetResponse{RawResponse: resp}
+	result := VirtualNetworksClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetwork); err != nil {
 		return VirtualNetworksClientGetResponse{}, err
 	}
@@ -341,7 +337,7 @@ func (client *VirtualNetworksClient) listCreateRequest(ctx context.Context, reso
 
 // listHandleResponse handles the List response.
 func (client *VirtualNetworksClient) listHandleResponse(resp *http.Response) (VirtualNetworksClientListResponse, error) {
-	result := VirtualNetworksClientListResponse{RawResponse: resp}
+	result := VirtualNetworksClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkListResult); err != nil {
 		return VirtualNetworksClientListResponse{}, err
 	}
@@ -383,7 +379,7 @@ func (client *VirtualNetworksClient) listAllCreateRequest(ctx context.Context, o
 
 // listAllHandleResponse handles the ListAll response.
 func (client *VirtualNetworksClient) listAllHandleResponse(resp *http.Response) (VirtualNetworksClientListAllResponse, error) {
-	result := VirtualNetworksClientListAllResponse{RawResponse: resp}
+	result := VirtualNetworksClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkListResult); err != nil {
 		return VirtualNetworksClientListAllResponse{}, err
 	}
@@ -436,7 +432,7 @@ func (client *VirtualNetworksClient) listUsageCreateRequest(ctx context.Context,
 
 // listUsageHandleResponse handles the ListUsage response.
 func (client *VirtualNetworksClient) listUsageHandleResponse(resp *http.Response) (VirtualNetworksClientListUsageResponse, error) {
-	result := VirtualNetworksClientListUsageResponse{RawResponse: resp}
+	result := VirtualNetworksClientListUsageResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkListUsageResult); err != nil {
 		return VirtualNetworksClientListUsageResponse{}, err
 	}
@@ -493,7 +489,7 @@ func (client *VirtualNetworksClient) updateTagsCreateRequest(ctx context.Context
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualNetworksClient) updateTagsHandleResponse(resp *http.Response) (VirtualNetworksClientUpdateTagsResponse, error) {
-	result := VirtualNetworksClientUpdateTagsResponse{RawResponse: resp}
+	result := VirtualNetworksClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetwork); err != nil {
 		return VirtualNetworksClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
@@ -62,9 +62,7 @@ func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return VirtualNetworkTapsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualNetworkTapsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkTapsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkTapsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkTapsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourc
 	if err != nil {
 		return VirtualNetworkTapsClientDeletePollerResponse{}, err
 	}
-	result := VirtualNetworkTapsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualNetworkTapsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkTapsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualNetworkTapsClientDeletePollerResponse{}, err
@@ -233,7 +229,7 @@ func (client *VirtualNetworkTapsClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client *VirtualNetworkTapsClient) getHandleResponse(resp *http.Response) (VirtualNetworkTapsClientGetResponse, error) {
-	result := VirtualNetworkTapsClientGetResponse{RawResponse: resp}
+	result := VirtualNetworkTapsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkTap); err != nil {
 		return VirtualNetworkTapsClientGetResponse{}, err
 	}
@@ -276,7 +272,7 @@ func (client *VirtualNetworkTapsClient) listAllCreateRequest(ctx context.Context
 
 // listAllHandleResponse handles the ListAll response.
 func (client *VirtualNetworkTapsClient) listAllHandleResponse(resp *http.Response) (VirtualNetworkTapsClientListAllResponse, error) {
-	result := VirtualNetworkTapsClientListAllResponse{RawResponse: resp}
+	result := VirtualNetworkTapsClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkTapListResult); err != nil {
 		return VirtualNetworkTapsClientListAllResponse{}, err
 	}
@@ -324,7 +320,7 @@ func (client *VirtualNetworkTapsClient) listByResourceGroupCreateRequest(ctx con
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualNetworkTapsClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualNetworkTapsClientListByResourceGroupResponse, error) {
-	result := VirtualNetworkTapsClientListByResourceGroupResponse{RawResponse: resp}
+	result := VirtualNetworkTapsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkTapListResult); err != nil {
 		return VirtualNetworkTapsClientListByResourceGroupResponse{}, err
 	}
@@ -381,7 +377,7 @@ func (client *VirtualNetworkTapsClient) updateTagsCreateRequest(ctx context.Cont
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualNetworkTapsClient) updateTagsHandleResponse(resp *http.Response) (VirtualNetworkTapsClientUpdateTagsResponse, error) {
-	result := VirtualNetworkTapsClientUpdateTagsResponse{RawResponse: resp}
+	result := VirtualNetworkTapsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkTap); err != nil {
 		return VirtualNetworkTapsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
@@ -63,9 +63,7 @@ func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Conte
 	if err != nil {
 		return VirtualRouterPeeringsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualRouterPeeringsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualRouterPeeringsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualRouterPeeringsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualRouterPeeringsClientCreateOrUpdatePollerResponse{}, err
@@ -135,9 +133,7 @@ func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, reso
 	if err != nil {
 		return VirtualRouterPeeringsClientDeletePollerResponse{}, err
 	}
-	result := VirtualRouterPeeringsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualRouterPeeringsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualRouterPeeringsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualRouterPeeringsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *VirtualRouterPeeringsClient) getCreateRequest(ctx context.Context,
 
 // getHandleResponse handles the Get response.
 func (client *VirtualRouterPeeringsClient) getHandleResponse(resp *http.Response) (VirtualRouterPeeringsClientGetResponse, error) {
-	result := VirtualRouterPeeringsClientGetResponse{RawResponse: resp}
+	result := VirtualRouterPeeringsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouterPeering); err != nil {
 		return VirtualRouterPeeringsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *VirtualRouterPeeringsClient) listCreateRequest(ctx context.Context
 
 // listHandleResponse handles the List response.
 func (client *VirtualRouterPeeringsClient) listHandleResponse(resp *http.Response) (VirtualRouterPeeringsClientListResponse, error) {
-	result := VirtualRouterPeeringsClientListResponse{RawResponse: resp}
+	result := VirtualRouterPeeringsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouterPeeringListResult); err != nil {
 		return VirtualRouterPeeringsClientListResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
@@ -62,9 +62,7 @@ func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return VirtualRoutersClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualRoutersClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualRoutersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualRoutersClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualRoutersClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return VirtualRoutersClientDeletePollerResponse{}, err
 	}
-	result := VirtualRoutersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualRoutersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualRoutersClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualRoutersClientDeletePollerResponse{}, err
@@ -236,7 +232,7 @@ func (client *VirtualRoutersClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client *VirtualRoutersClient) getHandleResponse(resp *http.Response) (VirtualRoutersClientGetResponse, error) {
-	result := VirtualRoutersClientGetResponse{RawResponse: resp}
+	result := VirtualRoutersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouter); err != nil {
 		return VirtualRoutersClientGetResponse{}, err
 	}
@@ -278,7 +274,7 @@ func (client *VirtualRoutersClient) listCreateRequest(ctx context.Context, optio
 
 // listHandleResponse handles the List response.
 func (client *VirtualRoutersClient) listHandleResponse(resp *http.Response) (VirtualRoutersClientListResponse, error) {
-	result := VirtualRoutersClientListResponse{RawResponse: resp}
+	result := VirtualRoutersClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouterListResult); err != nil {
 		return VirtualRoutersClientListResponse{}, err
 	}
@@ -326,7 +322,7 @@ func (client *VirtualRoutersClient) listByResourceGroupCreateRequest(ctx context
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualRoutersClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualRoutersClientListByResourceGroupResponse, error) {
-	result := VirtualRoutersClientListByResourceGroupResponse{RawResponse: resp}
+	result := VirtualRoutersClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouterListResult); err != nil {
 		return VirtualRoutersClientListByResourceGroupResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
@@ -62,9 +62,7 @@ func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return VirtualWansClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VirtualWansClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualWansClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualWansClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VirtualWansClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return VirtualWansClientDeletePollerResponse{}, err
 	}
-	result := VirtualWansClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VirtualWansClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualWansClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VirtualWansClientDeletePollerResponse{}, err
@@ -232,7 +228,7 @@ func (client *VirtualWansClient) getCreateRequest(ctx context.Context, resourceG
 
 // getHandleResponse handles the Get response.
 func (client *VirtualWansClient) getHandleResponse(resp *http.Response) (VirtualWansClientGetResponse, error) {
-	result := VirtualWansClientGetResponse{RawResponse: resp}
+	result := VirtualWansClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualWAN); err != nil {
 		return VirtualWansClientGetResponse{}, err
 	}
@@ -274,7 +270,7 @@ func (client *VirtualWansClient) listCreateRequest(ctx context.Context, options 
 
 // listHandleResponse handles the List response.
 func (client *VirtualWansClient) listHandleResponse(resp *http.Response) (VirtualWansClientListResponse, error) {
-	result := VirtualWansClientListResponse{RawResponse: resp}
+	result := VirtualWansClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualWANsResult); err != nil {
 		return VirtualWansClientListResponse{}, err
 	}
@@ -322,7 +318,7 @@ func (client *VirtualWansClient) listByResourceGroupCreateRequest(ctx context.Co
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualWansClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualWansClientListByResourceGroupResponse, error) {
-	result := VirtualWansClientListByResourceGroupResponse{RawResponse: resp}
+	result := VirtualWansClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualWANsResult); err != nil {
 		return VirtualWansClientListByResourceGroupResponse{}, err
 	}
@@ -378,7 +374,7 @@ func (client *VirtualWansClient) updateTagsCreateRequest(ctx context.Context, re
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualWansClient) updateTagsHandleResponse(resp *http.Response) (VirtualWansClientUpdateTagsResponse, error) {
-	result := VirtualWansClientUpdateTagsResponse{RawResponse: resp}
+	result := VirtualWansClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualWAN); err != nil {
 		return VirtualWansClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
@@ -64,9 +64,7 @@ func (client *VPNConnectionsClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return VPNConnectionsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VPNConnectionsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VPNConnectionsClientCreateOrUpdatePollerResponse{}, err
@@ -136,9 +134,7 @@ func (client *VPNConnectionsClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return VPNConnectionsClientDeletePollerResponse{}, err
 	}
-	result := VPNConnectionsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNConnectionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNConnectionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VPNConnectionsClientDeletePollerResponse{}, err
@@ -249,7 +245,7 @@ func (client *VPNConnectionsClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client *VPNConnectionsClient) getHandleResponse(resp *http.Response) (VPNConnectionsClientGetResponse, error) {
-	result := VPNConnectionsClientGetResponse{RawResponse: resp}
+	result := VPNConnectionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNConnection); err != nil {
 		return VPNConnectionsClientGetResponse{}, err
 	}
@@ -302,7 +298,7 @@ func (client *VPNConnectionsClient) listByVPNGatewayCreateRequest(ctx context.Co
 
 // listByVPNGatewayHandleResponse handles the ListByVPNGateway response.
 func (client *VPNConnectionsClient) listByVPNGatewayHandleResponse(resp *http.Response) (VPNConnectionsClientListByVPNGatewayResponse, error) {
-	result := VPNConnectionsClientListByVPNGatewayResponse{RawResponse: resp}
+	result := VPNConnectionsClientListByVPNGatewayResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNConnectionsResult); err != nil {
 		return VPNConnectionsClientListByVPNGatewayResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
@@ -62,9 +62,7 @@ func (client *VPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return VPNGatewaysClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VPNGatewaysClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VPNGatewaysClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *VPNGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return VPNGatewaysClientDeletePollerResponse{}, err
 	}
-	result := VPNGatewaysClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VPNGatewaysClientDeletePollerResponse{}, err
@@ -232,7 +228,7 @@ func (client *VPNGatewaysClient) getCreateRequest(ctx context.Context, resourceG
 
 // getHandleResponse handles the Get response.
 func (client *VPNGatewaysClient) getHandleResponse(resp *http.Response) (VPNGatewaysClientGetResponse, error) {
-	result := VPNGatewaysClientGetResponse{RawResponse: resp}
+	result := VPNGatewaysClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNGateway); err != nil {
 		return VPNGatewaysClientGetResponse{}, err
 	}
@@ -274,7 +270,7 @@ func (client *VPNGatewaysClient) listCreateRequest(ctx context.Context, options 
 
 // listHandleResponse handles the List response.
 func (client *VPNGatewaysClient) listHandleResponse(resp *http.Response) (VPNGatewaysClientListResponse, error) {
-	result := VPNGatewaysClientListResponse{RawResponse: resp}
+	result := VPNGatewaysClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNGatewaysResult); err != nil {
 		return VPNGatewaysClientListResponse{}, err
 	}
@@ -322,7 +318,7 @@ func (client *VPNGatewaysClient) listByResourceGroupCreateRequest(ctx context.Co
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VPNGatewaysClient) listByResourceGroupHandleResponse(resp *http.Response) (VPNGatewaysClientListByResourceGroupResponse, error) {
-	result := VPNGatewaysClientListByResourceGroupResponse{RawResponse: resp}
+	result := VPNGatewaysClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNGatewaysResult); err != nil {
 		return VPNGatewaysClientListByResourceGroupResponse{}, err
 	}
@@ -339,9 +335,7 @@ func (client *VPNGatewaysClient) BeginReset(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return VPNGatewaysClientResetPollerResponse{}, err
 	}
-	result := VPNGatewaysClientResetPollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNGatewaysClientResetPollerResponse{}
 	pt, err := armruntime.NewPoller("VPNGatewaysClient.Reset", "location", resp, client.pl)
 	if err != nil {
 		return VPNGatewaysClientResetPollerResponse{}, err
@@ -444,7 +438,7 @@ func (client *VPNGatewaysClient) updateTagsCreateRequest(ctx context.Context, re
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *VPNGatewaysClient) updateTagsHandleResponse(resp *http.Response) (VPNGatewaysClientUpdateTagsResponse, error) {
-	result := VPNGatewaysClientUpdateTagsResponse{RawResponse: resp}
+	result := VPNGatewaysClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNGateway); err != nil {
 		return VPNGatewaysClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections_client.go
@@ -101,7 +101,7 @@ func (client *VPNLinkConnectionsClient) listByVPNConnectionCreateRequest(ctx con
 
 // listByVPNConnectionHandleResponse handles the ListByVPNConnection response.
 func (client *VPNLinkConnectionsClient) listByVPNConnectionHandleResponse(resp *http.Response) (VPNLinkConnectionsClientListByVPNConnectionResponse, error) {
-	result := VPNLinkConnectionsClientListByVPNConnectionResponse{RawResponse: resp}
+	result := VPNLinkConnectionsClientListByVPNConnectionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNSiteLinkConnectionsResult); err != nil {
 		return VPNLinkConnectionsClientListByVPNConnectionResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
@@ -62,9 +62,7 @@ func (client *VPNServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return VPNServerConfigurationsClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VPNServerConfigurationsClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNServerConfigurationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNServerConfigurationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VPNServerConfigurationsClientCreateOrUpdatePollerResponse{}, err
@@ -129,9 +127,7 @@ func (client *VPNServerConfigurationsClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return VPNServerConfigurationsClientDeletePollerResponse{}, err
 	}
-	result := VPNServerConfigurationsClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNServerConfigurationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNServerConfigurationsClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VPNServerConfigurationsClientDeletePollerResponse{}, err
@@ -234,7 +230,7 @@ func (client *VPNServerConfigurationsClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client *VPNServerConfigurationsClient) getHandleResponse(resp *http.Response) (VPNServerConfigurationsClientGetResponse, error) {
-	result := VPNServerConfigurationsClientGetResponse{RawResponse: resp}
+	result := VPNServerConfigurationsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNServerConfiguration); err != nil {
 		return VPNServerConfigurationsClientGetResponse{}, err
 	}
@@ -277,7 +273,7 @@ func (client *VPNServerConfigurationsClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client *VPNServerConfigurationsClient) listHandleResponse(resp *http.Response) (VPNServerConfigurationsClientListResponse, error) {
-	result := VPNServerConfigurationsClientListResponse{RawResponse: resp}
+	result := VPNServerConfigurationsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNServerConfigurationsResult); err != nil {
 		return VPNServerConfigurationsClientListResponse{}, err
 	}
@@ -325,7 +321,7 @@ func (client *VPNServerConfigurationsClient) listByResourceGroupCreateRequest(ct
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VPNServerConfigurationsClient) listByResourceGroupHandleResponse(resp *http.Response) (VPNServerConfigurationsClientListByResourceGroupResponse, error) {
-	result := VPNServerConfigurationsClientListByResourceGroupResponse{RawResponse: resp}
+	result := VPNServerConfigurationsClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNServerConfigurationsResult); err != nil {
 		return VPNServerConfigurationsClientListByResourceGroupResponse{}, err
 	}
@@ -382,7 +378,7 @@ func (client *VPNServerConfigurationsClient) updateTagsCreateRequest(ctx context
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *VPNServerConfigurationsClient) updateTagsHandleResponse(resp *http.Response) (VPNServerConfigurationsClientUpdateTagsResponse, error) {
-	result := VPNServerConfigurationsClientUpdateTagsResponse{RawResponse: resp}
+	result := VPNServerConfigurationsClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNServerConfiguration); err != nil {
 		return VPNServerConfigurationsClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -61,9 +61,7 @@ func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) BeginList(c
 	if err != nil {
 		return VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse{}, err
 	}
-	result := VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse{}
 	pt, err := armruntime.NewPoller("VPNServerConfigurationsAssociatedWithVirtualWanClient.List", "location", resp, client.pl)
 	if err != nil {
 		return VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse{}, err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections_client.go
@@ -109,7 +109,7 @@ func (client *VPNSiteLinkConnectionsClient) getCreateRequest(ctx context.Context
 
 // getHandleResponse handles the Get response.
 func (client *VPNSiteLinkConnectionsClient) getHandleResponse(resp *http.Response) (VPNSiteLinkConnectionsClientGetResponse, error) {
-	result := VPNSiteLinkConnectionsClientGetResponse{RawResponse: resp}
+	result := VPNSiteLinkConnectionsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNSiteLinkConnection); err != nil {
 		return VPNSiteLinkConnectionsClientGetResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks_client.go
@@ -103,7 +103,7 @@ func (client *VPNSiteLinksClient) getCreateRequest(ctx context.Context, resource
 
 // getHandleResponse handles the Get response.
 func (client *VPNSiteLinksClient) getHandleResponse(resp *http.Response) (VPNSiteLinksClientGetResponse, error) {
-	result := VPNSiteLinksClientGetResponse{RawResponse: resp}
+	result := VPNSiteLinksClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNSiteLink); err != nil {
 		return VPNSiteLinksClientGetResponse{}, err
 	}
@@ -156,7 +156,7 @@ func (client *VPNSiteLinksClient) listByVPNSiteCreateRequest(ctx context.Context
 
 // listByVPNSiteHandleResponse handles the ListByVPNSite response.
 func (client *VPNSiteLinksClient) listByVPNSiteHandleResponse(resp *http.Response) (VPNSiteLinksClientListByVPNSiteResponse, error) {
-	result := VPNSiteLinksClientListByVPNSiteResponse{RawResponse: resp}
+	result := VPNSiteLinksClientListByVPNSiteResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNSiteLinksResult); err != nil {
 		return VPNSiteLinksClientListByVPNSiteResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
@@ -62,9 +62,7 @@ func (client *VPNSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return VPNSitesClientCreateOrUpdatePollerResponse{}, err
 	}
-	result := VPNSitesClientCreateOrUpdatePollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNSitesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNSitesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
 		return VPNSitesClientCreateOrUpdatePollerResponse{}, err
@@ -128,9 +126,7 @@ func (client *VPNSitesClient) BeginDelete(ctx context.Context, resourceGroupName
 	if err != nil {
 		return VPNSitesClientDeletePollerResponse{}, err
 	}
-	result := VPNSitesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNSitesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNSitesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return VPNSitesClientDeletePollerResponse{}, err
@@ -232,7 +228,7 @@ func (client *VPNSitesClient) getCreateRequest(ctx context.Context, resourceGrou
 
 // getHandleResponse handles the Get response.
 func (client *VPNSitesClient) getHandleResponse(resp *http.Response) (VPNSitesClientGetResponse, error) {
-	result := VPNSitesClientGetResponse{RawResponse: resp}
+	result := VPNSitesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNSite); err != nil {
 		return VPNSitesClientGetResponse{}, err
 	}
@@ -274,7 +270,7 @@ func (client *VPNSitesClient) listCreateRequest(ctx context.Context, options *VP
 
 // listHandleResponse handles the List response.
 func (client *VPNSitesClient) listHandleResponse(resp *http.Response) (VPNSitesClientListResponse, error) {
-	result := VPNSitesClientListResponse{RawResponse: resp}
+	result := VPNSitesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNSitesResult); err != nil {
 		return VPNSitesClientListResponse{}, err
 	}
@@ -322,7 +318,7 @@ func (client *VPNSitesClient) listByResourceGroupCreateRequest(ctx context.Conte
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VPNSitesClient) listByResourceGroupHandleResponse(resp *http.Response) (VPNSitesClientListByResourceGroupResponse, error) {
-	result := VPNSitesClientListByResourceGroupResponse{RawResponse: resp}
+	result := VPNSitesClientListByResourceGroupResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNSitesResult); err != nil {
 		return VPNSitesClientListByResourceGroupResponse{}, err
 	}
@@ -378,7 +374,7 @@ func (client *VPNSitesClient) updateTagsCreateRequest(ctx context.Context, resou
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *VPNSitesClient) updateTagsHandleResponse(resp *http.Response) (VPNSitesClientUpdateTagsResponse, error) {
-	result := VPNSitesClientUpdateTagsResponse{RawResponse: resp}
+	result := VPNSitesClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNSite); err != nil {
 		return VPNSitesClientUpdateTagsResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration_client.go
@@ -62,9 +62,7 @@ func (client *VPNSitesConfigurationClient) BeginDownload(ctx context.Context, re
 	if err != nil {
 		return VPNSitesConfigurationClientDownloadPollerResponse{}, err
 	}
-	result := VPNSitesConfigurationClientDownloadPollerResponse{
-		RawResponse: resp,
-	}
+	result := VPNSitesConfigurationClientDownloadPollerResponse{}
 	pt, err := armruntime.NewPoller("VPNSitesConfigurationClient.Download", "location", resp, client.pl)
 	if err != nil {
 		return VPNSitesConfigurationClientDownloadPollerResponse{}, err

--- a/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
@@ -63,9 +63,7 @@ func (client *WatchersClient) BeginCheckConnectivity(ctx context.Context, resour
 	if err != nil {
 		return WatchersClientCheckConnectivityPollerResponse{}, err
 	}
-	result := WatchersClientCheckConnectivityPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientCheckConnectivityPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.CheckConnectivity", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientCheckConnectivityPollerResponse{}, err
@@ -169,7 +167,7 @@ func (client *WatchersClient) createOrUpdateCreateRequest(ctx context.Context, r
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *WatchersClient) createOrUpdateHandleResponse(resp *http.Response) (WatchersClientCreateOrUpdateResponse, error) {
-	result := WatchersClientCreateOrUpdateResponse{RawResponse: resp}
+	result := WatchersClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Watcher); err != nil {
 		return WatchersClientCreateOrUpdateResponse{}, err
 	}
@@ -186,9 +184,7 @@ func (client *WatchersClient) BeginDelete(ctx context.Context, resourceGroupName
 	if err != nil {
 		return WatchersClientDeletePollerResponse{}, err
 	}
-	result := WatchersClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientDeletePollerResponse{}, err
@@ -290,7 +286,7 @@ func (client *WatchersClient) getCreateRequest(ctx context.Context, resourceGrou
 
 // getHandleResponse handles the Get response.
 func (client *WatchersClient) getHandleResponse(resp *http.Response) (WatchersClientGetResponse, error) {
-	result := WatchersClientGetResponse{RawResponse: resp}
+	result := WatchersClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Watcher); err != nil {
 		return WatchersClientGetResponse{}, err
 	}
@@ -310,9 +306,7 @@ func (client *WatchersClient) BeginGetAzureReachabilityReport(ctx context.Contex
 	if err != nil {
 		return WatchersClientGetAzureReachabilityReportPollerResponse{}, err
 	}
-	result := WatchersClientGetAzureReachabilityReportPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientGetAzureReachabilityReportPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetAzureReachabilityReport", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientGetAzureReachabilityReportPollerResponse{}, err
@@ -379,9 +373,7 @@ func (client *WatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourc
 	if err != nil {
 		return WatchersClientGetFlowLogStatusPollerResponse{}, err
 	}
-	result := WatchersClientGetFlowLogStatusPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientGetFlowLogStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetFlowLogStatus", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientGetFlowLogStatusPollerResponse{}, err
@@ -451,9 +443,7 @@ func (client *WatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context
 	if err != nil {
 		return WatchersClientGetNetworkConfigurationDiagnosticPollerResponse{}, err
 	}
-	result := WatchersClientGetNetworkConfigurationDiagnosticPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientGetNetworkConfigurationDiagnosticPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetNetworkConfigurationDiagnostic", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientGetNetworkConfigurationDiagnosticPollerResponse{}, err
@@ -523,9 +513,7 @@ func (client *WatchersClient) BeginGetNextHop(ctx context.Context, resourceGroup
 	if err != nil {
 		return WatchersClientGetNextHopPollerResponse{}, err
 	}
-	result := WatchersClientGetNextHopPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientGetNextHopPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetNextHop", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientGetNextHopPollerResponse{}, err
@@ -628,7 +616,7 @@ func (client *WatchersClient) getTopologyCreateRequest(ctx context.Context, reso
 
 // getTopologyHandleResponse handles the GetTopology response.
 func (client *WatchersClient) getTopologyHandleResponse(resp *http.Response) (WatchersClientGetTopologyResponse, error) {
-	result := WatchersClientGetTopologyResponse{RawResponse: resp}
+	result := WatchersClientGetTopologyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Topology); err != nil {
 		return WatchersClientGetTopologyResponse{}, err
 	}
@@ -647,9 +635,7 @@ func (client *WatchersClient) BeginGetTroubleshooting(ctx context.Context, resou
 	if err != nil {
 		return WatchersClientGetTroubleshootingPollerResponse{}, err
 	}
-	result := WatchersClientGetTroubleshootingPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientGetTroubleshootingPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetTroubleshooting", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientGetTroubleshootingPollerResponse{}, err
@@ -715,9 +701,7 @@ func (client *WatchersClient) BeginGetTroubleshootingResult(ctx context.Context,
 	if err != nil {
 		return WatchersClientGetTroubleshootingResultPollerResponse{}, err
 	}
-	result := WatchersClientGetTroubleshootingResultPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientGetTroubleshootingResultPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetTroubleshootingResult", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientGetTroubleshootingResultPollerResponse{}, err
@@ -783,9 +767,7 @@ func (client *WatchersClient) BeginGetVMSecurityRules(ctx context.Context, resou
 	if err != nil {
 		return WatchersClientGetVMSecurityRulesPollerResponse{}, err
 	}
-	result := WatchersClientGetVMSecurityRulesPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientGetVMSecurityRulesPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetVMSecurityRules", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientGetVMSecurityRulesPollerResponse{}, err
@@ -876,7 +858,7 @@ func (client *WatchersClient) listCreateRequest(ctx context.Context, resourceGro
 
 // listHandleResponse handles the List response.
 func (client *WatchersClient) listHandleResponse(resp *http.Response) (WatchersClientListResponse, error) {
-	result := WatchersClientListResponse{RawResponse: resp}
+	result := WatchersClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WatcherListResult); err != nil {
 		return WatchersClientListResponse{}, err
 	}
@@ -915,7 +897,7 @@ func (client *WatchersClient) listAllCreateRequest(ctx context.Context, options 
 
 // listAllHandleResponse handles the ListAll response.
 func (client *WatchersClient) listAllHandleResponse(resp *http.Response) (WatchersClientListAllResponse, error) {
-	result := WatchersClientListAllResponse{RawResponse: resp}
+	result := WatchersClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WatcherListResult); err != nil {
 		return WatchersClientListAllResponse{}, err
 	}
@@ -935,9 +917,7 @@ func (client *WatchersClient) BeginListAvailableProviders(ctx context.Context, r
 	if err != nil {
 		return WatchersClientListAvailableProvidersPollerResponse{}, err
 	}
-	result := WatchersClientListAvailableProvidersPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientListAvailableProvidersPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.ListAvailableProviders", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientListAvailableProvidersPollerResponse{}, err
@@ -1004,9 +984,7 @@ func (client *WatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, 
 	if err != nil {
 		return WatchersClientSetFlowLogConfigurationPollerResponse{}, err
 	}
-	result := WatchersClientSetFlowLogConfigurationPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientSetFlowLogConfigurationPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.SetFlowLogConfiguration", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientSetFlowLogConfigurationPollerResponse{}, err
@@ -1109,7 +1087,7 @@ func (client *WatchersClient) updateTagsCreateRequest(ctx context.Context, resou
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client *WatchersClient) updateTagsHandleResponse(resp *http.Response) (WatchersClientUpdateTagsResponse, error) {
-	result := WatchersClientUpdateTagsResponse{RawResponse: resp}
+	result := WatchersClientUpdateTagsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Watcher); err != nil {
 		return WatchersClientUpdateTagsResponse{}, err
 	}
@@ -1128,9 +1106,7 @@ func (client *WatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGro
 	if err != nil {
 		return WatchersClientVerifyIPFlowPollerResponse{}, err
 	}
-	result := WatchersClientVerifyIPFlowPollerResponse{
-		RawResponse: resp,
-	}
+	result := WatchersClientVerifyIPFlowPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.VerifyIPFlow", "location", resp, client.pl)
 	if err != nil {
 		return WatchersClientVerifyIPFlowPollerResponse{}, err

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
@@ -100,7 +100,7 @@ func (client *WebApplicationFirewallPoliciesClient) createOrUpdateCreateRequest(
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *WebApplicationFirewallPoliciesClient) createOrUpdateHandleResponse(resp *http.Response) (WebApplicationFirewallPoliciesClientCreateOrUpdateResponse, error) {
-	result := WebApplicationFirewallPoliciesClientCreateOrUpdateResponse{RawResponse: resp}
+	result := WebApplicationFirewallPoliciesClientCreateOrUpdateResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WebApplicationFirewallPolicy); err != nil {
 		return WebApplicationFirewallPoliciesClientCreateOrUpdateResponse{}, err
 	}
@@ -118,9 +118,7 @@ func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Cont
 	if err != nil {
 		return WebApplicationFirewallPoliciesClientDeletePollerResponse{}, err
 	}
-	result := WebApplicationFirewallPoliciesClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := WebApplicationFirewallPoliciesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("WebApplicationFirewallPoliciesClient.Delete", "location", resp, client.pl)
 	if err != nil {
 		return WebApplicationFirewallPoliciesClientDeletePollerResponse{}, err
@@ -223,7 +221,7 @@ func (client *WebApplicationFirewallPoliciesClient) getCreateRequest(ctx context
 
 // getHandleResponse handles the Get response.
 func (client *WebApplicationFirewallPoliciesClient) getHandleResponse(resp *http.Response) (WebApplicationFirewallPoliciesClientGetResponse, error) {
-	result := WebApplicationFirewallPoliciesClientGetResponse{RawResponse: resp}
+	result := WebApplicationFirewallPoliciesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WebApplicationFirewallPolicy); err != nil {
 		return WebApplicationFirewallPoliciesClientGetResponse{}, err
 	}
@@ -271,7 +269,7 @@ func (client *WebApplicationFirewallPoliciesClient) listCreateRequest(ctx contex
 
 // listHandleResponse handles the List response.
 func (client *WebApplicationFirewallPoliciesClient) listHandleResponse(resp *http.Response) (WebApplicationFirewallPoliciesClientListResponse, error) {
-	result := WebApplicationFirewallPoliciesClientListResponse{RawResponse: resp}
+	result := WebApplicationFirewallPoliciesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WebApplicationFirewallPolicyListResult); err != nil {
 		return WebApplicationFirewallPoliciesClientListResponse{}, err
 	}
@@ -314,7 +312,7 @@ func (client *WebApplicationFirewallPoliciesClient) listAllCreateRequest(ctx con
 
 // listAllHandleResponse handles the ListAll response.
 func (client *WebApplicationFirewallPoliciesClient) listAllHandleResponse(resp *http.Response) (WebApplicationFirewallPoliciesClientListAllResponse, error) {
-	result := WebApplicationFirewallPoliciesClientListAllResponse{RawResponse: resp}
+	result := WebApplicationFirewallPoliciesClientListAllResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WebApplicationFirewallPolicyListResult); err != nil {
 		return WebApplicationFirewallPoliciesClientListAllResponse{}, err
 	}

--- a/test/storage/2020-06-12/azblob/zz_generated_appendblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_appendblob_client.go
@@ -132,7 +132,7 @@ func (client *appendBlobClient) appendBlockCreateRequest(ctx context.Context, co
 
 // appendBlockHandleResponse handles the AppendBlock response.
 func (client *appendBlobClient) appendBlockHandleResponse(resp *http.Response) (appendBlobClientAppendBlockResponse, error) {
-	result := appendBlobClientAppendBlockResponse{RawResponse: resp}
+	result := appendBlobClientAppendBlockResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -315,7 +315,7 @@ func (client *appendBlobClient) appendBlockFromURLCreateRequest(ctx context.Cont
 
 // appendBlockFromURLHandleResponse handles the AppendBlockFromURL response.
 func (client *appendBlobClient) appendBlockFromURLHandleResponse(resp *http.Response) (appendBlobClientAppendBlockFromURLResponse, error) {
-	result := appendBlobClientAppendBlockFromURLResponse{RawResponse: resp}
+	result := appendBlobClientAppendBlockFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -493,7 +493,7 @@ func (client *appendBlobClient) createCreateRequest(ctx context.Context, content
 
 // createHandleResponse handles the Create response.
 func (client *appendBlobClient) createHandleResponse(resp *http.Response) (appendBlobClientCreateResponse, error) {
-	result := appendBlobClientCreateResponse{RawResponse: resp}
+	result := appendBlobClientCreateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -610,7 +610,7 @@ func (client *appendBlobClient) sealCreateRequest(ctx context.Context, comp Enum
 
 // sealHandleResponse handles the Seal response.
 func (client *appendBlobClient) sealHandleResponse(resp *http.Response) (appendBlobClientSealResponse, error) {
-	result := appendBlobClientSealResponse{RawResponse: resp}
+	result := appendBlobClientSealResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}

--- a/test/storage/2020-06-12/azblob/zz_generated_blockblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_blockblob_client.go
@@ -164,7 +164,7 @@ func (client *blockBlobClient) commitBlockListCreateRequest(ctx context.Context,
 
 // commitBlockListHandleResponse handles the CommitBlockList response.
 func (client *blockBlobClient) commitBlockListHandleResponse(resp *http.Response) (blockBlobClientCommitBlockListResponse, error) {
-	result := blockBlobClientCommitBlockListResponse{RawResponse: resp}
+	result := blockBlobClientCommitBlockListResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -278,7 +278,7 @@ func (client *blockBlobClient) getBlockListCreateRequest(ctx context.Context, co
 
 // getBlockListHandleResponse handles the GetBlockList response.
 func (client *blockBlobClient) getBlockListHandleResponse(resp *http.Response) (blockBlobClientGetBlockListResponse, error) {
-	result := blockBlobClientGetBlockListResponse{RawResponse: resp}
+	result := blockBlobClientGetBlockListResponse{}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -462,7 +462,7 @@ func (client *blockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, 
 
 // putBlobFromURLHandleResponse handles the PutBlobFromURL response.
 func (client *blockBlobClient) putBlobFromURLHandleResponse(resp *http.Response) (blockBlobClientPutBlobFromURLResponse, error) {
-	result := blockBlobClientPutBlobFromURLResponse{RawResponse: resp}
+	result := blockBlobClientPutBlobFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -587,7 +587,7 @@ func (client *blockBlobClient) stageBlockCreateRequest(ctx context.Context, comp
 
 // stageBlockHandleResponse handles the StageBlock response.
 func (client *blockBlobClient) stageBlockHandleResponse(resp *http.Response) (blockBlobClientStageBlockResponse, error) {
-	result := blockBlobClientStageBlockResponse{RawResponse: resp}
+	result := blockBlobClientStageBlockResponse{}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
@@ -725,7 +725,7 @@ func (client *blockBlobClient) stageBlockFromURLCreateRequest(ctx context.Contex
 
 // stageBlockFromURLHandleResponse handles the StageBlockFromURL response.
 func (client *blockBlobClient) stageBlockFromURLHandleResponse(resp *http.Response) (blockBlobClientStageBlockFromURLResponse, error) {
-	result := blockBlobClientStageBlockFromURLResponse{RawResponse: resp}
+	result := blockBlobClientStageBlockFromURLResponse{}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
@@ -895,7 +895,7 @@ func (client *blockBlobClient) uploadCreateRequest(ctx context.Context, contentL
 
 // uploadHandleResponse handles the Upload response.
 func (client *blockBlobClient) uploadHandleResponse(resp *http.Response) (blockBlobClientUploadResponse, error) {
-	result := blockBlobClientUploadResponse{RawResponse: resp}
+	result := blockBlobClientUploadResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}

--- a/test/storage/2020-06-12/azblob/zz_generated_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_client.go
@@ -90,7 +90,7 @@ func (client *client) abortCopyFromURLCreateRequest(ctx context.Context, comp En
 
 // abortCopyFromURLHandleResponse handles the AbortCopyFromURL response.
 func (client *client) abortCopyFromURLHandleResponse(resp *http.Response) (clientAbortCopyFromURLResponse, error) {
-	result := clientAbortCopyFromURLResponse{RawResponse: resp}
+	result := clientAbortCopyFromURLResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -173,7 +173,7 @@ func (client *client) acquireLeaseCreateRequest(ctx context.Context, comp Enum16
 
 // acquireLeaseHandleResponse handles the AcquireLease response.
 func (client *client) acquireLeaseHandleResponse(resp *http.Response) (clientAcquireLeaseResponse, error) {
-	result := clientAcquireLeaseResponse{RawResponse: resp}
+	result := clientAcquireLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -266,7 +266,7 @@ func (client *client) breakLeaseCreateRequest(ctx context.Context, comp Enum16, 
 
 // breakLeaseHandleResponse handles the BreakLease response.
 func (client *client) breakLeaseHandleResponse(resp *http.Response) (clientBreakLeaseResponse, error) {
-	result := clientBreakLeaseResponse{RawResponse: resp}
+	result := clientBreakLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -367,7 +367,7 @@ func (client *client) changeLeaseCreateRequest(ctx context.Context, comp Enum16,
 
 // changeLeaseHandleResponse handles the ChangeLease response.
 func (client *client) changeLeaseHandleResponse(resp *http.Response) (clientChangeLeaseResponse, error) {
-	result := clientChangeLeaseResponse{RawResponse: resp}
+	result := clientChangeLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -502,7 +502,7 @@ func (client *client) copyFromURLCreateRequest(ctx context.Context, xmsRequiresS
 
 // copyFromURLHandleResponse handles the CopyFromURL response.
 func (client *client) copyFromURLHandleResponse(resp *http.Response) (clientCopyFromURLResponse, error) {
-	result := clientCopyFromURLResponse{RawResponse: resp}
+	result := clientCopyFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -635,7 +635,7 @@ func (client *client) createSnapshotCreateRequest(ctx context.Context, comp Enum
 
 // createSnapshotHandleResponse handles the CreateSnapshot response.
 func (client *client) createSnapshotHandleResponse(resp *http.Response) (clientCreateSnapshotResponse, error) {
-	result := clientCreateSnapshotResponse{RawResponse: resp}
+	result := clientCreateSnapshotResponse{}
 	if val := resp.Header.Get("x-ms-snapshot"); val != "" {
 		result.Snapshot = &val
 	}
@@ -759,7 +759,7 @@ func (client *client) deleteCreateRequest(ctx context.Context, clientDeleteOptio
 
 // deleteHandleResponse handles the Delete response.
 func (client *client) deleteHandleResponse(resp *http.Response) (clientDeleteResponse, error) {
-	result := clientDeleteResponse{RawResponse: resp}
+	result := clientDeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -820,7 +820,7 @@ func (client *client) deleteImmutabilityPolicyCreateRequest(ctx context.Context,
 
 // deleteImmutabilityPolicyHandleResponse handles the DeleteImmutabilityPolicy response.
 func (client *client) deleteImmutabilityPolicyHandleResponse(resp *http.Response) (clientDeleteImmutabilityPolicyResponse, error) {
-	result := clientDeleteImmutabilityPolicyResponse{RawResponse: resp}
+	result := clientDeleteImmutabilityPolicyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -926,7 +926,7 @@ func (client *client) downloadCreateRequest(ctx context.Context, clientDownloadO
 
 // downloadHandleResponse handles the Download response.
 func (client *client) downloadHandleResponse(resp *http.Response) (clientDownloadResponse, error) {
-	result := clientDownloadResponse{RawResponse: resp}
+	result := clientDownloadResponse{Body: resp.Body}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -1195,7 +1195,7 @@ func (client *client) getAccessControlCreateRequest(ctx context.Context, action 
 
 // getAccessControlHandleResponse handles the GetAccessControl response.
 func (client *client) getAccessControlHandleResponse(resp *http.Response) (clientGetAccessControlResponse, error) {
-	result := clientGetAccessControlResponse{RawResponse: resp}
+	result := clientGetAccessControlResponse{}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -1269,7 +1269,7 @@ func (client *client) getAccountInfoCreateRequest(ctx context.Context, restype E
 
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *client) getAccountInfoHandleResponse(resp *http.Response) (clientGetAccountInfoResponse, error) {
-	result := clientGetAccountInfoResponse{RawResponse: resp}
+	result := clientGetAccountInfoResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -1371,7 +1371,7 @@ func (client *client) getPropertiesCreateRequest(ctx context.Context, clientGetP
 
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client *client) getPropertiesHandleResponse(resp *http.Response) (clientGetPropertiesResponse, error) {
-	result := clientGetPropertiesResponse{RawResponse: resp}
+	result := clientGetPropertiesResponse{}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -1663,7 +1663,7 @@ func (client *client) getTagsCreateRequest(ctx context.Context, comp Enum42, cli
 
 // getTagsHandleResponse handles the GetTags response.
 func (client *client) getTagsHandleResponse(resp *http.Response) (clientGetTagsResponse, error) {
-	result := clientGetTagsResponse{RawResponse: resp}
+	result := clientGetTagsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -1763,7 +1763,7 @@ func (client *client) queryCreateRequest(ctx context.Context, comp Enum40, clien
 
 // queryHandleResponse handles the Query response.
 func (client *client) queryHandleResponse(resp *http.Response) (clientQueryResponse, error) {
-	result := clientQueryResponse{RawResponse: resp}
+	result := clientQueryResponse{Body: resp.Body}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -1971,7 +1971,7 @@ func (client *client) releaseLeaseCreateRequest(ctx context.Context, comp Enum16
 
 // releaseLeaseHandleResponse handles the ReleaseLease response.
 func (client *client) releaseLeaseHandleResponse(resp *http.Response) (clientReleaseLeaseResponse, error) {
-	result := clientReleaseLeaseResponse{RawResponse: resp}
+	result := clientReleaseLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -2110,7 +2110,7 @@ func (client *client) renameCreateRequest(ctx context.Context, renameSource stri
 
 // renameHandleResponse handles the Rename response.
 func (client *client) renameHandleResponse(resp *http.Response) (clientRenameResponse, error) {
-	result := clientRenameResponse{RawResponse: resp}
+	result := clientRenameResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -2206,7 +2206,7 @@ func (client *client) renewLeaseCreateRequest(ctx context.Context, comp Enum16, 
 
 // renewLeaseHandleResponse handles the RenewLease response.
 func (client *client) renewLeaseHandleResponse(resp *http.Response) (clientRenewLeaseResponse, error) {
-	result := clientRenewLeaseResponse{RawResponse: resp}
+	result := clientRenewLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -2309,7 +2309,7 @@ func (client *client) setAccessControlCreateRequest(ctx context.Context, action 
 
 // setAccessControlHandleResponse handles the SetAccessControl response.
 func (client *client) setAccessControlHandleResponse(resp *http.Response) (clientSetAccessControlResponse, error) {
-	result := clientSetAccessControlResponse{RawResponse: resp}
+	result := clientSetAccessControlResponse{}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -2381,7 +2381,7 @@ func (client *client) setExpiryCreateRequest(ctx context.Context, comp Enum24, e
 
 // setExpiryHandleResponse handles the SetExpiry response.
 func (client *client) setExpiryHandleResponse(resp *http.Response) (clientSetExpiryResponse, error) {
-	result := clientSetExpiryResponse{RawResponse: resp}
+	result := clientSetExpiryResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -2491,7 +2491,7 @@ func (client *client) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum
 
 // setHTTPHeadersHandleResponse handles the SetHTTPHeaders response.
 func (client *client) setHTTPHeadersHandleResponse(resp *http.Response) (clientSetHTTPHeadersResponse, error) {
-	result := clientSetHTTPHeadersResponse{RawResponse: resp}
+	result := clientSetHTTPHeadersResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -2579,7 +2579,7 @@ func (client *client) setImmutabilityPolicyCreateRequest(ctx context.Context, co
 
 // setImmutabilityPolicyHandleResponse handles the SetImmutabilityPolicy response.
 func (client *client) setImmutabilityPolicyHandleResponse(resp *http.Response) (clientSetImmutabilityPolicyResponse, error) {
-	result := clientSetImmutabilityPolicyResponse{RawResponse: resp}
+	result := clientSetImmutabilityPolicyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -2651,7 +2651,7 @@ func (client *client) setLegalHoldCreateRequest(ctx context.Context, comp Enum27
 
 // setLegalHoldHandleResponse handles the SetLegalHold response.
 func (client *client) setLegalHoldHandleResponse(resp *http.Response) (clientSetLegalHoldResponse, error) {
-	result := clientSetLegalHoldResponse{RawResponse: resp}
+	result := clientSetLegalHoldResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -2758,7 +2758,7 @@ func (client *client) setMetadataCreateRequest(ctx context.Context, comp Enum12,
 
 // setMetadataHandleResponse handles the SetMetadata response.
 func (client *client) setMetadataHandleResponse(resp *http.Response) (clientSetMetadataResponse, error) {
-	result := clientSetMetadataResponse{RawResponse: resp}
+	result := clientSetMetadataResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -2864,7 +2864,7 @@ func (client *client) setTagsCreateRequest(ctx context.Context, comp Enum42, cli
 
 // setTagsHandleResponse handles the SetTags response.
 func (client *client) setTagsHandleResponse(resp *http.Response) (clientSetTagsResponse, error) {
-	result := clientSetTagsResponse{RawResponse: resp}
+	result := clientSetTagsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -2946,7 +2946,7 @@ func (client *client) setTierCreateRequest(ctx context.Context, comp Enum32, tie
 
 // setTierHandleResponse handles the SetTier response.
 func (client *client) setTierHandleResponse(resp *http.Response) (clientSetTierResponse, error) {
-	result := clientSetTierResponse{RawResponse: resp}
+	result := clientSetTierResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -3066,7 +3066,7 @@ func (client *client) startCopyFromURLCreateRequest(ctx context.Context, copySou
 
 // startCopyFromURLHandleResponse handles the StartCopyFromURL response.
 func (client *client) startCopyFromURLHandleResponse(resp *http.Response) (clientStartCopyFromURLResponse, error) {
-	result := clientStartCopyFromURLResponse{RawResponse: resp}
+	result := clientStartCopyFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -3145,7 +3145,7 @@ func (client *client) undeleteCreateRequest(ctx context.Context, comp Enum14, op
 
 // undeleteHandleResponse handles the Undelete response.
 func (client *client) undeleteHandleResponse(resp *http.Response) (clientUndeleteResponse, error) {
-	result := clientUndeleteResponse{RawResponse: resp}
+	result := clientUndeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}

--- a/test/storage/2020-06-12/azblob/zz_generated_container_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_container_client.go
@@ -97,7 +97,7 @@ func (client *containerClient) acquireLeaseCreateRequest(ctx context.Context, co
 
 // acquireLeaseHandleResponse handles the AcquireLease response.
 func (client *containerClient) acquireLeaseHandleResponse(resp *http.Response) (containerClientAcquireLeaseResponse, error) {
-	result := containerClientAcquireLeaseResponse{RawResponse: resp}
+	result := containerClientAcquireLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -184,7 +184,7 @@ func (client *containerClient) breakLeaseCreateRequest(ctx context.Context, comp
 
 // breakLeaseHandleResponse handles the BreakLease response.
 func (client *containerClient) breakLeaseHandleResponse(resp *http.Response) (containerClientBreakLeaseResponse, error) {
-	result := containerClientBreakLeaseResponse{RawResponse: resp}
+	result := containerClientBreakLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -279,7 +279,7 @@ func (client *containerClient) changeLeaseCreateRequest(ctx context.Context, com
 
 // changeLeaseHandleResponse handles the ChangeLease response.
 func (client *containerClient) changeLeaseHandleResponse(resp *http.Response) (containerClientChangeLeaseResponse, error) {
-	result := containerClientChangeLeaseResponse{RawResponse: resp}
+	result := containerClientChangeLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -369,7 +369,7 @@ func (client *containerClient) createCreateRequest(ctx context.Context, restype 
 
 // createHandleResponse handles the Create response.
 func (client *containerClient) createHandleResponse(resp *http.Response) (containerClientCreateResponse, error) {
-	result := containerClientCreateResponse{RawResponse: resp}
+	result := containerClientCreateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -452,7 +452,7 @@ func (client *containerClient) deleteCreateRequest(ctx context.Context, restype 
 
 // deleteHandleResponse handles the Delete response.
 func (client *containerClient) deleteHandleResponse(resp *http.Response) (containerClientDeleteResponse, error) {
-	result := containerClientDeleteResponse{RawResponse: resp}
+	result := containerClientDeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -519,7 +519,7 @@ func (client *containerClient) getAccessPolicyCreateRequest(ctx context.Context,
 
 // getAccessPolicyHandleResponse handles the GetAccessPolicy response.
 func (client *containerClient) getAccessPolicyHandleResponse(resp *http.Response) (containerClientGetAccessPolicyResponse, error) {
-	result := containerClientGetAccessPolicyResponse{RawResponse: resp}
+	result := containerClientGetAccessPolicyResponse{}
 	if val := resp.Header.Get("x-ms-blob-public-access"); val != "" {
 		result.BlobPublicAccess = (*PublicAccessType)(&val)
 	}
@@ -591,7 +591,7 @@ func (client *containerClient) getAccountInfoCreateRequest(ctx context.Context, 
 
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *containerClient) getAccountInfoHandleResponse(resp *http.Response) (containerClientGetAccountInfoResponse, error) {
-	result := containerClientGetAccountInfoResponse{RawResponse: resp}
+	result := containerClientGetAccountInfoResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -663,7 +663,7 @@ func (client *containerClient) getPropertiesCreateRequest(ctx context.Context, r
 
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client *containerClient) getPropertiesHandleResponse(resp *http.Response) (containerClientGetPropertiesResponse, error) {
-	result := containerClientGetPropertiesResponse{RawResponse: resp}
+	result := containerClientGetPropertiesResponse{}
 	for hh := range resp.Header {
 		if len(hh) > len("x-ms-meta-") && strings.EqualFold(hh[:len("x-ms-meta-")], "x-ms-meta-") {
 			if result.Metadata == nil {
@@ -795,7 +795,7 @@ func (client *containerClient) listBlobFlatSegmentCreateRequest(ctx context.Cont
 
 // listBlobFlatSegmentHandleResponse handles the ListBlobFlatSegment response.
 func (client *containerClient) listBlobFlatSegmentHandleResponse(resp *http.Response) (containerClientListBlobFlatSegmentResponse, error) {
-	result := containerClientListBlobFlatSegmentResponse{RawResponse: resp}
+	result := containerClientListBlobFlatSegmentResponse{}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}
@@ -876,7 +876,7 @@ func (client *containerClient) listBlobHierarchySegmentCreateRequest(ctx context
 
 // listBlobHierarchySegmentHandleResponse handles the ListBlobHierarchySegment response.
 func (client *containerClient) listBlobHierarchySegmentHandleResponse(resp *http.Response) (containerClientListBlobHierarchySegmentResponse, error) {
-	result := containerClientListBlobHierarchySegmentResponse{RawResponse: resp}
+	result := containerClientListBlobHierarchySegmentResponse{}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}
@@ -955,7 +955,7 @@ func (client *containerClient) releaseLeaseCreateRequest(ctx context.Context, co
 
 // releaseLeaseHandleResponse handles the ReleaseLease response.
 func (client *containerClient) releaseLeaseHandleResponse(resp *http.Response) (containerClientReleaseLeaseResponse, error) {
-	result := containerClientReleaseLeaseResponse{RawResponse: resp}
+	result := containerClientReleaseLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -1031,7 +1031,7 @@ func (client *containerClient) renameCreateRequest(ctx context.Context, restype 
 
 // renameHandleResponse handles the Rename response.
 func (client *containerClient) renameHandleResponse(resp *http.Response) (containerClientRenameResponse, error) {
-	result := containerClientRenameResponse{RawResponse: resp}
+	result := containerClientRenameResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -1104,7 +1104,7 @@ func (client *containerClient) renewLeaseCreateRequest(ctx context.Context, comp
 
 // renewLeaseHandleResponse handles the RenewLease response.
 func (client *containerClient) renewLeaseHandleResponse(resp *http.Response) (containerClientRenewLeaseResponse, error) {
-	result := containerClientRenewLeaseResponse{RawResponse: resp}
+	result := containerClientRenewLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -1184,7 +1184,7 @@ func (client *containerClient) restoreCreateRequest(ctx context.Context, restype
 
 // restoreHandleResponse handles the Restore response.
 func (client *containerClient) restoreHandleResponse(resp *http.Response) (containerClientRestoreResponse, error) {
-	result := containerClientRestoreResponse{RawResponse: resp}
+	result := containerClientRestoreResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -1268,7 +1268,7 @@ func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context,
 
 // setAccessPolicyHandleResponse handles the SetAccessPolicy response.
 func (client *containerClient) setAccessPolicyHandleResponse(resp *http.Response) (containerClientSetAccessPolicyResponse, error) {
-	result := containerClientSetAccessPolicyResponse{RawResponse: resp}
+	result := containerClientSetAccessPolicyResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -1353,7 +1353,7 @@ func (client *containerClient) setMetadataCreateRequest(ctx context.Context, res
 
 // setMetadataHandleResponse handles the SetMetadata response.
 func (client *containerClient) setMetadataHandleResponse(resp *http.Response) (containerClientSetMetadataResponse, error) {
-	result := containerClientSetMetadataResponse{RawResponse: resp}
+	result := containerClientSetMetadataResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -1431,7 +1431,7 @@ func (client *containerClient) submitBatchCreateRequest(ctx context.Context, res
 
 // submitBatchHandleResponse handles the SubmitBatch response.
 func (client *containerClient) submitBatchHandleResponse(resp *http.Response) (containerClientSubmitBatchResponse, error) {
-	result := containerClientSubmitBatchResponse{RawResponse: resp}
+	result := containerClientSubmitBatchResponse{Body: resp.Body}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}

--- a/test/storage/2020-06-12/azblob/zz_generated_directory_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_directory_client.go
@@ -126,7 +126,7 @@ func (client *directoryClient) createCreateRequest(ctx context.Context, resource
 
 // createHandleResponse handles the Create response.
 func (client *directoryClient) createHandleResponse(resp *http.Response) (directoryClientCreateResponse, error) {
-	result := directoryClientCreateResponse{RawResponse: resp}
+	result := directoryClientCreateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -226,7 +226,7 @@ func (client *directoryClient) deleteCreateRequest(ctx context.Context, recursiv
 
 // deleteHandleResponse handles the Delete response.
 func (client *directoryClient) deleteHandleResponse(resp *http.Response) (directoryClientDeleteResponse, error) {
-	result := directoryClientDeleteResponse{RawResponse: resp}
+	result := directoryClientDeleteResponse{}
 	if val := resp.Header.Get("x-ms-continuation"); val != "" {
 		result.Marker = &val
 	}
@@ -310,7 +310,7 @@ func (client *directoryClient) getAccessControlCreateRequest(ctx context.Context
 
 // getAccessControlHandleResponse handles the GetAccessControl response.
 func (client *directoryClient) getAccessControlHandleResponse(resp *http.Response) (directoryClientGetAccessControlResponse, error) {
-	result := directoryClientGetAccessControlResponse{RawResponse: resp}
+	result := directoryClientGetAccessControlResponse{}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -462,7 +462,7 @@ func (client *directoryClient) renameCreateRequest(ctx context.Context, renameSo
 
 // renameHandleResponse handles the Rename response.
 func (client *directoryClient) renameHandleResponse(resp *http.Response) (directoryClientRenameResponse, error) {
-	result := directoryClientRenameResponse{RawResponse: resp}
+	result := directoryClientRenameResponse{}
 	if val := resp.Header.Get("x-ms-continuation"); val != "" {
 		result.Marker = &val
 	}
@@ -572,7 +572,7 @@ func (client *directoryClient) setAccessControlCreateRequest(ctx context.Context
 
 // setAccessControlHandleResponse handles the SetAccessControl response.
 func (client *directoryClient) setAccessControlHandleResponse(resp *http.Response) (directoryClientSetAccessControlResponse, error) {
-	result := directoryClientSetAccessControlResponse{RawResponse: resp}
+	result := directoryClientSetAccessControlResponse{}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {

--- a/test/storage/2020-06-12/azblob/zz_generated_pageblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_pageblob_client.go
@@ -130,7 +130,7 @@ func (client *pageBlobClient) clearPagesCreateRequest(ctx context.Context, comp 
 
 // clearPagesHandleResponse handles the ClearPages response.
 func (client *pageBlobClient) clearPagesHandleResponse(resp *http.Response) (pageBlobClientClearPagesResponse, error) {
-	result := pageBlobClientClearPagesResponse{RawResponse: resp}
+	result := pageBlobClientClearPagesResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -246,7 +246,7 @@ func (client *pageBlobClient) copyIncrementalCreateRequest(ctx context.Context, 
 
 // copyIncrementalHandleResponse handles the CopyIncremental response.
 func (client *pageBlobClient) copyIncrementalHandleResponse(resp *http.Response) (pageBlobClientCopyIncrementalResponse, error) {
-	result := pageBlobClientCopyIncrementalResponse{RawResponse: resp}
+	result := pageBlobClientCopyIncrementalResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -404,7 +404,7 @@ func (client *pageBlobClient) createCreateRequest(ctx context.Context, contentLe
 
 // createHandleResponse handles the Create response.
 func (client *pageBlobClient) createHandleResponse(resp *http.Response) (pageBlobClientCreateResponse, error) {
-	result := pageBlobClientCreateResponse{RawResponse: resp}
+	result := pageBlobClientCreateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -525,7 +525,7 @@ func (client *pageBlobClient) getPageRangesCreateRequest(ctx context.Context, co
 
 // getPageRangesHandleResponse handles the GetPageRanges response.
 func (client *pageBlobClient) getPageRangesHandleResponse(resp *http.Response) (pageBlobClientGetPageRangesResponse, error) {
-	result := pageBlobClientGetPageRangesResponse{RawResponse: resp}
+	result := pageBlobClientGetPageRangesResponse{}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -639,7 +639,7 @@ func (client *pageBlobClient) getPageRangesDiffCreateRequest(ctx context.Context
 
 // getPageRangesDiffHandleResponse handles the GetPageRangesDiff response.
 func (client *pageBlobClient) getPageRangesDiffHandleResponse(resp *http.Response) (pageBlobClientGetPageRangesDiffResponse, error) {
-	result := pageBlobClientGetPageRangesDiffResponse{RawResponse: resp}
+	result := pageBlobClientGetPageRangesDiffResponse{}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -757,7 +757,7 @@ func (client *pageBlobClient) resizeCreateRequest(ctx context.Context, comp Enum
 
 // resizeHandleResponse handles the Resize response.
 func (client *pageBlobClient) resizeHandleResponse(resp *http.Response) (pageBlobClientResizeResponse, error) {
-	result := pageBlobClientResizeResponse{RawResponse: resp}
+	result := pageBlobClientResizeResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -861,7 +861,7 @@ func (client *pageBlobClient) updateSequenceNumberCreateRequest(ctx context.Cont
 
 // updateSequenceNumberHandleResponse handles the UpdateSequenceNumber response.
 func (client *pageBlobClient) updateSequenceNumberHandleResponse(resp *http.Response) (pageBlobClientUpdateSequenceNumberResponse, error) {
-	result := pageBlobClientUpdateSequenceNumberResponse{RawResponse: resp}
+	result := pageBlobClientUpdateSequenceNumberResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -997,7 +997,7 @@ func (client *pageBlobClient) uploadPagesCreateRequest(ctx context.Context, comp
 
 // uploadPagesHandleResponse handles the UploadPages response.
 func (client *pageBlobClient) uploadPagesHandleResponse(resp *http.Response) (pageBlobClientUploadPagesResponse, error) {
-	result := pageBlobClientUploadPagesResponse{RawResponse: resp}
+	result := pageBlobClientUploadPagesResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
@@ -1179,7 +1179,7 @@ func (client *pageBlobClient) uploadPagesFromURLCreateRequest(ctx context.Contex
 
 // uploadPagesFromURLHandleResponse handles the UploadPagesFromURL response.
 func (client *pageBlobClient) uploadPagesFromURLHandleResponse(resp *http.Response) (pageBlobClientUploadPagesFromURLResponse, error) {
-	result := pageBlobClientUploadPagesFromURLResponse{RawResponse: resp}
+	result := pageBlobClientUploadPagesFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}

--- a/test/storage/2020-06-12/azblob/zz_generated_response_types.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_response_types.go
@@ -9,7 +9,7 @@
 package azblob
 
 import (
-	"net/http"
+	"io"
 	"time"
 )
 
@@ -41,9 +41,6 @@ type appendBlobClientAppendBlockFromURLResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -87,9 +84,6 @@ type appendBlobClientAppendBlockResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -126,9 +120,6 @@ type appendBlobClientCreateResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -155,9 +146,6 @@ type appendBlobClientSealResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -191,9 +179,6 @@ type blockBlobClientCommitBlockListResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -229,9 +214,6 @@ type blockBlobClientGetBlockListResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time `xml:"LastModified"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -265,9 +247,6 @@ type blockBlobClientPutBlobFromURLResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -298,9 +277,6 @@ type blockBlobClientStageBlockFromURLResponse struct {
 	// IsServerEncrypted contains the information returned from the x-ms-request-server-encrypted header response.
 	IsServerEncrypted *bool
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -330,9 +306,6 @@ type blockBlobClientStageBlockResponse struct {
 
 	// IsServerEncrypted contains the information returned from the x-ms-request-server-encrypted header response.
 	IsServerEncrypted *bool
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -370,9 +343,6 @@ type blockBlobClientUploadResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -390,9 +360,6 @@ type clientAbortCopyFromURLResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -418,9 +385,6 @@ type clientAcquireLeaseResponse struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -445,9 +409,6 @@ type clientBreakLeaseResponse struct {
 	// LeaseTime contains the information returned from the x-ms-lease-time header response.
 	LeaseTime *int32
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -471,9 +432,6 @@ type clientChangeLeaseResponse struct {
 
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -505,9 +463,6 @@ type clientCopyFromURLResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -538,9 +493,6 @@ type clientCreateSnapshotResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -562,9 +514,6 @@ type clientDeleteImmutabilityPolicyResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -579,9 +528,6 @@ type clientDeleteResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -606,6 +552,9 @@ type clientDownloadResponse struct {
 
 	// BlobType contains the information returned from the x-ms-blob-type header response.
 	BlobType *BlobType
+
+	// Body contains the streaming response.
+	Body io.ReadCloser
 
 	// CacheControl contains the information returned from the Cache-Control header response.
 	CacheControl *string
@@ -709,9 +658,6 @@ type clientDownloadResponse struct {
 	// ObjectReplicationRules contains the information returned from the x-ms-or header response.
 	ObjectReplicationRules map[string]string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -735,9 +681,6 @@ type clientGetAccessControlResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -768,9 +711,6 @@ type clientGetAccountInfoResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -916,9 +856,6 @@ type clientGetPropertiesResponse struct {
 	// ObjectReplicationRules contains the information returned from the x-ms-or header response.
 	ObjectReplicationRules map[string]string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RehydratePriority contains the information returned from the x-ms-rehydrate-priority header response.
 	RehydratePriority *string
 
@@ -944,9 +881,6 @@ type clientGetTagsResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -970,6 +904,9 @@ type clientQueryResponse struct {
 
 	// BlobType contains the information returned from the x-ms-blob-type header response.
 	BlobType *BlobType
+
+	// Body contains the streaming response.
+	Body io.ReadCloser
 
 	// CacheControl contains the information returned from the Cache-Control header response.
 	CacheControl *string
@@ -1049,9 +986,6 @@ type clientQueryResponse struct {
 	// Metadata contains the information returned from the x-ms-meta header response.
 	Metadata map[string]string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1072,9 +1006,6 @@ type clientReleaseLeaseResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1100,9 +1031,6 @@ type clientRenameResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1127,9 +1055,6 @@ type clientRenewLeaseResponse struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1147,9 +1072,6 @@ type clientSetAccessControlResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1171,9 +1093,6 @@ type clientSetExpiryResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1199,9 +1118,6 @@ type clientSetHTTPHeadersResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1223,9 +1139,6 @@ type clientSetImmutabilityPolicyResponse struct {
 	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1243,9 +1156,6 @@ type clientSetLegalHoldResponse struct {
 
 	// LegalHold contains the information returned from the x-ms-legal-hold header response.
 	LegalHold *bool
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1277,9 +1187,6 @@ type clientSetMetadataResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1298,9 +1205,6 @@ type clientSetTagsResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1312,9 +1216,6 @@ type clientSetTagsResponse struct {
 type clientSetTierResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1343,9 +1244,6 @@ type clientStartCopyFromURLResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1363,9 +1261,6 @@ type clientUndeleteResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1391,9 +1286,6 @@ type containerClientAcquireLeaseResponse struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1417,9 +1309,6 @@ type containerClientBreakLeaseResponse struct {
 
 	// LeaseTime contains the information returned from the x-ms-lease-time header response.
 	LeaseTime *int32
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1445,9 +1334,6 @@ type containerClientChangeLeaseResponse struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1469,9 +1355,6 @@ type containerClientCreateResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1486,9 +1369,6 @@ type containerClientDeleteResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1514,9 +1394,6 @@ type containerClientGetAccessPolicyResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time `xml:"LastModified"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -1537,9 +1414,6 @@ type containerClientGetAccountInfoResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1595,9 +1469,6 @@ type containerClientGetPropertiesResponse struct {
 	// Metadata contains the information returned from the x-ms-meta header response.
 	Metadata map[string]string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1617,9 +1488,6 @@ type containerClientListBlobFlatSegmentResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -1638,9 +1506,6 @@ type containerClientListBlobHierarchySegmentResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -1663,9 +1528,6 @@ type containerClientReleaseLeaseResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1680,9 +1542,6 @@ type containerClientRenameResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1708,9 +1567,6 @@ type containerClientRenewLeaseResponse struct {
 	// LeaseID contains the information returned from the x-ms-lease-id header response.
 	LeaseID *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1725,9 +1581,6 @@ type containerClientRestoreResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1750,9 +1603,6 @@ type containerClientSetAccessPolicyResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1774,9 +1624,6 @@ type containerClientSetMetadataResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1786,11 +1633,11 @@ type containerClientSetMetadataResponse struct {
 
 // containerClientSubmitBatchResponse contains the response from method containerClient.SubmitBatch.
 type containerClientSubmitBatchResponse struct {
+	// Body contains the streaming response.
+	Body io.ReadCloser
+
 	// ContentType contains the information returned from the Content-Type header response.
 	ContentType *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1816,9 +1663,6 @@ type directoryClientCreateResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1837,9 +1681,6 @@ type directoryClientDeleteResponse struct {
 	// Marker contains the information returned from the x-ms-continuation header response.
 	Marker *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1857,9 +1698,6 @@ type directoryClientGetAccessControlResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1900,9 +1738,6 @@ type directoryClientRenameResponse struct {
 	// Marker contains the information returned from the x-ms-continuation header response.
 	Marker *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -1920,9 +1755,6 @@ type directoryClientSetAccessControlResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1950,9 +1782,6 @@ type pageBlobClientClearPagesResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -1983,9 +1812,6 @@ type pageBlobClientCopyIncrementalResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2020,9 +1846,6 @@ type pageBlobClientCreateResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2051,9 +1874,6 @@ type pageBlobClientGetPageRangesDiffResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time `xml:"LastModified"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -2079,9 +1899,6 @@ type pageBlobClientGetPageRangesResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time `xml:"LastModified"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -2106,9 +1923,6 @@ type pageBlobClientResizeResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2132,9 +1946,6 @@ type pageBlobClientUpdateSequenceNumberResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2168,9 +1979,6 @@ type pageBlobClientUploadPagesFromURLResponse struct {
 
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -2211,9 +2019,6 @@ type pageBlobClientUploadPagesResponse struct {
 	// LastModified contains the information returned from the Last-Modified header response.
 	LastModified *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2232,9 +2037,6 @@ type serviceClientFilterBlobsResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -2257,9 +2059,6 @@ type serviceClientGetAccountInfoResponse struct {
 	// IsHierarchicalNamespaceEnabled contains the information returned from the x-ms-is-hns-enabled header response.
 	IsHierarchicalNamespaceEnabled *bool
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2275,9 +2074,6 @@ type serviceClientGetPropertiesResponse struct {
 	StorageServiceProperties
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -2295,9 +2091,6 @@ type serviceClientGetStatisticsResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -2314,9 +2107,6 @@ type serviceClientGetUserDelegationKeyResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -2330,9 +2120,6 @@ type serviceClientListContainersSegmentResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -2345,9 +2132,6 @@ type serviceClientSetPropertiesResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -2357,11 +2141,11 @@ type serviceClientSetPropertiesResponse struct {
 
 // serviceClientSubmitBatchResponse contains the response from method serviceClient.SubmitBatch.
 type serviceClientSubmitBatchResponse struct {
+	// Body contains the streaming response.
+	Body io.ReadCloser
+
 	// ContentType contains the information returned from the Content-Type header response.
 	ContentType *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string

--- a/test/storage/2020-06-12/azblob/zz_generated_service_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_service_client.go
@@ -90,7 +90,7 @@ func (client *serviceClient) filterBlobsCreateRequest(ctx context.Context, comp 
 
 // filterBlobsHandleResponse handles the FilterBlobs response.
 func (client *serviceClient) filterBlobsHandleResponse(resp *http.Response) (serviceClientFilterBlobsResponse, error) {
-	result := serviceClientFilterBlobsResponse{RawResponse: resp}
+	result := serviceClientFilterBlobsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -148,7 +148,7 @@ func (client *serviceClient) getAccountInfoCreateRequest(ctx context.Context, re
 
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *serviceClient) getAccountInfoHandleResponse(resp *http.Response) (serviceClientGetAccountInfoResponse, error) {
-	result := serviceClientGetAccountInfoResponse{RawResponse: resp}
+	result := serviceClientGetAccountInfoResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -223,7 +223,7 @@ func (client *serviceClient) getPropertiesCreateRequest(ctx context.Context, res
 
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client *serviceClient) getPropertiesHandleResponse(resp *http.Response) (serviceClientGetPropertiesResponse, error) {
-	result := serviceClientGetPropertiesResponse{RawResponse: resp}
+	result := serviceClientGetPropertiesResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -281,7 +281,7 @@ func (client *serviceClient) getStatisticsCreateRequest(ctx context.Context, res
 
 // getStatisticsHandleResponse handles the GetStatistics response.
 func (client *serviceClient) getStatisticsHandleResponse(resp *http.Response) (serviceClientGetStatisticsResponse, error) {
-	result := serviceClientGetStatisticsResponse{RawResponse: resp}
+	result := serviceClientGetStatisticsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -347,7 +347,7 @@ func (client *serviceClient) getUserDelegationKeyCreateRequest(ctx context.Conte
 
 // getUserDelegationKeyHandleResponse handles the GetUserDelegationKey response.
 func (client *serviceClient) getUserDelegationKeyHandleResponse(resp *http.Response) (serviceClientGetUserDelegationKeyResponse, error) {
-	result := serviceClientGetUserDelegationKeyResponse{RawResponse: resp}
+	result := serviceClientGetUserDelegationKeyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -420,7 +420,7 @@ func (client *serviceClient) listContainersSegmentCreateRequest(ctx context.Cont
 
 // listContainersSegmentHandleResponse handles the ListContainersSegment response.
 func (client *serviceClient) listContainersSegmentHandleResponse(resp *http.Response) (serviceClientListContainersSegmentResponse, error) {
-	result := serviceClientListContainersSegmentResponse{RawResponse: resp}
+	result := serviceClientListContainersSegmentResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -479,7 +479,7 @@ func (client *serviceClient) setPropertiesCreateRequest(ctx context.Context, res
 
 // setPropertiesHandleResponse handles the SetProperties response.
 func (client *serviceClient) setPropertiesHandleResponse(resp *http.Response) (serviceClientSetPropertiesResponse, error) {
-	result := serviceClientSetPropertiesResponse{RawResponse: resp}
+	result := serviceClientSetPropertiesResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -539,7 +539,7 @@ func (client *serviceClient) submitBatchCreateRequest(ctx context.Context, comp 
 
 // submitBatchHandleResponse handles the SubmitBatch response.
 func (client *serviceClient) submitBatchHandleResponse(resp *http.Response) (serviceClientSubmitBatchResponse, error) {
-	result := serviceClientSubmitBatchResponse{RawResponse: resp}
+	result := serviceClientSubmitBatchResponse{Body: resp.Body}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools_client.go
@@ -73,7 +73,7 @@ func (client *bigDataPoolsClient) getCreateRequest(ctx context.Context, bigDataP
 
 // getHandleResponse handles the Get response.
 func (client *bigDataPoolsClient) getHandleResponse(resp *http.Response) (bigDataPoolsClientGetResponse, error) {
-	result := bigDataPoolsClientGetResponse{RawResponse: resp}
+	result := bigDataPoolsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BigDataPoolResourceInfo); err != nil {
 		return bigDataPoolsClientGetResponse{}, err
 	}
@@ -114,7 +114,7 @@ func (client *bigDataPoolsClient) listCreateRequest(ctx context.Context, options
 
 // listHandleResponse handles the List response.
 func (client *bigDataPoolsClient) listHandleResponse(resp *http.Response) (bigDataPoolsClientListResponse, error) {
-	result := bigDataPoolsClientListResponse{RawResponse: resp}
+	result := bigDataPoolsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BigDataPoolResourceInfoListResult); err != nil {
 		return bigDataPoolsClientListResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
@@ -45,9 +45,7 @@ func (client *dataFlowClient) BeginCreateOrUpdateDataFlow(ctx context.Context, d
 	if err != nil {
 		return dataFlowClientCreateOrUpdateDataFlowPollerResponse{}, err
 	}
-	result := dataFlowClientCreateOrUpdateDataFlowPollerResponse{
-		RawResponse: resp,
-	}
+	result := dataFlowClientCreateOrUpdateDataFlowPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowClient.CreateOrUpdateDataFlow", resp, client.pl)
 	if err != nil {
 		return dataFlowClientCreateOrUpdateDataFlowPollerResponse{}, err
@@ -106,9 +104,7 @@ func (client *dataFlowClient) BeginDeleteDataFlow(ctx context.Context, dataFlowN
 	if err != nil {
 		return dataFlowClientDeleteDataFlowPollerResponse{}, err
 	}
-	result := dataFlowClientDeleteDataFlowPollerResponse{
-		RawResponse: resp,
-	}
+	result := dataFlowClientDeleteDataFlowPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowClient.DeleteDataFlow", resp, client.pl)
 	if err != nil {
 		return dataFlowClientDeleteDataFlowPollerResponse{}, err
@@ -196,7 +192,7 @@ func (client *dataFlowClient) getDataFlowCreateRequest(ctx context.Context, data
 
 // getDataFlowHandleResponse handles the GetDataFlow response.
 func (client *dataFlowClient) getDataFlowHandleResponse(resp *http.Response) (dataFlowClientGetDataFlowResponse, error) {
-	result := dataFlowClientGetDataFlowResponse{RawResponse: resp}
+	result := dataFlowClientGetDataFlowResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataFlowResource); err != nil {
 		return dataFlowClientGetDataFlowResponse{}, err
 	}
@@ -235,7 +231,7 @@ func (client *dataFlowClient) getDataFlowsByWorkspaceCreateRequest(ctx context.C
 
 // getDataFlowsByWorkspaceHandleResponse handles the GetDataFlowsByWorkspace response.
 func (client *dataFlowClient) getDataFlowsByWorkspaceHandleResponse(resp *http.Response) (dataFlowClientGetDataFlowsByWorkspaceResponse, error) {
-	result := dataFlowClientGetDataFlowsByWorkspaceResponse{RawResponse: resp}
+	result := dataFlowClientGetDataFlowsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataFlowListResponse); err != nil {
 		return dataFlowClientGetDataFlowsByWorkspaceResponse{}, err
 	}
@@ -253,9 +249,7 @@ func (client *dataFlowClient) BeginRenameDataFlow(ctx context.Context, dataFlowN
 	if err != nil {
 		return dataFlowClientRenameDataFlowPollerResponse{}, err
 	}
-	result := dataFlowClientRenameDataFlowPollerResponse{
-		RawResponse: resp,
-	}
+	result := dataFlowClientRenameDataFlowPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowClient.RenameDataFlow", resp, client.pl)
 	if err != nil {
 		return dataFlowClientRenameDataFlowPollerResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
@@ -67,7 +67,7 @@ func (client *dataFlowDebugSessionClient) addDataFlowCreateRequest(ctx context.C
 
 // addDataFlowHandleResponse handles the AddDataFlow response.
 func (client *dataFlowDebugSessionClient) addDataFlowHandleResponse(resp *http.Response) (dataFlowDebugSessionClientAddDataFlowResponse, error) {
-	result := dataFlowDebugSessionClientAddDataFlowResponse{RawResponse: resp}
+	result := dataFlowDebugSessionClientAddDataFlowResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AddDataFlowToDebugSessionResponse); err != nil {
 		return dataFlowDebugSessionClientAddDataFlowResponse{}, err
 	}
@@ -84,9 +84,7 @@ func (client *dataFlowDebugSessionClient) BeginCreateDataFlowDebugSession(ctx co
 	if err != nil {
 		return dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse{}, err
 	}
-	result := dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse{
-		RawResponse: resp,
-	}
+	result := dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowDebugSessionClient.CreateDataFlowDebugSession", resp, client.pl)
 	if err != nil {
 		return dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse{}, err
@@ -145,7 +143,7 @@ func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSession(ctx context
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return dataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse{}, runtime.NewResponseError(resp)
 	}
-	return dataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse{RawResponse: resp}, nil
+	return dataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse{}, nil
 }
 
 // deleteDataFlowDebugSessionCreateRequest creates the DeleteDataFlowDebugSession request.
@@ -172,9 +170,7 @@ func (client *dataFlowDebugSessionClient) BeginExecuteCommand(ctx context.Contex
 	if err != nil {
 		return dataFlowDebugSessionClientExecuteCommandPollerResponse{}, err
 	}
-	result := dataFlowDebugSessionClientExecuteCommandPollerResponse{
-		RawResponse: resp,
-	}
+	result := dataFlowDebugSessionClientExecuteCommandPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowDebugSessionClient.ExecuteCommand", resp, client.pl)
 	if err != nil {
 		return dataFlowDebugSessionClientExecuteCommandPollerResponse{}, err
@@ -248,7 +244,7 @@ func (client *dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceC
 
 // queryDataFlowDebugSessionsByWorkspaceHandleResponse handles the QueryDataFlowDebugSessionsByWorkspace response.
 func (client *dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceHandleResponse(resp *http.Response) (dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse, error) {
-	result := dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{RawResponse: resp}
+	result := dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.QueryDataFlowDebugSessionsResponse); err != nil {
 		return dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
@@ -45,9 +45,7 @@ func (client *datasetClient) BeginCreateOrUpdateDataset(ctx context.Context, dat
 	if err != nil {
 		return datasetClientCreateOrUpdateDatasetPollerResponse{}, err
 	}
-	result := datasetClientCreateOrUpdateDatasetPollerResponse{
-		RawResponse: resp,
-	}
+	result := datasetClientCreateOrUpdateDatasetPollerResponse{}
 	pt, err := runtime.NewPoller("datasetClient.CreateOrUpdateDataset", resp, client.pl)
 	if err != nil {
 		return datasetClientCreateOrUpdateDatasetPollerResponse{}, err
@@ -106,9 +104,7 @@ func (client *datasetClient) BeginDeleteDataset(ctx context.Context, datasetName
 	if err != nil {
 		return datasetClientDeleteDatasetPollerResponse{}, err
 	}
-	result := datasetClientDeleteDatasetPollerResponse{
-		RawResponse: resp,
-	}
+	result := datasetClientDeleteDatasetPollerResponse{}
 	pt, err := runtime.NewPoller("datasetClient.DeleteDataset", resp, client.pl)
 	if err != nil {
 		return datasetClientDeleteDatasetPollerResponse{}, err
@@ -196,7 +192,7 @@ func (client *datasetClient) getDatasetCreateRequest(ctx context.Context, datase
 
 // getDatasetHandleResponse handles the GetDataset response.
 func (client *datasetClient) getDatasetHandleResponse(resp *http.Response) (datasetClientGetDatasetResponse, error) {
-	result := datasetClientGetDatasetResponse{RawResponse: resp}
+	result := datasetClientGetDatasetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DatasetResource); err != nil {
 		return datasetClientGetDatasetResponse{}, err
 	}
@@ -235,7 +231,7 @@ func (client *datasetClient) getDatasetsByWorkspaceCreateRequest(ctx context.Con
 
 // getDatasetsByWorkspaceHandleResponse handles the GetDatasetsByWorkspace response.
 func (client *datasetClient) getDatasetsByWorkspaceHandleResponse(resp *http.Response) (datasetClientGetDatasetsByWorkspaceResponse, error) {
-	result := datasetClientGetDatasetsByWorkspaceResponse{RawResponse: resp}
+	result := datasetClientGetDatasetsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DatasetListResponse); err != nil {
 		return datasetClientGetDatasetsByWorkspaceResponse{}, err
 	}
@@ -253,9 +249,7 @@ func (client *datasetClient) BeginRenameDataset(ctx context.Context, datasetName
 	if err != nil {
 		return datasetClientRenameDatasetPollerResponse{}, err
 	}
-	result := datasetClientRenameDatasetPollerResponse{
-		RawResponse: resp,
-	}
+	result := datasetClientRenameDatasetPollerResponse{}
 	pt, err := runtime.NewPoller("datasetClient.RenameDataset", resp, client.pl)
 	if err != nil {
 		return datasetClientRenameDatasetPollerResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes_client.go
@@ -73,7 +73,7 @@ func (client *integrationRuntimesClient) getCreateRequest(ctx context.Context, i
 
 // getHandleResponse handles the Get response.
 func (client *integrationRuntimesClient) getHandleResponse(resp *http.Response) (integrationRuntimesClientGetResponse, error) {
-	result := integrationRuntimesClientGetResponse{RawResponse: resp}
+	result := integrationRuntimesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IntegrationRuntimeResource); err != nil {
 		return integrationRuntimesClientGetResponse{}, err
 	}
@@ -115,7 +115,7 @@ func (client *integrationRuntimesClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client *integrationRuntimesClient) listHandleResponse(resp *http.Response) (integrationRuntimesClientListResponse, error) {
-	result := integrationRuntimesClientListResponse{RawResponse: resp}
+	result := integrationRuntimesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IntegrationRuntimeListResponse); err != nil {
 		return integrationRuntimesClientListResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
@@ -55,7 +55,7 @@ func (client *libraryClient) Append(ctx context.Context, libraryName string, con
 	if !runtime.HasStatusCode(resp, http.StatusCreated) {
 		return libraryClientAppendResponse{}, runtime.NewResponseError(resp)
 	}
-	return libraryClientAppendResponse{RawResponse: resp}, nil
+	return libraryClientAppendResponse{}, nil
 }
 
 // appendCreateRequest creates the Append request.
@@ -88,9 +88,7 @@ func (client *libraryClient) BeginCreate(ctx context.Context, libraryName string
 	if err != nil {
 		return libraryClientCreatePollerResponse{}, err
 	}
-	result := libraryClientCreatePollerResponse{
-		RawResponse: resp,
-	}
+	result := libraryClientCreatePollerResponse{}
 	pt, err := runtime.NewPoller("libraryClient.Create", resp, client.pl)
 	if err != nil {
 		return libraryClientCreatePollerResponse{}, err
@@ -145,9 +143,7 @@ func (client *libraryClient) BeginDelete(ctx context.Context, libraryName string
 	if err != nil {
 		return libraryClientDeletePollerResponse{}, err
 	}
-	result := libraryClientDeletePollerResponse{
-		RawResponse: resp,
-	}
+	result := libraryClientDeletePollerResponse{}
 	pt, err := runtime.NewPoller("libraryClient.Delete", resp, client.pl)
 	if err != nil {
 		return libraryClientDeletePollerResponse{}, err
@@ -202,9 +198,7 @@ func (client *libraryClient) BeginFlush(ctx context.Context, libraryName string,
 	if err != nil {
 		return libraryClientFlushPollerResponse{}, err
 	}
-	result := libraryClientFlushPollerResponse{
-		RawResponse: resp,
-	}
+	result := libraryClientFlushPollerResponse{}
 	pt, err := runtime.NewPoller("libraryClient.Flush", resp, client.pl)
 	if err != nil {
 		return libraryClientFlushPollerResponse{}, err
@@ -289,7 +283,7 @@ func (client *libraryClient) getCreateRequest(ctx context.Context, libraryName s
 
 // getHandleResponse handles the Get response.
 func (client *libraryClient) getHandleResponse(resp *http.Response) (libraryClientGetResponse, error) {
-	result := libraryClientGetResponse{RawResponse: resp}
+	result := libraryClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LibraryResource); err != nil {
 		return libraryClientGetResponse{}, err
 	}
@@ -336,7 +330,7 @@ func (client *libraryClient) getOperationResultCreateRequest(ctx context.Context
 
 // getOperationResultHandleResponse handles the GetOperationResult response.
 func (client *libraryClient) getOperationResultHandleResponse(resp *http.Response) (libraryClientGetOperationResultResponse, error) {
-	result := libraryClientGetOperationResultResponse{RawResponse: resp}
+	result := libraryClientGetOperationResultResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var val LibraryResource
@@ -387,7 +381,7 @@ func (client *libraryClient) listCreateRequest(ctx context.Context, options *lib
 
 // listHandleResponse handles the List response.
 func (client *libraryClient) listHandleResponse(resp *http.Response) (libraryClientListResponse, error) {
-	result := libraryClientListResponse{RawResponse: resp}
+	result := libraryClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LibraryListResponse); err != nil {
 		return libraryClientListResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
@@ -45,9 +45,7 @@ func (client *linkedServiceClient) BeginCreateOrUpdateLinkedService(ctx context.
 	if err != nil {
 		return linkedServiceClientCreateOrUpdateLinkedServicePollerResponse{}, err
 	}
-	result := linkedServiceClientCreateOrUpdateLinkedServicePollerResponse{
-		RawResponse: resp,
-	}
+	result := linkedServiceClientCreateOrUpdateLinkedServicePollerResponse{}
 	pt, err := runtime.NewPoller("linkedServiceClient.CreateOrUpdateLinkedService", resp, client.pl)
 	if err != nil {
 		return linkedServiceClientCreateOrUpdateLinkedServicePollerResponse{}, err
@@ -106,9 +104,7 @@ func (client *linkedServiceClient) BeginDeleteLinkedService(ctx context.Context,
 	if err != nil {
 		return linkedServiceClientDeleteLinkedServicePollerResponse{}, err
 	}
-	result := linkedServiceClientDeleteLinkedServicePollerResponse{
-		RawResponse: resp,
-	}
+	result := linkedServiceClientDeleteLinkedServicePollerResponse{}
 	pt, err := runtime.NewPoller("linkedServiceClient.DeleteLinkedService", resp, client.pl)
 	if err != nil {
 		return linkedServiceClientDeleteLinkedServicePollerResponse{}, err
@@ -197,7 +193,7 @@ func (client *linkedServiceClient) getLinkedServiceCreateRequest(ctx context.Con
 
 // getLinkedServiceHandleResponse handles the GetLinkedService response.
 func (client *linkedServiceClient) getLinkedServiceHandleResponse(resp *http.Response) (linkedServiceClientGetLinkedServiceResponse, error) {
-	result := linkedServiceClientGetLinkedServiceResponse{RawResponse: resp}
+	result := linkedServiceClientGetLinkedServiceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LinkedServiceResource); err != nil {
 		return linkedServiceClientGetLinkedServiceResponse{}, err
 	}
@@ -236,7 +232,7 @@ func (client *linkedServiceClient) getLinkedServicesByWorkspaceCreateRequest(ctx
 
 // getLinkedServicesByWorkspaceHandleResponse handles the GetLinkedServicesByWorkspace response.
 func (client *linkedServiceClient) getLinkedServicesByWorkspaceHandleResponse(resp *http.Response) (linkedServiceClientGetLinkedServicesByWorkspaceResponse, error) {
-	result := linkedServiceClientGetLinkedServicesByWorkspaceResponse{RawResponse: resp}
+	result := linkedServiceClientGetLinkedServicesByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LinkedServiceListResponse); err != nil {
 		return linkedServiceClientGetLinkedServicesByWorkspaceResponse{}, err
 	}
@@ -254,9 +250,7 @@ func (client *linkedServiceClient) BeginRenameLinkedService(ctx context.Context,
 	if err != nil {
 		return linkedServiceClientRenameLinkedServicePollerResponse{}, err
 	}
-	result := linkedServiceClientRenameLinkedServicePollerResponse{
-		RawResponse: resp,
-	}
+	result := linkedServiceClientRenameLinkedServicePollerResponse{}
 	pt, err := runtime.NewPoller("linkedServiceClient.RenameLinkedService", resp, client.pl)
 	if err != nil {
 		return linkedServiceClientRenameLinkedServicePollerResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
@@ -45,9 +45,7 @@ func (client *notebookClient) BeginCreateOrUpdateNotebook(ctx context.Context, n
 	if err != nil {
 		return notebookClientCreateOrUpdateNotebookPollerResponse{}, err
 	}
-	result := notebookClientCreateOrUpdateNotebookPollerResponse{
-		RawResponse: resp,
-	}
+	result := notebookClientCreateOrUpdateNotebookPollerResponse{}
 	pt, err := runtime.NewPoller("notebookClient.CreateOrUpdateNotebook", resp, client.pl)
 	if err != nil {
 		return notebookClientCreateOrUpdateNotebookPollerResponse{}, err
@@ -106,9 +104,7 @@ func (client *notebookClient) BeginDeleteNotebook(ctx context.Context, notebookN
 	if err != nil {
 		return notebookClientDeleteNotebookPollerResponse{}, err
 	}
-	result := notebookClientDeleteNotebookPollerResponse{
-		RawResponse: resp,
-	}
+	result := notebookClientDeleteNotebookPollerResponse{}
 	pt, err := runtime.NewPoller("notebookClient.DeleteNotebook", resp, client.pl)
 	if err != nil {
 		return notebookClientDeleteNotebookPollerResponse{}, err
@@ -196,7 +192,7 @@ func (client *notebookClient) getNotebookCreateRequest(ctx context.Context, note
 
 // getNotebookHandleResponse handles the GetNotebook response.
 func (client *notebookClient) getNotebookHandleResponse(resp *http.Response) (notebookClientGetNotebookResponse, error) {
-	result := notebookClientGetNotebookResponse{RawResponse: resp}
+	result := notebookClientGetNotebookResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookResource); err != nil {
 		return notebookClientGetNotebookResponse{}, err
 	}
@@ -235,7 +231,7 @@ func (client *notebookClient) getNotebookSummaryByWorkSpaceCreateRequest(ctx con
 
 // getNotebookSummaryByWorkSpaceHandleResponse handles the GetNotebookSummaryByWorkSpace response.
 func (client *notebookClient) getNotebookSummaryByWorkSpaceHandleResponse(resp *http.Response) (notebookClientGetNotebookSummaryByWorkSpaceResponse, error) {
-	result := notebookClientGetNotebookSummaryByWorkSpaceResponse{RawResponse: resp}
+	result := notebookClientGetNotebookSummaryByWorkSpaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookListResponse); err != nil {
 		return notebookClientGetNotebookSummaryByWorkSpaceResponse{}, err
 	}
@@ -274,7 +270,7 @@ func (client *notebookClient) getNotebooksByWorkspaceCreateRequest(ctx context.C
 
 // getNotebooksByWorkspaceHandleResponse handles the GetNotebooksByWorkspace response.
 func (client *notebookClient) getNotebooksByWorkspaceHandleResponse(resp *http.Response) (notebookClientGetNotebooksByWorkspaceResponse, error) {
-	result := notebookClientGetNotebooksByWorkspaceResponse{RawResponse: resp}
+	result := notebookClientGetNotebooksByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookListResponse); err != nil {
 		return notebookClientGetNotebooksByWorkspaceResponse{}, err
 	}
@@ -292,9 +288,7 @@ func (client *notebookClient) BeginRenameNotebook(ctx context.Context, notebookN
 	if err != nil {
 		return notebookClientRenameNotebookPollerResponse{}, err
 	}
-	result := notebookClientRenameNotebookPollerResponse{
-		RawResponse: resp,
-	}
+	result := notebookClientRenameNotebookPollerResponse{}
 	pt, err := runtime.NewPoller("notebookClient.RenameNotebook", resp, client.pl)
 	if err != nil {
 		return notebookClientRenameNotebookPollerResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
@@ -46,9 +46,7 @@ func (client *pipelineClient) BeginCreateOrUpdatePipeline(ctx context.Context, p
 	if err != nil {
 		return pipelineClientCreateOrUpdatePipelinePollerResponse{}, err
 	}
-	result := pipelineClientCreateOrUpdatePipelinePollerResponse{
-		RawResponse: resp,
-	}
+	result := pipelineClientCreateOrUpdatePipelinePollerResponse{}
 	pt, err := runtime.NewPoller("pipelineClient.CreateOrUpdatePipeline", resp, client.pl)
 	if err != nil {
 		return pipelineClientCreateOrUpdatePipelinePollerResponse{}, err
@@ -149,7 +147,7 @@ func (client *pipelineClient) createPipelineRunCreateRequest(ctx context.Context
 
 // createPipelineRunHandleResponse handles the CreatePipelineRun response.
 func (client *pipelineClient) createPipelineRunHandleResponse(resp *http.Response) (pipelineClientCreatePipelineRunResponse, error) {
-	result := pipelineClientCreatePipelineRunResponse{RawResponse: resp}
+	result := pipelineClientCreatePipelineRunResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CreateRunResponse); err != nil {
 		return pipelineClientCreatePipelineRunResponse{}, err
 	}
@@ -166,9 +164,7 @@ func (client *pipelineClient) BeginDeletePipeline(ctx context.Context, pipelineN
 	if err != nil {
 		return pipelineClientDeletePipelinePollerResponse{}, err
 	}
-	result := pipelineClientDeletePipelinePollerResponse{
-		RawResponse: resp,
-	}
+	result := pipelineClientDeletePipelinePollerResponse{}
 	pt, err := runtime.NewPoller("pipelineClient.DeletePipeline", resp, client.pl)
 	if err != nil {
 		return pipelineClientDeletePipelinePollerResponse{}, err
@@ -256,7 +252,7 @@ func (client *pipelineClient) getPipelineCreateRequest(ctx context.Context, pipe
 
 // getPipelineHandleResponse handles the GetPipeline response.
 func (client *pipelineClient) getPipelineHandleResponse(resp *http.Response) (pipelineClientGetPipelineResponse, error) {
-	result := pipelineClientGetPipelineResponse{RawResponse: resp}
+	result := pipelineClientGetPipelineResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineResource); err != nil {
 		return pipelineClientGetPipelineResponse{}, err
 	}
@@ -295,7 +291,7 @@ func (client *pipelineClient) getPipelinesByWorkspaceCreateRequest(ctx context.C
 
 // getPipelinesByWorkspaceHandleResponse handles the GetPipelinesByWorkspace response.
 func (client *pipelineClient) getPipelinesByWorkspaceHandleResponse(resp *http.Response) (pipelineClientGetPipelinesByWorkspaceResponse, error) {
-	result := pipelineClientGetPipelinesByWorkspaceResponse{RawResponse: resp}
+	result := pipelineClientGetPipelinesByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineListResponse); err != nil {
 		return pipelineClientGetPipelinesByWorkspaceResponse{}, err
 	}
@@ -313,9 +309,7 @@ func (client *pipelineClient) BeginRenamePipeline(ctx context.Context, pipelineN
 	if err != nil {
 		return pipelineClientRenamePipelinePollerResponse{}, err
 	}
-	result := pipelineClientRenamePipelinePollerResponse{
-		RawResponse: resp,
-	}
+	result := pipelineClientRenamePipelinePollerResponse{}
 	pt, err := runtime.NewPoller("pipelineClient.RenamePipeline", resp, client.pl)
 	if err != nil {
 		return pipelineClientRenamePipelinePollerResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun_client.go
@@ -52,7 +52,7 @@ func (client *pipelineRunClient) CancelPipelineRun(ctx context.Context, runID st
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return pipelineRunClientCancelPipelineRunResponse{}, runtime.NewResponseError(resp)
 	}
-	return pipelineRunClientCancelPipelineRunResponse{RawResponse: resp}, nil
+	return pipelineRunClientCancelPipelineRunResponse{}, nil
 }
 
 // cancelPipelineRunCreateRequest creates the CancelPipelineRun request.
@@ -116,7 +116,7 @@ func (client *pipelineRunClient) getPipelineRunCreateRequest(ctx context.Context
 
 // getPipelineRunHandleResponse handles the GetPipelineRun response.
 func (client *pipelineRunClient) getPipelineRunHandleResponse(resp *http.Response) (pipelineRunClientGetPipelineRunResponse, error) {
-	result := pipelineRunClientGetPipelineRunResponse{RawResponse: resp}
+	result := pipelineRunClientGetPipelineRunResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineRun); err != nil {
 		return pipelineRunClientGetPipelineRunResponse{}, err
 	}
@@ -169,7 +169,7 @@ func (client *pipelineRunClient) queryActivityRunsCreateRequest(ctx context.Cont
 
 // queryActivityRunsHandleResponse handles the QueryActivityRuns response.
 func (client *pipelineRunClient) queryActivityRunsHandleResponse(resp *http.Response) (pipelineRunClientQueryActivityRunsResponse, error) {
-	result := pipelineRunClientQueryActivityRunsResponse{RawResponse: resp}
+	result := pipelineRunClientQueryActivityRunsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ActivityRunsQueryResponse); err != nil {
 		return pipelineRunClientQueryActivityRunsResponse{}, err
 	}
@@ -212,7 +212,7 @@ func (client *pipelineRunClient) queryPipelineRunsByWorkspaceCreateRequest(ctx c
 
 // queryPipelineRunsByWorkspaceHandleResponse handles the QueryPipelineRunsByWorkspace response.
 func (client *pipelineRunClient) queryPipelineRunsByWorkspaceHandleResponse(resp *http.Response) (pipelineRunClientQueryPipelineRunsByWorkspaceResponse, error) {
-	result := pipelineRunClientQueryPipelineRunsByWorkspaceResponse{RawResponse: resp}
+	result := pipelineRunClientQueryPipelineRunsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineRunsQueryResponse); err != nil {
 		return pipelineRunClientQueryPipelineRunsByWorkspaceResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
@@ -43,11 +43,10 @@ func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final dataFlowClientCreateOrUpdateDataFlowResponse will be returned.
 func (p *dataFlowClientCreateOrUpdateDataFlowPoller) FinalResponse(ctx context.Context) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
 	respType := dataFlowClientCreateOrUpdateDataFlowResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DataFlowResource)
+	_, err := p.pt.FinalResponse(ctx, &respType.DataFlowResource)
 	if err != nil {
 		return dataFlowClientCreateOrUpdateDataFlowResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -86,11 +85,10 @@ func (p *dataFlowClientDeleteDataFlowPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final dataFlowClientDeleteDataFlowResponse will be returned.
 func (p *dataFlowClientDeleteDataFlowPoller) FinalResponse(ctx context.Context) (dataFlowClientDeleteDataFlowResponse, error) {
 	respType := dataFlowClientDeleteDataFlowResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return dataFlowClientDeleteDataFlowResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -129,11 +127,10 @@ func (p *dataFlowClientRenameDataFlowPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final dataFlowClientRenameDataFlowResponse will be returned.
 func (p *dataFlowClientRenameDataFlowPoller) FinalResponse(ctx context.Context) (dataFlowClientRenameDataFlowResponse, error) {
 	respType := dataFlowClientRenameDataFlowResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return dataFlowClientRenameDataFlowResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -172,11 +169,10 @@ func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Poll(ctx co
 // If the final GET succeeded then the final dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse will be returned.
 func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) FinalResponse(ctx context.Context) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
 	respType := dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.CreateDataFlowDebugSessionResponse)
+	_, err := p.pt.FinalResponse(ctx, &respType.CreateDataFlowDebugSessionResponse)
 	if err != nil {
 		return dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -215,11 +211,10 @@ func (p *dataFlowDebugSessionClientExecuteCommandPoller) Poll(ctx context.Contex
 // If the final GET succeeded then the final dataFlowDebugSessionClientExecuteCommandResponse will be returned.
 func (p *dataFlowDebugSessionClientExecuteCommandPoller) FinalResponse(ctx context.Context) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
 	respType := dataFlowDebugSessionClientExecuteCommandResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DataFlowDebugCommandResponse)
+	_, err := p.pt.FinalResponse(ctx, &respType.DataFlowDebugCommandResponse)
 	if err != nil {
 		return dataFlowDebugSessionClientExecuteCommandResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -258,11 +253,10 @@ func (p *datasetClientCreateOrUpdateDatasetPoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final datasetClientCreateOrUpdateDatasetResponse will be returned.
 func (p *datasetClientCreateOrUpdateDatasetPoller) FinalResponse(ctx context.Context) (datasetClientCreateOrUpdateDatasetResponse, error) {
 	respType := datasetClientCreateOrUpdateDatasetResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.DatasetResource)
+	_, err := p.pt.FinalResponse(ctx, &respType.DatasetResource)
 	if err != nil {
 		return datasetClientCreateOrUpdateDatasetResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -301,11 +295,10 @@ func (p *datasetClientDeleteDatasetPoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final datasetClientDeleteDatasetResponse will be returned.
 func (p *datasetClientDeleteDatasetPoller) FinalResponse(ctx context.Context) (datasetClientDeleteDatasetResponse, error) {
 	respType := datasetClientDeleteDatasetResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return datasetClientDeleteDatasetResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -344,11 +337,10 @@ func (p *datasetClientRenameDatasetPoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final datasetClientRenameDatasetResponse will be returned.
 func (p *datasetClientRenameDatasetPoller) FinalResponse(ctx context.Context) (datasetClientRenameDatasetResponse, error) {
 	respType := datasetClientRenameDatasetResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return datasetClientRenameDatasetResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -387,11 +379,10 @@ func (p *libraryClientCreatePoller) Poll(ctx context.Context) (*http.Response, e
 // If the final GET succeeded then the final libraryClientCreateResponse will be returned.
 func (p *libraryClientCreatePoller) FinalResponse(ctx context.Context) (libraryClientCreateResponse, error) {
 	respType := libraryClientCreateResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
+	_, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
 	if err != nil {
 		return libraryClientCreateResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -430,11 +421,10 @@ func (p *libraryClientDeletePoller) Poll(ctx context.Context) (*http.Response, e
 // If the final GET succeeded then the final libraryClientDeleteResponse will be returned.
 func (p *libraryClientDeletePoller) FinalResponse(ctx context.Context) (libraryClientDeleteResponse, error) {
 	respType := libraryClientDeleteResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
+	_, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
 	if err != nil {
 		return libraryClientDeleteResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -473,11 +463,10 @@ func (p *libraryClientFlushPoller) Poll(ctx context.Context) (*http.Response, er
 // If the final GET succeeded then the final libraryClientFlushResponse will be returned.
 func (p *libraryClientFlushPoller) FinalResponse(ctx context.Context) (libraryClientFlushResponse, error) {
 	respType := libraryClientFlushResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
+	_, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
 	if err != nil {
 		return libraryClientFlushResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -516,11 +505,10 @@ func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Poll(ctx context.
 // If the final GET succeeded then the final linkedServiceClientCreateOrUpdateLinkedServiceResponse will be returned.
 func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) FinalResponse(ctx context.Context) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
 	respType := linkedServiceClientCreateOrUpdateLinkedServiceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.LinkedServiceResource)
+	_, err := p.pt.FinalResponse(ctx, &respType.LinkedServiceResource)
 	if err != nil {
 		return linkedServiceClientCreateOrUpdateLinkedServiceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -559,11 +547,10 @@ func (p *linkedServiceClientDeleteLinkedServicePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final linkedServiceClientDeleteLinkedServiceResponse will be returned.
 func (p *linkedServiceClientDeleteLinkedServicePoller) FinalResponse(ctx context.Context) (linkedServiceClientDeleteLinkedServiceResponse, error) {
 	respType := linkedServiceClientDeleteLinkedServiceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return linkedServiceClientDeleteLinkedServiceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -602,11 +589,10 @@ func (p *linkedServiceClientRenameLinkedServicePoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final linkedServiceClientRenameLinkedServiceResponse will be returned.
 func (p *linkedServiceClientRenameLinkedServicePoller) FinalResponse(ctx context.Context) (linkedServiceClientRenameLinkedServiceResponse, error) {
 	respType := linkedServiceClientRenameLinkedServiceResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return linkedServiceClientRenameLinkedServiceResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -645,11 +631,10 @@ func (p *notebookClientCreateOrUpdateNotebookPoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final notebookClientCreateOrUpdateNotebookResponse will be returned.
 func (p *notebookClientCreateOrUpdateNotebookPoller) FinalResponse(ctx context.Context) (notebookClientCreateOrUpdateNotebookResponse, error) {
 	respType := notebookClientCreateOrUpdateNotebookResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.NotebookResource)
+	_, err := p.pt.FinalResponse(ctx, &respType.NotebookResource)
 	if err != nil {
 		return notebookClientCreateOrUpdateNotebookResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -688,11 +673,10 @@ func (p *notebookClientDeleteNotebookPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final notebookClientDeleteNotebookResponse will be returned.
 func (p *notebookClientDeleteNotebookPoller) FinalResponse(ctx context.Context) (notebookClientDeleteNotebookResponse, error) {
 	respType := notebookClientDeleteNotebookResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return notebookClientDeleteNotebookResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -731,11 +715,10 @@ func (p *notebookClientRenameNotebookPoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final notebookClientRenameNotebookResponse will be returned.
 func (p *notebookClientRenameNotebookPoller) FinalResponse(ctx context.Context) (notebookClientRenameNotebookResponse, error) {
 	respType := notebookClientRenameNotebookResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return notebookClientRenameNotebookResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -774,11 +757,10 @@ func (p *pipelineClientCreateOrUpdatePipelinePoller) Poll(ctx context.Context) (
 // If the final GET succeeded then the final pipelineClientCreateOrUpdatePipelineResponse will be returned.
 func (p *pipelineClientCreateOrUpdatePipelinePoller) FinalResponse(ctx context.Context) (pipelineClientCreateOrUpdatePipelineResponse, error) {
 	respType := pipelineClientCreateOrUpdatePipelineResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.PipelineResource)
+	_, err := p.pt.FinalResponse(ctx, &respType.PipelineResource)
 	if err != nil {
 		return pipelineClientCreateOrUpdatePipelineResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -817,11 +799,10 @@ func (p *pipelineClientDeletePipelinePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final pipelineClientDeletePipelineResponse will be returned.
 func (p *pipelineClientDeletePipelinePoller) FinalResponse(ctx context.Context) (pipelineClientDeletePipelineResponse, error) {
 	respType := pipelineClientDeletePipelineResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return pipelineClientDeletePipelineResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -860,11 +841,10 @@ func (p *pipelineClientRenamePipelinePoller) Poll(ctx context.Context) (*http.Re
 // If the final GET succeeded then the final pipelineClientRenamePipelineResponse will be returned.
 func (p *pipelineClientRenamePipelinePoller) FinalResponse(ctx context.Context) (pipelineClientRenamePipelineResponse, error) {
 	respType := pipelineClientRenamePipelineResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return pipelineClientRenamePipelineResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -903,11 +883,10 @@ func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Poll(ct
 // If the final GET succeeded then the final sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse will be returned.
 func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SparkJobDefinitionResource)
+	_, err := p.pt.FinalResponse(ctx, &respType.SparkJobDefinitionResource)
 	if err != nil {
 		return sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -946,11 +925,10 @@ func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Poll(ctx context
 // If the final GET succeeded then the final sparkJobDefinitionClientDebugSparkJobDefinitionResponse will be returned.
 func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SparkBatchJob)
+	_, err := p.pt.FinalResponse(ctx, &respType.SparkBatchJob)
 	if err != nil {
 		return sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -989,11 +967,10 @@ func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Poll(ctx contex
 // If the final GET succeeded then the final sparkJobDefinitionClientDeleteSparkJobDefinitionResponse will be returned.
 func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1032,11 +1009,10 @@ func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Poll(ctx conte
 // If the final GET succeeded then the final sparkJobDefinitionClientExecuteSparkJobDefinitionResponse will be returned.
 func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SparkBatchJob)
+	_, err := p.pt.FinalResponse(ctx, &respType.SparkBatchJob)
 	if err != nil {
 		return sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1075,11 +1051,10 @@ func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Poll(ctx contex
 // If the final GET succeeded then the final sparkJobDefinitionClientRenameSparkJobDefinitionResponse will be returned.
 func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1118,11 +1093,10 @@ func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Poll(ctx context.Context)
 // If the final GET succeeded then the final sqlScriptClientCreateOrUpdateSQLScriptResponse will be returned.
 func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) FinalResponse(ctx context.Context) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
 	respType := sqlScriptClientCreateOrUpdateSQLScriptResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.SQLScriptResource)
+	_, err := p.pt.FinalResponse(ctx, &respType.SQLScriptResource)
 	if err != nil {
 		return sqlScriptClientCreateOrUpdateSQLScriptResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1161,11 +1135,10 @@ func (p *sqlScriptClientDeleteSQLScriptPoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final sqlScriptClientDeleteSQLScriptResponse will be returned.
 func (p *sqlScriptClientDeleteSQLScriptPoller) FinalResponse(ctx context.Context) (sqlScriptClientDeleteSQLScriptResponse, error) {
 	respType := sqlScriptClientDeleteSQLScriptResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return sqlScriptClientDeleteSQLScriptResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1204,11 +1177,10 @@ func (p *sqlScriptClientRenameSQLScriptPoller) Poll(ctx context.Context) (*http.
 // If the final GET succeeded then the final sqlScriptClientRenameSQLScriptResponse will be returned.
 func (p *sqlScriptClientRenameSQLScriptPoller) FinalResponse(ctx context.Context) (sqlScriptClientRenameSQLScriptResponse, error) {
 	respType := sqlScriptClientRenameSQLScriptResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return sqlScriptClientRenameSQLScriptResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1247,11 +1219,10 @@ func (p *triggerClientCreateOrUpdateTriggerPoller) Poll(ctx context.Context) (*h
 // If the final GET succeeded then the final triggerClientCreateOrUpdateTriggerResponse will be returned.
 func (p *triggerClientCreateOrUpdateTriggerPoller) FinalResponse(ctx context.Context) (triggerClientCreateOrUpdateTriggerResponse, error) {
 	respType := triggerClientCreateOrUpdateTriggerResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.TriggerResource)
+	_, err := p.pt.FinalResponse(ctx, &respType.TriggerResource)
 	if err != nil {
 		return triggerClientCreateOrUpdateTriggerResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1290,11 +1261,10 @@ func (p *triggerClientDeleteTriggerPoller) Poll(ctx context.Context) (*http.Resp
 // If the final GET succeeded then the final triggerClientDeleteTriggerResponse will be returned.
 func (p *triggerClientDeleteTriggerPoller) FinalResponse(ctx context.Context) (triggerClientDeleteTriggerResponse, error) {
 	respType := triggerClientDeleteTriggerResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return triggerClientDeleteTriggerResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1333,11 +1303,10 @@ func (p *triggerClientStartTriggerPoller) Poll(ctx context.Context) (*http.Respo
 // If the final GET succeeded then the final triggerClientStartTriggerResponse will be returned.
 func (p *triggerClientStartTriggerPoller) FinalResponse(ctx context.Context) (triggerClientStartTriggerResponse, error) {
 	respType := triggerClientStartTriggerResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return triggerClientStartTriggerResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1376,11 +1345,10 @@ func (p *triggerClientStopTriggerPoller) Poll(ctx context.Context) (*http.Respon
 // If the final GET succeeded then the final triggerClientStopTriggerResponse will be returned.
 func (p *triggerClientStopTriggerPoller) FinalResponse(ctx context.Context) (triggerClientStopTriggerResponse, error) {
 	respType := triggerClientStopTriggerResponse{}
-	resp, err := p.pt.FinalResponse(ctx, nil)
+	_, err := p.pt.FinalResponse(ctx, nil)
 	if err != nil {
 		return triggerClientStopTriggerResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1419,11 +1387,10 @@ func (p *triggerClientSubscribeTriggerToEventsPoller) Poll(ctx context.Context) 
 // If the final GET succeeded then the final triggerClientSubscribeTriggerToEventsResponse will be returned.
 func (p *triggerClientSubscribeTriggerToEventsPoller) FinalResponse(ctx context.Context) (triggerClientSubscribeTriggerToEventsResponse, error) {
 	respType := triggerClientSubscribeTriggerToEventsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.TriggerSubscriptionOperationStatus)
+	_, err := p.pt.FinalResponse(ctx, &respType.TriggerSubscriptionOperationStatus)
 	if err != nil {
 		return triggerClientSubscribeTriggerToEventsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1462,11 +1429,10 @@ func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Poll(ctx context.Conte
 // If the final GET succeeded then the final triggerClientUnsubscribeTriggerFromEventsResponse will be returned.
 func (p *triggerClientUnsubscribeTriggerFromEventsPoller) FinalResponse(ctx context.Context) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
 	respType := triggerClientUnsubscribeTriggerFromEventsResponse{}
-	resp, err := p.pt.FinalResponse(ctx, &respType.TriggerSubscriptionOperationStatus)
+	_, err := p.pt.FinalResponse(ctx, &respType.TriggerSubscriptionOperationStatus)
 	if err != nil {
 		return triggerClientUnsubscribeTriggerFromEventsResponse{}, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_response_types.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_response_types.go
@@ -11,42 +11,33 @@ package azartifacts
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"net/http"
 	"time"
 )
 
 // bigDataPoolsClientGetResponse contains the response from method bigDataPoolsClient.Get.
 type bigDataPoolsClientGetResponse struct {
 	BigDataPoolResourceInfo
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // bigDataPoolsClientListResponse contains the response from method bigDataPoolsClient.List.
 type bigDataPoolsClientListResponse struct {
 	BigDataPoolResourceInfoListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // dataFlowClientCreateOrUpdateDataFlowPollerResponse contains the response from method dataFlowClient.CreateOrUpdateDataFlow.
 type dataFlowClientCreateOrUpdateDataFlowPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *dataFlowClientCreateOrUpdateDataFlowPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l dataFlowClientCreateOrUpdateDataFlowPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
 	respType := dataFlowClientCreateOrUpdateDataFlowResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DataFlowResource)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DataFlowResource)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -59,40 +50,33 @@ func (l *dataFlowClientCreateOrUpdateDataFlowPollerResponse) Resume(ctx context.
 	poller := &dataFlowClientCreateOrUpdateDataFlowPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // dataFlowClientCreateOrUpdateDataFlowResponse contains the response from method dataFlowClient.CreateOrUpdateDataFlow.
 type dataFlowClientCreateOrUpdateDataFlowResponse struct {
 	DataFlowResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // dataFlowClientDeleteDataFlowPollerResponse contains the response from method dataFlowClient.DeleteDataFlow.
 type dataFlowClientDeleteDataFlowPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *dataFlowClientDeleteDataFlowPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l dataFlowClientDeleteDataFlowPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientDeleteDataFlowResponse, error) {
 	respType := dataFlowClientDeleteDataFlowResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -105,53 +89,43 @@ func (l *dataFlowClientDeleteDataFlowPollerResponse) Resume(ctx context.Context,
 	poller := &dataFlowClientDeleteDataFlowPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // dataFlowClientDeleteDataFlowResponse contains the response from method dataFlowClient.DeleteDataFlow.
 type dataFlowClientDeleteDataFlowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // dataFlowClientGetDataFlowResponse contains the response from method dataFlowClient.GetDataFlow.
 type dataFlowClientGetDataFlowResponse struct {
 	DataFlowResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // dataFlowClientGetDataFlowsByWorkspaceResponse contains the response from method dataFlowClient.GetDataFlowsByWorkspace.
 type dataFlowClientGetDataFlowsByWorkspaceResponse struct {
 	DataFlowListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // dataFlowClientRenameDataFlowPollerResponse contains the response from method dataFlowClient.RenameDataFlow.
 type dataFlowClientRenameDataFlowPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *dataFlowClientRenameDataFlowPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l dataFlowClientRenameDataFlowPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientRenameDataFlowResponse, error) {
 	respType := dataFlowClientRenameDataFlowResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -164,46 +138,38 @@ func (l *dataFlowClientRenameDataFlowPollerResponse) Resume(ctx context.Context,
 	poller := &dataFlowClientRenameDataFlowPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // dataFlowClientRenameDataFlowResponse contains the response from method dataFlowClient.RenameDataFlow.
 type dataFlowClientRenameDataFlowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // dataFlowDebugSessionClientAddDataFlowResponse contains the response from method dataFlowDebugSessionClient.AddDataFlow.
 type dataFlowDebugSessionClientAddDataFlowResponse struct {
 	AddDataFlowToDebugSessionResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse contains the response from method dataFlowDebugSessionClient.CreateDataFlowDebugSession.
 type dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
 	respType := dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.CreateDataFlowDebugSessionResponse)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.CreateDataFlowDebugSessionResponse)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -217,46 +183,38 @@ func (l *dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse) Res
 	poller := &dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse contains the response from method dataFlowDebugSessionClient.CreateDataFlowDebugSession.
 type dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse struct {
 	CreateDataFlowDebugSessionResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // dataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse contains the response from method dataFlowDebugSessionClient.DeleteDataFlowDebugSession.
 type dataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // dataFlowDebugSessionClientExecuteCommandPollerResponse contains the response from method dataFlowDebugSessionClient.ExecuteCommand.
 type dataFlowDebugSessionClientExecuteCommandPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *dataFlowDebugSessionClientExecuteCommandPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l dataFlowDebugSessionClientExecuteCommandPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
 	respType := dataFlowDebugSessionClientExecuteCommandResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DataFlowDebugCommandResponse)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DataFlowDebugCommandResponse)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -269,47 +227,38 @@ func (l *dataFlowDebugSessionClientExecuteCommandPollerResponse) Resume(ctx cont
 	poller := &dataFlowDebugSessionClientExecuteCommandPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // dataFlowDebugSessionClientExecuteCommandResponse contains the response from method dataFlowDebugSessionClient.ExecuteCommand.
 type dataFlowDebugSessionClientExecuteCommandResponse struct {
 	DataFlowDebugCommandResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse contains the response from method dataFlowDebugSessionClient.QueryDataFlowDebugSessionsByWorkspace.
 type dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse struct {
 	QueryDataFlowDebugSessionsResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // datasetClientCreateOrUpdateDatasetPollerResponse contains the response from method datasetClient.CreateOrUpdateDataset.
 type datasetClientCreateOrUpdateDatasetPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *datasetClientCreateOrUpdateDatasetPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l datasetClientCreateOrUpdateDatasetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientCreateOrUpdateDatasetResponse, error) {
 	respType := datasetClientCreateOrUpdateDatasetResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DatasetResource)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DatasetResource)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -322,40 +271,33 @@ func (l *datasetClientCreateOrUpdateDatasetPollerResponse) Resume(ctx context.Co
 	poller := &datasetClientCreateOrUpdateDatasetPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // datasetClientCreateOrUpdateDatasetResponse contains the response from method datasetClient.CreateOrUpdateDataset.
 type datasetClientCreateOrUpdateDatasetResponse struct {
 	DatasetResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // datasetClientDeleteDatasetPollerResponse contains the response from method datasetClient.DeleteDataset.
 type datasetClientDeleteDatasetPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *datasetClientDeleteDatasetPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l datasetClientDeleteDatasetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientDeleteDatasetResponse, error) {
 	respType := datasetClientDeleteDatasetResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -368,53 +310,43 @@ func (l *datasetClientDeleteDatasetPollerResponse) Resume(ctx context.Context, c
 	poller := &datasetClientDeleteDatasetPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // datasetClientDeleteDatasetResponse contains the response from method datasetClient.DeleteDataset.
 type datasetClientDeleteDatasetResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // datasetClientGetDatasetResponse contains the response from method datasetClient.GetDataset.
 type datasetClientGetDatasetResponse struct {
 	DatasetResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // datasetClientGetDatasetsByWorkspaceResponse contains the response from method datasetClient.GetDatasetsByWorkspace.
 type datasetClientGetDatasetsByWorkspaceResponse struct {
 	DatasetListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // datasetClientRenameDatasetPollerResponse contains the response from method datasetClient.RenameDataset.
 type datasetClientRenameDatasetPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *datasetClientRenameDatasetPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l datasetClientRenameDatasetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientRenameDatasetResponse, error) {
 	respType := datasetClientRenameDatasetResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -427,59 +359,48 @@ func (l *datasetClientRenameDatasetPollerResponse) Resume(ctx context.Context, c
 	poller := &datasetClientRenameDatasetPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // datasetClientRenameDatasetResponse contains the response from method datasetClient.RenameDataset.
 type datasetClientRenameDatasetResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // integrationRuntimesClientGetResponse contains the response from method integrationRuntimesClient.Get.
 type integrationRuntimesClientGetResponse struct {
 	IntegrationRuntimeResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // integrationRuntimesClientListResponse contains the response from method integrationRuntimesClient.List.
 type integrationRuntimesClientListResponse struct {
 	IntegrationRuntimeListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // libraryClientAppendResponse contains the response from method libraryClient.Append.
 type libraryClientAppendResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // libraryClientCreatePollerResponse contains the response from method libraryClient.Create.
 type libraryClientCreatePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *libraryClientCreatePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l libraryClientCreatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientCreateResponse, error) {
 	respType := libraryClientCreateResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -492,40 +413,33 @@ func (l *libraryClientCreatePollerResponse) Resume(ctx context.Context, client *
 	poller := &libraryClientCreatePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // libraryClientCreateResponse contains the response from method libraryClient.Create.
 type libraryClientCreateResponse struct {
 	LibraryResourceInfo
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // libraryClientDeletePollerResponse contains the response from method libraryClient.Delete.
 type libraryClientDeletePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *libraryClientDeletePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l libraryClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientDeleteResponse, error) {
 	respType := libraryClientDeleteResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -538,40 +452,33 @@ func (l *libraryClientDeletePollerResponse) Resume(ctx context.Context, client *
 	poller := &libraryClientDeletePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // libraryClientDeleteResponse contains the response from method libraryClient.Delete.
 type libraryClientDeleteResponse struct {
 	LibraryResourceInfo
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // libraryClientFlushPollerResponse contains the response from method libraryClient.Flush.
 type libraryClientFlushPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *libraryClientFlushPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l libraryClientFlushPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientFlushResponse, error) {
 	respType := libraryClientFlushResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -584,27 +491,21 @@ func (l *libraryClientFlushPollerResponse) Resume(ctx context.Context, client *l
 	poller := &libraryClientFlushPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // libraryClientFlushResponse contains the response from method libraryClient.Flush.
 type libraryClientFlushResponse struct {
 	LibraryResourceInfo
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // libraryClientGetOperationResultResponse contains the response from method libraryClient.GetOperationResult.
 type libraryClientGetOperationResultResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// // Possible types are LibraryResource, OperationResult
 	Value interface{}
 }
@@ -612,35 +513,27 @@ type libraryClientGetOperationResultResponse struct {
 // libraryClientGetResponse contains the response from method libraryClient.Get.
 type libraryClientGetResponse struct {
 	LibraryResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // libraryClientListResponse contains the response from method libraryClient.List.
 type libraryClientListResponse struct {
 	LibraryListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // linkedServiceClientCreateOrUpdateLinkedServicePollerResponse contains the response from method linkedServiceClient.CreateOrUpdateLinkedService.
 type linkedServiceClientCreateOrUpdateLinkedServicePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *linkedServiceClientCreateOrUpdateLinkedServicePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l linkedServiceClientCreateOrUpdateLinkedServicePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
 	respType := linkedServiceClientCreateOrUpdateLinkedServiceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LinkedServiceResource)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LinkedServiceResource)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -653,40 +546,33 @@ func (l *linkedServiceClientCreateOrUpdateLinkedServicePollerResponse) Resume(ct
 	poller := &linkedServiceClientCreateOrUpdateLinkedServicePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // linkedServiceClientCreateOrUpdateLinkedServiceResponse contains the response from method linkedServiceClient.CreateOrUpdateLinkedService.
 type linkedServiceClientCreateOrUpdateLinkedServiceResponse struct {
 	LinkedServiceResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // linkedServiceClientDeleteLinkedServicePollerResponse contains the response from method linkedServiceClient.DeleteLinkedService.
 type linkedServiceClientDeleteLinkedServicePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *linkedServiceClientDeleteLinkedServicePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l linkedServiceClientDeleteLinkedServicePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientDeleteLinkedServiceResponse, error) {
 	respType := linkedServiceClientDeleteLinkedServiceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -699,53 +585,43 @@ func (l *linkedServiceClientDeleteLinkedServicePollerResponse) Resume(ctx contex
 	poller := &linkedServiceClientDeleteLinkedServicePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // linkedServiceClientDeleteLinkedServiceResponse contains the response from method linkedServiceClient.DeleteLinkedService.
 type linkedServiceClientDeleteLinkedServiceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // linkedServiceClientGetLinkedServiceResponse contains the response from method linkedServiceClient.GetLinkedService.
 type linkedServiceClientGetLinkedServiceResponse struct {
 	LinkedServiceResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // linkedServiceClientGetLinkedServicesByWorkspaceResponse contains the response from method linkedServiceClient.GetLinkedServicesByWorkspace.
 type linkedServiceClientGetLinkedServicesByWorkspaceResponse struct {
 	LinkedServiceListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // linkedServiceClientRenameLinkedServicePollerResponse contains the response from method linkedServiceClient.RenameLinkedService.
 type linkedServiceClientRenameLinkedServicePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *linkedServiceClientRenameLinkedServicePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l linkedServiceClientRenameLinkedServicePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientRenameLinkedServiceResponse, error) {
 	respType := linkedServiceClientRenameLinkedServiceResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -758,39 +634,33 @@ func (l *linkedServiceClientRenameLinkedServicePollerResponse) Resume(ctx contex
 	poller := &linkedServiceClientRenameLinkedServicePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // linkedServiceClientRenameLinkedServiceResponse contains the response from method linkedServiceClient.RenameLinkedService.
 type linkedServiceClientRenameLinkedServiceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // notebookClientCreateOrUpdateNotebookPollerResponse contains the response from method notebookClient.CreateOrUpdateNotebook.
 type notebookClientCreateOrUpdateNotebookPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *notebookClientCreateOrUpdateNotebookPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l notebookClientCreateOrUpdateNotebookPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientCreateOrUpdateNotebookResponse, error) {
 	respType := notebookClientCreateOrUpdateNotebookResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NotebookResource)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NotebookResource)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -803,40 +673,33 @@ func (l *notebookClientCreateOrUpdateNotebookPollerResponse) Resume(ctx context.
 	poller := &notebookClientCreateOrUpdateNotebookPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // notebookClientCreateOrUpdateNotebookResponse contains the response from method notebookClient.CreateOrUpdateNotebook.
 type notebookClientCreateOrUpdateNotebookResponse struct {
 	NotebookResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // notebookClientDeleteNotebookPollerResponse contains the response from method notebookClient.DeleteNotebook.
 type notebookClientDeleteNotebookPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *notebookClientDeleteNotebookPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l notebookClientDeleteNotebookPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientDeleteNotebookResponse, error) {
 	respType := notebookClientDeleteNotebookResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -849,60 +712,48 @@ func (l *notebookClientDeleteNotebookPollerResponse) Resume(ctx context.Context,
 	poller := &notebookClientDeleteNotebookPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // notebookClientDeleteNotebookResponse contains the response from method notebookClient.DeleteNotebook.
 type notebookClientDeleteNotebookResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // notebookClientGetNotebookResponse contains the response from method notebookClient.GetNotebook.
 type notebookClientGetNotebookResponse struct {
 	NotebookResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // notebookClientGetNotebookSummaryByWorkSpaceResponse contains the response from method notebookClient.GetNotebookSummaryByWorkSpace.
 type notebookClientGetNotebookSummaryByWorkSpaceResponse struct {
 	NotebookListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // notebookClientGetNotebooksByWorkspaceResponse contains the response from method notebookClient.GetNotebooksByWorkspace.
 type notebookClientGetNotebooksByWorkspaceResponse struct {
 	NotebookListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // notebookClientRenameNotebookPollerResponse contains the response from method notebookClient.RenameNotebook.
 type notebookClientRenameNotebookPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *notebookClientRenameNotebookPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l notebookClientRenameNotebookPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientRenameNotebookResponse, error) {
 	respType := notebookClientRenameNotebookResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -915,39 +766,33 @@ func (l *notebookClientRenameNotebookPollerResponse) Resume(ctx context.Context,
 	poller := &notebookClientRenameNotebookPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // notebookClientRenameNotebookResponse contains the response from method notebookClient.RenameNotebook.
 type notebookClientRenameNotebookResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // pipelineClientCreateOrUpdatePipelinePollerResponse contains the response from method pipelineClient.CreateOrUpdatePipeline.
 type pipelineClientCreateOrUpdatePipelinePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *pipelineClientCreateOrUpdatePipelinePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l pipelineClientCreateOrUpdatePipelinePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientCreateOrUpdatePipelineResponse, error) {
 	respType := pipelineClientCreateOrUpdatePipelineResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PipelineResource)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PipelineResource)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -960,47 +805,38 @@ func (l *pipelineClientCreateOrUpdatePipelinePollerResponse) Resume(ctx context.
 	poller := &pipelineClientCreateOrUpdatePipelinePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // pipelineClientCreateOrUpdatePipelineResponse contains the response from method pipelineClient.CreateOrUpdatePipeline.
 type pipelineClientCreateOrUpdatePipelineResponse struct {
 	PipelineResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // pipelineClientCreatePipelineRunResponse contains the response from method pipelineClient.CreatePipelineRun.
 type pipelineClientCreatePipelineRunResponse struct {
 	CreateRunResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // pipelineClientDeletePipelinePollerResponse contains the response from method pipelineClient.DeletePipeline.
 type pipelineClientDeletePipelinePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *pipelineClientDeletePipelinePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l pipelineClientDeletePipelinePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientDeletePipelineResponse, error) {
 	respType := pipelineClientDeletePipelineResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1013,53 +849,43 @@ func (l *pipelineClientDeletePipelinePollerResponse) Resume(ctx context.Context,
 	poller := &pipelineClientDeletePipelinePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // pipelineClientDeletePipelineResponse contains the response from method pipelineClient.DeletePipeline.
 type pipelineClientDeletePipelineResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // pipelineClientGetPipelineResponse contains the response from method pipelineClient.GetPipeline.
 type pipelineClientGetPipelineResponse struct {
 	PipelineResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // pipelineClientGetPipelinesByWorkspaceResponse contains the response from method pipelineClient.GetPipelinesByWorkspace.
 type pipelineClientGetPipelinesByWorkspaceResponse struct {
 	PipelineListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // pipelineClientRenamePipelinePollerResponse contains the response from method pipelineClient.RenamePipeline.
 type pipelineClientRenamePipelinePollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *pipelineClientRenamePipelinePoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l pipelineClientRenamePipelinePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientRenamePipelineResponse, error) {
 	respType := pipelineClientRenamePipelineResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1072,66 +898,53 @@ func (l *pipelineClientRenamePipelinePollerResponse) Resume(ctx context.Context,
 	poller := &pipelineClientRenamePipelinePoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // pipelineClientRenamePipelineResponse contains the response from method pipelineClient.RenamePipeline.
 type pipelineClientRenamePipelineResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // pipelineRunClientCancelPipelineRunResponse contains the response from method pipelineRunClient.CancelPipelineRun.
 type pipelineRunClientCancelPipelineRunResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // pipelineRunClientGetPipelineRunResponse contains the response from method pipelineRunClient.GetPipelineRun.
 type pipelineRunClientGetPipelineRunResponse struct {
 	PipelineRun
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // pipelineRunClientQueryActivityRunsResponse contains the response from method pipelineRunClient.QueryActivityRuns.
 type pipelineRunClientQueryActivityRunsResponse struct {
 	ActivityRunsQueryResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // pipelineRunClientQueryPipelineRunsByWorkspaceResponse contains the response from method pipelineRunClient.QueryPipelineRunsByWorkspace.
 type pipelineRunClientQueryPipelineRunsByWorkspaceResponse struct {
 	PipelineRunsQueryResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition.
 type sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkJobDefinitionResource)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkJobDefinitionResource)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1145,40 +958,33 @@ func (l *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse)
 	poller := &sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition.
 type sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse struct {
 	SparkJobDefinitionResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.DebugSparkJobDefinition.
 type sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *sparkJobDefinitionClientDebugSparkJobDefinitionPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkBatchJob)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkBatchJob)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1191,40 +997,33 @@ func (l *sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse) Resume(c
 	poller := &sparkJobDefinitionClientDebugSparkJobDefinitionPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // sparkJobDefinitionClientDebugSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.DebugSparkJobDefinition.
 type sparkJobDefinitionClientDebugSparkJobDefinitionResponse struct {
 	SparkBatchJob
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.DeleteSparkJobDefinition.
 type sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1238,39 +1037,33 @@ func (l *sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse) Resume(
 	poller := &sparkJobDefinitionClientDeleteSparkJobDefinitionPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // sparkJobDefinitionClientDeleteSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.DeleteSparkJobDefinition.
 type sparkJobDefinitionClientDeleteSparkJobDefinitionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.ExecuteSparkJobDefinition.
 type sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkBatchJob)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkBatchJob)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1284,54 +1077,43 @@ func (l *sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse) Resume
 	poller := &sparkJobDefinitionClientExecuteSparkJobDefinitionPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // sparkJobDefinitionClientExecuteSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.ExecuteSparkJobDefinition.
 type sparkJobDefinitionClientExecuteSparkJobDefinitionResponse struct {
 	SparkBatchJob
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sparkJobDefinitionClientGetSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.GetSparkJobDefinition.
 type sparkJobDefinitionClientGetSparkJobDefinitionResponse struct {
 	SparkJobDefinitionResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse contains the response from method sparkJobDefinitionClient.GetSparkJobDefinitionsByWorkspace.
 type sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse struct {
 	SparkJobDefinitionsListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.RenameSparkJobDefinition.
 type sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *sparkJobDefinitionClientRenameSparkJobDefinitionPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
 	respType := sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1345,53 +1127,43 @@ func (l *sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse) Resume(
 	poller := &sparkJobDefinitionClientRenameSparkJobDefinitionPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // sparkJobDefinitionClientRenameSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.RenameSparkJobDefinition.
 type sparkJobDefinitionClientRenameSparkJobDefinitionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // sqlPoolsClientGetResponse contains the response from method sqlPoolsClient.Get.
 type sqlPoolsClientGetResponse struct {
 	SQLPool
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sqlPoolsClientListResponse contains the response from method sqlPoolsClient.List.
 type sqlPoolsClientListResponse struct {
 	SQLPoolInfoListResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sqlScriptClientCreateOrUpdateSQLScriptPollerResponse contains the response from method sqlScriptClient.CreateOrUpdateSQLScript.
 type sqlScriptClientCreateOrUpdateSQLScriptPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *sqlScriptClientCreateOrUpdateSQLScriptPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l sqlScriptClientCreateOrUpdateSQLScriptPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
 	respType := sqlScriptClientCreateOrUpdateSQLScriptResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SQLScriptResource)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SQLScriptResource)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1404,40 +1176,33 @@ func (l *sqlScriptClientCreateOrUpdateSQLScriptPollerResponse) Resume(ctx contex
 	poller := &sqlScriptClientCreateOrUpdateSQLScriptPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // sqlScriptClientCreateOrUpdateSQLScriptResponse contains the response from method sqlScriptClient.CreateOrUpdateSQLScript.
 type sqlScriptClientCreateOrUpdateSQLScriptResponse struct {
 	SQLScriptResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sqlScriptClientDeleteSQLScriptPollerResponse contains the response from method sqlScriptClient.DeleteSQLScript.
 type sqlScriptClientDeleteSQLScriptPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *sqlScriptClientDeleteSQLScriptPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l sqlScriptClientDeleteSQLScriptPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientDeleteSQLScriptResponse, error) {
 	respType := sqlScriptClientDeleteSQLScriptResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1450,53 +1215,43 @@ func (l *sqlScriptClientDeleteSQLScriptPollerResponse) Resume(ctx context.Contex
 	poller := &sqlScriptClientDeleteSQLScriptPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // sqlScriptClientDeleteSQLScriptResponse contains the response from method sqlScriptClient.DeleteSQLScript.
 type sqlScriptClientDeleteSQLScriptResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // sqlScriptClientGetSQLScriptResponse contains the response from method sqlScriptClient.GetSQLScript.
 type sqlScriptClientGetSQLScriptResponse struct {
 	SQLScriptResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sqlScriptClientGetSQLScriptsByWorkspaceResponse contains the response from method sqlScriptClient.GetSQLScriptsByWorkspace.
 type sqlScriptClientGetSQLScriptsByWorkspaceResponse struct {
 	SQLScriptsListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sqlScriptClientRenameSQLScriptPollerResponse contains the response from method sqlScriptClient.RenameSQLScript.
 type sqlScriptClientRenameSQLScriptPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *sqlScriptClientRenameSQLScriptPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l sqlScriptClientRenameSQLScriptPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientRenameSQLScriptResponse, error) {
 	respType := sqlScriptClientRenameSQLScriptResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1509,39 +1264,33 @@ func (l *sqlScriptClientRenameSQLScriptPollerResponse) Resume(ctx context.Contex
 	poller := &sqlScriptClientRenameSQLScriptPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // sqlScriptClientRenameSQLScriptResponse contains the response from method sqlScriptClient.RenameSQLScript.
 type sqlScriptClientRenameSQLScriptResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // triggerClientCreateOrUpdateTriggerPollerResponse contains the response from method triggerClient.CreateOrUpdateTrigger.
 type triggerClientCreateOrUpdateTriggerPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *triggerClientCreateOrUpdateTriggerPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l triggerClientCreateOrUpdateTriggerPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientCreateOrUpdateTriggerResponse, error) {
 	respType := triggerClientCreateOrUpdateTriggerResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerResource)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerResource)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1554,40 +1303,33 @@ func (l *triggerClientCreateOrUpdateTriggerPollerResponse) Resume(ctx context.Co
 	poller := &triggerClientCreateOrUpdateTriggerPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // triggerClientCreateOrUpdateTriggerResponse contains the response from method triggerClient.CreateOrUpdateTrigger.
 type triggerClientCreateOrUpdateTriggerResponse struct {
 	TriggerResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // triggerClientDeleteTriggerPollerResponse contains the response from method triggerClient.DeleteTrigger.
 type triggerClientDeleteTriggerPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *triggerClientDeleteTriggerPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l triggerClientDeleteTriggerPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientDeleteTriggerResponse, error) {
 	respType := triggerClientDeleteTriggerResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1600,60 +1342,48 @@ func (l *triggerClientDeleteTriggerPollerResponse) Resume(ctx context.Context, c
 	poller := &triggerClientDeleteTriggerPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // triggerClientDeleteTriggerResponse contains the response from method triggerClient.DeleteTrigger.
 type triggerClientDeleteTriggerResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // triggerClientGetEventSubscriptionStatusResponse contains the response from method triggerClient.GetEventSubscriptionStatus.
 type triggerClientGetEventSubscriptionStatusResponse struct {
 	TriggerSubscriptionOperationStatus
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // triggerClientGetTriggerResponse contains the response from method triggerClient.GetTrigger.
 type triggerClientGetTriggerResponse struct {
 	TriggerResource
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // triggerClientGetTriggersByWorkspaceResponse contains the response from method triggerClient.GetTriggersByWorkspace.
 type triggerClientGetTriggersByWorkspaceResponse struct {
 	TriggerListResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // triggerClientStartTriggerPollerResponse contains the response from method triggerClient.StartTrigger.
 type triggerClientStartTriggerPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *triggerClientStartTriggerPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l triggerClientStartTriggerPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientStartTriggerResponse, error) {
 	respType := triggerClientStartTriggerResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1666,39 +1396,33 @@ func (l *triggerClientStartTriggerPollerResponse) Resume(ctx context.Context, cl
 	poller := &triggerClientStartTriggerPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // triggerClientStartTriggerResponse contains the response from method triggerClient.StartTrigger.
 type triggerClientStartTriggerResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // triggerClientStopTriggerPollerResponse contains the response from method triggerClient.StopTrigger.
 type triggerClientStopTriggerPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *triggerClientStopTriggerPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l triggerClientStopTriggerPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientStopTriggerResponse, error) {
 	respType := triggerClientStopTriggerResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1711,39 +1435,33 @@ func (l *triggerClientStopTriggerPollerResponse) Resume(ctx context.Context, cli
 	poller := &triggerClientStopTriggerPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // triggerClientStopTriggerResponse contains the response from method triggerClient.StopTrigger.
 type triggerClientStopTriggerResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // triggerClientSubscribeTriggerToEventsPollerResponse contains the response from method triggerClient.SubscribeTriggerToEvents.
 type triggerClientSubscribeTriggerToEventsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *triggerClientSubscribeTriggerToEventsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l triggerClientSubscribeTriggerToEventsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientSubscribeTriggerToEventsResponse, error) {
 	respType := triggerClientSubscribeTriggerToEventsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerSubscriptionOperationStatus)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerSubscriptionOperationStatus)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1756,40 +1474,33 @@ func (l *triggerClientSubscribeTriggerToEventsPollerResponse) Resume(ctx context
 	poller := &triggerClientSubscribeTriggerToEventsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // triggerClientSubscribeTriggerToEventsResponse contains the response from method triggerClient.SubscribeTriggerToEvents.
 type triggerClientSubscribeTriggerToEventsResponse struct {
 	TriggerSubscriptionOperationStatus
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // triggerClientUnsubscribeTriggerFromEventsPollerResponse contains the response from method triggerClient.UnsubscribeTriggerFromEvents.
 type triggerClientUnsubscribeTriggerFromEventsPollerResponse struct {
 	// Poller contains an initialized poller.
 	Poller *triggerClientUnsubscribeTriggerFromEventsPoller
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
 // freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
 func (l triggerClientUnsubscribeTriggerFromEventsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
 	respType := triggerClientUnsubscribeTriggerFromEventsResponse{}
-	resp, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerSubscriptionOperationStatus)
+	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerSubscriptionOperationStatus)
 	if err != nil {
 		return respType, err
 	}
-	respType.RawResponse = resp
 	return respType, nil
 }
 
@@ -1802,51 +1513,40 @@ func (l *triggerClientUnsubscribeTriggerFromEventsPollerResponse) Resume(ctx con
 	poller := &triggerClientUnsubscribeTriggerFromEventsPoller{
 		pt: pt,
 	}
-	resp, err := poller.Poll(ctx)
+	_, err = poller.Poll(ctx)
 	if err != nil {
 		return err
 	}
 	l.Poller = poller
-	l.RawResponse = resp
 	return nil
 }
 
 // triggerClientUnsubscribeTriggerFromEventsResponse contains the response from method triggerClient.UnsubscribeTriggerFromEvents.
 type triggerClientUnsubscribeTriggerFromEventsResponse struct {
 	TriggerSubscriptionOperationStatus
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // triggerRunClientCancelTriggerInstanceResponse contains the response from method triggerRunClient.CancelTriggerInstance.
 type triggerRunClientCancelTriggerInstanceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // triggerRunClientQueryTriggerRunsByWorkspaceResponse contains the response from method triggerRunClient.QueryTriggerRunsByWorkspace.
 type triggerRunClientQueryTriggerRunsByWorkspaceResponse struct {
 	TriggerRunsQueryResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // triggerRunClientRerunTriggerInstanceResponse contains the response from method triggerRunClient.RerunTriggerInstance.
 type triggerRunClientRerunTriggerInstanceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // workspaceClientGetResponse contains the response from method workspaceClient.Get.
 type workspaceClientGetResponse struct {
 	Workspace
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // workspaceGitRepoManagementClientGetGitHubAccessTokenResponse contains the response from method workspaceGitRepoManagementClient.GetGitHubAccessToken.
 type workspaceGitRepoManagementClientGetGitHubAccessTokenResponse struct {
 	GitHubAccessTokenResponse
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
@@ -45,9 +45,7 @@ func (client *sparkJobDefinitionClient) BeginCreateOrUpdateSparkJobDefinition(ct
 	if err != nil {
 		return sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse{}, err
 	}
-	result := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse{
-		RawResponse: resp,
-	}
+	result := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", resp, client.pl)
 	if err != nil {
 		return sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse{}, err
@@ -106,9 +104,7 @@ func (client *sparkJobDefinitionClient) BeginDebugSparkJobDefinition(ctx context
 	if err != nil {
 		return sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse{}, err
 	}
-	result := sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse{
-		RawResponse: resp,
-	}
+	result := sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.DebugSparkJobDefinition", resp, client.pl)
 	if err != nil {
 		return sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse{}, err
@@ -160,9 +156,7 @@ func (client *sparkJobDefinitionClient) BeginDeleteSparkJobDefinition(ctx contex
 	if err != nil {
 		return sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse{}, err
 	}
-	result := sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse{
-		RawResponse: resp,
-	}
+	result := sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.DeleteSparkJobDefinition", resp, client.pl)
 	if err != nil {
 		return sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse{}, err
@@ -218,9 +212,7 @@ func (client *sparkJobDefinitionClient) BeginExecuteSparkJobDefinition(ctx conte
 	if err != nil {
 		return sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse{}, err
 	}
-	result := sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse{
-		RawResponse: resp,
-	}
+	result := sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.ExecuteSparkJobDefinition", resp, client.pl)
 	if err != nil {
 		return sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse{}, err
@@ -309,7 +301,7 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionCreateRequest(ctx c
 
 // getSparkJobDefinitionHandleResponse handles the GetSparkJobDefinition response.
 func (client *sparkJobDefinitionClient) getSparkJobDefinitionHandleResponse(resp *http.Response) (sparkJobDefinitionClientGetSparkJobDefinitionResponse, error) {
-	result := sparkJobDefinitionClientGetSparkJobDefinitionResponse{RawResponse: resp}
+	result := sparkJobDefinitionClientGetSparkJobDefinitionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkJobDefinitionResource); err != nil {
 		return sparkJobDefinitionClientGetSparkJobDefinitionResponse{}, err
 	}
@@ -348,7 +340,7 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceCreateR
 
 // getSparkJobDefinitionsByWorkspaceHandleResponse handles the GetSparkJobDefinitionsByWorkspace response.
 func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceHandleResponse(resp *http.Response) (sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse, error) {
-	result := sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{RawResponse: resp}
+	result := sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkJobDefinitionsListResponse); err != nil {
 		return sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, err
 	}
@@ -366,9 +358,7 @@ func (client *sparkJobDefinitionClient) BeginRenameSparkJobDefinition(ctx contex
 	if err != nil {
 		return sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse{}, err
 	}
-	result := sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse{
-		RawResponse: resp,
-	}
+	result := sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.RenameSparkJobDefinition", resp, client.pl)
 	if err != nil {
 		return sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools_client.go
@@ -73,7 +73,7 @@ func (client *sqlPoolsClient) getCreateRequest(ctx context.Context, sqlPoolName 
 
 // getHandleResponse handles the Get response.
 func (client *sqlPoolsClient) getHandleResponse(resp *http.Response) (sqlPoolsClientGetResponse, error) {
-	result := sqlPoolsClientGetResponse{RawResponse: resp}
+	result := sqlPoolsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLPool); err != nil {
 		return sqlPoolsClientGetResponse{}, err
 	}
@@ -114,7 +114,7 @@ func (client *sqlPoolsClient) listCreateRequest(ctx context.Context, options *sq
 
 // listHandleResponse handles the List response.
 func (client *sqlPoolsClient) listHandleResponse(resp *http.Response) (sqlPoolsClientListResponse, error) {
-	result := sqlPoolsClientListResponse{RawResponse: resp}
+	result := sqlPoolsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLPoolInfoListResult); err != nil {
 		return sqlPoolsClientListResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
@@ -45,9 +45,7 @@ func (client *sqlScriptClient) BeginCreateOrUpdateSQLScript(ctx context.Context,
 	if err != nil {
 		return sqlScriptClientCreateOrUpdateSQLScriptPollerResponse{}, err
 	}
-	result := sqlScriptClientCreateOrUpdateSQLScriptPollerResponse{
-		RawResponse: resp,
-	}
+	result := sqlScriptClientCreateOrUpdateSQLScriptPollerResponse{}
 	pt, err := runtime.NewPoller("sqlScriptClient.CreateOrUpdateSQLScript", resp, client.pl)
 	if err != nil {
 		return sqlScriptClientCreateOrUpdateSQLScriptPollerResponse{}, err
@@ -106,9 +104,7 @@ func (client *sqlScriptClient) BeginDeleteSQLScript(ctx context.Context, sqlScri
 	if err != nil {
 		return sqlScriptClientDeleteSQLScriptPollerResponse{}, err
 	}
-	result := sqlScriptClientDeleteSQLScriptPollerResponse{
-		RawResponse: resp,
-	}
+	result := sqlScriptClientDeleteSQLScriptPollerResponse{}
 	pt, err := runtime.NewPoller("sqlScriptClient.DeleteSQLScript", resp, client.pl)
 	if err != nil {
 		return sqlScriptClientDeleteSQLScriptPollerResponse{}, err
@@ -196,7 +192,7 @@ func (client *sqlScriptClient) getSQLScriptCreateRequest(ctx context.Context, sq
 
 // getSQLScriptHandleResponse handles the GetSQLScript response.
 func (client *sqlScriptClient) getSQLScriptHandleResponse(resp *http.Response) (sqlScriptClientGetSQLScriptResponse, error) {
-	result := sqlScriptClientGetSQLScriptResponse{RawResponse: resp}
+	result := sqlScriptClientGetSQLScriptResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLScriptResource); err != nil {
 		return sqlScriptClientGetSQLScriptResponse{}, err
 	}
@@ -235,7 +231,7 @@ func (client *sqlScriptClient) getSQLScriptsByWorkspaceCreateRequest(ctx context
 
 // getSQLScriptsByWorkspaceHandleResponse handles the GetSQLScriptsByWorkspace response.
 func (client *sqlScriptClient) getSQLScriptsByWorkspaceHandleResponse(resp *http.Response) (sqlScriptClientGetSQLScriptsByWorkspaceResponse, error) {
-	result := sqlScriptClientGetSQLScriptsByWorkspaceResponse{RawResponse: resp}
+	result := sqlScriptClientGetSQLScriptsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLScriptsListResponse); err != nil {
 		return sqlScriptClientGetSQLScriptsByWorkspaceResponse{}, err
 	}
@@ -253,9 +249,7 @@ func (client *sqlScriptClient) BeginRenameSQLScript(ctx context.Context, sqlScri
 	if err != nil {
 		return sqlScriptClientRenameSQLScriptPollerResponse{}, err
 	}
-	result := sqlScriptClientRenameSQLScriptPollerResponse{
-		RawResponse: resp,
-	}
+	result := sqlScriptClientRenameSQLScriptPollerResponse{}
 	pt, err := runtime.NewPoller("sqlScriptClient.RenameSQLScript", resp, client.pl)
 	if err != nil {
 		return sqlScriptClientRenameSQLScriptPollerResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
@@ -45,9 +45,7 @@ func (client *triggerClient) BeginCreateOrUpdateTrigger(ctx context.Context, tri
 	if err != nil {
 		return triggerClientCreateOrUpdateTriggerPollerResponse{}, err
 	}
-	result := triggerClientCreateOrUpdateTriggerPollerResponse{
-		RawResponse: resp,
-	}
+	result := triggerClientCreateOrUpdateTriggerPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.CreateOrUpdateTrigger", resp, client.pl)
 	if err != nil {
 		return triggerClientCreateOrUpdateTriggerPollerResponse{}, err
@@ -106,9 +104,7 @@ func (client *triggerClient) BeginDeleteTrigger(ctx context.Context, triggerName
 	if err != nil {
 		return triggerClientDeleteTriggerPollerResponse{}, err
 	}
-	result := triggerClientDeleteTriggerPollerResponse{
-		RawResponse: resp,
-	}
+	result := triggerClientDeleteTriggerPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.DeleteTrigger", resp, client.pl)
 	if err != nil {
 		return triggerClientDeleteTriggerPollerResponse{}, err
@@ -194,7 +190,7 @@ func (client *triggerClient) getEventSubscriptionStatusCreateRequest(ctx context
 
 // getEventSubscriptionStatusHandleResponse handles the GetEventSubscriptionStatus response.
 func (client *triggerClient) getEventSubscriptionStatusHandleResponse(resp *http.Response) (triggerClientGetEventSubscriptionStatusResponse, error) {
-	result := triggerClientGetEventSubscriptionStatusResponse{RawResponse: resp}
+	result := triggerClientGetEventSubscriptionStatusResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerSubscriptionOperationStatus); err != nil {
 		return triggerClientGetEventSubscriptionStatusResponse{}, err
 	}
@@ -243,7 +239,7 @@ func (client *triggerClient) getTriggerCreateRequest(ctx context.Context, trigge
 
 // getTriggerHandleResponse handles the GetTrigger response.
 func (client *triggerClient) getTriggerHandleResponse(resp *http.Response) (triggerClientGetTriggerResponse, error) {
-	result := triggerClientGetTriggerResponse{RawResponse: resp}
+	result := triggerClientGetTriggerResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerResource); err != nil {
 		return triggerClientGetTriggerResponse{}, err
 	}
@@ -282,7 +278,7 @@ func (client *triggerClient) getTriggersByWorkspaceCreateRequest(ctx context.Con
 
 // getTriggersByWorkspaceHandleResponse handles the GetTriggersByWorkspace response.
 func (client *triggerClient) getTriggersByWorkspaceHandleResponse(resp *http.Response) (triggerClientGetTriggersByWorkspaceResponse, error) {
-	result := triggerClientGetTriggersByWorkspaceResponse{RawResponse: resp}
+	result := triggerClientGetTriggersByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerListResponse); err != nil {
 		return triggerClientGetTriggersByWorkspaceResponse{}, err
 	}
@@ -299,9 +295,7 @@ func (client *triggerClient) BeginStartTrigger(ctx context.Context, triggerName 
 	if err != nil {
 		return triggerClientStartTriggerPollerResponse{}, err
 	}
-	result := triggerClientStartTriggerPollerResponse{
-		RawResponse: resp,
-	}
+	result := triggerClientStartTriggerPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.StartTrigger", resp, client.pl)
 	if err != nil {
 		return triggerClientStartTriggerPollerResponse{}, err
@@ -357,9 +351,7 @@ func (client *triggerClient) BeginStopTrigger(ctx context.Context, triggerName s
 	if err != nil {
 		return triggerClientStopTriggerPollerResponse{}, err
 	}
-	result := triggerClientStopTriggerPollerResponse{
-		RawResponse: resp,
-	}
+	result := triggerClientStopTriggerPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.StopTrigger", resp, client.pl)
 	if err != nil {
 		return triggerClientStopTriggerPollerResponse{}, err
@@ -415,9 +407,7 @@ func (client *triggerClient) BeginSubscribeTriggerToEvents(ctx context.Context, 
 	if err != nil {
 		return triggerClientSubscribeTriggerToEventsPollerResponse{}, err
 	}
-	result := triggerClientSubscribeTriggerToEventsPollerResponse{
-		RawResponse: resp,
-	}
+	result := triggerClientSubscribeTriggerToEventsPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.SubscribeTriggerToEvents", resp, client.pl)
 	if err != nil {
 		return triggerClientSubscribeTriggerToEventsPollerResponse{}, err
@@ -473,9 +463,7 @@ func (client *triggerClient) BeginUnsubscribeTriggerFromEvents(ctx context.Conte
 	if err != nil {
 		return triggerClientUnsubscribeTriggerFromEventsPollerResponse{}, err
 	}
-	result := triggerClientUnsubscribeTriggerFromEventsPollerResponse{
-		RawResponse: resp,
-	}
+	result := triggerClientUnsubscribeTriggerFromEventsPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.UnsubscribeTriggerFromEvents", resp, client.pl)
 	if err != nil {
 		return triggerClientUnsubscribeTriggerFromEventsPollerResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun_client.go
@@ -52,7 +52,7 @@ func (client *triggerRunClient) CancelTriggerInstance(ctx context.Context, trigg
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return triggerRunClientCancelTriggerInstanceResponse{}, runtime.NewResponseError(resp)
 	}
-	return triggerRunClientCancelTriggerInstanceResponse{RawResponse: resp}, nil
+	return triggerRunClientCancelTriggerInstanceResponse{}, nil
 }
 
 // cancelTriggerInstanceCreateRequest creates the CancelTriggerInstance request.
@@ -113,7 +113,7 @@ func (client *triggerRunClient) queryTriggerRunsByWorkspaceCreateRequest(ctx con
 
 // queryTriggerRunsByWorkspaceHandleResponse handles the QueryTriggerRunsByWorkspace response.
 func (client *triggerRunClient) queryTriggerRunsByWorkspaceHandleResponse(resp *http.Response) (triggerRunClientQueryTriggerRunsByWorkspaceResponse, error) {
-	result := triggerRunClientQueryTriggerRunsByWorkspaceResponse{RawResponse: resp}
+	result := triggerRunClientQueryTriggerRunsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerRunsQueryResponse); err != nil {
 		return triggerRunClientQueryTriggerRunsByWorkspaceResponse{}, err
 	}
@@ -138,7 +138,7 @@ func (client *triggerRunClient) RerunTriggerInstance(ctx context.Context, trigge
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return triggerRunClientRerunTriggerInstanceResponse{}, runtime.NewResponseError(resp)
 	}
-	return triggerRunClientRerunTriggerInstanceResponse{RawResponse: resp}, nil
+	return triggerRunClientRerunTriggerInstanceResponse{}, nil
 }
 
 // rerunTriggerInstanceCreateRequest creates the RerunTriggerInstance request.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspace_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspace_client.go
@@ -65,7 +65,7 @@ func (client *workspaceClient) getCreateRequest(ctx context.Context, options *wo
 
 // getHandleResponse handles the Get response.
 func (client *workspaceClient) getHandleResponse(resp *http.Response) (workspaceClientGetResponse, error) {
-	result := workspaceClientGetResponse{RawResponse: resp}
+	result := workspaceClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Workspace); err != nil {
 		return workspaceClientGetResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspacegitrepomanagement_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspacegitrepomanagement_client.go
@@ -69,7 +69,7 @@ func (client *workspaceGitRepoManagementClient) getGitHubAccessTokenCreateReques
 
 // getGitHubAccessTokenHandleResponse handles the GetGitHubAccessToken response.
 func (client *workspaceGitRepoManagementClient) getGitHubAccessTokenHandleResponse(resp *http.Response) (workspaceGitRepoManagementClientGetGitHubAccessTokenResponse, error) {
-	result := workspaceGitRepoManagementClientGetGitHubAccessTokenResponse{RawResponse: resp}
+	result := workspaceGitRepoManagementClientGetGitHubAccessTokenResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GitHubAccessTokenResponse); err != nil {
 		return workspaceGitRepoManagementClientGetGitHubAccessTokenResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azspark/zz_generated_batch_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_batch_client.go
@@ -61,7 +61,7 @@ func (client *batchClient) CancelSparkBatchJob(ctx context.Context, batchID int3
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return batchClientCancelSparkBatchJobResponse{}, runtime.NewResponseError(resp)
 	}
-	return batchClientCancelSparkBatchJobResponse{RawResponse: resp}, nil
+	return batchClientCancelSparkBatchJobResponse{}, nil
 }
 
 // cancelSparkBatchJobCreateRequest creates the CancelSparkBatchJob request.
@@ -113,7 +113,7 @@ func (client *batchClient) createSparkBatchJobCreateRequest(ctx context.Context,
 
 // createSparkBatchJobHandleResponse handles the CreateSparkBatchJob response.
 func (client *batchClient) createSparkBatchJobHandleResponse(resp *http.Response) (batchClientCreateSparkBatchJobResponse, error) {
-	result := batchClientCreateSparkBatchJobResponse{RawResponse: resp}
+	result := batchClientCreateSparkBatchJobResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJob); err != nil {
 		return batchClientCreateSparkBatchJobResponse{}, err
 	}
@@ -158,7 +158,7 @@ func (client *batchClient) getSparkBatchJobCreateRequest(ctx context.Context, ba
 
 // getSparkBatchJobHandleResponse handles the GetSparkBatchJob response.
 func (client *batchClient) getSparkBatchJobHandleResponse(resp *http.Response) (batchClientGetSparkBatchJobResponse, error) {
-	result := batchClientGetSparkBatchJobResponse{RawResponse: resp}
+	result := batchClientGetSparkBatchJobResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJob); err != nil {
 		return batchClientGetSparkBatchJobResponse{}, err
 	}
@@ -207,7 +207,7 @@ func (client *batchClient) getSparkBatchJobsCreateRequest(ctx context.Context, o
 
 // getSparkBatchJobsHandleResponse handles the GetSparkBatchJobs response.
 func (client *batchClient) getSparkBatchJobsHandleResponse(resp *http.Response) (batchClientGetSparkBatchJobsResponse, error) {
-	result := batchClientGetSparkBatchJobsResponse{RawResponse: resp}
+	result := batchClientGetSparkBatchJobsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJobCollection); err != nil {
 		return batchClientGetSparkBatchJobsResponse{}, err
 	}

--- a/test/synapse/2019-06-01/azspark/zz_generated_response_types.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_response_types.go
@@ -8,92 +8,67 @@
 
 package azspark
 
-import "net/http"
-
 // batchClientCancelSparkBatchJobResponse contains the response from method batchClient.CancelSparkBatchJob.
 type batchClientCancelSparkBatchJobResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // batchClientCreateSparkBatchJobResponse contains the response from method batchClient.CreateSparkBatchJob.
 type batchClientCreateSparkBatchJobResponse struct {
 	BatchJob
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // batchClientGetSparkBatchJobResponse contains the response from method batchClient.GetSparkBatchJob.
 type batchClientGetSparkBatchJobResponse struct {
 	BatchJob
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // batchClientGetSparkBatchJobsResponse contains the response from method batchClient.GetSparkBatchJobs.
 type batchClientGetSparkBatchJobsResponse struct {
 	BatchJobCollection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sessionClientCancelSparkSessionResponse contains the response from method sessionClient.CancelSparkSession.
 type sessionClientCancelSparkSessionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }
 
 // sessionClientCancelSparkStatementResponse contains the response from method sessionClient.CancelSparkStatement.
 type sessionClientCancelSparkStatementResponse struct {
 	StatementCancellationResult
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sessionClientCreateSparkSessionResponse contains the response from method sessionClient.CreateSparkSession.
 type sessionClientCreateSparkSessionResponse struct {
 	Session
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sessionClientCreateSparkStatementResponse contains the response from method sessionClient.CreateSparkStatement.
 type sessionClientCreateSparkStatementResponse struct {
 	Statement
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sessionClientGetSparkSessionResponse contains the response from method sessionClient.GetSparkSession.
 type sessionClientGetSparkSessionResponse struct {
 	Session
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sessionClientGetSparkSessionsResponse contains the response from method sessionClient.GetSparkSessions.
 type sessionClientGetSparkSessionsResponse struct {
 	SessionCollection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sessionClientGetSparkStatementResponse contains the response from method sessionClient.GetSparkStatement.
 type sessionClientGetSparkStatementResponse struct {
 	Statement
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sessionClientGetSparkStatementsResponse contains the response from method sessionClient.GetSparkStatements.
 type sessionClientGetSparkStatementsResponse struct {
 	StatementCollection
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // sessionClientResetSparkSessionTimeoutResponse contains the response from method sessionClient.ResetSparkSessionTimeout.
 type sessionClientResetSparkSessionTimeoutResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+	// placeholder for future response values
 }

--- a/test/synapse/2019-06-01/azspark/zz_generated_session_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_session_client.go
@@ -61,7 +61,7 @@ func (client *sessionClient) CancelSparkSession(ctx context.Context, sessionID i
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return sessionClientCancelSparkSessionResponse{}, runtime.NewResponseError(resp)
 	}
-	return sessionClientCancelSparkSessionResponse{RawResponse: resp}, nil
+	return sessionClientCancelSparkSessionResponse{}, nil
 }
 
 // cancelSparkSessionCreateRequest creates the CancelSparkSession request.
@@ -111,7 +111,7 @@ func (client *sessionClient) cancelSparkStatementCreateRequest(ctx context.Conte
 
 // cancelSparkStatementHandleResponse handles the CancelSparkStatement response.
 func (client *sessionClient) cancelSparkStatementHandleResponse(resp *http.Response) (sessionClientCancelSparkStatementResponse, error) {
-	result := sessionClientCancelSparkStatementResponse{RawResponse: resp}
+	result := sessionClientCancelSparkStatementResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StatementCancellationResult); err != nil {
 		return sessionClientCancelSparkStatementResponse{}, err
 	}
@@ -156,7 +156,7 @@ func (client *sessionClient) createSparkSessionCreateRequest(ctx context.Context
 
 // createSparkSessionHandleResponse handles the CreateSparkSession response.
 func (client *sessionClient) createSparkSessionHandleResponse(resp *http.Response) (sessionClientCreateSparkSessionResponse, error) {
-	result := sessionClientCreateSparkSessionResponse{RawResponse: resp}
+	result := sessionClientCreateSparkSessionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Session); err != nil {
 		return sessionClientCreateSparkSessionResponse{}, err
 	}
@@ -198,7 +198,7 @@ func (client *sessionClient) createSparkStatementCreateRequest(ctx context.Conte
 
 // createSparkStatementHandleResponse handles the CreateSparkStatement response.
 func (client *sessionClient) createSparkStatementHandleResponse(resp *http.Response) (sessionClientCreateSparkStatementResponse, error) {
-	result := sessionClientCreateSparkStatementResponse{RawResponse: resp}
+	result := sessionClientCreateSparkStatementResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Statement); err != nil {
 		return sessionClientCreateSparkStatementResponse{}, err
 	}
@@ -243,7 +243,7 @@ func (client *sessionClient) getSparkSessionCreateRequest(ctx context.Context, s
 
 // getSparkSessionHandleResponse handles the GetSparkSession response.
 func (client *sessionClient) getSparkSessionHandleResponse(resp *http.Response) (sessionClientGetSparkSessionResponse, error) {
-	result := sessionClientGetSparkSessionResponse{RawResponse: resp}
+	result := sessionClientGetSparkSessionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Session); err != nil {
 		return sessionClientGetSparkSessionResponse{}, err
 	}
@@ -293,7 +293,7 @@ func (client *sessionClient) getSparkSessionsCreateRequest(ctx context.Context, 
 
 // getSparkSessionsHandleResponse handles the GetSparkSessions response.
 func (client *sessionClient) getSparkSessionsHandleResponse(resp *http.Response) (sessionClientGetSparkSessionsResponse, error) {
-	result := sessionClientGetSparkSessionsResponse{RawResponse: resp}
+	result := sessionClientGetSparkSessionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SessionCollection); err != nil {
 		return sessionClientGetSparkSessionsResponse{}, err
 	}
@@ -336,7 +336,7 @@ func (client *sessionClient) getSparkStatementCreateRequest(ctx context.Context,
 
 // getSparkStatementHandleResponse handles the GetSparkStatement response.
 func (client *sessionClient) getSparkStatementHandleResponse(resp *http.Response) (sessionClientGetSparkStatementResponse, error) {
-	result := sessionClientGetSparkStatementResponse{RawResponse: resp}
+	result := sessionClientGetSparkStatementResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Statement); err != nil {
 		return sessionClientGetSparkStatementResponse{}, err
 	}
@@ -377,7 +377,7 @@ func (client *sessionClient) getSparkStatementsCreateRequest(ctx context.Context
 
 // getSparkStatementsHandleResponse handles the GetSparkStatements response.
 func (client *sessionClient) getSparkStatementsHandleResponse(resp *http.Response) (sessionClientGetSparkStatementsResponse, error) {
-	result := sessionClientGetSparkStatementsResponse{RawResponse: resp}
+	result := sessionClientGetSparkStatementsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StatementCollection); err != nil {
 		return sessionClientGetSparkStatementsResponse{}, err
 	}
@@ -401,7 +401,7 @@ func (client *sessionClient) ResetSparkSessionTimeout(ctx context.Context, sessi
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return sessionClientResetSparkSessionTimeoutResponse{}, runtime.NewResponseError(resp)
 	}
-	return sessionClientResetSparkSessionTimeoutResponse{RawResponse: resp}, nil
+	return sessionClientResetSparkSessionTimeoutResponse{}, nil
 }
 
 // resetSparkSessionTimeoutCreateRequest creates the ResetSparkSessionTimeout request.

--- a/test/tables/2019-02-02/aztables/zz_generated_client.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_client.go
@@ -88,7 +88,7 @@ func (client *Client) createCreateRequest(ctx context.Context, dataServiceVersio
 
 // createHandleResponse handles the Create response.
 func (client *Client) createHandleResponse(resp *http.Response) (ClientCreateResponse, error) {
-	result := ClientCreateResponse{RawResponse: resp}
+	result := ClientCreateResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -154,7 +154,7 @@ func (client *Client) deleteCreateRequest(ctx context.Context, table string, opt
 
 // deleteHandleResponse handles the Delete response.
 func (client *Client) deleteHandleResponse(resp *http.Response) (ClientDeleteResponse, error) {
-	result := ClientDeleteResponse{RawResponse: resp}
+	result := ClientDeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -237,7 +237,7 @@ func (client *Client) deleteEntityCreateRequest(ctx context.Context, dataService
 
 // deleteEntityHandleResponse handles the DeleteEntity response.
 func (client *Client) deleteEntityHandleResponse(resp *http.Response) (ClientDeleteEntityResponse, error) {
-	result := ClientDeleteEntityResponse{RawResponse: resp}
+	result := ClientDeleteEntityResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -305,7 +305,7 @@ func (client *Client) getAccessPolicyCreateRequest(ctx context.Context, table st
 
 // getAccessPolicyHandleResponse handles the GetAccessPolicy response.
 func (client *Client) getAccessPolicyHandleResponse(resp *http.Response) (ClientGetAccessPolicyResponse, error) {
-	result := ClientGetAccessPolicyResponse{RawResponse: resp}
+	result := ClientGetAccessPolicyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -384,7 +384,7 @@ func (client *Client) insertEntityCreateRequest(ctx context.Context, dataService
 
 // insertEntityHandleResponse handles the InsertEntity response.
 func (client *Client) insertEntityHandleResponse(resp *http.Response) (ClientInsertEntityResponse, error) {
-	result := ClientInsertEntityResponse{RawResponse: resp}
+	result := ClientInsertEntityResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -482,7 +482,7 @@ func (client *Client) mergeEntityCreateRequest(ctx context.Context, dataServiceV
 
 // mergeEntityHandleResponse handles the MergeEntity response.
 func (client *Client) mergeEntityHandleResponse(resp *http.Response) (ClientMergeEntityResponse, error) {
-	result := ClientMergeEntityResponse{RawResponse: resp}
+	result := ClientMergeEntityResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -559,7 +559,7 @@ func (client *Client) queryCreateRequest(ctx context.Context, dataServiceVersion
 
 // queryHandleResponse handles the Query response.
 func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryResponse, error) {
-	result := ClientQueryResponse{RawResponse: resp}
+	result := ClientQueryResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -650,7 +650,7 @@ func (client *Client) queryEntitiesCreateRequest(ctx context.Context, dataServic
 
 // queryEntitiesHandleResponse handles the QueryEntities response.
 func (client *Client) queryEntitiesHandleResponse(resp *http.Response) (ClientQueryEntitiesResponse, error) {
-	result := ClientQueryEntitiesResponse{RawResponse: resp}
+	result := ClientQueryEntitiesResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -746,7 +746,7 @@ func (client *Client) queryEntityWithPartitionAndRowKeyCreateRequest(ctx context
 
 // queryEntityWithPartitionAndRowKeyHandleResponse handles the QueryEntityWithPartitionAndRowKey response.
 func (client *Client) queryEntityWithPartitionAndRowKeyHandleResponse(resp *http.Response) (ClientQueryEntityWithPartitionAndRowKeyResponse, error) {
-	result := ClientQueryEntityWithPartitionAndRowKeyResponse{RawResponse: resp}
+	result := ClientQueryEntityWithPartitionAndRowKeyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -832,7 +832,7 @@ func (client *Client) setAccessPolicyCreateRequest(ctx context.Context, table st
 
 // setAccessPolicyHandleResponse handles the SetAccessPolicy response.
 func (client *Client) setAccessPolicyHandleResponse(resp *http.Response) (ClientSetAccessPolicyResponse, error) {
-	result := ClientSetAccessPolicyResponse{RawResponse: resp}
+	result := ClientSetAccessPolicyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -918,7 +918,7 @@ func (client *Client) updateEntityCreateRequest(ctx context.Context, dataService
 
 // updateEntityHandleResponse handles the UpdateEntity response.
 func (client *Client) updateEntityHandleResponse(resp *http.Response) (ClientUpdateEntityResponse, error) {
-	result := ClientUpdateEntityResponse{RawResponse: resp}
+	result := ClientUpdateEntityResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}

--- a/test/tables/2019-02-02/aztables/zz_generated_response_types.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_response_types.go
@@ -8,10 +8,7 @@
 
 package aztables
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 // ClientCreateResponse contains the response from method Client.Create.
 type ClientCreateResponse struct {
@@ -24,9 +21,6 @@ type ClientCreateResponse struct {
 
 	// PreferenceApplied contains the information returned from the Preference-Applied header response.
 	PreferenceApplied *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -43,9 +37,6 @@ type ClientDeleteEntityResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -61,9 +52,6 @@ type ClientDeleteResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -78,9 +66,6 @@ type ClientGetAccessPolicyResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -109,9 +94,6 @@ type ClientInsertEntityResponse struct {
 	// PreferenceApplied contains the information returned from the Preference-Applied header response.
 	PreferenceApplied *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -133,9 +115,6 @@ type ClientMergeEntityResponse struct {
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -151,9 +130,6 @@ type ClientQueryEntitiesResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -178,9 +154,6 @@ type ClientQueryEntityWithPartitionAndRowKeyResponse struct {
 
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -207,9 +180,6 @@ type ClientQueryResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -227,9 +197,6 @@ type ClientSetAccessPolicyResponse struct {
 
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
@@ -249,9 +216,6 @@ type ClientUpdateEntityResponse struct {
 	// ETag contains the information returned from the ETag header response.
 	ETag *string
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
 
@@ -264,9 +228,6 @@ type ServiceClientGetPropertiesResponse struct {
 	ServiceProperties
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
@@ -284,9 +245,6 @@ type ServiceClientGetStatisticsResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time `xml:"Date"`
 
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string `xml:"RequestID"`
 
@@ -298,9 +256,6 @@ type ServiceClientGetStatisticsResponse struct {
 type ServiceClientSetPropertiesResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string

--- a/test/tables/2019-02-02/aztables/zz_generated_service_client.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_service_client.go
@@ -82,7 +82,7 @@ func (client *ServiceClient) getPropertiesCreateRequest(ctx context.Context, res
 
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client *ServiceClient) getPropertiesHandleResponse(resp *http.Response) (ServiceClientGetPropertiesResponse, error) {
-	result := ServiceClientGetPropertiesResponse{RawResponse: resp}
+	result := ServiceClientGetPropertiesResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -142,7 +142,7 @@ func (client *ServiceClient) getStatisticsCreateRequest(ctx context.Context, res
 
 // getStatisticsHandleResponse handles the GetStatistics response.
 func (client *ServiceClient) getStatisticsHandleResponse(resp *http.Response) (ServiceClientGetStatisticsResponse, error) {
-	result := ServiceClientGetStatisticsResponse{RawResponse: resp}
+	result := ServiceClientGetStatisticsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -210,7 +210,7 @@ func (client *ServiceClient) setPropertiesCreateRequest(ctx context.Context, res
 
 // setPropertiesHandleResponse handles the SetProperties response.
 func (client *ServiceClient) setPropertiesHandleResponse(resp *http.Response) (ServiceClientSetPropertiesResponse, error) {
-	result := ServiceClientSetPropertiesResponse{RawResponse: resp}
+	result := ServiceClientSetPropertiesResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}


### PR DESCRIPTION
It's typically not needed in the common, success case.  Other means will
be added to retrieve it when required.
If the response envelope is empty, it will contain a placeholder
comment.
For binary response types, their response envelopes now contain an
io.ReadCloser field.