### PR TITLE
Poller API refactor

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,7 +6,7 @@ dependencies:
   '@azure-tools/codegen': 2.9.0
   '@azure-tools/linq': 3.1.261
   '@azure-tools/tasks': 3.0.252
-  '@microsoft.azure/autorest.testserver': 3.1.8_e58605af5d62eced51e25286a407a18b
+  '@microsoft.azure/autorest.testserver': 3.3.5_e58605af5d62eced51e25286a407a18b
   '@rush-temp/go': 'file:projects/go.tgz'
   '@types/html-to-text': 5.1.2
   '@types/jest': 26.0.24
@@ -306,6 +306,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==
+  /@babel/parser/7.17.3:
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.14.3:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
@@ -428,7 +435,7 @@ packages:
   /@babel/template/7.12.13:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/parser': 7.14.3
+      '@babel/parser': 7.17.3
       '@babel/types': 7.14.2
     dev: false
     resolution:
@@ -439,7 +446,7 @@ packages:
       '@babel/generator': 7.14.3
       '@babel/helper-function-name': 7.14.2
       '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.14.3
+      '@babel/parser': 7.17.3
       '@babel/types': 7.14.2
       debug: 4.2.0
       globals: 11.12.0
@@ -457,6 +464,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+  /@colors/colors/1.5.0:
+    dev: false
+    engines:
+      node: '>=0.1.90'
+    resolution:
+      integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
   /@dabh/diagnostics/2.0.2:
     dependencies:
       colorspace: 1.1.2
@@ -496,19 +509,19 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-35z+RqsK2CCgNxn+lWyK8X4KkaDtfL4BggT7oeZ0JffIiAiEYFYPo5B67V50ZubqDS1ehBrdCR2jduFnIrZOYw==
-  /@jest/console/27.3.1:
+  /@jest/console/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
       chalk: 4.1.0
-      jest-message-util: 27.3.1
-      jest-util: 27.3.1
+      jest-message-util: 27.5.1
+      jest-util: 27.5.1
       slash: 3.0.0
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-RkFNWmv0iui+qsOr/29q9dyfKTTT5DCuP31kUwg7rmOKPT/ozLeGLKJKVIiOfbiKyleUZKIrHwhmiZWVe8IMdw==
+      integrity: sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==
   /@jest/core/27.2.1:
     dependencies:
       '@jest/console': 27.2.0
@@ -550,32 +563,32 @@ packages:
         optional: true
     resolution:
       integrity: sha512-XcGt9UgPyzylThvezwUIMCNVp8xxN78Ic3WwhJZehZt4n2hPHR6Bd85A1nKFZBeqW58Vd+Cx/LaN6YL4n58KlA==
-  /@jest/core/27.3.1:
+  /@jest/core/27.5.1:
     dependencies:
-      '@jest/console': 27.3.1
-      '@jest/reporters': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/console': 27.5.1
+      '@jest/reporters': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
       ansi-escapes: 4.3.1
       chalk: 4.1.0
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-changed-files: 27.3.0
-      jest-config: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-message-util: 27.3.1
-      jest-regex-util: 27.0.6
-      jest-resolve: 27.3.1_jest-resolve@27.3.1
-      jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1
-      jest-runtime: 27.3.1
-      jest-snapshot: 27.3.1
-      jest-util: 27.3.1
-      jest-validate: 27.3.1
-      jest-watcher: 27.3.1
+      graceful-fs: 4.2.9
+      jest-changed-files: 27.5.1
+      jest-config: 27.5.1
+      jest-haste-map: 27.5.1
+      jest-message-util: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1_jest-resolve@27.5.1
+      jest-resolve-dependencies: 27.5.1
+      jest-runner: 27.5.1
+      jest-runtime: 27.5.1
+      jest-snapshot: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      jest-watcher: 27.5.1
       micromatch: 4.0.4
       rimraf: 3.0.2
       slash: 3.0.0
@@ -589,7 +602,7 @@ packages:
       node-notifier:
         optional: true
     resolution:
-      integrity: sha512-DMNE90RR5QKx0EA+wqe3/TNEwiRpOkhshKNxtLxd4rt3IZpCt+RSL+FoJsGeblRZmqdK4upHA/mKKGPPRAifhg==
+      integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==
   /@jest/environment/27.2.0:
     dependencies:
       '@jest/fake-timers': 27.2.0
@@ -601,17 +614,17 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-iPWmQI0wRIYSZX3wKu4FXHK4eIqkfq6n1DCDJS+v3uby7SOXrHvX4eiTBuEdSvtDRMTIH2kjrSkjHf/F9JIYyQ==
-  /@jest/environment/27.3.1:
+  /@jest/environment/27.5.1:
     dependencies:
-      '@jest/fake-timers': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/fake-timers': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
-      jest-mock: 27.3.0
+      jest-mock: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-BCKCj4mOVLme6Tanoyc9k0ultp3pnmuyHw73UHRPeeZxirsU/7E3HC4le/VDb/SMzE1JcPnto+XBKFOcoiJzVw==
+      integrity: sha512-/WQjhPJe3/ghaol/4Bq480JKXV/Rfw8nQdN7f41fM8VDHLcxKXou6QyXAh3EFr9/bVG3x74z1NWDkP87EiY8gA==
   /@jest/fake-timers/27.2.0:
     dependencies:
       '@jest/types': 27.1.1
@@ -625,19 +638,19 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-gSu3YHvQOoVaTWYGgHFB7IYFtcF2HBzX4l7s47VcjvkUgL4/FBnE20x7TNLa3W6ABERtGd5gStSwsA8bcn+c4w==
-  /@jest/fake-timers/27.3.1:
+  /@jest/fake-timers/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.0.1
       '@types/node': 12.7.2
-      jest-message-util: 27.3.1
-      jest-mock: 27.3.0
-      jest-util: 27.3.1
+      jest-message-util: 27.5.1
+      jest-mock: 27.5.1
+      jest-util: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-M3ZFgwwlqJtWZ+QkBG5NmC23A9w+A6ZxNsO5nJxJsKYt4yguBd3i8TpjQz5NfCX91nEve1KqD9RA2Q+Q1uWqoA==
+      integrity: sha512-/aPowoolwa07k7/oM3aASneNeBGCmGQsc3ugN4u6s4C/+s5M64MFo/+djTdiwcbQlRfFElGuDXWzaWj6QgKObQ==
   /@jest/globals/27.2.1:
     dependencies:
       '@jest/environment': 27.2.0
@@ -648,16 +661,16 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-4P46Zr4cckSitsWtOMRvgMMn7mOKbBsQdYxHeGSIG3kpI4gNR2vk51balPulZHnBQCQb/XBptprtoSv1REfaew==
-  /@jest/globals/27.3.1:
+  /@jest/globals/27.5.1:
     dependencies:
-      '@jest/environment': 27.3.1
-      '@jest/types': 27.2.5
-      expect: 27.3.1
+      '@jest/environment': 27.5.1
+      '@jest/types': 27.5.1
+      expect: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-Q651FWiWQAIFiN+zS51xqhdZ8g9b88nGCobC87argAxA7nMfNQq0Q0i9zTfQYgLa6qFXk2cGANEqfK051CZ8Pg==
+      integrity: sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==
   /@jest/reporters/27.2.1:
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
@@ -694,28 +707,28 @@ packages:
         optional: true
     resolution:
       integrity: sha512-ILqR+bIIBlhaHjDtQR/0Z20YkKAQVM+NVRuJLaWFCoRx/rKQQSxG01ZLiLV0MsA6wkBHf6J9fzFuXp0k5l7epw==
-  /@jest/reporters/27.3.1:
+  /@jest/reporters/27.5.1:
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/console': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
       chalk: 4.1.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.6
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.9
       istanbul-lib-coverage: 3.0.0
-      istanbul-lib-instrument: 4.0.3
+      istanbul-lib-instrument: 5.1.0
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.0
-      istanbul-reports: 3.0.2
-      jest-haste-map: 27.3.1
-      jest-resolve: 27.3.1_jest-resolve@27.3.1
-      jest-util: 27.3.1
-      jest-worker: 27.3.1
+      istanbul-reports: 3.1.4
+      jest-haste-map: 27.5.1
+      jest-resolve: 27.5.1_jest-resolve@27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
       slash: 3.0.0
       source-map: 0.6.1
       string-length: 4.0.2
@@ -730,7 +743,7 @@ packages:
       node-notifier:
         optional: true
     resolution:
-      integrity: sha512-m2YxPmL9Qn1emFVgZGEiMwDntDxRRQ2D58tiDQlwYTg5GvbFOKseYCcHtn0WsI8CG4vzPglo3nqbOiT8ySBT/w==
+      integrity: sha512-cPXh9hWIlVJMQkVk84aIvXuBB4uQQmFqZiacloFuGiP3ah1sbCxCosidXFDfqG8+6fO1oR2dTJTlsOy4VFmUfw==
   /@jest/source-map/27.0.6:
     dependencies:
       callsites: 3.1.0
@@ -741,6 +754,16 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-Fek4mi5KQrqmlY07T23JRi0e7Z9bXTOOD86V/uS0EIW4PClvPDqZOyFlLpNJheS6QI0FNX1CgmPjtJ4EA/2M+g==
+  /@jest/source-map/27.5.1:
+    dependencies:
+      callsites: 3.1.0
+      graceful-fs: 4.2.9
+      source-map: 0.6.1
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==
   /@jest/test-result/27.2.0:
     dependencies:
       '@jest/console': 27.2.0
@@ -752,17 +775,17 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-JPPqn8h0RGr4HyeY1Km+FivDIjTFzDROU46iAvzVjD42ooGwYoqYO/MQTilhfajdz6jpVnnphFrKZI5OYrBONA==
-  /@jest/test-result/27.3.1:
+  /@jest/test-result/27.5.1:
     dependencies:
-      '@jest/console': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/console': 27.5.1
+      '@jest/types': 27.5.1
       '@types/istanbul-lib-coverage': 2.0.3
       collect-v8-coverage: 1.0.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-mLn6Thm+w2yl0opM8J/QnPTqrfS4FoXsXF2WIWJb2O/GBSyResL71BRuMYbYRsGt7ELwS5JGcEcGb52BNrumgg==
+      integrity: sha512-EW35l2RYFUcUQxFJz5Cv5MTOxlJIQs4I7gxzi2zVU7PJhOwfYq1MdC5nhSmYjX1gmMmLPvB3sIaC+BkcHRBfag==
   /@jest/test-sequencer/27.2.1:
     dependencies:
       '@jest/test-result': 27.2.0
@@ -774,17 +797,17 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-fWcEgWQXgvU4DFY5YHfQsGwqfJWyuCUzdOzLZTYtyLB3WK1mFPQGYAszM7mCEZjyVon5XRuCa+2/+hif/uMucQ==
-  /@jest/test-sequencer/27.3.1:
+  /@jest/test-sequencer/27.5.1:
     dependencies:
-      '@jest/test-result': 27.3.1
-      graceful-fs: 4.2.4
-      jest-haste-map: 27.3.1
-      jest-runtime: 27.3.1
+      '@jest/test-result': 27.5.1
+      graceful-fs: 4.2.9
+      jest-haste-map: 27.5.1
+      jest-runtime: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-siySLo07IMEdSjA4fqEnxfIX8lB/lWYsBPwNFtkOvsFQvmBrL3yj3k3uFNZv/JDyApTakRpxbKLJ3CT8UGVCrA==
+      integrity: sha512-LCheJF7WB2+9JuCS7VB/EmGIdQuhtqjRNI9A43idHv3E4KltCTsPsLxvdaubFHSYwY/fNjMWjl6vNRhDiN7vpQ==
   /@jest/transform/27.2.1:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
@@ -807,20 +830,20 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==
-  /@jest/transform/27.3.1:
+  /@jest/transform/27.5.1:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
-      '@jest/types': 27.2.5
-      babel-plugin-istanbul: 6.0.0
+      '@jest/types': 27.5.1
+      babel-plugin-istanbul: 6.1.1
       chalk: 4.1.0
       convert-source-map: 1.7.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.4
-      jest-haste-map: 27.3.1
-      jest-regex-util: 27.0.6
-      jest-util: 27.3.1
+      graceful-fs: 4.2.9
+      jest-haste-map: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-util: 27.5.1
       micromatch: 4.0.4
-      pirates: 4.0.1
+      pirates: 4.0.5
       slash: 3.0.0
       source-map: 0.6.1
       write-file-atomic: 3.0.3
@@ -828,7 +851,7 @@ packages:
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-3fSvQ02kuvjOI1C1ssqMVBKJpZf6nwoCiSu00zAKh5nrp3SptNtZy/8s5deayHnqxhjD9CWDJ+yqQwuQ0ZafXQ==
+      integrity: sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==
   /@jest/types/26.6.2:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
@@ -865,28 +888,40 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==
-  /@microsoft.azure/autorest.testserver/3.1.8_e58605af5d62eced51e25286a407a18b:
+  /@jest/types/27.5.1:
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.3
+      '@types/istanbul-reports': 3.0.0
+      '@types/node': 12.7.2
+      '@types/yargs': 16.0.4
+      chalk: 4.1.0
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
+  /@microsoft.azure/autorest.testserver/3.3.5_e58605af5d62eced51e25286a407a18b:
     dependencies:
       axios: 0.21.4
-      azure-storage: 2.10.5
-      body-parser: 1.19.0
+      azure-storage: 2.10.7
+      body-parser: 1.19.2
       busboy: 0.3.1
       commonmark: 0.30.0
       deep-equal: 2.0.5
-      express: 4.17.1
-      express-promise-router: 4.1.0_express@4.17.1
-      jest: 27.3.1
+      express: 4.17.3
+      express-promise-router: 4.1.1_express@4.17.3
+      jest: 27.5.1
       js-yaml: 4.1.0
       morgan: 1.10.0
       mustache: 4.2.0
       request: 2.88.2
       request-promise-native: 1.0.9_request@2.88.2
-      source-map-support: 0.5.20
-      ts-jest: 27.0.7_9292ac17e77615ba05d77e294f382bc2
-      underscore: 1.13.1
-      winston: 3.3.3
+      source-map-support: 0.5.21
+      ts-jest: 27.1.3_9ebec92bf2cee74e3e77e3f363a31225
+      underscore: 1.13.2
+      winston: 3.6.0
       xml2js: 0.4.23
-      yargs: 17.2.1
+      yargs: 17.3.1
     dev: false
     engines:
       node: '>=10'
@@ -895,7 +930,7 @@ packages:
       '@types/jest': '*'
       typescript: '*'
     resolution:
-      integrity: sha512-aiYrEB67OdlWAAPQyEgA+e++92DDUt4wtC12FalE5jkQ1lzsGnepM8rphG6CXWBuQTgG0HnNfdPdk9muEg8kMA==
+      integrity: sha512-+9PG+Sly07TY74KxpE8DlaKbQP7AERpxJW8dxUu3DXc341tZ8ibT8ikKSo/OflDKt6bkpCnvfIAq4qWKYGUJLQ==
   /@sinonjs/commons/1.8.3:
     dependencies:
       type-detect: 4.0.8
@@ -922,7 +957,7 @@ packages:
       integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
   /@types/babel__core/7.1.14:
     dependencies:
-      '@babel/parser': 7.14.3
+      '@babel/parser': 7.17.3
       '@babel/types': 7.14.2
       '@types/babel__generator': 7.6.2
       '@types/babel__template': 7.4.0
@@ -938,7 +973,7 @@ packages:
       integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==
   /@types/babel__template/7.4.0:
     dependencies:
-      '@babel/parser': 7.14.3
+      '@babel/parser': 7.17.3
       '@babel/types': 7.14.2
     dev: false
     resolution:
@@ -1106,15 +1141,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
-  /accepts/1.3.7:
+  /accepts/1.3.8:
     dependencies:
-      mime-types: 2.1.27
-      negotiator: 0.6.2
+      mime-types: 2.1.34
+      negotiator: 0.6.3
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
+      integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
   /acorn-globals/6.0.0:
     dependencies:
       acorn: 7.4.1
@@ -1280,10 +1315,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-  /async/3.2.0:
+  /async/3.2.3:
     dev: false
     resolution:
-      integrity: sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+      integrity: sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
   /asynckit/0.4.0:
     dev: false
     resolution:
@@ -1310,24 +1345,26 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  /azure-storage/2.10.5:
+  /azure-storage/2.10.7:
     dependencies:
       browserify-mime: 1.2.9
       extend: 3.0.2
       json-edm-parser: 0.1.2
+      json-schema: 0.4.0
       md5.js: 1.3.4
-      readable-stream: 2.0.6
+      readable-stream: 2.3.7
       request: 2.88.2
-      underscore: 1.13.1
+      underscore: 1.13.2
       uuid: 3.4.0
-      validator: 13.6.0
+      validator: 13.7.0
       xml2js: 0.2.8
       xmlbuilder: 9.0.7
+    deprecated: 'Please note: newer packages @azure/storage-blob, @azure/storage-queue and @azure/storage-file are available as of November 2019 and @azure/data-tables is available as of June 2021. While the legacy azure-storage package will continue to receive critical bug fixes, we strongly encourage you to upgrade. Migration guide can be found: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/MigrationGuide.md'
     dev: false
     engines:
       node: '>= 0.8.26'
     resolution:
-      integrity: sha512-kLCbiW1lvwwJwB/iOX7ic7xw/RIcSReF1sUFetEyFSiE+HDdv/wpSlsQx0F0khkXrPtJmBJRH0y9s/CRuRBWLQ==
+      integrity: sha512-4oeFGtn3Ziw/fGs/zkoIpKKtygnCVIcZwzJ7UQzKTxhkGQqVCByOFbYqMGYR3L+wOsunX9lNfD0jc51SQuKSSA==
   /babel-jest/27.2.1_@babel+core@7.14.3:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
@@ -1346,16 +1383,16 @@ packages:
       '@babel/core': ^7.8.0
     resolution:
       integrity: sha512-kkaekSJHew1zfDW3cA2QiSBPg4uiLpiW0OwJKqFv0r2/mFgym/IBn7hxPntL6FvS66G/ROh+lz4pRiCJAH1/UQ==
-  /babel-jest/27.3.1_@babel+core@7.14.3:
+  /babel-jest/27.5.1_@babel+core@7.14.3:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
       '@types/babel__core': 7.1.14
-      babel-plugin-istanbul: 6.0.0
-      babel-preset-jest: 27.2.0_@babel+core@7.14.3
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 27.5.1_@babel+core@7.14.3
       chalk: 4.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.9
       slash: 3.0.0
     dev: false
     engines:
@@ -1363,7 +1400,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.8.0
     resolution:
-      integrity: sha512-SjIF8hh/ir0peae2D6S6ZKRhUy7q/DnpH7k/V6fT4Bgs/LXXUztOpX4G2tCgq8mLo5HA9mN6NmlFMeYtKmIsTQ==
+      integrity: sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==
   /babel-plugin-istanbul/6.0.0:
     dependencies:
       '@babel/helper-plugin-utils': 7.14.5
@@ -1376,6 +1413,18 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
+  /babel-plugin-istanbul/6.1.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.14.5
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 5.1.0
+      test-exclude: 6.0.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==
   /babel-plugin-jest-hoist/27.2.0:
     dependencies:
       '@babel/template': 7.12.13
@@ -1387,6 +1436,17 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-TOux9khNKdi64mW+0OIhcmbAn75tTlzKhxmiNXevQaPbrBYK7YKjP1jl6NHTJ6XR5UgUrJbCnWlKVnJn29dfjw==
+  /babel-plugin-jest-hoist/27.5.1:
+    dependencies:
+      '@babel/template': 7.12.13
+      '@babel/types': 7.14.2
+      '@types/babel__core': 7.1.14
+      '@types/babel__traverse': 7.11.1
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==
   /babel-preset-current-node-syntax/1.0.1_@babel+core@7.14.3:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
@@ -1419,6 +1479,18 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==
+  /babel-preset-jest/27.5.1_@babel+core@7.14.3:
+    dependencies:
+      '@babel/core': 7.14.3_@babel+core@7.14.3
+      babel-plugin-jest-hoist: 27.5.1
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.14.3
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==
   /balanced-match/1.0.0:
     dev: false
     resolution:
@@ -1437,23 +1509,23 @@ packages:
     dev: false
     resolution:
       integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
-  /body-parser/1.19.0:
+  /body-parser/1.19.2:
     dependencies:
-      bytes: 3.1.0
+      bytes: 3.1.2
       content-type: 1.0.4
       debug: 2.6.9
       depd: 1.1.2
-      http-errors: 1.7.2
+      http-errors: 1.8.1
       iconv-lite: 0.4.24
       on-finished: 2.3.0
-      qs: 6.7.0
-      raw-body: 2.4.0
+      qs: 6.9.7
+      raw-body: 2.4.3
       type-is: 1.6.18
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
+      integrity: sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==
   /brace-expansion/1.1.11:
     dependencies:
       balanced-match: 1.0.0
@@ -1520,12 +1592,12 @@ packages:
       node: '>=4.5.0'
     resolution:
       integrity: sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==
-  /bytes/3.1.0:
+  /bytes/3.1.2:
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+      integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
   /call-bind/1.0.2:
     dependencies:
       function-bind: 1.1.1
@@ -1634,7 +1706,7 @@ packages:
       integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
   /cliui/7.0.4:
     dependencies:
-      string-width: 4.2.0
+      string-width: 4.2.3
       strip-ansi: 6.0.0
       wrap-ansi: 7.0.0
     dev: false
@@ -1697,12 +1769,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
-  /colors/1.4.0:
-    dev: false
-    engines:
-      node: '>=0.1.90'
-    resolution:
-      integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
   /colorspace/1.1.2:
     dependencies:
       color: 3.0.0
@@ -1736,14 +1802,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-  /content-disposition/0.5.3:
+  /content-disposition/0.5.4:
     dependencies:
-      safe-buffer: 5.1.2
+      safe-buffer: 5.2.1
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
+      integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
   /content-type/1.0.4:
     dev: false
     engines:
@@ -1760,12 +1826,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
-  /cookie/0.4.0:
+  /cookie/0.4.2:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+      integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
   /core-util-is/1.0.2:
     dev: false
     resolution:
@@ -1952,6 +2018,12 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
+  /diff-sequences/27.5.1:
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
   /diff/3.5.0:
     dev: false
     engines:
@@ -2059,6 +2131,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+  /error-ex/1.3.2:
+    dependencies:
+      is-arrayish: 0.2.1
+    dev: false
+    resolution:
+      integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   /es-abstract/1.18.0:
     dependencies:
       call-bind: 1.0.2
@@ -2319,22 +2397,20 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-ekOA2mBtT2phxcoPVHCXIzbJxCvRXhx2fr7m28IgGdZxUOh8UvxvoRz1FcPlfgZMpE92biHB6woIcAKXqR28hA==
-  /expect/27.3.1:
+  /expect/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
-      ansi-styles: 5.2.0
-      jest-get-type: 27.3.1
-      jest-matcher-utils: 27.3.1
-      jest-message-util: 27.3.1
-      jest-regex-util: 27.0.6
+      '@jest/types': 27.5.1
+      jest-get-type: 27.5.1
+      jest-matcher-utils: 27.5.1
+      jest-message-util: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-MrNXV2sL9iDRebWPGOGFdPQRl2eDQNu/uhxIMShjjx74T6kC6jFIkmQ6OqXDtevjGUkyB2IT56RzDBqXf/QPCg==
-  /express-promise-router/4.1.0_express@4.17.1:
+      integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==
+  /express-promise-router/4.1.1_express@4.17.3:
     dependencies:
-      express: 4.17.1
+      express: 4.17.3
       is-promise: 4.0.0
       lodash.flattendeep: 4.4.0
       methods: 1.1.2
@@ -2348,15 +2424,15 @@ packages:
       '@types/express':
         optional: true
     resolution:
-      integrity: sha512-nvg0X1Rj8oajPPC+fG3t4e740aNmQZRZY6dRLbiiM56Dvd8213RJ4kaxhZVTdQLut+l4DZdfeJkyx2VENPMBdw==
-  /express/4.17.1:
+      integrity: sha512-Lkvcy/ZGrBhzkl3y7uYBHLMtLI4D6XQ2kiFg9dq7fbktBch5gjqJ0+KovX0cvCAvTJw92raWunRLM/OM+5l4fA==
+  /express/4.17.3:
     dependencies:
-      accepts: 1.3.7
+      accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.19.0
-      content-disposition: 0.5.3
+      body-parser: 1.19.2
+      content-disposition: 0.5.4
       content-type: 1.0.4
-      cookie: 0.4.0
+      cookie: 0.4.2
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 1.1.2
@@ -2370,13 +2446,13 @@ packages:
       on-finished: 2.3.0
       parseurl: 1.3.3
       path-to-regexp: 0.1.7
-      proxy-addr: 2.0.6
-      qs: 6.7.0
+      proxy-addr: 2.0.7
+      qs: 6.9.7
       range-parser: 1.2.1
-      safe-buffer: 5.1.2
-      send: 0.17.1
-      serve-static: 1.14.1
-      setprototypeof: 1.1.1
+      safe-buffer: 5.2.1
+      send: 0.17.2
+      serve-static: 1.14.2
+      setprototypeof: 1.2.0
       statuses: 1.5.0
       type-is: 1.6.18
       utils-merge: 1.0.1
@@ -2385,7 +2461,7 @@ packages:
     engines:
       node: '>= 0.10.0'
     resolution:
-      integrity: sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
+      integrity: sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==
   /extend/3.0.2:
     dev: false
     resolution:
@@ -2418,10 +2494,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
-  /fast-safe-stringify/2.0.7:
-    dev: false
-    resolution:
-      integrity: sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
   /fb-watchman/2.0.1:
     dependencies:
       bser: 2.1.1
@@ -2546,18 +2618,18 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.27
+      mime-types: 2.1.34
     dev: false
     engines:
       node: '>= 6'
     resolution:
       integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
-  /forwarded/0.1.2:
+  /forwarded/0.2.0:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+      integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
   /fresh/0.5.2:
     dev: false
     engines:
@@ -2675,6 +2747,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+  /graceful-fs/4.2.9:
+    dev: false
+    resolution:
+      integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
   /growl/1.10.5:
     dev: false
     engines:
@@ -2782,30 +2858,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
-  /http-errors/1.7.2:
-    dependencies:
-      depd: 1.1.2
-      inherits: 2.0.3
-      setprototypeof: 1.1.1
-      statuses: 1.5.0
-      toidentifier: 1.0.0
-    dev: false
-    engines:
-      node: '>= 0.6'
-    resolution:
-      integrity: sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
-  /http-errors/1.7.3:
+  /http-errors/1.8.1:
     dependencies:
       depd: 1.1.2
       inherits: 2.0.4
-      setprototypeof: 1.1.1
+      setprototypeof: 1.2.0
       statuses: 1.5.0
-      toidentifier: 1.0.0
+      toidentifier: 1.0.1
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
+      integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
   /http-proxy-agent/4.0.1:
     dependencies:
       '@tootallnate/once': 1.1.2
@@ -2888,10 +2952,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
-  /inherits/2.0.3:
-    dev: false
-    resolution:
-      integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
   /inherits/2.0.4:
     dev: false
     resolution:
@@ -2936,6 +2996,10 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
+  /is-arrayish/0.2.1:
+    dev: false
+    resolution:
+      integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
   /is-arrayish/0.3.2:
     dev: false
     resolution:
@@ -3132,6 +3196,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+  /istanbul-lib-coverage/3.2.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
@@ -3143,6 +3213,18 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
+  /istanbul-lib-instrument/5.1.0:
+    dependencies:
+      '@babel/core': 7.14.3_@babel+core@7.14.3
+      '@babel/parser': 7.17.3
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.0
+      semver: 6.3.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==
   /istanbul-lib-report/3.0.0:
     dependencies:
       istanbul-lib-coverage: 3.0.0
@@ -3172,6 +3254,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
+  /istanbul-reports/3.1.4:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==
   /jest-changed-files/27.1.1:
     dependencies:
       '@jest/types': 27.1.1
@@ -3182,16 +3273,16 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-5TV9+fYlC2A6hu3qtoyGHprBwCAn0AuGA77bZdUgYvVlRMjHXo063VcWTEAyx6XAZ85DYHqp0+aHKbPlfRDRvA==
-  /jest-changed-files/27.3.0:
+  /jest-changed-files/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       execa: 5.1.1
       throat: 6.0.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-9DJs9garMHv4RhylUMZgbdCJ3+jHSkpL9aaVKp13xtXAD80qLTLrqcDZL1PHA9dYA0bCI86Nv2BhkLpLhrBcPg==
+      integrity: sha512-buBLMiByfWGCoMsLLzGUUSpAmIAGnbR2KJoMN10ziLhOLvP4e0SlypHnAel8iqQXTrcbmfEY9sSqae5sgUsTvw==
   /jest-circus/27.2.1:
     dependencies:
       '@jest/environment': 27.2.0
@@ -3218,24 +3309,24 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-9q/8X8DgJmW8IqXsJNnS2E28iarx990hf6D+frS3P0lB+avhFDD33alLwZzKgm45u0wvEi6iFh43WjNbp5fhjw==
-  /jest-circus/27.3.1:
+  /jest-circus/27.5.1:
     dependencies:
-      '@jest/environment': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/environment': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
       chalk: 4.1.0
       co: 4.6.0
       dedent: 0.7.0
-      expect: 27.3.1
+      expect: 27.5.1
       is-generator-fn: 2.1.0
-      jest-each: 27.3.1
-      jest-matcher-utils: 27.3.1
-      jest-message-util: 27.3.1
-      jest-runtime: 27.3.1
-      jest-snapshot: 27.3.1
-      jest-util: 27.3.1
-      pretty-format: 27.3.1
+      jest-each: 27.5.1
+      jest-matcher-utils: 27.5.1
+      jest-message-util: 27.5.1
+      jest-runtime: 27.5.1
+      jest-snapshot: 27.5.1
+      jest-util: 27.5.1
+      pretty-format: 27.5.1
       slash: 3.0.0
       stack-utils: 2.0.3
       throat: 6.0.1
@@ -3243,7 +3334,7 @@ packages:
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-v1dsM9II6gvXokgqq6Yh2jHCpfg7ZqV4jWY66u7npz24JnhP3NHxI0sKT7+ZMQ7IrOWHYAaeEllOySbDbWsiXw==
+      integrity: sha512-D95R7x5UtlMA5iBYsOHFFbMD/GVA4R/Kdq15f7xYWUfWHBto9NYRsOvnSauTgdF+ogCpJ4tyKOXhUifxS65gdw==
   /jest-cli/27.2.1:
     dependencies:
       '@jest/core': 27.2.1
@@ -3269,18 +3360,18 @@ packages:
         optional: true
     resolution:
       integrity: sha512-IfxuGkBZS/ogY7yFvvD1dFidzQRXlSBHtUZQ3UTIHydzNMF4/ZRTdGFso6HkbCkemwLh4hnNybONexEqWmYwjw==
-  /jest-cli/27.3.1:
+  /jest-cli/27.5.1:
     dependencies:
-      '@jest/core': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/core': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/types': 27.5.1
       chalk: 4.1.0
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.9
       import-local: 3.0.2
-      jest-config: 27.3.1
-      jest-util: 27.3.1
-      jest-validate: 27.3.1
+      jest-config: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
       prompts: 2.4.1
       yargs: 16.2.0
     dev: false
@@ -3293,7 +3384,7 @@ packages:
       node-notifier:
         optional: true
     resolution:
-      integrity: sha512-WHnCqpfK+6EvT62me6WVs8NhtbjAS4/6vZJnk7/2+oOr50cwAzG4Wxt6RXX0hu6m1169ZGMlhYYUNeKBXCph/Q==
+      integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==
   /jest-config/27.2.1:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
@@ -3327,29 +3418,32 @@ packages:
         optional: true
     resolution:
       integrity: sha512-BAOemP8udmFw9nkgaLAac7vXORdvrt4yrJWoh7uYb0nPZeSsu0kGwJU18SwtY4paq9fed5OgAssC3A+Bf4WMQA==
-  /jest-config/27.3.1:
+  /jest-config/27.5.1:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
-      '@jest/test-sequencer': 27.3.1
-      '@jest/types': 27.2.5
-      babel-jest: 27.3.1_@babel+core@7.14.3
+      '@jest/test-sequencer': 27.5.1
+      '@jest/types': 27.5.1
+      babel-jest: 27.5.1_@babel+core@7.14.3
       chalk: 4.1.0
       ci-info: 3.2.0
       deepmerge: 4.2.2
       glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-circus: 27.3.1
-      jest-environment-jsdom: 27.3.1
-      jest-environment-node: 27.3.1
-      jest-get-type: 27.3.1
-      jest-jasmine2: 27.3.1
-      jest-regex-util: 27.0.6
-      jest-resolve: 27.3.1_jest-resolve@27.3.1
-      jest-runner: 27.3.1
-      jest-util: 27.3.1
-      jest-validate: 27.3.1
+      graceful-fs: 4.2.9
+      jest-circus: 27.5.1
+      jest-environment-jsdom: 27.5.1
+      jest-environment-node: 27.5.1
+      jest-get-type: 27.5.1
+      jest-jasmine2: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1_jest-resolve@27.5.1
+      jest-runner: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
       micromatch: 4.0.4
-      pretty-format: 27.3.1
+      parse-json: 5.2.0
+      pretty-format: 27.5.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -3359,7 +3453,7 @@ packages:
       ts-node:
         optional: true
     resolution:
-      integrity: sha512-KY8xOIbIACZ/vdYCKSopL44I0xboxC751IX+DXL2+Wx6DKNycyEfV3rryC3BPm5Uq/BBqDoMrKuqLEUNJmMKKg==
+      integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==
   /jest-diff/26.6.2:
     dependencies:
       chalk: 4.1.0
@@ -3382,17 +3476,17 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==
-  /jest-diff/27.3.1:
+  /jest-diff/27.5.1:
     dependencies:
       chalk: 4.1.0
-      diff-sequences: 27.0.6
-      jest-get-type: 27.3.1
-      pretty-format: 27.3.1
+      diff-sequences: 27.5.1
+      jest-get-type: 27.5.1
+      pretty-format: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-PCeuAH4AWUo2O5+ksW4pL9v5xJAcIKPUPfIhZBcG1RKv/0+dvaWTQK1Nrau8d67dp65fOqbeMdoil+6PedyEPQ==
+      integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
   /jest-docblock/27.0.6:
     dependencies:
       detect-newline: 3.1.0
@@ -3401,6 +3495,14 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==
+  /jest-docblock/27.5.1:
+    dependencies:
+      detect-newline: 3.1.0
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-rl7hlABeTsRYxKiUfpHrQrG4e2obOiTQWfMEH3PxPjOtdsfLQO4ReWSZaQ7DETm4xu07rl4q/h4zcKXyU0/OzQ==
   /jest-each/27.2.0:
     dependencies:
       '@jest/types': 27.1.1
@@ -3413,18 +3515,18 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-biDmmUQjg+HZOB7MfY2RHSFL3j418nMoC3TK3pGAj880fQQSxvQe1y2Wy23JJJNUlk6YXiGU0yWy86Le1HBPmA==
-  /jest-each/27.3.1:
+  /jest-each/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       chalk: 4.1.0
-      jest-get-type: 27.3.1
-      jest-util: 27.3.1
-      pretty-format: 27.3.1
+      jest-get-type: 27.5.1
+      jest-util: 27.5.1
+      pretty-format: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-E4SwfzKJWYcvOYCjOxhZcxwL+AY0uFMvdCOwvzgutJiaiodFjkxQQDxHm8FQBeTqDnSmKsQWn7ldMRzTn2zJaQ==
+      integrity: sha512-1Ff6p+FbhT/bXQnEouYy00bkNSY7OUpfIcmdl8vZ31A1UUaurOLPA8a8BbJOF2RDUElwJhmeaV7LnagI+5UwNQ==
   /jest-environment-jsdom/27.2.0:
     dependencies:
       '@jest/environment': 27.2.0
@@ -3439,20 +3541,20 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-wNQJi6Rd/AkUWqTc4gWhuTIFPo7tlMK0RPZXeM6AqRHZA3D3vwvTa9ktAktyVyWYmUoXdYstOfyYMG3w4jt7eA==
-  /jest-environment-jsdom/27.3.1:
+  /jest-environment-jsdom/27.5.1:
     dependencies:
-      '@jest/environment': 27.3.1
-      '@jest/fake-timers': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/environment': 27.5.1
+      '@jest/fake-timers': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
-      jest-mock: 27.3.0
-      jest-util: 27.3.1
+      jest-mock: 27.5.1
+      jest-util: 27.5.1
       jsdom: 16.7.0
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-3MOy8qMzIkQlfb3W1TfrD7uZHj+xx8Olix5vMENkj5djPmRqndMaXtpnaZkxmxM+Qc3lo+yVzJjzuXbCcZjAlg==
+      integrity: sha512-TFBvkTC1Hnnnrka/fUb56atfDtJ9VMZ94JkjTbggl1PEpwrYtUBKMezB3inLmWqQsXYLcMwNoDQwoBTAvFfsfw==
   /jest-environment-node/27.2.0:
     dependencies:
       '@jest/environment': 27.2.0
@@ -3466,19 +3568,19 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-WbW+vdM4u88iy6Q3ftUEQOSgMPtSgjm3qixYYK2AKEuqmFO2zmACTw1vFUB0qI/QN88X6hA6ZkVKIdIWWzz+yg==
-  /jest-environment-node/27.3.1:
+  /jest-environment-node/27.5.1:
     dependencies:
-      '@jest/environment': 27.3.1
-      '@jest/fake-timers': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/environment': 27.5.1
+      '@jest/fake-timers': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
-      jest-mock: 27.3.0
-      jest-util: 27.3.1
+      jest-mock: 27.5.1
+      jest-util: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-T89F/FgkE8waqrTSA7/ydMkcc52uYPgZZ6q8OaZgyiZkJb5QNNCF6oPZjH9IfPFfcc9uBWh1574N0kY0pSvTXw==
+      integrity: sha512-Jt4ZUnxdOsTGwSRAfKEnE6BcwsSPNOijjwifq5sDFSA2kesnXTvNqKHYgM0hDq3549Uf/KzdXNYn4wMZJPlFLw==
   /jest-get-type/26.3.0:
     dev: false
     engines:
@@ -3491,12 +3593,12 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
-  /jest-get-type/27.3.1:
+  /jest-get-type/27.5.1:
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==
+      integrity: sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
   /jest-haste-map/27.2.0:
     dependencies:
       '@jest/types': 27.1.1
@@ -3518,18 +3620,18 @@ packages:
       fsevents: 2.3.2
     resolution:
       integrity: sha512-laFet7QkNlWjwZtMGHCucLvF8o9PAh2cgePRck1+uadSM4E4XH9J4gnx4do+a6do8ZV5XHNEAXEkIoNg5XUH2Q==
-  /jest-haste-map/27.3.1:
+  /jest-haste-map/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.5
       '@types/node': 12.7.2
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.4
-      jest-regex-util: 27.0.6
-      jest-serializer: 27.0.6
-      jest-util: 27.3.1
-      jest-worker: 27.3.1
+      graceful-fs: 4.2.9
+      jest-regex-util: 27.5.1
+      jest-serializer: 27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
       micromatch: 4.0.4
       walker: 1.0.7
     dev: false
@@ -3538,7 +3640,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     resolution:
-      integrity: sha512-lYfNZIzwPccDJZIyk9Iz5iQMM/MH56NIIcGj7AFU1YyA4ewWFBl8z+YPJuSCRML/ee2cCt2y3W4K3VXPT6Nhzg==
+      integrity: sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==
   /jest-jasmine2/27.2.1:
     dependencies:
       '@babel/traverse': 7.14.2
@@ -3564,31 +3666,30 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-3vytj3+S49+XYsxGJyjlchDo4xblYzjDY4XK7pV2IAdspbMFOpmeNMOeDonYuvlbUtcV8yrFLA6XtliXapDmMA==
-  /jest-jasmine2/27.3.1:
+  /jest-jasmine2/27.5.1:
     dependencies:
-      '@babel/traverse': 7.14.2
-      '@jest/environment': 27.3.1
-      '@jest/source-map': 27.0.6
-      '@jest/test-result': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/environment': 27.5.1
+      '@jest/source-map': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
       chalk: 4.1.0
       co: 4.6.0
-      expect: 27.3.1
+      expect: 27.5.1
       is-generator-fn: 2.1.0
-      jest-each: 27.3.1
-      jest-matcher-utils: 27.3.1
-      jest-message-util: 27.3.1
-      jest-runtime: 27.3.1
-      jest-snapshot: 27.3.1
-      jest-util: 27.3.1
-      pretty-format: 27.3.1
+      jest-each: 27.5.1
+      jest-matcher-utils: 27.5.1
+      jest-message-util: 27.5.1
+      jest-runtime: 27.5.1
+      jest-snapshot: 27.5.1
+      jest-util: 27.5.1
+      pretty-format: 27.5.1
       throat: 6.0.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-WK11ZUetDQaC09w4/j7o4FZDUIp+4iYWH/Lik34Pv7ukL+DuXFGdnmmi7dT58J2ZYKFB5r13GyE0z3NPeyJmsg==
+      integrity: sha512-jtq7VVyG8SqAorDpApwiJJImd0V2wv1xzdheGHRGyuT7gZm6gG47QEskOlzsN1PG/6WNaCo5pmwMHDf3AkG2pQ==
   /jest-leak-detector/27.2.0:
     dependencies:
       jest-get-type: 27.0.6
@@ -3598,15 +3699,15 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-e91BIEmbZw5+MHkB4Hnrq7S86coTxUMCkz4n7DLmQYvl9pEKmRx9H/JFH87bBqbIU5B2Ju1soKxRWX6/eGFGpA==
-  /jest-leak-detector/27.3.1:
+  /jest-leak-detector/27.5.1:
     dependencies:
-      jest-get-type: 27.3.1
-      pretty-format: 27.3.1
+      jest-get-type: 27.5.1
+      pretty-format: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-78QstU9tXbaHzwlRlKmTpjP9k4Pvre5l0r8Spo4SbFFVy/4Abg9I6ZjHwjg2QyKEAMg020XcjP+UgLZIY50yEg==
+      integrity: sha512-POXfWAMvfU6WMUXftV4HolnJfnPOGEu10fscNCA76KBpRRhcMN2c8d3iT2pxQS3HLbA+5X4sOUPzYO2NUyIlHQ==
   /jest-matcher-utils/27.2.0:
     dependencies:
       chalk: 4.1.0
@@ -3618,17 +3719,17 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-F+LG3iTwJ0gPjxBX6HCyrARFXq6jjiqhwBQeskkJQgSLeF1j6ui1RTV08SR7O51XTUhtc8zqpDj8iCG4RGmdKw==
-  /jest-matcher-utils/27.3.1:
+  /jest-matcher-utils/27.5.1:
     dependencies:
       chalk: 4.1.0
-      jest-diff: 27.3.1
-      jest-get-type: 27.3.1
-      pretty-format: 27.3.1
+      jest-diff: 27.5.1
+      jest-get-type: 27.5.1
+      pretty-format: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-hX8N7zXS4k+8bC1Aj0OWpGb7D3gIXxYvPNK1inP5xvE4ztbz3rc4AkI6jGVaerepBnfWB17FL5lWFJT3s7qo8w==
+      integrity: sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
   /jest-message-util/27.2.0:
     dependencies:
       '@babel/code-frame': 7.12.13
@@ -3645,22 +3746,22 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-y+sfT/94CiP8rKXgwCOzO1mUazIEdEhrLjuiu+RKmCP+8O/TJTSne9dqQRbFIHBtlR2+q7cddJlWGir8UATu5w==
-  /jest-message-util/27.3.1:
+  /jest-message-util/27.5.1:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.0
       chalk: 4.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.9
       micromatch: 4.0.4
-      pretty-format: 27.3.1
+      pretty-format: 27.5.1
       slash: 3.0.0
       stack-utils: 2.0.3
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==
+      integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==
   /jest-mock/27.1.1:
     dependencies:
       '@jest/types': 27.1.1
@@ -3670,15 +3771,15 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-SClsFKuYBf+6SSi8jtAYOuPw8DDMsTElUWEae3zq7vDhH01ayVSIHUSIa8UgbDOUalCFp6gNsaikN0rbxN4dbw==
-  /jest-mock/27.3.0:
+  /jest-mock/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-ziZiLk0elZOQjD08bLkegBzv5hCABu/c8Ytx45nJKkysQwGaonvmTxwjLqEA4qGdasq9o2I8/HtdGMNnVsMTGw==
+      integrity: sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og==
   /jest-pnp-resolver/1.2.2_jest-resolve@27.2.0:
     dependencies:
       jest-resolve: 27.2.0_jest-resolve@27.2.0
@@ -3692,9 +3793,9 @@ packages:
         optional: true
     resolution:
       integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
-  /jest-pnp-resolver/1.2.2_jest-resolve@27.3.1:
+  /jest-pnp-resolver/1.2.2_jest-resolve@27.5.1:
     dependencies:
-      jest-resolve: 27.3.1_jest-resolve@27.3.1
+      jest-resolve: 27.5.1_jest-resolve@27.5.1
     dev: false
     engines:
       node: '>=6'
@@ -3711,6 +3812,12 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==
+  /jest-regex-util/27.5.1:
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==
   /jest-resolve-dependencies/27.2.1:
     dependencies:
       '@jest/types': 27.1.1
@@ -3721,16 +3828,16 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-9bKEwmz4YshGPjGZAVZOVw6jt7pq2/FjWJmyhnWhvDuiRCHVZBcJhycinX+e/EJ7jafsq26bTpzBIQas3xql1g==
-  /jest-resolve-dependencies/27.3.1:
+  /jest-resolve-dependencies/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
-      jest-regex-util: 27.0.6
-      jest-snapshot: 27.3.1
+      '@jest/types': 27.5.1
+      jest-regex-util: 27.5.1
+      jest-snapshot: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-X7iLzY8pCiYOnvYo2YrK3P9oSE8/3N2f4pUZMJ8IUcZnT81vlSonya1KTO9ZfKGuC+svE6FHK/XOb8SsoRUV1A==
+      integrity: sha512-QQOOdY4PE39iawDn5rzbIePNigfe5B9Z91GDD1ae/xNDlu9kaat8QQ5EKnNmVWPV54hUdxCVwwj6YMgR2O7IOg==
   /jest-resolve/27.2.0_jest-resolve@27.2.0:
     dependencies:
       '@jest/types': 27.1.1
@@ -3750,15 +3857,15 @@ packages:
       jest-resolve: '*'
     resolution:
       integrity: sha512-v09p9Ib/VtpHM6Cz+i9lEAv1Z/M5NVxsyghRHRMEUOqwPQs3zwTdwp1xS3O/k5LocjKiGS0OTaJoBSpjbM2Jlw==
-  /jest-resolve/27.3.1_jest-resolve@27.3.1:
+  /jest-resolve/27.5.1_jest-resolve@27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       chalk: 4.1.0
-      graceful-fs: 4.2.4
-      jest-haste-map: 27.3.1
-      jest-pnp-resolver: 1.2.2_jest-resolve@27.3.1
-      jest-util: 27.3.1
-      jest-validate: 27.3.1
+      graceful-fs: 4.2.9
+      jest-haste-map: 27.5.1
+      jest-pnp-resolver: 1.2.2_jest-resolve@27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
       resolve: 1.20.0
       resolve.exports: 1.1.0
       slash: 3.0.0
@@ -3768,7 +3875,7 @@ packages:
     peerDependencies:
       jest-resolve: '*'
     resolution:
-      integrity: sha512-Dfzt25CFSPo3Y3GCbxynRBZzxq9AdyNN+x/v2IqYx6KVT5Z6me2Z/PsSGFSv3cOSUZqJ9pHxilao/I/m9FouLw==
+      integrity: sha512-FFDy8/9E6CV83IMbDpcjOhumAQPDyETnU2KZ1O98DwTnz8AOBsW/Xv3GySr1mOZdItLR+zDZ7I/UdTFbgSOVCw==
   /jest-runner/27.2.1:
     dependencies:
       '@jest/console': 27.2.0
@@ -3798,35 +3905,34 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-USHitkUUzcB3Y5mRdzlp+KHgRRR2VsXDq5OeATuDmq1qXfT/RwwnQykUhn+KVx3FotxK3pID74UY7o6HYIR8vA==
-  /jest-runner/27.3.1:
+  /jest-runner/27.5.1:
     dependencies:
-      '@jest/console': 27.3.1
-      '@jest/environment': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/console': 27.5.1
+      '@jest/environment': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
       chalk: 4.1.0
       emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-docblock: 27.0.6
-      jest-environment-jsdom: 27.3.1
-      jest-environment-node: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-leak-detector: 27.3.1
-      jest-message-util: 27.3.1
-      jest-resolve: 27.3.1_jest-resolve@27.3.1
-      jest-runtime: 27.3.1
-      jest-util: 27.3.1
-      jest-worker: 27.3.1
-      source-map-support: 0.5.20
+      graceful-fs: 4.2.9
+      jest-docblock: 27.5.1
+      jest-environment-jsdom: 27.5.1
+      jest-environment-node: 27.5.1
+      jest-haste-map: 27.5.1
+      jest-leak-detector: 27.5.1
+      jest-message-util: 27.5.1
+      jest-resolve: 27.5.1_jest-resolve@27.5.1
+      jest-runtime: 27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
+      source-map-support: 0.5.21
       throat: 6.0.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
+      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runtime/27.2.1:
     dependencies:
       '@jest/console': 27.2.0
@@ -3861,39 +3967,35 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-QJNnwL4iteDE/Jq4TfQK7AjhPoUZflBKTtUIkRnFYFkTAZTP/o8k7ekaROiVjmo+NYop5+DQPqX6pz4vWbZSOQ==
-  /jest-runtime/27.3.1:
+  /jest-runtime/27.5.1:
     dependencies:
-      '@jest/console': 27.3.1
-      '@jest/environment': 27.3.1
-      '@jest/globals': 27.3.1
-      '@jest/source-map': 27.0.6
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
-      '@types/yargs': 16.0.4
+      '@jest/environment': 27.5.1
+      '@jest/fake-timers': 27.5.1
+      '@jest/globals': 27.5.1
+      '@jest/source-map': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
       chalk: 4.1.0
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
       execa: 5.1.1
-      exit: 0.1.2
       glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-haste-map: 27.3.1
-      jest-message-util: 27.3.1
-      jest-mock: 27.3.0
-      jest-regex-util: 27.0.6
-      jest-resolve: 27.3.1_jest-resolve@27.3.1
-      jest-snapshot: 27.3.1
-      jest-util: 27.3.1
-      jest-validate: 27.3.1
+      graceful-fs: 4.2.9
+      jest-haste-map: 27.5.1
+      jest-message-util: 27.5.1
+      jest-mock: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1_jest-resolve@27.5.1
+      jest-snapshot: 27.5.1
+      jest-util: 27.5.1
       slash: 3.0.0
       strip-bom: 4.0.0
-      yargs: 16.2.0
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-qtO6VxPbS8umqhEDpjA4pqTkKQ1Hy4ZSi9mDVeE9Za7LKBo2LdW2jmT+Iod3XFaJqINikZQsn2wEi0j9wPRbLg==
+      integrity: sha512-o7gxw3Gf+H2IGt8fv0RiyE1+r83FJBRruoA+FXrlHw6xEyBsU8ugA6IPfTdVyA0w8HClpbK+DGJxH59UrNMx8A==
   /jest-serializer/27.0.6:
     dependencies:
       '@types/node': 12.7.2
@@ -3903,6 +4005,15 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==
+  /jest-serializer/27.5.1:
+    dependencies:
+      '@types/node': 12.7.2
+      graceful-fs: 4.2.9
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==
   /jest-snapshot/27.2.1:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
@@ -3934,37 +4045,35 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-8CTg2YrgZuQbPHW7G0YvLTj4yTRXLmSeEO+ka3eC5lbu5dsTRyoDNS1L7x7EFUTyYQhFH9HQG1/TNlbUgR9Lug==
-  /jest-snapshot/27.3.1:
+  /jest-snapshot/27.5.1:
     dependencies:
       '@babel/core': 7.14.3_@babel+core@7.14.3
       '@babel/generator': 7.14.3
-      '@babel/parser': 7.14.3
       '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.14.3
       '@babel/traverse': 7.14.2
       '@babel/types': 7.14.2
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
       '@types/babel__traverse': 7.11.1
       '@types/prettier': 2.2.3
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.14.3
       chalk: 4.1.0
-      expect: 27.3.1
-      graceful-fs: 4.2.4
-      jest-diff: 27.3.1
-      jest-get-type: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-matcher-utils: 27.3.1
-      jest-message-util: 27.3.1
-      jest-resolve: 27.3.1_jest-resolve@27.3.1
-      jest-util: 27.3.1
+      expect: 27.5.1
+      graceful-fs: 4.2.9
+      jest-diff: 27.5.1
+      jest-get-type: 27.5.1
+      jest-haste-map: 27.5.1
+      jest-matcher-utils: 27.5.1
+      jest-message-util: 27.5.1
+      jest-util: 27.5.1
       natural-compare: 1.4.0
-      pretty-format: 27.3.1
+      pretty-format: 27.5.1
       semver: 7.3.5
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-APZyBvSgQgOT0XumwfFu7X3G5elj6TGhCBLbBdn3R1IzYustPGPE38F51dBWMQ8hRXa9je0vAdeVDtqHLvB6lg==
+      integrity: sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==
   /jest-util/27.2.0:
     dependencies:
       '@jest/types': 27.1.1
@@ -3991,6 +4100,19 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-8fg+ifEH3GDryLQf/eKZck1DEs2YuVPBCMOaHQxVVLmQwl/CDhWzrvChTX4efLZxGrw+AA0mSXv78cyytBt/uw==
+  /jest-util/27.5.1:
+    dependencies:
+      '@jest/types': 27.5.1
+      '@types/node': 12.7.2
+      chalk: 4.1.0
+      ci-info: 3.2.0
+      graceful-fs: 4.2.9
+      picomatch: 2.2.3
+    dev: false
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==
   /jest-validate/27.2.0:
     dependencies:
       '@jest/types': 27.1.1
@@ -4004,19 +4126,19 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-uIEZGkFKk3+4liA81Xu0maG5aGDyPLdp+4ed244c+Ql0k3aLWQYcMbaMLXOIFcb83LPHzYzqQ8hwNnIxTqfAGQ==
-  /jest-validate/27.3.1:
+  /jest-validate/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
+      '@jest/types': 27.5.1
       camelcase: 6.2.0
       chalk: 4.1.0
-      jest-get-type: 27.3.1
+      jest-get-type: 27.5.1
       leven: 3.1.0
-      pretty-format: 27.3.1
+      pretty-format: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-3H0XCHDFLA9uDII67Bwi1Vy7AqwA5HqEEjyy934lgVhtJ3eisw6ShOF1MDmRPspyikef5MyExvIm0/TuLzZ86Q==
+      integrity: sha512-thkNli0LYTmOI1tDB3FI1S1RTp/Bqyd9pTarJwL87OIBFuqEb5Apv5EaApEudYg4g86e3CT6kM0RowkhtEnCBQ==
   /jest-watcher/27.2.0:
     dependencies:
       '@jest/test-result': 27.2.0
@@ -4031,20 +4153,20 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-SjRWhnr+qO8aBsrcnYIyF+qRxNZk6MZH8TIDgvi+VlsyrvOyqg0d+Rm/v9KHiTtC9mGGeFi9BFqgavyWib6xLg==
-  /jest-watcher/27.3.1:
+  /jest-watcher/27.5.1:
     dependencies:
-      '@jest/test-result': 27.3.1
-      '@jest/types': 27.2.5
+      '@jest/test-result': 27.5.1
+      '@jest/types': 27.5.1
       '@types/node': 12.7.2
       ansi-escapes: 4.3.1
       chalk: 4.1.0
-      jest-util: 27.3.1
+      jest-util: 27.5.1
       string-length: 4.0.2
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-9/xbV6chABsGHWh9yPaAGYVVKurWoP3ZMCv6h+O1v9/+pkOroigs6WzZ0e9gLP/njokUwM7yQhr01LKJVMkaZA==
+      integrity: sha512-z676SuD6Z8o8qbmEGhoEUFOM1+jfEiL3DXHK/xgEiG2EyNYfFG60jluWcupY6dATjfEsKQuibReS1djInQnoVw==
   /jest-worker/27.2.0:
     dependencies:
       '@types/node': 12.7.2
@@ -4055,7 +4177,7 @@ packages:
       node: '>= 10.13.0'
     resolution:
       integrity: sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==
-  /jest-worker/27.3.1:
+  /jest-worker/27.5.1:
     dependencies:
       '@types/node': 12.7.2
       merge-stream: 2.0.0
@@ -4064,7 +4186,7 @@ packages:
     engines:
       node: '>= 10.13.0'
     resolution:
-      integrity: sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==
+      integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==
   /jest/27.0.6:
     dependencies:
       '@jest/core': 27.2.1
@@ -4081,11 +4203,11 @@ packages:
         optional: true
     resolution:
       integrity: sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==
-  /jest/27.3.1:
+  /jest/27.5.1:
     dependencies:
-      '@jest/core': 27.3.1
+      '@jest/core': 27.5.1
       import-local: 3.0.2
-      jest-cli: 27.3.1
+      jest-cli: 27.5.1
     dev: false
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -4096,7 +4218,7 @@ packages:
       node-notifier:
         optional: true
     resolution:
-      integrity: sha512-U2AX0AgQGd5EzMsiZpYt8HyZ+nSVIh5ujQ9CPp9EQZJMjXIiSZpJNweZl0swatKRoqHWgGKM3zaSwm4Zaz87ng==
+      integrity: sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==
   /js-tokens/4.0.0:
     dev: false
     resolution:
@@ -4179,6 +4301,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=
+  /json-parse-even-better-errors/2.3.1:
+    dev: false
+    resolution:
+      integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
   /json-schema-traverse/0.4.1:
     dev: false
     resolution:
@@ -4187,6 +4313,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+  /json-schema/0.4.0:
+    dev: false
+    resolution:
+      integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
   /json-stable-stringify-without-jsonify/1.0.1:
     dev: false
     resolution:
@@ -4254,6 +4384,10 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+  /lines-and-columns/1.2.4:
+    dev: false
+    resolution:
+      integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
   /locate-path/2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -4296,16 +4430,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-  /logform/2.2.0:
+  /logform/2.4.0:
     dependencies:
-      colors: 1.4.0
-      fast-safe-stringify: 2.0.7
+      '@colors/colors': 1.5.0
       fecha: 4.2.1
       ms: 2.1.2
+      safe-stable-stringify: 2.3.1
       triple-beam: 1.3.0
     dev: false
     resolution:
-      integrity: sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==
+      integrity: sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==
   /lru-cache/6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -4396,6 +4530,12 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+  /mime-db/1.51.0:
+    dev: false
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
   /mime-types/2.1.27:
     dependencies:
       mime-db: 1.44.0
@@ -4404,6 +4544,14 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  /mime-types/2.1.34:
+    dependencies:
+      mime-db: 1.51.0
+    dev: false
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
   /mime/1.6.0:
     dev: false
     engines:
@@ -4492,14 +4640,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
-  /ms/2.1.1:
-    dev: false
-    resolution:
-      integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
   /ms/2.1.2:
     dev: false
     resolution:
       integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+  /ms/2.1.3:
+    dev: false
+    resolution:
+      integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
   /mustache/4.2.0:
     dev: false
     hasBin: true
@@ -4513,12 +4661,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-  /negotiator/0.6.2:
+  /negotiator/0.6.3:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+      integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
   /nice-try/1.0.5:
     dev: false
     resolution:
@@ -4750,6 +4898,17 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  /parse-json/5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.12.13
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
   /parse5/6.0.1:
     dev: false
     resolution:
@@ -4816,6 +4975,12 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
+  /pirates/4.0.5:
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
   /pkg-dir/4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -4852,9 +5017,8 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==
-  /pretty-format/27.3.1:
+  /pretty-format/27.5.1:
     dependencies:
-      '@jest/types': 27.2.5
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
@@ -4862,11 +5026,7 @@ packages:
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
-      integrity: sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==
-  /process-nextick-args/1.0.7:
-    dev: false
-    resolution:
-      integrity: sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
+      integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
   /process-nextick-args/2.0.1:
     dev: false
     resolution:
@@ -4895,15 +5055,15 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha1-FZ+wYZPTIAP0s2kd0uwaY0qoDR0=
-  /proxy-addr/2.0.6:
+  /proxy-addr/2.0.7:
     dependencies:
-      forwarded: 0.1.2
+      forwarded: 0.2.0
       ipaddr.js: 1.9.1
     dev: false
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==
+      integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
   /psl/1.8.0:
     dev: false
     resolution:
@@ -4927,44 +5087,33 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-  /qs/6.7.0:
+  /qs/6.9.7:
     dev: false
     engines:
       node: '>=0.6'
     resolution:
-      integrity: sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+      integrity: sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
   /range-parser/1.2.1:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
       integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
-  /raw-body/2.4.0:
+  /raw-body/2.4.3:
     dependencies:
-      bytes: 3.1.0
-      http-errors: 1.7.2
+      bytes: 3.1.2
+      http-errors: 1.8.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+      integrity: sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==
   /react-is/17.0.2:
     dev: false
     resolution:
       integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-  /readable-stream/2.0.6:
-    dependencies:
-      core-util-is: 1.0.2
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 1.0.7
-      string_decoder: 0.10.31
-      util-deprecate: 1.0.2
-    dev: false
-    resolution:
-      integrity: sha1-j5A0HmilPMySh4jaz80Rs265t44=
   /readable-stream/2.3.7:
     dependencies:
       core-util-is: 1.0.2
@@ -5151,6 +5300,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+  /safe-stable-stringify/2.3.1:
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==
   /safer-buffer/2.1.2:
     dev: false
     resolution:
@@ -5190,7 +5345,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  /send/0.17.1:
+  /send/0.17.2:
     dependencies:
       debug: 2.6.9
       depd: 1.1.2
@@ -5199,9 +5354,9 @@ packages:
       escape-html: 1.0.3
       etag: 1.8.1
       fresh: 0.5.2
-      http-errors: 1.7.3
+      http-errors: 1.8.1
       mime: 1.6.0
-      ms: 2.1.1
+      ms: 2.1.3
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.5.0
@@ -5209,26 +5364,26 @@ packages:
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
-  /serve-static/1.14.1:
+      integrity: sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==
+  /serve-static/1.14.2:
     dependencies:
       encodeurl: 1.0.2
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.17.1
+      send: 0.17.2
     dev: false
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
+      integrity: sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==
   /set-blocking/2.0.0:
     dev: false
     resolution:
       integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-  /setprototypeof/1.1.1:
+  /setprototypeof/1.2.0:
     dev: false
     resolution:
-      integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+      integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
   /shebang-command/1.2.0:
     dependencies:
       shebang-regex: 1.0.0
@@ -5316,13 +5471,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
-  /source-map-support/0.5.20:
+  /source-map-support/0.5.21:
     dependencies:
       buffer-from: 1.1.1
       source-map: 0.6.1
     dev: false
     resolution:
-      integrity: sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
+      integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   /source-map/0.5.7:
     dev: false
     engines:
@@ -5395,7 +5550,7 @@ packages:
   /string-length/4.0.2:
     dependencies:
       char-regex: 1.0.2
-      strip-ansi: 6.0.0
+      strip-ansi: 6.0.1
     dev: false
     engines:
       node: '>=10'
@@ -5440,6 +5595,16 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  /string-width/4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   /string.prototype.repeat/0.2.0:
     dev: false
     resolution:
@@ -5458,10 +5623,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
-  /string_decoder/0.10.31:
-    dev: false
-    resolution:
-      integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
   /string_decoder/1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -5506,6 +5667,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  /strip-ansi/6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   /strip-bom/4.0.0:
     dev: false
     engines:
@@ -5647,12 +5816,12 @@ packages:
       node: '>=8.0'
     resolution:
       integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
-  /toidentifier/1.0.0:
+  /toidentifier/1.0.1:
     dev: false
     engines:
       node: '>=0.6'
     resolution:
-      integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+      integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
   /tough-cookie/2.5.0:
     dependencies:
       psl: 1.8.0
@@ -5716,12 +5885,12 @@ packages:
         optional: true
     resolution:
       integrity: sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==
-  /ts-jest/27.0.7_9292ac17e77615ba05d77e294f382bc2:
+  /ts-jest/27.1.3_9ebec92bf2cee74e3e77e3f363a31225:
     dependencies:
       '@types/jest': 26.0.24
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.3.1
+      jest: 27.5.1
       jest-util: 27.3.1
       json5: 2.2.0
       lodash.memoize: 4.1.2
@@ -5737,6 +5906,7 @@ packages:
       '@babel/core': '>=7.0.0-beta.0 <8'
       '@types/jest': ^27.0.0
       babel-jest: '>=27.0.0 <28'
+      esbuild: ~0.14.0
       jest: ^27.0.0
       typescript: '>=3.8 <5.0'
     peerDependenciesMeta:
@@ -5746,8 +5916,10 @@ packages:
         optional: true
       babel-jest:
         optional: true
+      esbuild:
+        optional: true
     resolution:
-      integrity: sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==
+      integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==
   /tslib/1.14.1:
     dev: false
     resolution:
@@ -5824,10 +5996,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
-  /underscore/1.13.1:
+  /underscore/1.13.2:
     dev: false
     resolution:
-      integrity: sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
+      integrity: sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
   /universalify/0.1.2:
     dev: false
     engines:
@@ -5886,12 +6058,12 @@ packages:
       node: '>=10.12.0'
     resolution:
       integrity: sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==
-  /validator/13.6.0:
+  /validator/13.7.0:
     dev: false
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==
+      integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
   /vary/1.1.2:
     dev: false
     engines:
@@ -6019,31 +6191,33 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  /winston-transport/4.4.0:
+  /winston-transport/4.5.0:
     dependencies:
-      readable-stream: 2.3.7
+      logform: 2.4.0
+      readable-stream: 3.6.0
       triple-beam: 1.3.0
     dev: false
     engines:
       node: '>= 6.4.0'
     resolution:
-      integrity: sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
-  /winston/3.3.3:
+      integrity: sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==
+  /winston/3.6.0:
     dependencies:
       '@dabh/diagnostics': 2.0.2
-      async: 3.2.0
+      async: 3.2.3
       is-stream: 2.0.0
-      logform: 2.2.0
+      logform: 2.4.0
       one-time: 1.0.0
       readable-stream: 3.6.0
+      safe-stable-stringify: 2.3.1
       stack-trace: 0.0.10
       triple-beam: 1.3.0
-      winston-transport: 4.4.0
+      winston-transport: 4.5.0
     dev: false
     engines:
-      node: '>= 6.4.0'
+      node: '>= 12.0.0'
     resolution:
-      integrity: sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
+      integrity: sha512-9j8T75p+bcN6D00sF/zjFVmPp+t8KMPB1MzbbzYjeN9VWxdsYnTB40TkbNUEXAmILEfChMvAMgidlX64OG3p6w==
   /word-wrap/1.2.3:
     dev: false
     engines:
@@ -6072,8 +6246,8 @@ packages:
   /wrap-ansi/7.0.0:
     dependencies:
       ansi-styles: 4.3.0
-      string-width: 4.2.0
-      strip-ansi: 6.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
     dev: false
     engines:
       node: '>=10'
@@ -6180,6 +6354,12 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+  /yargs-parser/21.0.1:
+    dev: false
+    engines:
+      node: '>=12'
+    resolution:
+      integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
   /yargs-parser/9.0.2:
     dependencies:
       camelcase: 4.1.0
@@ -6225,7 +6405,7 @@ packages:
       escalade: 3.1.1
       get-caller-file: 2.0.5
       require-directory: 2.1.1
-      string-width: 4.2.0
+      string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.7
     dev: false
@@ -6233,20 +6413,20 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
-  /yargs/17.2.1:
+  /yargs/17.3.1:
     dependencies:
       cliui: 7.0.4
       escalade: 3.1.1
       get-caller-file: 2.0.5
       require-directory: 2.1.1
-      string-width: 4.2.0
+      string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 20.2.7
+      yargs-parser: 21.0.1
     dev: false
     engines:
       node: '>=12'
     resolution:
-      integrity: sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
+      integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
   'file:projects/go.tgz':
     dependencies:
       '@autorest/autorest': 3.0.6187
@@ -6258,7 +6438,7 @@ packages:
       '@azure-tools/codemodel': 4.13.349
       '@azure-tools/linq': 3.1.261
       '@azure-tools/tasks': 3.0.252
-      '@microsoft.azure/autorest.testserver': 3.1.8_e58605af5d62eced51e25286a407a18b
+      '@microsoft.azure/autorest.testserver': 3.3.5_e58605af5d62eced51e25286a407a18b
       '@types/html-to-text': 5.1.2
       '@types/jest': 26.0.24
       '@types/js-yaml': 3.12.1
@@ -6280,7 +6460,7 @@ packages:
     dev: false
     name: '@rush-temp/go'
     resolution:
-      integrity: sha512-AY9ucPZxGDE9fJ02RNyNk/ru800f7mUSsPyOk5c7ALUYFOIlk8YX4vHRs4dUpNrnmTEoAIC/qcoP3YyMRjRWfw==
+      integrity: sha512-Cvgverbb1MbhU1o5AGTGcQSR8rYza0CuwGx4DayrrAGjB3ycQqPDaJnCToImt5PesCT7iu0jXsHUfaoNqBLpaw==
       tarball: 'file:projects/go.tgz'
     version: 0.0.0
 registry: ''
@@ -6292,7 +6472,7 @@ specifiers:
   '@azure-tools/codegen': ~2.9.0
   '@azure-tools/linq': ~3.1.0
   '@azure-tools/tasks': ~3.0.0
-  '@microsoft.azure/autorest.testserver': 3.1.8
+  '@microsoft.azure/autorest.testserver': 3.3.5
   '@rush-temp/go': 'file:./projects/go.tgz'
   '@types/html-to-text': ^5.1.2
   '@types/jest': ~26.0.24

--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -16,7 +16,7 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
   text += 'go 1.16\n\n';
   // here we specify the minimum version of azcore as required by the code generator
   // TODO: come up with a way to get the latest minor/patch versions.
-  const version = 'v0.21.0';
+  const version = 'v0.21.1';
   const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore ' + version;
   text += `require ${azcore}\n`;
   return text;

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -6,7 +6,7 @@
 import { Session } from '@autorest/extension-base';
 import { values } from '@azure-tools/linq';
 import { capitalize, comment, uncapitalize } from '@azure-tools/codegen';
-import { aggregateParameters, isLROOperation, isPageableOperation, isSchemaResponse, isMultiRespOperation, PollerInfo } from '../common/helpers';
+import { aggregateParameters, isSchemaResponse, isMultiRespOperation } from '../common/helpers';
 import { ArraySchema, CodeModel, DictionarySchema, Language, Parameter, Schema, SchemaType, ObjectSchema, Operation, Property, GroupProperty, ImplementationLocation, SerializationStyle, ByteArraySchema, ConstantSchema, NumberSchema, DateTimeSchema } from '@autorest/codemodel';
 import { ImportManager } from './imports';
 
@@ -313,14 +313,6 @@ export function getResponseEnvelopeName(op: Operation): string {
   return op.language.go!.responseEnv.language.go!.name;
 }
 
-// returns the final response envelope type name for LROs
-export function getFinalResponseEnvelopeName(op: Operation): string {
-  if (!isLROOperation(op)) {
-    throw new Error(`getFinalResponseEnvelopeName() called for ${op.language.go!.name} which isn't an LRO`);
-  }
-  return op.language.go!.finalResponseEnv.language.go!.name;
-}
-
 // returns the result property for the operation or undefined if it doesn't return a model
 export function hasResultProperty(op: Operation): Property | undefined {
   const responseEnv = getResponseEnvelope(op);
@@ -331,12 +323,7 @@ export function hasResultProperty(op: Operation): Property | undefined {
 }
 
 export function getResponseEnvelope(op: Operation): ObjectSchema {
-  let responseEnv = op.language.go!.responseEnv;
-  if (isLROOperation(op)) {
-    // we need to consult the final response envelope for LROs
-    responseEnv = op.language.go!.finalResponseEnv;
-  }
-  return responseEnv;
+  return op.language.go!.responseEnv;
 }
 
 // returns the name of the response field within the response envelope
@@ -345,10 +332,6 @@ export function getResultFieldName(op: Operation): string {
     return 'Value';
   }
   let responseEnv = op.language.go!.responseEnv;
-  if (isLROOperation(op)) {
-    // we need to consult the final response envelope for LROs
-    responseEnv = op.language.go!.finalResponseEnv;
-  }
   if (responseEnv.language.go!.resultProp.schema.serialization?.xml?.name) {
     // here we use the schema name instead of the result field name as it's anonymously embedded in the response envelope.
     // this is to handle XML cases that specify a custom XML name for the propery within the result field.
@@ -381,17 +364,6 @@ export function formatStatusCodes(statusCodes: Array<string>): string {
     asHTTPStatus.push(formatStatusCode(rawCode));
   }
   return asHTTPStatus.join(', ');
-}
-
-// emits a poller declaration
-export function emitPoller(op: Operation): string {
-  let text = `&${(<PollerInfo>op.language.go!.pollerType).name} {\n`;
-  text += '\t\tpt: pt,\n';
-  if (isPageableOperation(op)) {
-    text += '\t\tclient: client,\n';
-  }
-  text += '\t}\n';
-  return text;
 }
 
 export function formatStatusCode(statusCode: string): string {

--- a/src/generator/pagers.ts
+++ b/src/generator/pagers.ts
@@ -7,7 +7,7 @@ import { Session } from '@autorest/extension-base';
 import { CodeModel } from '@autorest/codemodel';
 import { values } from '@azure-tools/linq';
 import { isLROOperation, PagerInfo } from '../common/helpers';
-import { contentPreamble, getResponseEnvelopeName, getResultFieldName, getStatusCodes, formatStatusCodes, sortAscending, getFinalResponseEnvelopeName } from './helpers';
+import { contentPreamble, getResponseEnvelopeName, getResultFieldName, getStatusCodes, formatStatusCodes, sortAscending } from './helpers';
 import { ImportManager } from './imports';
 
 // Creates the content in pagers.go
@@ -32,7 +32,7 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
   for (const pager of values(pagers)) {
     let respEnv = getResponseEnvelopeName(pager.op);
     if (isLROOperation(pager.op)) {
-      respEnv = getFinalResponseEnvelopeName(pager.op);
+      respEnv = getResponseEnvelopeName(pager.op);
     }
     // create pager type
     text += `// ${pager.name} provides operations for iterating over paged responses.\n`;

--- a/src/generator/structs.ts
+++ b/src/generator/structs.ts
@@ -166,10 +166,6 @@ export class StructDef {
 }
 
 export function generateStruct(imports: ImportManager, lang: Language, props?: Property[]): StructDef {
-  if (lang.isLRO) {
-    imports.add('time');
-    imports.add('context');
-  }
   const st = new StructDef(lang, props);
   for (const prop of values(props)) {
     imports.addImportForSchemaType(prop.schema);

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -24,16 +24,15 @@ func newLRORetrysClient() *LRORetrysClient {
 
 func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginDelete202Retry200(context.Background(), nil)
+	poller, err := op.BeginDelete202Retry200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LRORetrysClientDelete202Retry200PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LRORetrysClientDelete202Retry200Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	result, err := resp.PollUntilDone(context.Background(), time.Second)
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if !reflect.ValueOf(result).IsZero() {
 		t.Fatal("expected zero-value result")
@@ -42,31 +41,29 @@ func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 
 func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginDeleteAsyncRelativeRetrySucceeded(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncRelativeRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background(), nil)
+	poller, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(res.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -81,46 +78,43 @@ func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 
 func TestLRORetrysBeginPost202Retry200(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginPost202Retry200(context.Background(), nil)
+	poller, err := op.BeginPost202Retry200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LRORetrysClientPost202Retry200PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LRORetrysClientPost202Retry200Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginPostAsyncRelativeRetrySucceeded(context.Background(), nil)
+	poller, err := op.BeginPostAsyncRelativeRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LRORetrysClientPostAsyncRelativeRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginPut201CreatingSucceeded200(context.Background(), nil)
+	poller, err := op.BeginPut201CreatingSucceeded200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LRORetrysClientPut201CreatingSucceeded200PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LRORetrysClientPut201CreatingSucceeded200Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(res.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -135,16 +129,15 @@ func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
 
 func TestLRORetrysBeginPutAsyncRelativeRetrySucceeded(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginPutAsyncRelativeRetrySucceeded(context.Background(), nil)
+	poller, err := op.BeginPutAsyncRelativeRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LRORetrysClientPutAsyncRelativeRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(res.Product, Product{
 		ID:   to.StringPtr("100"),

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -29,9 +29,7 @@ func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LRORetrysClientDelete202Retry200Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	result, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if !reflect.ValueOf(result).IsZero() {
@@ -46,9 +44,7 @@ func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -60,9 +56,7 @@ func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(res.Product, Product{
@@ -83,9 +77,7 @@ func TestLRORetrysBeginPost202Retry200(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LRORetrysClientPost202Retry200Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -97,9 +89,7 @@ func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LRORetrysClientPostAsyncRelativeRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -111,9 +101,7 @@ func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LRORetrysClientPut201CreatingSucceeded200Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(res.Product, Product{
@@ -134,9 +122,7 @@ func TestLRORetrysBeginPutAsyncRelativeRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LRORetrysClientPutAsyncRelativeRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(res.Product, Product{

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -37,102 +37,95 @@ func httpClientWithCookieJar() policy.Transporter {
 
 func TestLROResumeWrongPoller(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDelete202NoRetry204(context.Background(), nil)
+	poller, err := op.BeginDelete202NoRetry204(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp2 := LROsClientDelete202Retry200PollerResponse{}
-	if err = resp2.Resume(context.Background(), op, rt); err == nil {
+	resp2 := LROsClientDelete202Retry200Poller{}
+	if _, err = resp2.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not find receive one")
 	}
 }
 
 func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDelete202NoRetry204(context.Background(), nil)
+	poller, err := op.BeginDelete202NoRetry204(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDelete202NoRetry204PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDelete202NoRetry204Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginDelete202Retry200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDelete202Retry200(context.Background(), nil)
+	poller, err := op.BeginDelete202Retry200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDelete202Retry200PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDelete202Retry200Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginDelete204Succeeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDelete204Succeeded(context.Background(), nil)
+	poller, err := op.BeginDelete204Succeeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	_, err = poller.ResumeToken()
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDeleteAsyncNoHeaderInRetryPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDeleteAsyncNoHeaderInRetryPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDeleteAsyncNoRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDeleteAsyncNoRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncRetryFailed(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncRetryFailed(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDeleteAsyncRetryFailedPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDeleteAsyncRetryFailedPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -149,31 +142,29 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 
 func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncRetrySucceeded(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDeleteAsyncRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDeleteAsyncRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncRetrycanceled(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncRetrycanceled(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDeleteAsyncRetrycanceledPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDeleteAsyncRetrycanceledPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -190,70 +181,65 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 
 func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteNoHeaderInRetry(context.Background(), nil)
+	poller, err := op.BeginDeleteNoHeaderInRetry(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDeleteNoHeaderInRetryPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDeleteNoHeaderInRetryPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background(), nil)
+	poller, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientDeleteProvisioning202Accepted200SucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background(), nil)
+	poller, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background(), nil)
+	poller, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROBeginPost200WithPayload(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPost200WithPayload(context.Background(), nil)
+	poller, err := op.BeginPost200WithPayload(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPost200WithPayloadPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPost200WithPayloadPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SKU, SKU{
 		ID:   to.StringPtr("1"),
@@ -265,16 +251,15 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 
 func TestLROBeginPost202List(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPost202List(context.Background(), nil)
+	poller, err := op.BeginPost202List(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPost202ListPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPost202ListPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.ProductArray, []*Product{
 		{
@@ -288,46 +273,43 @@ func TestLROBeginPost202List(t *testing.T) {
 
 func TestLROBeginPost202NoRetry204(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPost202NoRetry204(context.Background(), nil)
+	poller, err := op.BeginPost202NoRetry204(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPost202NoRetry204PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPost202NoRetry204Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginPost202Retry200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPost202Retry200(context.Background(), nil)
+	poller, err := op.BeginPost202Retry200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPost202Retry200PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPost202Retry200Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostAsyncNoRetrySucceeded(context.Background(), nil)
+	poller, err := op.BeginPostAsyncNoRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPostAsyncNoRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPostAsyncNoRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -342,16 +324,15 @@ func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 
 func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostAsyncRetryFailed(context.Background(), nil)
+	poller, err := op.BeginPostAsyncRetryFailed(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPostAsyncRetryFailedPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPostAsyncRetryFailedPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -368,16 +349,15 @@ func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
 
 func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostAsyncRetrySucceeded(context.Background(), nil)
+	poller, err := op.BeginPostAsyncRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPostAsyncRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPostAsyncRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -392,16 +372,15 @@ func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
 
 func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostAsyncRetrycanceled(context.Background(), nil)
+	poller, err := op.BeginPostAsyncRetrycanceled(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPostAsyncRetrycanceledPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPostAsyncRetrycanceledPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -418,16 +397,15 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background(), nil)
+	poller, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID: to.StringPtr("100"),
@@ -438,16 +416,15 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(context.Background(), nil)
+	poller, err := op.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -459,16 +436,15 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 
 func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostDoubleHeadersFinalLocationGet(context.Background(), nil)
+	poller, err := op.BeginPostDoubleHeadersFinalLocationGet(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPostDoubleHeadersFinalLocationGetPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPostDoubleHeadersFinalLocationGetPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -480,12 +456,11 @@ func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 
 func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPut200Acceptedcanceled200(context.Background(), nil)
+	poller, err := op.BeginPut200Acceptedcanceled200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 	var respErr *azcore.ResponseError
@@ -498,14 +473,13 @@ func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
 
 func TestLROBeginPut200Succeeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPut200Succeeded(context.Background(), nil)
+	poller, err := op.BeginPut200Succeeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	_, err = poller.ResumeToken()
 	if err == nil {
 		t.Fatal("Expected an error but did not receive one")
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -520,14 +494,13 @@ func TestLROBeginPut200Succeeded(t *testing.T) {
 
 func TestLROBeginPut200SucceededNoState(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPut200SucceededNoState(context.Background(), nil)
+	poller, err := op.BeginPut200SucceededNoState(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	_, err = poller.ResumeToken()
 	if err == nil {
 		t.Fatal("Expected an error but did not receive one")
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -540,16 +513,15 @@ func TestLROBeginPut200SucceededNoState(t *testing.T) {
 // TODO check if this test should actually be returning a 200 or a 204
 func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPut200UpdatingSucceeded204(context.Background(), nil)
+	poller, err := op.BeginPut200UpdatingSucceeded204(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPut200UpdatingSucceeded204PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPut200UpdatingSucceeded204Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -564,12 +536,11 @@ func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
 
 func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPut201CreatingFailed200(context.Background(), nil)
+	poller, err := op.BeginPut201CreatingFailed200(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 	var respErr *azcore.ResponseError
@@ -582,16 +553,15 @@ func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 
 func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPut201CreatingSucceeded200(context.Background(), &LROsClientBeginPut201CreatingSucceeded200Options{Product: &Product{}})
+	poller, err := op.BeginPut201CreatingSucceeded200(context.Background(), &LROsClientBeginPut201CreatingSucceeded200Options{Product: &Product{}})
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPut201CreatingSucceeded200PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPut201CreatingSucceeded200Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -606,16 +576,15 @@ func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 
 func TestLROBeginPut202Retry200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPut202Retry200(context.Background(), &LROsClientBeginPut202Retry200Options{Product: &Product{}})
+	poller, err := op.BeginPut202Retry200(context.Background(), &LROsClientBeginPut202Retry200Options{Product: &Product{}})
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPut202Retry200PollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPut202Retry200Poller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -627,16 +596,15 @@ func TestLROBeginPut202Retry200(t *testing.T) {
 
 func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPutAsyncNoHeaderInRetry(context.Background(), &LROsClientBeginPutAsyncNoHeaderInRetryOptions{Product: &Product{}})
+	poller, err := op.BeginPutAsyncNoHeaderInRetry(context.Background(), &LROsClientBeginPutAsyncNoHeaderInRetryOptions{Product: &Product{}})
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutAsyncNoHeaderInRetryPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutAsyncNoHeaderInRetryPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -651,16 +619,15 @@ func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 
 func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPutAsyncNoRetrySucceeded(context.Background(), &LROsClientBeginPutAsyncNoRetrySucceededOptions{Product: &Product{}})
+	poller, err := op.BeginPutAsyncNoRetrySucceeded(context.Background(), &LROsClientBeginPutAsyncNoRetrySucceededOptions{Product: &Product{}})
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutAsyncNoRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutAsyncNoRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -675,16 +642,15 @@ func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 
 func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPutAsyncNoRetrycanceled(context.Background(), nil)
+	poller, err := op.BeginPutAsyncNoRetrycanceled(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutAsyncNoRetrycanceledPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutAsyncNoRetrycanceledPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -701,16 +667,15 @@ func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 
 func TestLROBeginPutAsyncNonResource(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPutAsyncNonResource(context.Background(), nil)
+	poller, err := op.BeginPutAsyncNonResource(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutAsyncNonResourcePollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutAsyncNonResourcePoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SKU, SKU{
 		ID:   to.StringPtr("100"),
@@ -722,16 +687,15 @@ func TestLROBeginPutAsyncNonResource(t *testing.T) {
 
 func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPutAsyncRetryFailed(context.Background(), nil)
+	poller, err := op.BeginPutAsyncRetryFailed(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutAsyncRetryFailedPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutAsyncRetryFailedPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Second)
+	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -748,16 +712,15 @@ func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
 
 func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPutAsyncRetrySucceeded(context.Background(), nil)
+	poller, err := op.BeginPutAsyncRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutAsyncRetrySucceededPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutAsyncRetrySucceededPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -772,16 +735,15 @@ func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
 
 func TestLROBeginPutAsyncSubResource(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPutAsyncSubResource(context.Background(), nil)
+	poller, err := op.BeginPutAsyncSubResource(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutAsyncSubResourcePollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutAsyncSubResourcePoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SubProduct, SubProduct{
 		ID: to.StringPtr("100"),
@@ -796,16 +758,15 @@ func TestLROBeginPutAsyncSubResource(t *testing.T) {
 func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 	t.Skip("problem with put flow")
 	op := newLROSClient()
-	resp, err := op.BeginPutNoHeaderInRetry(context.Background(), nil)
+	poller, err := op.BeginPutNoHeaderInRetry(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutNoHeaderInRetryPollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutNoHeaderInRetryPoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
 		ID: to.StringPtr("100"),
@@ -820,16 +781,15 @@ func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 func TestLROBeginPutNonResource(t *testing.T) {
 	t.Skip("problem with put flow")
 	op := newLROSClient()
-	resp, err := op.BeginPutNonResource(context.Background(), nil)
+	poller, err := op.BeginPutNonResource(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutNonResourcePollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutNonResourcePoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SKU, SKU{
 		ID:   to.StringPtr("100"),
@@ -842,16 +802,15 @@ func TestLROBeginPutNonResource(t *testing.T) {
 func TestLROBeginPutSubResource(t *testing.T) {
 	t.Skip("problem with put flow")
 	op := newLROSClient()
-	resp, err := op.BeginPutSubResource(context.Background(), nil)
+	poller, err := op.BeginPutSubResource(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = LROsClientPutSubResourcePollerResponse{}
-	if err = resp.Resume(context.Background(), op, rt); err != nil {
+	poller = &LROsClientPutSubResourcePoller{}
+	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
 		t.Fatal(err)
 	}
-	pollResp, err := resp.PollUntilDone(context.Background(), time.Second)
+	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SubProduct, SubProduct{
 		ID: to.StringPtr("100"),

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -42,9 +42,7 @@ func TestLROResumeWrongPoller(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	resp2 := LROsClientDelete202Retry200Poller{}
-	if _, err = resp2.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not find receive one")
-	}
+	require.Error(t, resp2.Resume(rt, op))
 }
 
 func TestLROBeginDelete202NoRetry204(t *testing.T) {
@@ -54,9 +52,7 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDelete202NoRetry204Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -68,9 +64,7 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDelete202Retry200Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -94,9 +88,7 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDeleteAsyncNoHeaderInRetryPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -108,9 +100,7 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDeleteAsyncNoRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -122,9 +112,7 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDeleteAsyncRetryFailedPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -147,9 +135,7 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDeleteAsyncRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -161,9 +147,7 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDeleteAsyncRetrycanceledPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -186,9 +170,7 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDeleteNoHeaderInRetryPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -200,9 +182,7 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientDeleteProvisioning202Accepted200SucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -213,9 +193,10 @@ func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
@@ -224,9 +205,10 @@ func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROBeginPost200WithPayload(t *testing.T) {
@@ -236,9 +218,7 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPost200WithPayloadPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SKU, SKU{
@@ -256,9 +236,7 @@ func TestLROBeginPost202List(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPost202ListPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.ProductArray, []*Product{
@@ -278,9 +256,7 @@ func TestLROBeginPost202NoRetry204(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPost202NoRetry204Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -292,9 +268,7 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPost202Retry200Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
@@ -306,9 +280,7 @@ func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPostAsyncNoRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -329,9 +301,7 @@ func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPostAsyncRetryFailedPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -354,9 +324,7 @@ func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPostAsyncRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -377,9 +345,7 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPostAsyncRetrycanceledPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -402,9 +368,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -421,9 +385,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -441,9 +403,7 @@ func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPostDoubleHeadersFinalLocationGetPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -460,9 +420,9 @@ func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) {
 		t.Fatal("expected azcore.ResponseError")
@@ -518,9 +478,7 @@ func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPut200UpdatingSucceeded204Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -540,9 +498,9 @@ func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) {
 		t.Fatal("expected azcore.ResponseError")
@@ -558,9 +516,7 @@ func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPut201CreatingSucceeded200Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -581,9 +537,7 @@ func TestLROBeginPut202Retry200(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPut202Retry200Poller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -601,9 +555,7 @@ func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutAsyncNoHeaderInRetryPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -624,9 +576,7 @@ func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutAsyncNoRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -647,9 +597,7 @@ func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutAsyncNoRetrycanceledPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -672,9 +620,7 @@ func TestLROBeginPutAsyncNonResource(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutAsyncNonResourcePoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SKU, SKU{
@@ -692,9 +638,7 @@ func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutAsyncRetryFailedPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	res, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -717,9 +661,7 @@ func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutAsyncRetrySucceededPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -740,9 +682,7 @@ func TestLROBeginPutAsyncSubResource(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutAsyncSubResourcePoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SubProduct, SubProduct{
@@ -763,9 +703,7 @@ func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutNoHeaderInRetryPoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.Product, Product{
@@ -786,9 +724,7 @@ func TestLROBeginPutNonResource(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutNonResourcePoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SKU, SKU{
@@ -807,9 +743,7 @@ func TestLROBeginPutSubResource(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsClientPutSubResourcePoller{}
-	if _, err = poller.Resume(context.Background(), op, rt); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, poller.Resume(rt, op))
 	pollResp, err := poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 	if r := cmp.Diff(pollResp.SubProduct, SubProduct{

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -21,12 +21,11 @@ func newLrosaDsClient() *LROSADsClient {
 
 func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDelete202NonRetry400(context.Background(), nil)
+	poller, err := op.BeginDelete202NonRetry400(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
@@ -41,9 +40,8 @@ func TestLROSADSBeginDelete202RetryInvalidHeader(t *testing.T) {
 
 func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDelete204Succeeded(context.Background(), nil)
+	poller, err := op.BeginDelete204Succeeded(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -51,18 +49,17 @@ func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
 	if rt != "" {
 		t.Fatal("expected an empty resume token")
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Second)
+	_, err = poller.PollUntilDone(context.Background(), time.Second)
 	require.NoError(t, err)
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDeleteAsyncRelativeRetry400(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncRelativeRetry400(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
@@ -77,24 +74,22 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidHeader(t *testing.T) {
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDeleteAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDeleteAsyncRelativeRetryNoStatus(context.Background(), nil)
+	poller, err := op.BeginDeleteAsyncRelativeRetryNoStatus(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
@@ -117,12 +112,11 @@ func TestLROSADSBeginPost202NoLocation(t *testing.T) {
 
 func TestLROSADSBeginPost202NonRetry400(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPost202NonRetry400(context.Background(), nil)
+	poller, err := op.BeginPost202NonRetry400(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
@@ -137,12 +131,11 @@ func TestLROSADSBeginPost202RetryInvalidHeader(t *testing.T) {
 
 func TestLROSADSBeginPostAsyncRelativeRetry400(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPostAsyncRelativeRetry400(context.Background(), nil)
+	poller, err := op.BeginPostAsyncRelativeRetry400(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
@@ -157,24 +150,22 @@ func TestLROSADSBeginPostAsyncRelativeRetryInvalidHeader(t *testing.T) {
 
 func TestLROSADSBeginPostAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPostAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
+	poller, err := op.BeginPostAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryNoPayload(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPostAsyncRelativeRetryNoPayload(context.Background(), nil)
+	poller, err := op.BeginPostAsyncRelativeRetryNoPayload(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
@@ -197,12 +188,11 @@ func TestLROSADSBeginPut200InvalidJSON(t *testing.T) {
 
 func TestLROSADSBeginPutAsyncRelativeRetry400(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPutAsyncRelativeRetry400(context.Background(), nil)
+	poller, err := op.BeginPutAsyncRelativeRetry400(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
@@ -217,72 +207,66 @@ func TestLROSADSBeginPutAsyncRelativeRetryInvalidHeader(t *testing.T) {
 
 func TestLROSADSBeginPutAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPutAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
+	poller, err := op.BeginPutAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryNoStatus(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPutAsyncRelativeRetryNoStatus(context.Background(), nil)
+	poller, err := op.BeginPutAsyncRelativeRetryNoStatus(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryNoStatusPayload(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPutAsyncRelativeRetryNoStatusPayload(context.Background(), nil)
+	poller, err := op.BeginPutAsyncRelativeRetryNoStatusPayload(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROSADSBeginPutError201NoProvisioningStatePayload(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPutError201NoProvisioningStatePayload(context.Background(), nil)
+	poller, err := op.BeginPutError201NoProvisioningStatePayload(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROSADSBeginPutNonRetry201Creating400(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPutNonRetry201Creating400(context.Background(), nil)
+	poller, err := op.BeginPutNonRetry201Creating400(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }
 
 func TestLROSADSBeginPutNonRetry201Creating400InvalidJSON(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginPutNonRetry201Creating400InvalidJSON(context.Background(), nil)
+	poller, err := op.BeginPutNonRetry201Creating400InvalidJSON(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if err = resp.Resume(context.Background(), op, rt); err == nil {
+	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
 }

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -25,9 +25,10 @@ func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginDelete202RetryInvalidHeader(t *testing.T) {
@@ -59,9 +60,10 @@ func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidHeader(t *testing.T) {
@@ -78,9 +80,10 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
@@ -89,9 +92,10 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginDeleteNonRetry400(t *testing.T) {
@@ -116,9 +120,10 @@ func TestLROSADSBeginPost202NonRetry400(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPost202RetryInvalidHeader(t *testing.T) {
@@ -135,9 +140,10 @@ func TestLROSADSBeginPostAsyncRelativeRetry400(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryInvalidHeader(t *testing.T) {
@@ -154,9 +160,10 @@ func TestLROSADSBeginPostAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryNoPayload(t *testing.T) {
@@ -165,9 +172,10 @@ func TestLROSADSBeginPostAsyncRelativeRetryNoPayload(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPostNonRetry400(t *testing.T) {
@@ -192,9 +200,10 @@ func TestLROSADSBeginPutAsyncRelativeRetry400(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryInvalidHeader(t *testing.T) {
@@ -211,9 +220,10 @@ func TestLROSADSBeginPutAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryNoStatus(t *testing.T) {
@@ -222,9 +232,10 @@ func TestLROSADSBeginPutAsyncRelativeRetryNoStatus(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryNoStatusPayload(t *testing.T) {
@@ -233,9 +244,10 @@ func TestLROSADSBeginPutAsyncRelativeRetryNoStatusPayload(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPutError201NoProvisioningStatePayload(t *testing.T) {
@@ -244,9 +256,10 @@ func TestLROSADSBeginPutError201NoProvisioningStatePayload(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPutNonRetry201Creating400(t *testing.T) {
@@ -255,9 +268,10 @@ func TestLROSADSBeginPutNonRetry201Creating400(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPutNonRetry201Creating400InvalidJSON(t *testing.T) {
@@ -266,9 +280,10 @@ func TestLROSADSBeginPutNonRetry201Creating400InvalidJSON(t *testing.T) {
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	if _, err = poller.Resume(context.Background(), op, rt); err == nil {
-		t.Fatal("expected an error but did not receive one")
-	}
+	require.NoError(t, poller.Resume(rt, op))
+	result, err := poller.PollUntilDone(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Zero(t, result)
 }
 
 func TestLROSADSBeginPutNonRetry400(t *testing.T) {

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -6,6 +6,7 @@ package lrogroup
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -32,76 +33,66 @@ func ctxWithHTTPHeader() context.Context {
 // BeginPost202Retry200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
 func TestBeginPost202Retry200(t *testing.T) {
 	op := newLrOSCustomHeaderClient()
-	env, err := op.BeginPost202Retry200(ctxWithHTTPHeader(), nil)
+	poller, err := op.BeginPost202Retry200(ctxWithHTTPHeader(), nil)
 	require.NoError(t, err)
-	tk, err := env.Poller.ResumeToken()
+	tk, err := poller.ResumeToken()
 	require.NoError(t, err)
-	env = LROsCustomHeaderClientPost202Retry200PollerResponse{}
-	if err = env.Resume(ctxWithHTTPHeader(), op, tk); err != nil {
-		t.Fatal(err)
-	}
-	for {
-		_, err = env.Poller.Poll(ctxWithHTTPHeader())
+	poller = &LROsCustomHeaderClientPost202Retry200Poller{}
+	pr, err := poller.Resume(ctxWithHTTPHeader(), op, tk)
+	require.NoError(t, err)
+	for !poller.Done() {
+		pr, err = poller.Poll(ctxWithHTTPHeader())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if env.Poller.Done() {
-			break
-		}
 	}
-	_, err = env.Poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	if !reflect.ValueOf(pr).IsZero() {
+		t.Fatal("expected zero-value final response")
 	}
 }
 
 // BeginPostAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func TestBeginPostAsyncRetrySucceeded(t *testing.T) {
 	op := newLrOSCustomHeaderClient()
-	env, err := op.BeginPostAsyncRetrySucceeded(ctxWithHTTPHeader(), nil)
+	poller, err := op.BeginPostAsyncRetrySucceeded(ctxWithHTTPHeader(), nil)
 	require.NoError(t, err)
-	tk, err := env.Poller.ResumeToken()
+	tk, err := poller.ResumeToken()
 	require.NoError(t, err)
-	env = LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse{}
-	if err = env.Resume(ctxWithHTTPHeader(), op, tk); err != nil {
-		t.Fatal(err)
-	}
-	for {
-		_, err = env.Poller.Poll(ctxWithHTTPHeader())
+	poller = &LROsCustomHeaderClientPostAsyncRetrySucceededPoller{}
+	pr, err := poller.Resume(ctxWithHTTPHeader(), op, tk)
+	require.NoError(t, err)
+	for !poller.Done() {
+		pr, err = poller.Poll(ctxWithHTTPHeader())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if env.Poller.Done() {
-			break
-		}
 	}
-	_, err = env.Poller.FinalResponse(context.Background())
+	pr, err = poller.Poll(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !reflect.ValueOf(pr).IsZero() {
+		t.Fatal("expected zero-value final response")
 	}
 }
 
 // BeginPut201CreatingSucceeded200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func TestBeginPut201CreatingSucceeded200(t *testing.T) {
 	op := newLrOSCustomHeaderClient()
-	env, err := op.BeginPut201CreatingSucceeded200(ctxWithHTTPHeader(), nil)
+	poller, err := op.BeginPut201CreatingSucceeded200(ctxWithHTTPHeader(), nil)
 	require.NoError(t, err)
-	tk, err := env.Poller.ResumeToken()
+	tk, err := poller.ResumeToken()
 	require.NoError(t, err)
-	env = LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse{}
-	if err = env.Resume(ctxWithHTTPHeader(), op, tk); err != nil {
-		t.Fatal(err)
-	}
-	for {
-		_, err = env.Poller.Poll(ctxWithHTTPHeader())
+	poller = &LROsCustomHeaderClientPut201CreatingSucceeded200Poller{}
+	pr, err := poller.Resume(ctxWithHTTPHeader(), op, tk)
+	require.NoError(t, err)
+	for !poller.Done() {
+		pr, err = poller.Poll(ctxWithHTTPHeader())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if env.Poller.Done() {
-			break
-		}
 	}
-	pr, err := env.Poller.FinalResponse(ctxWithHTTPHeader())
+	pr, err = poller.Poll(ctxWithHTTPHeader())
 	require.NoError(t, err)
 	if r := cmp.Diff(pr.Product, Product{
 		ID:   to.StringPtr("100"),
@@ -117,25 +108,19 @@ func TestBeginPut201CreatingSucceeded200(t *testing.T) {
 // BeginPutAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func TestBeginPutAsyncRetrySucceeded(t *testing.T) {
 	op := newLrOSCustomHeaderClient()
-	env, err := op.BeginPutAsyncRetrySucceeded(ctxWithHTTPHeader(), nil)
+	poller, err := op.BeginPutAsyncRetrySucceeded(ctxWithHTTPHeader(), nil)
 	require.NoError(t, err)
-	tk, err := env.Poller.ResumeToken()
+	tk, err := poller.ResumeToken()
 	require.NoError(t, err)
-	env = LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse{}
-	if err = env.Resume(ctxWithHTTPHeader(), op, tk); err != nil {
-		t.Fatal(err)
-	}
-	for {
-		_, err = env.Poller.Poll(ctxWithHTTPHeader())
+	poller = &LROsCustomHeaderClientPutAsyncRetrySucceededPoller{}
+	pr, err := poller.Resume(ctxWithHTTPHeader(), op, tk)
+	require.NoError(t, err)
+	for !poller.Done() {
+		pr, err = poller.Poll(ctxWithHTTPHeader())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if env.Poller.Done() {
-			break
-		}
 	}
-	pr, err := env.Poller.FinalResponse(ctxWithHTTPHeader())
-	require.NoError(t, err)
 	if r := cmp.Diff(pr.Product, Product{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("foo"),

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -38,15 +38,14 @@ func TestBeginPost202Retry200(t *testing.T) {
 	tk, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsCustomHeaderClientPost202Retry200Poller{}
-	pr, err := poller.Resume(ctxWithHTTPHeader(), op, tk)
-	require.NoError(t, err)
+	require.NoError(t, poller.Resume(tk, op))
 	for !poller.Done() {
-		pr, err = poller.Poll(ctxWithHTTPHeader())
-		if err != nil {
-			t.Fatal(err)
-		}
+		_, err = poller.Poll(ctxWithHTTPHeader())
+		require.NoError(t, err)
 	}
-	if !reflect.ValueOf(pr).IsZero() {
+	result, err := poller.Result(context.Background())
+	require.NoError(t, err)
+	if !reflect.ValueOf(result).IsZero() {
 		t.Fatal("expected zero-value final response")
 	}
 }
@@ -59,19 +58,14 @@ func TestBeginPostAsyncRetrySucceeded(t *testing.T) {
 	tk, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsCustomHeaderClientPostAsyncRetrySucceededPoller{}
-	pr, err := poller.Resume(ctxWithHTTPHeader(), op, tk)
-	require.NoError(t, err)
+	require.NoError(t, poller.Resume(tk, op))
 	for !poller.Done() {
-		pr, err = poller.Poll(ctxWithHTTPHeader())
-		if err != nil {
-			t.Fatal(err)
-		}
+		_, err = poller.Poll(ctxWithHTTPHeader())
+		require.NoError(t, err)
 	}
-	pr, err = poller.Poll(context.Background())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if !reflect.ValueOf(pr).IsZero() {
+	result, err := poller.Result(context.Background())
+	require.NoError(t, err)
+	if !reflect.ValueOf(result).IsZero() {
 		t.Fatal("expected zero-value final response")
 	}
 }
@@ -84,17 +78,14 @@ func TestBeginPut201CreatingSucceeded200(t *testing.T) {
 	tk, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsCustomHeaderClientPut201CreatingSucceeded200Poller{}
-	pr, err := poller.Resume(ctxWithHTTPHeader(), op, tk)
-	require.NoError(t, err)
+	require.NoError(t, poller.Resume(tk, op))
 	for !poller.Done() {
-		pr, err = poller.Poll(ctxWithHTTPHeader())
-		if err != nil {
-			t.Fatal(err)
-		}
+		_, err = poller.Poll(ctxWithHTTPHeader())
+		require.NoError(t, err)
 	}
-	pr, err = poller.Poll(ctxWithHTTPHeader())
+	result, err := poller.Result(context.Background())
 	require.NoError(t, err)
-	if r := cmp.Diff(pr.Product, Product{
+	if r := cmp.Diff(result.Product, Product{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("foo"),
 		Properties: &ProductProperties{
@@ -113,15 +104,14 @@ func TestBeginPutAsyncRetrySucceeded(t *testing.T) {
 	tk, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &LROsCustomHeaderClientPutAsyncRetrySucceededPoller{}
-	pr, err := poller.Resume(ctxWithHTTPHeader(), op, tk)
-	require.NoError(t, err)
+	require.NoError(t, poller.Resume(tk, op))
 	for !poller.Done() {
-		pr, err = poller.Poll(ctxWithHTTPHeader())
-		if err != nil {
-			t.Fatal(err)
-		}
+		_, err = poller.Poll(ctxWithHTTPHeader())
+		require.NoError(t, err)
 	}
-	if r := cmp.Diff(pr.Product, Product{
+	result, err := poller.Result(ctxWithHTTPHeader())
+	require.NoError(t, err)
+	if r := cmp.Diff(result.Product, Product{
 		ID:   to.StringPtr("100"),
 		Name: to.StringPtr("foo"),
 		Properties: &ProductProperties{

--- a/test/autorest/lrogroup/zz_generated_lroretrys_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys_client.go
@@ -40,20 +40,16 @@ func NewLRORetrysClient(options *azcore.ClientOptions) *LRORetrysClient {
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LRORetrysClientBeginDelete202Retry200Options contains the optional parameters for the LRORetrysClient.BeginDelete202Retry200
 // method.
-func (client *LRORetrysClient) BeginDelete202Retry200(ctx context.Context, options *LRORetrysClientBeginDelete202Retry200Options) (LRORetrysClientDelete202Retry200PollerResponse, error) {
+func (client *LRORetrysClient) BeginDelete202Retry200(ctx context.Context, options *LRORetrysClientBeginDelete202Retry200Options) (*LRORetrysClientDelete202Retry200Poller, error) {
 	resp, err := client.delete202Retry200(ctx, options)
 	if err != nil {
-		return LRORetrysClientDelete202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result := LRORetrysClientDelete202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.Delete202Retry200", "", resp, client.pl)
 	if err != nil {
-		return LRORetrysClientDelete202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LRORetrysClientDelete202Retry200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LRORetrysClientDelete202Retry200Poller{pt: pt}, nil
 }
 
 // Delete202Retry200 - Long running delete request, service returns a 500, then a 202 to the initial request. Polls return
@@ -90,20 +86,16 @@ func (client *LRORetrysClient) delete202Retry200CreateRequest(ctx context.Contex
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LRORetrysClientBeginDeleteAsyncRelativeRetrySucceededOptions contains the optional parameters for the LRORetrysClient.BeginDeleteAsyncRelativeRetrySucceeded
 // method.
-func (client *LRORetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx context.Context, options *LRORetrysClientBeginDeleteAsyncRelativeRetrySucceededOptions) (LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse, error) {
+func (client *LRORetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx context.Context, options *LRORetrysClientBeginDeleteAsyncRelativeRetrySucceededOptions) (*LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller, error) {
 	resp, err := client.deleteAsyncRelativeRetrySucceeded(ctx, options)
 	if err != nil {
-		return LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.DeleteAsyncRelativeRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller{pt: pt}, nil
 }
 
 // DeleteAsyncRelativeRetrySucceeded - Long running delete request, service returns a 500, then a 202 to the initial request.
@@ -142,20 +134,16 @@ func (client *LRORetrysClient) deleteAsyncRelativeRetrySucceededCreateRequest(ct
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LRORetrysClientBeginDeleteProvisioning202Accepted200SucceededOptions contains the optional parameters for the
 // LRORetrysClient.BeginDeleteProvisioning202Accepted200Succeeded method.
-func (client *LRORetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LRORetrysClientBeginDeleteProvisioning202Accepted200SucceededOptions) (LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse, error) {
+func (client *LRORetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LRORetrysClientBeginDeleteProvisioning202Accepted200SucceededOptions) (*LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller, error) {
 	resp, err := client.deleteProvisioning202Accepted200Succeeded(ctx, options)
 	if err != nil {
-		return LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.DeleteProvisioning202Accepted200Succeeded", "", resp, client.pl)
 	if err != nil {
-		return LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller{pt: pt}, nil
 }
 
 // DeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 500, then a 202 to the initial
@@ -194,20 +182,16 @@ func (client *LRORetrysClient) deleteProvisioning202Accepted200SucceededCreateRe
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LRORetrysClientBeginPost202Retry200Options contains the optional parameters for the LRORetrysClient.BeginPost202Retry200
 // method.
-func (client *LRORetrysClient) BeginPost202Retry200(ctx context.Context, options *LRORetrysClientBeginPost202Retry200Options) (LRORetrysClientPost202Retry200PollerResponse, error) {
+func (client *LRORetrysClient) BeginPost202Retry200(ctx context.Context, options *LRORetrysClientBeginPost202Retry200Options) (*LRORetrysClientPost202Retry200Poller, error) {
 	resp, err := client.post202Retry200(ctx, options)
 	if err != nil {
-		return LRORetrysClientPost202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result := LRORetrysClientPost202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.Post202Retry200", "", resp, client.pl)
 	if err != nil {
-		return LRORetrysClientPost202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LRORetrysClientPost202Retry200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LRORetrysClientPost202Retry200Poller{pt: pt}, nil
 }
 
 // Post202Retry200 - Long running post request, service returns a 500, then a 202 to the initial request, with 'Location'
@@ -248,20 +232,16 @@ func (client *LRORetrysClient) post202Retry200CreateRequest(ctx context.Context,
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LRORetrysClientBeginPostAsyncRelativeRetrySucceededOptions contains the optional parameters for the LRORetrysClient.BeginPostAsyncRelativeRetrySucceeded
 // method.
-func (client *LRORetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.Context, options *LRORetrysClientBeginPostAsyncRelativeRetrySucceededOptions) (LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse, error) {
+func (client *LRORetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.Context, options *LRORetrysClientBeginPostAsyncRelativeRetrySucceededOptions) (*LRORetrysClientPostAsyncRelativeRetrySucceededPoller, error) {
 	resp, err := client.postAsyncRelativeRetrySucceeded(ctx, options)
 	if err != nil {
-		return LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.PostAsyncRelativeRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LRORetrysClientPostAsyncRelativeRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LRORetrysClientPostAsyncRelativeRetrySucceededPoller{pt: pt}, nil
 }
 
 // PostAsyncRelativeRetrySucceeded - Long running post request, service returns a 500, then a 202 to the initial request,
@@ -303,20 +283,16 @@ func (client *LRORetrysClient) postAsyncRelativeRetrySucceededCreateRequest(ctx 
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LRORetrysClientBeginPut201CreatingSucceeded200Options contains the optional parameters for the LRORetrysClient.BeginPut201CreatingSucceeded200
 // method.
-func (client *LRORetrysClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LRORetrysClientBeginPut201CreatingSucceeded200Options) (LRORetrysClientPut201CreatingSucceeded200PollerResponse, error) {
+func (client *LRORetrysClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LRORetrysClientBeginPut201CreatingSucceeded200Options) (*LRORetrysClientPut201CreatingSucceeded200Poller, error) {
 	resp, err := client.put201CreatingSucceeded200(ctx, options)
 	if err != nil {
-		return LRORetrysClientPut201CreatingSucceeded200PollerResponse{}, err
+		return nil, err
 	}
-	result := LRORetrysClientPut201CreatingSucceeded200PollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.Put201CreatingSucceeded200", "", resp, client.pl)
 	if err != nil {
-		return LRORetrysClientPut201CreatingSucceeded200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LRORetrysClientPut201CreatingSucceeded200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LRORetrysClientPut201CreatingSucceeded200Poller{pt: pt}, nil
 }
 
 // Put201CreatingSucceeded200 - Long running put request, service returns a 500, then a 201 to the initial request, with an
@@ -358,20 +334,16 @@ func (client *LRORetrysClient) put201CreatingSucceeded200CreateRequest(ctx conte
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LRORetrysClientBeginPutAsyncRelativeRetrySucceededOptions contains the optional parameters for the LRORetrysClient.BeginPutAsyncRelativeRetrySucceeded
 // method.
-func (client *LRORetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.Context, options *LRORetrysClientBeginPutAsyncRelativeRetrySucceededOptions) (LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse, error) {
+func (client *LRORetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.Context, options *LRORetrysClientBeginPutAsyncRelativeRetrySucceededOptions) (*LRORetrysClientPutAsyncRelativeRetrySucceededPoller, error) {
 	resp, err := client.putAsyncRelativeRetrySucceeded(ctx, options)
 	if err != nil {
-		return LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LRORetrysClient.PutAsyncRelativeRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LRORetrysClientPutAsyncRelativeRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LRORetrysClientPutAsyncRelativeRetrySucceededPoller{pt: pt}, nil
 }
 
 // PutAsyncRelativeRetrySucceeded - Long running put request, service returns a 500, then a 200 to the initial request, with

--- a/test/autorest/lrogroup/zz_generated_lros_client.go
+++ b/test/autorest/lrogroup/zz_generated_lros_client.go
@@ -40,20 +40,16 @@ func NewLROsClient(options *azcore.ClientOptions) *LROsClient {
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDelete202NoRetry204Options contains the optional parameters for the LROsClient.BeginDelete202NoRetry204
 // method.
-func (client *LROsClient) BeginDelete202NoRetry204(ctx context.Context, options *LROsClientBeginDelete202NoRetry204Options) (LROsClientDelete202NoRetry204PollerResponse, error) {
+func (client *LROsClient) BeginDelete202NoRetry204(ctx context.Context, options *LROsClientBeginDelete202NoRetry204Options) (*LROsClientDelete202NoRetry204Poller, error) {
 	resp, err := client.delete202NoRetry204(ctx, options)
 	if err != nil {
-		return LROsClientDelete202NoRetry204PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDelete202NoRetry204PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Delete202NoRetry204", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDelete202NoRetry204PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDelete202NoRetry204Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDelete202NoRetry204Poller{pt: pt}, nil
 }
 
 // Delete202NoRetry204 - Long running delete request, service returns a 202 to the initial request. Polls return this value
@@ -90,20 +86,16 @@ func (client *LROsClient) delete202NoRetry204CreateRequest(ctx context.Context, 
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDelete202Retry200Options contains the optional parameters for the LROsClient.BeginDelete202Retry200
 // method.
-func (client *LROsClient) BeginDelete202Retry200(ctx context.Context, options *LROsClientBeginDelete202Retry200Options) (LROsClientDelete202Retry200PollerResponse, error) {
+func (client *LROsClient) BeginDelete202Retry200(ctx context.Context, options *LROsClientBeginDelete202Retry200Options) (*LROsClientDelete202Retry200Poller, error) {
 	resp, err := client.delete202Retry200(ctx, options)
 	if err != nil {
-		return LROsClientDelete202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDelete202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Delete202Retry200", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDelete202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDelete202Retry200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDelete202Retry200Poller{pt: pt}, nil
 }
 
 // Delete202Retry200 - Long running delete request, service returns a 202 to the initial request. Polls return this value
@@ -139,20 +131,16 @@ func (client *LROsClient) delete202Retry200CreateRequest(ctx context.Context, op
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDelete204SucceededOptions contains the optional parameters for the LROsClient.BeginDelete204Succeeded
 // method.
-func (client *LROsClient) BeginDelete204Succeeded(ctx context.Context, options *LROsClientBeginDelete204SucceededOptions) (LROsClientDelete204SucceededPollerResponse, error) {
+func (client *LROsClient) BeginDelete204Succeeded(ctx context.Context, options *LROsClientBeginDelete204SucceededOptions) (*LROsClientDelete204SucceededPoller, error) {
 	resp, err := client.delete204Succeeded(ctx, options)
 	if err != nil {
-		return LROsClientDelete204SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDelete204SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Delete204Succeeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDelete204SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDelete204SucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDelete204SucceededPoller{pt: pt}, nil
 }
 
 // Delete204Succeeded - Long running delete succeeds and returns right away
@@ -188,20 +176,16 @@ func (client *LROsClient) delete204SucceededCreateRequest(ctx context.Context, o
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteAsyncNoHeaderInRetryOptions contains the optional parameters for the LROsClient.BeginDeleteAsyncNoHeaderInRetry
 // method.
-func (client *LROsClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context, options *LROsClientBeginDeleteAsyncNoHeaderInRetryOptions) (LROsClientDeleteAsyncNoHeaderInRetryPollerResponse, error) {
+func (client *LROsClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context, options *LROsClientBeginDeleteAsyncNoHeaderInRetryOptions) (*LROsClientDeleteAsyncNoHeaderInRetryPoller, error) {
 	resp, err := client.deleteAsyncNoHeaderInRetry(ctx, options)
 	if err != nil {
-		return LROsClientDeleteAsyncNoHeaderInRetryPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteAsyncNoHeaderInRetryPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncNoHeaderInRetry", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteAsyncNoHeaderInRetryPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteAsyncNoHeaderInRetryPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteAsyncNoHeaderInRetryPoller{pt: pt}, nil
 }
 
 // DeleteAsyncNoHeaderInRetry - Long running delete request, service returns an Azure-AsyncOperation header in the initial
@@ -238,20 +222,16 @@ func (client *LROsClient) deleteAsyncNoHeaderInRetryCreateRequest(ctx context.Co
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteAsyncNoRetrySucceededOptions contains the optional parameters for the LROsClient.BeginDeleteAsyncNoRetrySucceeded
 // method.
-func (client *LROsClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context, options *LROsClientBeginDeleteAsyncNoRetrySucceededOptions) (LROsClientDeleteAsyncNoRetrySucceededPollerResponse, error) {
+func (client *LROsClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context, options *LROsClientBeginDeleteAsyncNoRetrySucceededOptions) (*LROsClientDeleteAsyncNoRetrySucceededPoller, error) {
 	resp, err := client.deleteAsyncNoRetrySucceeded(ctx, options)
 	if err != nil {
-		return LROsClientDeleteAsyncNoRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteAsyncNoRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncNoRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteAsyncNoRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteAsyncNoRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteAsyncNoRetrySucceededPoller{pt: pt}, nil
 }
 
 // DeleteAsyncNoRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint
@@ -288,20 +268,16 @@ func (client *LROsClient) deleteAsyncNoRetrySucceededCreateRequest(ctx context.C
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteAsyncRetryFailedOptions contains the optional parameters for the LROsClient.BeginDeleteAsyncRetryFailed
 // method.
-func (client *LROsClient) BeginDeleteAsyncRetryFailed(ctx context.Context, options *LROsClientBeginDeleteAsyncRetryFailedOptions) (LROsClientDeleteAsyncRetryFailedPollerResponse, error) {
+func (client *LROsClient) BeginDeleteAsyncRetryFailed(ctx context.Context, options *LROsClientBeginDeleteAsyncRetryFailedOptions) (*LROsClientDeleteAsyncRetryFailedPoller, error) {
 	resp, err := client.deleteAsyncRetryFailed(ctx, options)
 	if err != nil {
-		return LROsClientDeleteAsyncRetryFailedPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteAsyncRetryFailedPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncRetryFailed", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteAsyncRetryFailedPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteAsyncRetryFailedPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteAsyncRetryFailedPoller{pt: pt}, nil
 }
 
 // DeleteAsyncRetryFailed - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated
@@ -338,20 +314,16 @@ func (client *LROsClient) deleteAsyncRetryFailedCreateRequest(ctx context.Contex
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteAsyncRetrySucceededOptions contains the optional parameters for the LROsClient.BeginDeleteAsyncRetrySucceeded
 // method.
-func (client *LROsClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context, options *LROsClientBeginDeleteAsyncRetrySucceededOptions) (LROsClientDeleteAsyncRetrySucceededPollerResponse, error) {
+func (client *LROsClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context, options *LROsClientBeginDeleteAsyncRetrySucceededOptions) (*LROsClientDeleteAsyncRetrySucceededPoller, error) {
 	resp, err := client.deleteAsyncRetrySucceeded(ctx, options)
 	if err != nil {
-		return LROsClientDeleteAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteAsyncRetrySucceededPoller{pt: pt}, nil
 }
 
 // DeleteAsyncRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint
@@ -388,20 +360,16 @@ func (client *LROsClient) deleteAsyncRetrySucceededCreateRequest(ctx context.Con
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteAsyncRetrycanceledOptions contains the optional parameters for the LROsClient.BeginDeleteAsyncRetrycanceled
 // method.
-func (client *LROsClient) BeginDeleteAsyncRetrycanceled(ctx context.Context, options *LROsClientBeginDeleteAsyncRetrycanceledOptions) (LROsClientDeleteAsyncRetrycanceledPollerResponse, error) {
+func (client *LROsClient) BeginDeleteAsyncRetrycanceled(ctx context.Context, options *LROsClientBeginDeleteAsyncRetrycanceledOptions) (*LROsClientDeleteAsyncRetrycanceledPoller, error) {
 	resp, err := client.deleteAsyncRetrycanceled(ctx, options)
 	if err != nil {
-		return LROsClientDeleteAsyncRetrycanceledPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteAsyncRetrycanceledPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteAsyncRetrycanceled", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteAsyncRetrycanceledPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteAsyncRetrycanceledPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteAsyncRetrycanceledPoller{pt: pt}, nil
 }
 
 // DeleteAsyncRetrycanceled - Long running delete request, service returns a 202 to the initial request. Poll the endpoint
@@ -438,20 +406,16 @@ func (client *LROsClient) deleteAsyncRetrycanceledCreateRequest(ctx context.Cont
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteNoHeaderInRetryOptions contains the optional parameters for the LROsClient.BeginDeleteNoHeaderInRetry
 // method.
-func (client *LROsClient) BeginDeleteNoHeaderInRetry(ctx context.Context, options *LROsClientBeginDeleteNoHeaderInRetryOptions) (LROsClientDeleteNoHeaderInRetryPollerResponse, error) {
+func (client *LROsClient) BeginDeleteNoHeaderInRetry(ctx context.Context, options *LROsClientBeginDeleteNoHeaderInRetryOptions) (*LROsClientDeleteNoHeaderInRetryPoller, error) {
 	resp, err := client.deleteNoHeaderInRetry(ctx, options)
 	if err != nil {
-		return LROsClientDeleteNoHeaderInRetryPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteNoHeaderInRetryPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteNoHeaderInRetry", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteNoHeaderInRetryPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteNoHeaderInRetryPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteNoHeaderInRetryPoller{pt: pt}, nil
 }
 
 // DeleteNoHeaderInRetry - Long running delete request, service returns a location header in the initial request. Subsequent
@@ -490,20 +454,16 @@ func (client *LROsClient) deleteNoHeaderInRetryCreateRequest(ctx context.Context
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteProvisioning202Accepted200SucceededOptions contains the optional parameters for the LROsClient.BeginDeleteProvisioning202Accepted200Succeeded
 // method.
-func (client *LROsClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LROsClientBeginDeleteProvisioning202Accepted200SucceededOptions) (LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse, error) {
+func (client *LROsClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LROsClientBeginDeleteProvisioning202Accepted200SucceededOptions) (*LROsClientDeleteProvisioning202Accepted200SucceededPoller, error) {
 	resp, err := client.deleteProvisioning202Accepted200Succeeded(ctx, options)
 	if err != nil {
-		return LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteProvisioning202Accepted200Succeeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteProvisioning202Accepted200SucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteProvisioning202Accepted200SucceededPoller{pt: pt}, nil
 }
 
 // DeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 202 to the initial request,
@@ -544,20 +504,16 @@ func (client *LROsClient) deleteProvisioning202Accepted200SucceededCreateRequest
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteProvisioning202DeletingFailed200Options contains the optional parameters for the LROsClient.BeginDeleteProvisioning202DeletingFailed200
 // method.
-func (client *LROsClient) BeginDeleteProvisioning202DeletingFailed200(ctx context.Context, options *LROsClientBeginDeleteProvisioning202DeletingFailed200Options) (LROsClientDeleteProvisioning202DeletingFailed200PollerResponse, error) {
+func (client *LROsClient) BeginDeleteProvisioning202DeletingFailed200(ctx context.Context, options *LROsClientBeginDeleteProvisioning202DeletingFailed200Options) (*LROsClientDeleteProvisioning202DeletingFailed200Poller, error) {
 	resp, err := client.deleteProvisioning202DeletingFailed200(ctx, options)
 	if err != nil {
-		return LROsClientDeleteProvisioning202DeletingFailed200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteProvisioning202DeletingFailed200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteProvisioning202DeletingFailed200", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteProvisioning202DeletingFailed200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteProvisioning202DeletingFailed200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteProvisioning202DeletingFailed200Poller{pt: pt}, nil
 }
 
 // DeleteProvisioning202DeletingFailed200 - Long running delete request, service returns a 202 to the initial request, with
@@ -597,20 +553,16 @@ func (client *LROsClient) deleteProvisioning202DeletingFailed200CreateRequest(ct
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginDeleteProvisioning202Deletingcanceled200Options contains the optional parameters for the LROsClient.BeginDeleteProvisioning202Deletingcanceled200
 // method.
-func (client *LROsClient) BeginDeleteProvisioning202Deletingcanceled200(ctx context.Context, options *LROsClientBeginDeleteProvisioning202Deletingcanceled200Options) (LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse, error) {
+func (client *LROsClient) BeginDeleteProvisioning202Deletingcanceled200(ctx context.Context, options *LROsClientBeginDeleteProvisioning202Deletingcanceled200Options) (*LROsClientDeleteProvisioning202Deletingcanceled200Poller, error) {
 	resp, err := client.deleteProvisioning202Deletingcanceled200(ctx, options)
 	if err != nil {
-		return LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.DeleteProvisioning202Deletingcanceled200", "", resp, client.pl)
 	if err != nil {
-		return LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientDeleteProvisioning202Deletingcanceled200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientDeleteProvisioning202Deletingcanceled200Poller{pt: pt}, nil
 }
 
 // DeleteProvisioning202Deletingcanceled200 - Long running delete request, service returns a 202 to the initial request, with
@@ -648,20 +600,16 @@ func (client *LROsClient) deleteProvisioning202Deletingcanceled200CreateRequest(
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPatch200SucceededIgnoreHeadersOptions contains the optional parameters for the LROsClient.BeginPatch200SucceededIgnoreHeaders
 // method.
-func (client *LROsClient) BeginPatch200SucceededIgnoreHeaders(ctx context.Context, options *LROsClientBeginPatch200SucceededIgnoreHeadersOptions) (LROsClientPatch200SucceededIgnoreHeadersPollerResponse, error) {
+func (client *LROsClient) BeginPatch200SucceededIgnoreHeaders(ctx context.Context, options *LROsClientBeginPatch200SucceededIgnoreHeadersOptions) (*LROsClientPatch200SucceededIgnoreHeadersPoller, error) {
 	resp, err := client.patch200SucceededIgnoreHeaders(ctx, options)
 	if err != nil {
-		return LROsClientPatch200SucceededIgnoreHeadersPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPatch200SucceededIgnoreHeadersPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Patch200SucceededIgnoreHeaders", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPatch200SucceededIgnoreHeadersPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPatch200SucceededIgnoreHeadersPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPatch200SucceededIgnoreHeadersPoller{pt: pt}, nil
 }
 
 // Patch200SucceededIgnoreHeaders - Long running put request, service returns a 200 to the initial request with location header.
@@ -696,130 +644,21 @@ func (client *LROsClient) patch200SucceededIgnoreHeadersCreateRequest(ctx contex
 	return req, nil
 }
 
-// BeginPatch201RetryWithAsyncHeader - Long running patch request, service returns a 201 to the initial request with async
-// header.
-// If the operation fails it returns an *azcore.ResponseError type.
-// options - LROsClientBeginPatch201RetryWithAsyncHeaderOptions contains the optional parameters for the LROsClient.BeginPatch201RetryWithAsyncHeader
-// method.
-func (client *LROsClient) BeginPatch201RetryWithAsyncHeader(ctx context.Context, options *LROsClientBeginPatch201RetryWithAsyncHeaderOptions) (LROsClientPatch201RetryWithAsyncHeaderPollerResponse, error) {
-	resp, err := client.patch201RetryWithAsyncHeader(ctx, options)
-	if err != nil {
-		return LROsClientPatch201RetryWithAsyncHeaderPollerResponse{}, err
-	}
-	result := LROsClientPatch201RetryWithAsyncHeaderPollerResponse{}
-	pt, err := armruntime.NewPoller("LROsClient.Patch201RetryWithAsyncHeader", "azure-async-operation", resp, client.pl)
-	if err != nil {
-		return LROsClientPatch201RetryWithAsyncHeaderPollerResponse{}, err
-	}
-	result.Poller = &LROsClientPatch201RetryWithAsyncHeaderPoller{
-		pt: pt,
-	}
-	return result, nil
-}
-
-// Patch201RetryWithAsyncHeader - Long running patch request, service returns a 201 to the initial request with async header.
-// If the operation fails it returns an *azcore.ResponseError type.
-func (client *LROsClient) patch201RetryWithAsyncHeader(ctx context.Context, options *LROsClientBeginPatch201RetryWithAsyncHeaderOptions) (*http.Response, error) {
-	req, err := client.patch201RetryWithAsyncHeaderCreateRequest(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated) {
-		return nil, runtime.NewResponseError(resp)
-	}
-	return resp, nil
-}
-
-// patch201RetryWithAsyncHeaderCreateRequest creates the Patch201RetryWithAsyncHeader request.
-func (client *LROsClient) patch201RetryWithAsyncHeaderCreateRequest(ctx context.Context, options *LROsClientBeginPatch201RetryWithAsyncHeaderOptions) (*policy.Request, error) {
-	urlPath := "/lro/patch/201/retry/onlyAsyncHeader"
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(host, urlPath))
-	if err != nil {
-		return nil, err
-	}
-	req.Raw().Header.Set("Accept", "application/json")
-	if options != nil && options.Product != nil {
-		return req, runtime.MarshalAsJSON(req, *options.Product)
-	}
-	return req, nil
-}
-
-// BeginPatch202RetryWithAsyncAndLocationHeader - Long running patch request, service returns a 202 to the initial request
-// with async and location header.
-// If the operation fails it returns an *azcore.ResponseError type.
-// options - LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions contains the optional parameters for the LROsClient.BeginPatch202RetryWithAsyncAndLocationHeader
-// method.
-func (client *LROsClient) BeginPatch202RetryWithAsyncAndLocationHeader(ctx context.Context, options *LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions) (LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse, error) {
-	resp, err := client.patch202RetryWithAsyncAndLocationHeader(ctx, options)
-	if err != nil {
-		return LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse{}, err
-	}
-	result := LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse{}
-	pt, err := armruntime.NewPoller("LROsClient.Patch202RetryWithAsyncAndLocationHeader", "", resp, client.pl)
-	if err != nil {
-		return LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse{}, err
-	}
-	result.Poller = &LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller{
-		pt: pt,
-	}
-	return result, nil
-}
-
-// Patch202RetryWithAsyncAndLocationHeader - Long running patch request, service returns a 202 to the initial request with
-// async and location header.
-// If the operation fails it returns an *azcore.ResponseError type.
-func (client *LROsClient) patch202RetryWithAsyncAndLocationHeader(ctx context.Context, options *LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions) (*http.Response, error) {
-	req, err := client.patch202RetryWithAsyncAndLocationHeaderCreateRequest(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted) {
-		return nil, runtime.NewResponseError(resp)
-	}
-	return resp, nil
-}
-
-// patch202RetryWithAsyncAndLocationHeaderCreateRequest creates the Patch202RetryWithAsyncAndLocationHeader request.
-func (client *LROsClient) patch202RetryWithAsyncAndLocationHeaderCreateRequest(ctx context.Context, options *LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions) (*policy.Request, error) {
-	urlPath := "/lro/patch/202/retry/asyncAndLocationHeader"
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(host, urlPath))
-	if err != nil {
-		return nil, err
-	}
-	req.Raw().Header.Set("Accept", "application/json")
-	if options != nil && options.Product != nil {
-		return req, runtime.MarshalAsJSON(req, *options.Product)
-	}
-	return req, nil
-}
-
 // BeginPost200WithPayload - Long running post request, service returns a 202 to the initial request, with 'Location' header.
 // Poll returns a 200 with a response body after success.
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPost200WithPayloadOptions contains the optional parameters for the LROsClient.BeginPost200WithPayload
 // method.
-func (client *LROsClient) BeginPost200WithPayload(ctx context.Context, options *LROsClientBeginPost200WithPayloadOptions) (LROsClientPost200WithPayloadPollerResponse, error) {
+func (client *LROsClient) BeginPost200WithPayload(ctx context.Context, options *LROsClientBeginPost200WithPayloadOptions) (*LROsClientPost200WithPayloadPoller, error) {
 	resp, err := client.post200WithPayload(ctx, options)
 	if err != nil {
-		return LROsClientPost200WithPayloadPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPost200WithPayloadPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Post200WithPayload", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPost200WithPayloadPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPost200WithPayloadPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPost200WithPayloadPoller{pt: pt}, nil
 }
 
 // Post200WithPayload - Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll
@@ -855,20 +694,16 @@ func (client *LROsClient) post200WithPayloadCreateRequest(ctx context.Context, o
 // body [{ 'id': '100', 'name': 'foo' }].
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPost202ListOptions contains the optional parameters for the LROsClient.BeginPost202List method.
-func (client *LROsClient) BeginPost202List(ctx context.Context, options *LROsClientBeginPost202ListOptions) (LROsClientPost202ListPollerResponse, error) {
+func (client *LROsClient) BeginPost202List(ctx context.Context, options *LROsClientBeginPost202ListOptions) (*LROsClientPost202ListPoller, error) {
 	resp, err := client.post202List(ctx, options)
 	if err != nil {
-		return LROsClientPost202ListPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPost202ListPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Post202List", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPost202ListPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPost202ListPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPost202ListPoller{pt: pt}, nil
 }
 
 // Post202List - Long running put request, service returns a 202 with empty body to first request, returns a 200 with body
@@ -905,20 +740,16 @@ func (client *LROsClient) post202ListCreateRequest(ctx context.Context, options 
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPost202NoRetry204Options contains the optional parameters for the LROsClient.BeginPost202NoRetry204
 // method.
-func (client *LROsClient) BeginPost202NoRetry204(ctx context.Context, options *LROsClientBeginPost202NoRetry204Options) (LROsClientPost202NoRetry204PollerResponse, error) {
+func (client *LROsClient) BeginPost202NoRetry204(ctx context.Context, options *LROsClientBeginPost202NoRetry204Options) (*LROsClientPost202NoRetry204Poller, error) {
 	resp, err := client.post202NoRetry204(ctx, options)
 	if err != nil {
-		return LROsClientPost202NoRetry204PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPost202NoRetry204PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Post202NoRetry204", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPost202NoRetry204PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPost202NoRetry204Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPost202NoRetry204Poller{pt: pt}, nil
 }
 
 // Post202NoRetry204 - Long running post request, service returns a 202 to the initial request, with 'Location' header, 204
@@ -958,20 +789,16 @@ func (client *LROsClient) post202NoRetry204CreateRequest(ctx context.Context, op
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPost202Retry200Options contains the optional parameters for the LROsClient.BeginPost202Retry200
 // method.
-func (client *LROsClient) BeginPost202Retry200(ctx context.Context, options *LROsClientBeginPost202Retry200Options) (LROsClientPost202Retry200PollerResponse, error) {
+func (client *LROsClient) BeginPost202Retry200(ctx context.Context, options *LROsClientBeginPost202Retry200Options) (*LROsClientPost202Retry200Poller, error) {
 	resp, err := client.post202Retry200(ctx, options)
 	if err != nil {
-		return LROsClientPost202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPost202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Post202Retry200", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPost202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPost202Retry200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPost202Retry200Poller{pt: pt}, nil
 }
 
 // Post202Retry200 - Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After'
@@ -1012,20 +839,16 @@ func (client *LROsClient) post202Retry200CreateRequest(ctx context.Context, opti
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPostAsyncNoRetrySucceededOptions contains the optional parameters for the LROsClient.BeginPostAsyncNoRetrySucceeded
 // method.
-func (client *LROsClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, options *LROsClientBeginPostAsyncNoRetrySucceededOptions) (LROsClientPostAsyncNoRetrySucceededPollerResponse, error) {
+func (client *LROsClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, options *LROsClientBeginPostAsyncNoRetrySucceededOptions) (*LROsClientPostAsyncNoRetrySucceededPoller, error) {
 	resp, err := client.postAsyncNoRetrySucceeded(ctx, options)
 	if err != nil {
-		return LROsClientPostAsyncNoRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPostAsyncNoRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostAsyncNoRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPostAsyncNoRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPostAsyncNoRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPostAsyncNoRetrySucceededPoller{pt: pt}, nil
 }
 
 // PostAsyncNoRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that
@@ -1067,20 +890,16 @@ func (client *LROsClient) postAsyncNoRetrySucceededCreateRequest(ctx context.Con
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPostAsyncRetryFailedOptions contains the optional parameters for the LROsClient.BeginPostAsyncRetryFailed
 // method.
-func (client *LROsClient) BeginPostAsyncRetryFailed(ctx context.Context, options *LROsClientBeginPostAsyncRetryFailedOptions) (LROsClientPostAsyncRetryFailedPollerResponse, error) {
+func (client *LROsClient) BeginPostAsyncRetryFailed(ctx context.Context, options *LROsClientBeginPostAsyncRetryFailedOptions) (*LROsClientPostAsyncRetryFailedPoller, error) {
 	resp, err := client.postAsyncRetryFailed(ctx, options)
 	if err != nil {
-		return LROsClientPostAsyncRetryFailedPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPostAsyncRetryFailedPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostAsyncRetryFailed", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPostAsyncRetryFailedPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPostAsyncRetryFailedPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPostAsyncRetryFailedPoller{pt: pt}, nil
 }
 
 // PostAsyncRetryFailed - Long running post request, service returns a 202 to the initial request, with an entity that contains
@@ -1122,20 +941,16 @@ func (client *LROsClient) postAsyncRetryFailedCreateRequest(ctx context.Context,
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPostAsyncRetrySucceededOptions contains the optional parameters for the LROsClient.BeginPostAsyncRetrySucceeded
 // method.
-func (client *LROsClient) BeginPostAsyncRetrySucceeded(ctx context.Context, options *LROsClientBeginPostAsyncRetrySucceededOptions) (LROsClientPostAsyncRetrySucceededPollerResponse, error) {
+func (client *LROsClient) BeginPostAsyncRetrySucceeded(ctx context.Context, options *LROsClientBeginPostAsyncRetrySucceededOptions) (*LROsClientPostAsyncRetrySucceededPoller, error) {
 	resp, err := client.postAsyncRetrySucceeded(ctx, options)
 	if err != nil {
-		return LROsClientPostAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPostAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPostAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPostAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPostAsyncRetrySucceededPoller{pt: pt}, nil
 }
 
 // PostAsyncRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that
@@ -1177,20 +992,16 @@ func (client *LROsClient) postAsyncRetrySucceededCreateRequest(ctx context.Conte
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPostAsyncRetrycanceledOptions contains the optional parameters for the LROsClient.BeginPostAsyncRetrycanceled
 // method.
-func (client *LROsClient) BeginPostAsyncRetrycanceled(ctx context.Context, options *LROsClientBeginPostAsyncRetrycanceledOptions) (LROsClientPostAsyncRetrycanceledPollerResponse, error) {
+func (client *LROsClient) BeginPostAsyncRetrycanceled(ctx context.Context, options *LROsClientBeginPostAsyncRetrycanceledOptions) (*LROsClientPostAsyncRetrycanceledPoller, error) {
 	resp, err := client.postAsyncRetrycanceled(ctx, options)
 	if err != nil {
-		return LROsClientPostAsyncRetrycanceledPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPostAsyncRetrycanceledPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostAsyncRetrycanceled", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPostAsyncRetrycanceledPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPostAsyncRetrycanceledPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPostAsyncRetrycanceledPoller{pt: pt}, nil
 }
 
 // PostAsyncRetrycanceled - Long running post request, service returns a 202 to the initial request, with an entity that contains
@@ -1231,20 +1042,16 @@ func (client *LROsClient) postAsyncRetrycanceledCreateRequest(ctx context.Contex
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPostDoubleHeadersFinalAzureHeaderGetOptions contains the optional parameters for the LROsClient.BeginPostDoubleHeadersFinalAzureHeaderGet
 // method.
-func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.Context, options *LROsClientBeginPostDoubleHeadersFinalAzureHeaderGetOptions) (LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse, error) {
+func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.Context, options *LROsClientBeginPostDoubleHeadersFinalAzureHeaderGetOptions) (*LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller, error) {
 	resp, err := client.postDoubleHeadersFinalAzureHeaderGet(ctx, options)
 	if err != nil {
-		return LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostDoubleHeadersFinalAzureHeaderGet", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller{pt: pt}, nil
 }
 
 // PostDoubleHeadersFinalAzureHeaderGet - Long running post request, service returns a 202 to the initial request with both
@@ -1283,20 +1090,16 @@ func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx 
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPostDoubleHeadersFinalAzureHeaderGetDefaultOptions contains the optional parameters for the LROsClient.BeginPostDoubleHeadersFinalAzureHeaderGetDefault
 // method.
-func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context, options *LROsClientBeginPostDoubleHeadersFinalAzureHeaderGetDefaultOptions) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse, error) {
+func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context, options *LROsClientBeginPostDoubleHeadersFinalAzureHeaderGetDefaultOptions) (*LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller, error) {
 	resp, err := client.postDoubleHeadersFinalAzureHeaderGetDefault(ctx, options)
 	if err != nil {
-		return LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller{pt: pt}, nil
 }
 
 // PostDoubleHeadersFinalAzureHeaderGetDefault - Long running post request, service returns a 202 to the initial request with
@@ -1334,20 +1137,16 @@ func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetDefaultCreateReque
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPostDoubleHeadersFinalLocationGetOptions contains the optional parameters for the LROsClient.BeginPostDoubleHeadersFinalLocationGet
 // method.
-func (client *LROsClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Context, options *LROsClientBeginPostDoubleHeadersFinalLocationGetOptions) (LROsClientPostDoubleHeadersFinalLocationGetPollerResponse, error) {
+func (client *LROsClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Context, options *LROsClientBeginPostDoubleHeadersFinalLocationGetOptions) (*LROsClientPostDoubleHeadersFinalLocationGetPoller, error) {
 	resp, err := client.postDoubleHeadersFinalLocationGet(ctx, options)
 	if err != nil {
-		return LROsClientPostDoubleHeadersFinalLocationGetPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPostDoubleHeadersFinalLocationGetPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PostDoubleHeadersFinalLocationGet", "location", resp, client.pl)
 	if err != nil {
-		return LROsClientPostDoubleHeadersFinalLocationGetPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPostDoubleHeadersFinalLocationGetPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPostDoubleHeadersFinalLocationGetPoller{pt: pt}, nil
 }
 
 // PostDoubleHeadersFinalLocationGet - Long running post request, service returns a 202 to the initial request with both Location
@@ -1385,20 +1184,16 @@ func (client *LROsClient) postDoubleHeadersFinalLocationGetCreateRequest(ctx con
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPut200Acceptedcanceled200Options contains the optional parameters for the LROsClient.BeginPut200Acceptedcanceled200
 // method.
-func (client *LROsClient) BeginPut200Acceptedcanceled200(ctx context.Context, options *LROsClientBeginPut200Acceptedcanceled200Options) (LROsClientPut200Acceptedcanceled200PollerResponse, error) {
+func (client *LROsClient) BeginPut200Acceptedcanceled200(ctx context.Context, options *LROsClientBeginPut200Acceptedcanceled200Options) (*LROsClientPut200Acceptedcanceled200Poller, error) {
 	resp, err := client.put200Acceptedcanceled200(ctx, options)
 	if err != nil {
-		return LROsClientPut200Acceptedcanceled200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPut200Acceptedcanceled200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put200Acceptedcanceled200", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPut200Acceptedcanceled200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPut200Acceptedcanceled200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPut200Acceptedcanceled200Poller{pt: pt}, nil
 }
 
 // Put200Acceptedcanceled200 - Long running put request, service returns a 201 to the initial request, with an entity that
@@ -1439,20 +1234,16 @@ func (client *LROsClient) put200Acceptedcanceled200CreateRequest(ctx context.Con
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPut200SucceededOptions contains the optional parameters for the LROsClient.BeginPut200Succeeded
 // method.
-func (client *LROsClient) BeginPut200Succeeded(ctx context.Context, options *LROsClientBeginPut200SucceededOptions) (LROsClientPut200SucceededPollerResponse, error) {
+func (client *LROsClient) BeginPut200Succeeded(ctx context.Context, options *LROsClientBeginPut200SucceededOptions) (*LROsClientPut200SucceededPoller, error) {
 	resp, err := client.put200Succeeded(ctx, options)
 	if err != nil {
-		return LROsClientPut200SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPut200SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put200Succeeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPut200SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPut200SucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPut200SucceededPoller{pt: pt}, nil
 }
 
 // Put200Succeeded - Long running put request, service returns a 200 to the initial request, with an entity that contains
@@ -1492,20 +1283,16 @@ func (client *LROsClient) put200SucceededCreateRequest(ctx context.Context, opti
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPut200SucceededNoStateOptions contains the optional parameters for the LROsClient.BeginPut200SucceededNoState
 // method.
-func (client *LROsClient) BeginPut200SucceededNoState(ctx context.Context, options *LROsClientBeginPut200SucceededNoStateOptions) (LROsClientPut200SucceededNoStatePollerResponse, error) {
+func (client *LROsClient) BeginPut200SucceededNoState(ctx context.Context, options *LROsClientBeginPut200SucceededNoStateOptions) (*LROsClientPut200SucceededNoStatePoller, error) {
 	resp, err := client.put200SucceededNoState(ctx, options)
 	if err != nil {
-		return LROsClientPut200SucceededNoStatePollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPut200SucceededNoStatePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put200SucceededNoState", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPut200SucceededNoStatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPut200SucceededNoStatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPut200SucceededNoStatePoller{pt: pt}, nil
 }
 
 // Put200SucceededNoState - Long running put request, service returns a 200 to the initial request, with an entity that does
@@ -1546,20 +1333,16 @@ func (client *LROsClient) put200SucceededNoStateCreateRequest(ctx context.Contex
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPut200UpdatingSucceeded204Options contains the optional parameters for the LROsClient.BeginPut200UpdatingSucceeded204
 // method.
-func (client *LROsClient) BeginPut200UpdatingSucceeded204(ctx context.Context, options *LROsClientBeginPut200UpdatingSucceeded204Options) (LROsClientPut200UpdatingSucceeded204PollerResponse, error) {
+func (client *LROsClient) BeginPut200UpdatingSucceeded204(ctx context.Context, options *LROsClientBeginPut200UpdatingSucceeded204Options) (*LROsClientPut200UpdatingSucceeded204Poller, error) {
 	resp, err := client.put200UpdatingSucceeded204(ctx, options)
 	if err != nil {
-		return LROsClientPut200UpdatingSucceeded204PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPut200UpdatingSucceeded204PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put200UpdatingSucceeded204", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPut200UpdatingSucceeded204PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPut200UpdatingSucceeded204Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPut200UpdatingSucceeded204Poller{pt: pt}, nil
 }
 
 // Put200UpdatingSucceeded204 - Long running put request, service returns a 201 to the initial request, with an entity that
@@ -1601,20 +1384,16 @@ func (client *LROsClient) put200UpdatingSucceeded204CreateRequest(ctx context.Co
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPut201CreatingFailed200Options contains the optional parameters for the LROsClient.BeginPut201CreatingFailed200
 // method.
-func (client *LROsClient) BeginPut201CreatingFailed200(ctx context.Context, options *LROsClientBeginPut201CreatingFailed200Options) (LROsClientPut201CreatingFailed200PollerResponse, error) {
+func (client *LROsClient) BeginPut201CreatingFailed200(ctx context.Context, options *LROsClientBeginPut201CreatingFailed200Options) (*LROsClientPut201CreatingFailed200Poller, error) {
 	resp, err := client.put201CreatingFailed200(ctx, options)
 	if err != nil {
-		return LROsClientPut201CreatingFailed200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPut201CreatingFailed200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put201CreatingFailed200", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPut201CreatingFailed200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPut201CreatingFailed200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPut201CreatingFailed200Poller{pt: pt}, nil
 }
 
 // Put201CreatingFailed200 - Long running put request, service returns a 201 to the initial request, with an entity that contains
@@ -1656,20 +1435,16 @@ func (client *LROsClient) put201CreatingFailed200CreateRequest(ctx context.Conte
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPut201CreatingSucceeded200Options contains the optional parameters for the LROsClient.BeginPut201CreatingSucceeded200
 // method.
-func (client *LROsClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LROsClientBeginPut201CreatingSucceeded200Options) (LROsClientPut201CreatingSucceeded200PollerResponse, error) {
+func (client *LROsClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LROsClientBeginPut201CreatingSucceeded200Options) (*LROsClientPut201CreatingSucceeded200Poller, error) {
 	resp, err := client.put201CreatingSucceeded200(ctx, options)
 	if err != nil {
-		return LROsClientPut201CreatingSucceeded200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPut201CreatingSucceeded200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put201CreatingSucceeded200", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPut201CreatingSucceeded200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPut201CreatingSucceeded200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPut201CreatingSucceeded200Poller{pt: pt}, nil
 }
 
 // Put201CreatingSucceeded200 - Long running put request, service returns a 201 to the initial request, with an entity that
@@ -1710,20 +1485,16 @@ func (client *LROsClient) put201CreatingSucceeded200CreateRequest(ctx context.Co
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPut201SucceededOptions contains the optional parameters for the LROsClient.BeginPut201Succeeded
 // method.
-func (client *LROsClient) BeginPut201Succeeded(ctx context.Context, options *LROsClientBeginPut201SucceededOptions) (LROsClientPut201SucceededPollerResponse, error) {
+func (client *LROsClient) BeginPut201Succeeded(ctx context.Context, options *LROsClientBeginPut201SucceededOptions) (*LROsClientPut201SucceededPoller, error) {
 	resp, err := client.put201Succeeded(ctx, options)
 	if err != nil {
-		return LROsClientPut201SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPut201SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put201Succeeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPut201SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPut201SucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPut201SucceededPoller{pt: pt}, nil
 }
 
 // Put201Succeeded - Long running put request, service returns a 201 to the initial request, with an entity that contains
@@ -1763,20 +1534,16 @@ func (client *LROsClient) put201SucceededCreateRequest(ctx context.Context, opti
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPut202Retry200Options contains the optional parameters for the LROsClient.BeginPut202Retry200
 // method.
-func (client *LROsClient) BeginPut202Retry200(ctx context.Context, options *LROsClientBeginPut202Retry200Options) (LROsClientPut202Retry200PollerResponse, error) {
+func (client *LROsClient) BeginPut202Retry200(ctx context.Context, options *LROsClientBeginPut202Retry200Options) (*LROsClientPut202Retry200Poller, error) {
 	resp, err := client.put202Retry200(ctx, options)
 	if err != nil {
-		return LROsClientPut202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPut202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.Put202Retry200", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPut202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPut202Retry200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPut202Retry200Poller{pt: pt}, nil
 }
 
 // Put202Retry200 - Long running put request, service returns a 202 to the initial request, with a location header that points
@@ -1816,20 +1583,16 @@ func (client *LROsClient) put202Retry200CreateRequest(ctx context.Context, optio
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutAsyncNoHeaderInRetryOptions contains the optional parameters for the LROsClient.BeginPutAsyncNoHeaderInRetry
 // method.
-func (client *LROsClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, options *LROsClientBeginPutAsyncNoHeaderInRetryOptions) (LROsClientPutAsyncNoHeaderInRetryPollerResponse, error) {
+func (client *LROsClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, options *LROsClientBeginPutAsyncNoHeaderInRetryOptions) (*LROsClientPutAsyncNoHeaderInRetryPoller, error) {
 	resp, err := client.putAsyncNoHeaderInRetry(ctx, options)
 	if err != nil {
-		return LROsClientPutAsyncNoHeaderInRetryPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutAsyncNoHeaderInRetryPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncNoHeaderInRetry", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutAsyncNoHeaderInRetryPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutAsyncNoHeaderInRetryPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutAsyncNoHeaderInRetryPoller{pt: pt}, nil
 }
 
 // PutAsyncNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation
@@ -1870,20 +1633,16 @@ func (client *LROsClient) putAsyncNoHeaderInRetryCreateRequest(ctx context.Conte
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutAsyncNoRetrySucceededOptions contains the optional parameters for the LROsClient.BeginPutAsyncNoRetrySucceeded
 // method.
-func (client *LROsClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, options *LROsClientBeginPutAsyncNoRetrySucceededOptions) (LROsClientPutAsyncNoRetrySucceededPollerResponse, error) {
+func (client *LROsClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, options *LROsClientBeginPutAsyncNoRetrySucceededOptions) (*LROsClientPutAsyncNoRetrySucceededPoller, error) {
 	resp, err := client.putAsyncNoRetrySucceeded(ctx, options)
 	if err != nil {
-		return LROsClientPutAsyncNoRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutAsyncNoRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncNoRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutAsyncNoRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutAsyncNoRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutAsyncNoRetrySucceededPoller{pt: pt}, nil
 }
 
 // PutAsyncNoRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that
@@ -1925,20 +1684,16 @@ func (client *LROsClient) putAsyncNoRetrySucceededCreateRequest(ctx context.Cont
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutAsyncNoRetrycanceledOptions contains the optional parameters for the LROsClient.BeginPutAsyncNoRetrycanceled
 // method.
-func (client *LROsClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, options *LROsClientBeginPutAsyncNoRetrycanceledOptions) (LROsClientPutAsyncNoRetrycanceledPollerResponse, error) {
+func (client *LROsClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, options *LROsClientBeginPutAsyncNoRetrycanceledOptions) (*LROsClientPutAsyncNoRetrycanceledPoller, error) {
 	resp, err := client.putAsyncNoRetrycanceled(ctx, options)
 	if err != nil {
-		return LROsClientPutAsyncNoRetrycanceledPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutAsyncNoRetrycanceledPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncNoRetrycanceled", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutAsyncNoRetrycanceledPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutAsyncNoRetrycanceledPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutAsyncNoRetrycanceledPoller{pt: pt}, nil
 }
 
 // PutAsyncNoRetrycanceled - Long running put request, service returns a 200 to the initial request, with an entity that contains
@@ -1978,20 +1733,16 @@ func (client *LROsClient) putAsyncNoRetrycanceledCreateRequest(ctx context.Conte
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutAsyncNonResourceOptions contains the optional parameters for the LROsClient.BeginPutAsyncNonResource
 // method.
-func (client *LROsClient) BeginPutAsyncNonResource(ctx context.Context, options *LROsClientBeginPutAsyncNonResourceOptions) (LROsClientPutAsyncNonResourcePollerResponse, error) {
+func (client *LROsClient) BeginPutAsyncNonResource(ctx context.Context, options *LROsClientBeginPutAsyncNonResourceOptions) (*LROsClientPutAsyncNonResourcePoller, error) {
 	resp, err := client.putAsyncNonResource(ctx, options)
 	if err != nil {
-		return LROsClientPutAsyncNonResourcePollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutAsyncNonResourcePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncNonResource", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutAsyncNonResourcePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutAsyncNonResourcePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutAsyncNonResourcePoller{pt: pt}, nil
 }
 
 // PutAsyncNonResource - Long running put request with non resource.
@@ -2031,20 +1782,16 @@ func (client *LROsClient) putAsyncNonResourceCreateRequest(ctx context.Context, 
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutAsyncRetryFailedOptions contains the optional parameters for the LROsClient.BeginPutAsyncRetryFailed
 // method.
-func (client *LROsClient) BeginPutAsyncRetryFailed(ctx context.Context, options *LROsClientBeginPutAsyncRetryFailedOptions) (LROsClientPutAsyncRetryFailedPollerResponse, error) {
+func (client *LROsClient) BeginPutAsyncRetryFailed(ctx context.Context, options *LROsClientBeginPutAsyncRetryFailedOptions) (*LROsClientPutAsyncRetryFailedPoller, error) {
 	resp, err := client.putAsyncRetryFailed(ctx, options)
 	if err != nil {
-		return LROsClientPutAsyncRetryFailedPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutAsyncRetryFailedPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncRetryFailed", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutAsyncRetryFailedPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutAsyncRetryFailedPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutAsyncRetryFailedPoller{pt: pt}, nil
 }
 
 // PutAsyncRetryFailed - Long running put request, service returns a 200 to the initial request, with an entity that contains
@@ -2086,20 +1833,16 @@ func (client *LROsClient) putAsyncRetryFailedCreateRequest(ctx context.Context, 
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutAsyncRetrySucceededOptions contains the optional parameters for the LROsClient.BeginPutAsyncRetrySucceeded
 // method.
-func (client *LROsClient) BeginPutAsyncRetrySucceeded(ctx context.Context, options *LROsClientBeginPutAsyncRetrySucceededOptions) (LROsClientPutAsyncRetrySucceededPollerResponse, error) {
+func (client *LROsClient) BeginPutAsyncRetrySucceeded(ctx context.Context, options *LROsClientBeginPutAsyncRetrySucceededOptions) (*LROsClientPutAsyncRetrySucceededPoller, error) {
 	resp, err := client.putAsyncRetrySucceeded(ctx, options)
 	if err != nil {
-		return LROsClientPutAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutAsyncRetrySucceededPoller{pt: pt}, nil
 }
 
 // PutAsyncRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains
@@ -2139,20 +1882,16 @@ func (client *LROsClient) putAsyncRetrySucceededCreateRequest(ctx context.Contex
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutAsyncSubResourceOptions contains the optional parameters for the LROsClient.BeginPutAsyncSubResource
 // method.
-func (client *LROsClient) BeginPutAsyncSubResource(ctx context.Context, options *LROsClientBeginPutAsyncSubResourceOptions) (LROsClientPutAsyncSubResourcePollerResponse, error) {
+func (client *LROsClient) BeginPutAsyncSubResource(ctx context.Context, options *LROsClientBeginPutAsyncSubResourceOptions) (*LROsClientPutAsyncSubResourcePoller, error) {
 	resp, err := client.putAsyncSubResource(ctx, options)
 	if err != nil {
-		return LROsClientPutAsyncSubResourcePollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutAsyncSubResourcePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutAsyncSubResource", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutAsyncSubResourcePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutAsyncSubResourcePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutAsyncSubResourcePoller{pt: pt}, nil
 }
 
 // PutAsyncSubResource - Long running put request with sub resource.
@@ -2191,20 +1930,16 @@ func (client *LROsClient) putAsyncSubResourceCreateRequest(ctx context.Context, 
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutNoHeaderInRetryOptions contains the optional parameters for the LROsClient.BeginPutNoHeaderInRetry
 // method.
-func (client *LROsClient) BeginPutNoHeaderInRetry(ctx context.Context, options *LROsClientBeginPutNoHeaderInRetryOptions) (LROsClientPutNoHeaderInRetryPollerResponse, error) {
+func (client *LROsClient) BeginPutNoHeaderInRetry(ctx context.Context, options *LROsClientBeginPutNoHeaderInRetryOptions) (*LROsClientPutNoHeaderInRetryPoller, error) {
 	resp, err := client.putNoHeaderInRetry(ctx, options)
 	if err != nil {
-		return LROsClientPutNoHeaderInRetryPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutNoHeaderInRetryPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutNoHeaderInRetry", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutNoHeaderInRetryPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutNoHeaderInRetryPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutNoHeaderInRetryPoller{pt: pt}, nil
 }
 
 // PutNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with location header. Subsequent
@@ -2243,20 +1978,16 @@ func (client *LROsClient) putNoHeaderInRetryCreateRequest(ctx context.Context, o
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutNonResourceOptions contains the optional parameters for the LROsClient.BeginPutNonResource
 // method.
-func (client *LROsClient) BeginPutNonResource(ctx context.Context, options *LROsClientBeginPutNonResourceOptions) (LROsClientPutNonResourcePollerResponse, error) {
+func (client *LROsClient) BeginPutNonResource(ctx context.Context, options *LROsClientBeginPutNonResourceOptions) (*LROsClientPutNonResourcePoller, error) {
 	resp, err := client.putNonResource(ctx, options)
 	if err != nil {
-		return LROsClientPutNonResourcePollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutNonResourcePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutNonResource", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutNonResourcePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutNonResourcePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutNonResourcePoller{pt: pt}, nil
 }
 
 // PutNonResource - Long running put request with non resource.
@@ -2294,20 +2025,16 @@ func (client *LROsClient) putNonResourceCreateRequest(ctx context.Context, optio
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsClientBeginPutSubResourceOptions contains the optional parameters for the LROsClient.BeginPutSubResource
 // method.
-func (client *LROsClient) BeginPutSubResource(ctx context.Context, options *LROsClientBeginPutSubResourceOptions) (LROsClientPutSubResourcePollerResponse, error) {
+func (client *LROsClient) BeginPutSubResource(ctx context.Context, options *LROsClientBeginPutSubResourceOptions) (*LROsClientPutSubResourcePoller, error) {
 	resp, err := client.putSubResource(ctx, options)
 	if err != nil {
-		return LROsClientPutSubResourcePollerResponse{}, err
+		return nil, err
 	}
-	result := LROsClientPutSubResourcePollerResponse{}
 	pt, err := armruntime.NewPoller("LROsClient.PutSubResource", "", resp, client.pl)
 	if err != nil {
-		return LROsClientPutSubResourcePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsClientPutSubResourcePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsClientPutSubResourcePoller{pt: pt}, nil
 }
 
 // PutSubResource - Long running put request with sub resource.

--- a/test/autorest/lrogroup/zz_generated_lros_client.go
+++ b/test/autorest/lrogroup/zz_generated_lros_client.go
@@ -644,6 +644,103 @@ func (client *LROsClient) patch200SucceededIgnoreHeadersCreateRequest(ctx contex
 	return req, nil
 }
 
+// BeginPatch201RetryWithAsyncHeader - Long running patch request, service returns a 201 to the initial request with async
+// header.
+// If the operation fails it returns an *azcore.ResponseError type.
+// options - LROsClientBeginPatch201RetryWithAsyncHeaderOptions contains the optional parameters for the LROsClient.BeginPatch201RetryWithAsyncHeader
+// method.
+func (client *LROsClient) BeginPatch201RetryWithAsyncHeader(ctx context.Context, options *LROsClientBeginPatch201RetryWithAsyncHeaderOptions) (*LROsClientPatch201RetryWithAsyncHeaderPoller, error) {
+	resp, err := client.patch201RetryWithAsyncHeader(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	pt, err := armruntime.NewPoller("LROsClient.Patch201RetryWithAsyncHeader", "azure-async-operation", resp, client.pl)
+	if err != nil {
+		return nil, err
+	}
+	return &LROsClientPatch201RetryWithAsyncHeaderPoller{pt: pt}, nil
+}
+
+// Patch201RetryWithAsyncHeader - Long running patch request, service returns a 201 to the initial request with async header.
+// If the operation fails it returns an *azcore.ResponseError type.
+func (client *LROsClient) patch201RetryWithAsyncHeader(ctx context.Context, options *LROsClientBeginPatch201RetryWithAsyncHeaderOptions) (*http.Response, error) {
+	req, err := client.patch201RetryWithAsyncHeaderCreateRequest(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated) {
+		return nil, runtime.NewResponseError(resp)
+	}
+	return resp, nil
+}
+
+// patch201RetryWithAsyncHeaderCreateRequest creates the Patch201RetryWithAsyncHeader request.
+func (client *LROsClient) patch201RetryWithAsyncHeaderCreateRequest(ctx context.Context, options *LROsClientBeginPatch201RetryWithAsyncHeaderOptions) (*policy.Request, error) {
+	urlPath := "/lro/patch/201/retry/onlyAsyncHeader"
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Accept", "application/json")
+	if options != nil && options.Product != nil {
+		return req, runtime.MarshalAsJSON(req, *options.Product)
+	}
+	return req, nil
+}
+
+// BeginPatch202RetryWithAsyncAndLocationHeader - Long running patch request, service returns a 202 to the initial request
+// with async and location header.
+// If the operation fails it returns an *azcore.ResponseError type.
+// options - LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions contains the optional parameters for the LROsClient.BeginPatch202RetryWithAsyncAndLocationHeader
+// method.
+func (client *LROsClient) BeginPatch202RetryWithAsyncAndLocationHeader(ctx context.Context, options *LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions) (*LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller, error) {
+	resp, err := client.patch202RetryWithAsyncAndLocationHeader(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	pt, err := armruntime.NewPoller("LROsClient.Patch202RetryWithAsyncAndLocationHeader", "", resp, client.pl)
+	if err != nil {
+		return nil, err
+	}
+	return &LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller{pt: pt}, nil
+}
+
+// Patch202RetryWithAsyncAndLocationHeader - Long running patch request, service returns a 202 to the initial request with
+// async and location header.
+// If the operation fails it returns an *azcore.ResponseError type.
+func (client *LROsClient) patch202RetryWithAsyncAndLocationHeader(ctx context.Context, options *LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions) (*http.Response, error) {
+	req, err := client.patch202RetryWithAsyncAndLocationHeaderCreateRequest(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted) {
+		return nil, runtime.NewResponseError(resp)
+	}
+	return resp, nil
+}
+
+// patch202RetryWithAsyncAndLocationHeaderCreateRequest creates the Patch202RetryWithAsyncAndLocationHeader request.
+func (client *LROsClient) patch202RetryWithAsyncAndLocationHeaderCreateRequest(ctx context.Context, options *LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions) (*policy.Request, error) {
+	urlPath := "/lro/patch/202/retry/asyncAndLocationHeader"
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Accept", "application/json")
+	if options != nil && options.Product != nil {
+		return req, runtime.MarshalAsJSON(req, *options.Product)
+	}
+	return req, nil
+}
+
 // BeginPost200WithPayload - Long running post request, service returns a 202 to the initial request, with 'Location' header.
 // Poll returns a 200 with a response body after success.
 // If the operation fails it returns an *azcore.ResponseError type.

--- a/test/autorest/lrogroup/zz_generated_lrosads_client.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads_client.go
@@ -39,20 +39,16 @@ func NewLROSADsClient(options *azcore.ClientOptions) *LROSADsClient {
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginDelete202NonRetry400Options contains the optional parameters for the LROSADsClient.BeginDelete202NonRetry400
 // method.
-func (client *LROSADsClient) BeginDelete202NonRetry400(ctx context.Context, options *LROSADsClientBeginDelete202NonRetry400Options) (LROSADsClientDelete202NonRetry400PollerResponse, error) {
+func (client *LROSADsClient) BeginDelete202NonRetry400(ctx context.Context, options *LROSADsClientBeginDelete202NonRetry400Options) (*LROSADsClientDelete202NonRetry400Poller, error) {
 	resp, err := client.delete202NonRetry400(ctx, options)
 	if err != nil {
-		return LROSADsClientDelete202NonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientDelete202NonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Delete202NonRetry400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientDelete202NonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientDelete202NonRetry400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientDelete202NonRetry400Poller{pt: pt}, nil
 }
 
 // Delete202NonRetry400 - Long running delete request, service returns a 202 with a location header
@@ -88,20 +84,16 @@ func (client *LROSADsClient) delete202NonRetry400CreateRequest(ctx context.Conte
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginDelete202RetryInvalidHeaderOptions contains the optional parameters for the LROSADsClient.BeginDelete202RetryInvalidHeader
 // method.
-func (client *LROSADsClient) BeginDelete202RetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginDelete202RetryInvalidHeaderOptions) (LROSADsClientDelete202RetryInvalidHeaderPollerResponse, error) {
+func (client *LROSADsClient) BeginDelete202RetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginDelete202RetryInvalidHeaderOptions) (*LROSADsClientDelete202RetryInvalidHeaderPoller, error) {
 	resp, err := client.delete202RetryInvalidHeader(ctx, options)
 	if err != nil {
-		return LROSADsClientDelete202RetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientDelete202RetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Delete202RetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientDelete202RetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientDelete202RetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientDelete202RetryInvalidHeaderPoller{pt: pt}, nil
 }
 
 // Delete202RetryInvalidHeader - Long running delete request, service returns a 202 to the initial request receing a reponse
@@ -137,20 +129,16 @@ func (client *LROSADsClient) delete202RetryInvalidHeaderCreateRequest(ctx contex
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginDelete204SucceededOptions contains the optional parameters for the LROSADsClient.BeginDelete204Succeeded
 // method.
-func (client *LROSADsClient) BeginDelete204Succeeded(ctx context.Context, options *LROSADsClientBeginDelete204SucceededOptions) (LROSADsClientDelete204SucceededPollerResponse, error) {
+func (client *LROSADsClient) BeginDelete204Succeeded(ctx context.Context, options *LROSADsClientBeginDelete204SucceededOptions) (*LROSADsClientDelete204SucceededPoller, error) {
 	resp, err := client.delete204Succeeded(ctx, options)
 	if err != nil {
-		return LROSADsClientDelete204SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientDelete204SucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Delete204Succeeded", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientDelete204SucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientDelete204SucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientDelete204SucceededPoller{pt: pt}, nil
 }
 
 // Delete204Succeeded - Long running delete request, service returns a 204 to the initial request, indicating success.
@@ -186,20 +174,16 @@ func (client *LROSADsClient) delete204SucceededCreateRequest(ctx context.Context
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginDeleteAsyncRelativeRetry400Options contains the optional parameters for the LROSADsClient.BeginDeleteAsyncRelativeRetry400
 // method.
-func (client *LROSADsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Context, options *LROSADsClientBeginDeleteAsyncRelativeRetry400Options) (LROSADsClientDeleteAsyncRelativeRetry400PollerResponse, error) {
+func (client *LROSADsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Context, options *LROSADsClientBeginDeleteAsyncRelativeRetry400Options) (*LROSADsClientDeleteAsyncRelativeRetry400Poller, error) {
 	resp, err := client.deleteAsyncRelativeRetry400(ctx, options)
 	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientDeleteAsyncRelativeRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteAsyncRelativeRetry400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientDeleteAsyncRelativeRetry400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientDeleteAsyncRelativeRetry400Poller{pt: pt}, nil
 }
 
 // DeleteAsyncRelativeRetry400 - Long running delete request, service returns a 202 to the initial request. Poll the endpoint
@@ -236,20 +220,16 @@ func (client *LROSADsClient) deleteAsyncRelativeRetry400CreateRequest(ctx contex
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginDeleteAsyncRelativeRetryInvalidHeaderOptions contains the optional parameters for the LROSADsClient.BeginDeleteAsyncRelativeRetryInvalidHeader
 // method.
-func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginDeleteAsyncRelativeRetryInvalidHeaderOptions) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse, error) {
+func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginDeleteAsyncRelativeRetryInvalidHeaderOptions) (*LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller, error) {
 	resp, err := client.deleteAsyncRelativeRetryInvalidHeader(ctx, options)
 	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller{pt: pt}, nil
 }
 
 // DeleteAsyncRelativeRetryInvalidHeader - Long running delete request, service returns a 202 to the initial request. The
@@ -286,20 +266,16 @@ func (client *LROSADsClient) deleteAsyncRelativeRetryInvalidHeaderCreateRequest(
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginDeleteAsyncRelativeRetryInvalidJSONPollingOptions contains the optional parameters for the
 // LROSADsClient.BeginDeleteAsyncRelativeRetryInvalidJSONPolling method.
-func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LROSADsClientBeginDeleteAsyncRelativeRetryInvalidJSONPollingOptions) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse, error) {
+func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LROSADsClientBeginDeleteAsyncRelativeRetryInvalidJSONPollingOptions) (*LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller, error) {
 	resp, err := client.deleteAsyncRelativeRetryInvalidJSONPolling(ctx, options)
 	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller{pt: pt}, nil
 }
 
 // DeleteAsyncRelativeRetryInvalidJSONPolling - Long running delete request, service returns a 202 to the initial request.
@@ -336,20 +312,16 @@ func (client *LROSADsClient) deleteAsyncRelativeRetryInvalidJSONPollingCreateReq
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginDeleteAsyncRelativeRetryNoStatusOptions contains the optional parameters for the LROSADsClient.BeginDeleteAsyncRelativeRetryNoStatus
 // method.
-func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.Context, options *LROSADsClientBeginDeleteAsyncRelativeRetryNoStatusOptions) (LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse, error) {
+func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.Context, options *LROSADsClientBeginDeleteAsyncRelativeRetryNoStatusOptions) (*LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller, error) {
 	resp, err := client.deleteAsyncRelativeRetryNoStatus(ctx, options)
 	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteAsyncRelativeRetryNoStatus", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller{pt: pt}, nil
 }
 
 // DeleteAsyncRelativeRetryNoStatus - Long running delete request, service returns a 202 to the initial request. Poll the
@@ -385,20 +357,16 @@ func (client *LROSADsClient) deleteAsyncRelativeRetryNoStatusCreateRequest(ctx c
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginDeleteNonRetry400Options contains the optional parameters for the LROSADsClient.BeginDeleteNonRetry400
 // method.
-func (client *LROSADsClient) BeginDeleteNonRetry400(ctx context.Context, options *LROSADsClientBeginDeleteNonRetry400Options) (LROSADsClientDeleteNonRetry400PollerResponse, error) {
+func (client *LROSADsClient) BeginDeleteNonRetry400(ctx context.Context, options *LROSADsClientBeginDeleteNonRetry400Options) (*LROSADsClientDeleteNonRetry400Poller, error) {
 	resp, err := client.deleteNonRetry400(ctx, options)
 	if err != nil {
-		return LROSADsClientDeleteNonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientDeleteNonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.DeleteNonRetry400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientDeleteNonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientDeleteNonRetry400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientDeleteNonRetry400Poller{pt: pt}, nil
 }
 
 // DeleteNonRetry400 - Long running delete request, service returns a 400 with an error body
@@ -433,20 +401,16 @@ func (client *LROSADsClient) deleteNonRetry400CreateRequest(ctx context.Context,
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPost202NoLocationOptions contains the optional parameters for the LROSADsClient.BeginPost202NoLocation
 // method.
-func (client *LROSADsClient) BeginPost202NoLocation(ctx context.Context, options *LROSADsClientBeginPost202NoLocationOptions) (LROSADsClientPost202NoLocationPollerResponse, error) {
+func (client *LROSADsClient) BeginPost202NoLocation(ctx context.Context, options *LROSADsClientBeginPost202NoLocationOptions) (*LROSADsClientPost202NoLocationPoller, error) {
 	resp, err := client.post202NoLocation(ctx, options)
 	if err != nil {
-		return LROSADsClientPost202NoLocationPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPost202NoLocationPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Post202NoLocation", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPost202NoLocationPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPost202NoLocationPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPost202NoLocationPoller{pt: pt}, nil
 }
 
 // Post202NoLocation - Long running post request, service returns a 202 to the initial request, without a location header.
@@ -484,20 +448,16 @@ func (client *LROSADsClient) post202NoLocationCreateRequest(ctx context.Context,
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPost202NonRetry400Options contains the optional parameters for the LROSADsClient.BeginPost202NonRetry400
 // method.
-func (client *LROSADsClient) BeginPost202NonRetry400(ctx context.Context, options *LROSADsClientBeginPost202NonRetry400Options) (LROSADsClientPost202NonRetry400PollerResponse, error) {
+func (client *LROSADsClient) BeginPost202NonRetry400(ctx context.Context, options *LROSADsClientBeginPost202NonRetry400Options) (*LROSADsClientPost202NonRetry400Poller, error) {
 	resp, err := client.post202NonRetry400(ctx, options)
 	if err != nil {
-		return LROSADsClientPost202NonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPost202NonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Post202NonRetry400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPost202NonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPost202NonRetry400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPost202NonRetry400Poller{pt: pt}, nil
 }
 
 // Post202NonRetry400 - Long running post request, service returns a 202 with a location header
@@ -536,20 +496,16 @@ func (client *LROSADsClient) post202NonRetry400CreateRequest(ctx context.Context
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPost202RetryInvalidHeaderOptions contains the optional parameters for the LROSADsClient.BeginPost202RetryInvalidHeader
 // method.
-func (client *LROSADsClient) BeginPost202RetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginPost202RetryInvalidHeaderOptions) (LROSADsClientPost202RetryInvalidHeaderPollerResponse, error) {
+func (client *LROSADsClient) BeginPost202RetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginPost202RetryInvalidHeaderOptions) (*LROSADsClientPost202RetryInvalidHeaderPoller, error) {
 	resp, err := client.post202RetryInvalidHeader(ctx, options)
 	if err != nil {
-		return LROSADsClientPost202RetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPost202RetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Post202RetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPost202RetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPost202RetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPost202RetryInvalidHeaderPoller{pt: pt}, nil
 }
 
 // Post202RetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with invalid 'Location'
@@ -589,20 +545,16 @@ func (client *LROSADsClient) post202RetryInvalidHeaderCreateRequest(ctx context.
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPostAsyncRelativeRetry400Options contains the optional parameters for the LROSADsClient.BeginPostAsyncRelativeRetry400
 // method.
-func (client *LROSADsClient) BeginPostAsyncRelativeRetry400(ctx context.Context, options *LROSADsClientBeginPostAsyncRelativeRetry400Options) (LROSADsClientPostAsyncRelativeRetry400PollerResponse, error) {
+func (client *LROSADsClient) BeginPostAsyncRelativeRetry400(ctx context.Context, options *LROSADsClientBeginPostAsyncRelativeRetry400Options) (*LROSADsClientPostAsyncRelativeRetry400Poller, error) {
 	resp, err := client.postAsyncRelativeRetry400(ctx, options)
 	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPostAsyncRelativeRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostAsyncRelativeRetry400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPostAsyncRelativeRetry400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPostAsyncRelativeRetry400Poller{pt: pt}, nil
 }
 
 // PostAsyncRelativeRetry400 - Long running post request, service returns a 202 to the initial request Poll the endpoint indicated
@@ -643,20 +595,16 @@ func (client *LROSADsClient) postAsyncRelativeRetry400CreateRequest(ctx context.
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPostAsyncRelativeRetryInvalidHeaderOptions contains the optional parameters for the LROSADsClient.BeginPostAsyncRelativeRetryInvalidHeader
 // method.
-func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginPostAsyncRelativeRetryInvalidHeaderOptions) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse, error) {
+func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginPostAsyncRelativeRetryInvalidHeaderOptions) (*LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller, error) {
 	resp, err := client.postAsyncRelativeRetryInvalidHeader(ctx, options)
 	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostAsyncRelativeRetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller{pt: pt}, nil
 }
 
 // PostAsyncRelativeRetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with an
@@ -699,20 +647,16 @@ func (client *LROSADsClient) postAsyncRelativeRetryInvalidHeaderCreateRequest(ct
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPostAsyncRelativeRetryInvalidJSONPollingOptions contains the optional parameters for the LROSADsClient.BeginPostAsyncRelativeRetryInvalidJSONPolling
 // method.
-func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LROSADsClientBeginPostAsyncRelativeRetryInvalidJSONPollingOptions) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse, error) {
+func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LROSADsClientBeginPostAsyncRelativeRetryInvalidJSONPollingOptions) (*LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller, error) {
 	resp, err := client.postAsyncRelativeRetryInvalidJSONPolling(ctx, options)
 	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller{pt: pt}, nil
 }
 
 // PostAsyncRelativeRetryInvalidJSONPolling - Long running post request, service returns a 202 to the initial request, with
@@ -754,20 +698,16 @@ func (client *LROSADsClient) postAsyncRelativeRetryInvalidJSONPollingCreateReque
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPostAsyncRelativeRetryNoPayloadOptions contains the optional parameters for the LROSADsClient.BeginPostAsyncRelativeRetryNoPayload
 // method.
-func (client *LROSADsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Context, options *LROSADsClientBeginPostAsyncRelativeRetryNoPayloadOptions) (LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse, error) {
+func (client *LROSADsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Context, options *LROSADsClientBeginPostAsyncRelativeRetryNoPayloadOptions) (*LROSADsClientPostAsyncRelativeRetryNoPayloadPoller, error) {
 	resp, err := client.postAsyncRelativeRetryNoPayload(ctx, options)
 	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostAsyncRelativeRetryNoPayload", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPostAsyncRelativeRetryNoPayloadPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPostAsyncRelativeRetryNoPayloadPoller{pt: pt}, nil
 }
 
 // PostAsyncRelativeRetryNoPayload - Long running post request, service returns a 202 to the initial request, with an entity
@@ -807,20 +747,16 @@ func (client *LROSADsClient) postAsyncRelativeRetryNoPayloadCreateRequest(ctx co
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPostNonRetry400Options contains the optional parameters for the LROSADsClient.BeginPostNonRetry400
 // method.
-func (client *LROSADsClient) BeginPostNonRetry400(ctx context.Context, options *LROSADsClientBeginPostNonRetry400Options) (LROSADsClientPostNonRetry400PollerResponse, error) {
+func (client *LROSADsClient) BeginPostNonRetry400(ctx context.Context, options *LROSADsClientBeginPostNonRetry400Options) (*LROSADsClientPostNonRetry400Poller, error) {
 	resp, err := client.postNonRetry400(ctx, options)
 	if err != nil {
-		return LROSADsClientPostNonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPostNonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PostNonRetry400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPostNonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPostNonRetry400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPostNonRetry400Poller{pt: pt}, nil
 }
 
 // PostNonRetry400 - Long running post request, service returns a 400 with no error body
@@ -859,20 +795,16 @@ func (client *LROSADsClient) postNonRetry400CreateRequest(ctx context.Context, o
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPut200InvalidJSONOptions contains the optional parameters for the LROSADsClient.BeginPut200InvalidJSON
 // method.
-func (client *LROSADsClient) BeginPut200InvalidJSON(ctx context.Context, options *LROSADsClientBeginPut200InvalidJSONOptions) (LROSADsClientPut200InvalidJSONPollerResponse, error) {
+func (client *LROSADsClient) BeginPut200InvalidJSON(ctx context.Context, options *LROSADsClientBeginPut200InvalidJSONOptions) (*LROSADsClientPut200InvalidJSONPoller, error) {
 	resp, err := client.put200InvalidJSON(ctx, options)
 	if err != nil {
-		return LROSADsClientPut200InvalidJSONPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPut200InvalidJSONPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.Put200InvalidJSON", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPut200InvalidJSONPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPut200InvalidJSONPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPut200InvalidJSONPoller{pt: pt}, nil
 }
 
 // Put200InvalidJSON - Long running put request, service returns a 200 to the initial request, with an entity that is not
@@ -912,20 +844,16 @@ func (client *LROSADsClient) put200InvalidJSONCreateRequest(ctx context.Context,
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutAsyncRelativeRetry400Options contains the optional parameters for the LROSADsClient.BeginPutAsyncRelativeRetry400
 // method.
-func (client *LROSADsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetry400Options) (LROSADsClientPutAsyncRelativeRetry400PollerResponse, error) {
+func (client *LROSADsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetry400Options) (*LROSADsClientPutAsyncRelativeRetry400Poller, error) {
 	resp, err := client.putAsyncRelativeRetry400(ctx, options)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetry400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutAsyncRelativeRetry400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutAsyncRelativeRetry400Poller{pt: pt}, nil
 }
 
 // PutAsyncRelativeRetry400 - Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the
@@ -965,20 +893,16 @@ func (client *LROSADsClient) putAsyncRelativeRetry400CreateRequest(ctx context.C
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutAsyncRelativeRetryInvalidHeaderOptions contains the optional parameters for the LROSADsClient.BeginPutAsyncRelativeRetryInvalidHeader
 // method.
-func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetryInvalidHeaderOptions) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse, error) {
+func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetryInvalidHeaderOptions) (*LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller, error) {
 	resp, err := client.putAsyncRelativeRetryInvalidHeader(ctx, options)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetryInvalidHeader", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller{pt: pt}, nil
 }
 
 // PutAsyncRelativeRetryInvalidHeader - Long running put request, service returns a 200 to the initial request, with an entity
@@ -1020,20 +944,16 @@ func (client *LROSADsClient) putAsyncRelativeRetryInvalidHeaderCreateRequest(ctx
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutAsyncRelativeRetryInvalidJSONPollingOptions contains the optional parameters for the LROSADsClient.BeginPutAsyncRelativeRetryInvalidJSONPolling
 // method.
-func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetryInvalidJSONPollingOptions) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse, error) {
+func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetryInvalidJSONPollingOptions) (*LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller, error) {
 	resp, err := client.putAsyncRelativeRetryInvalidJSONPolling(ctx, options)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller{pt: pt}, nil
 }
 
 // PutAsyncRelativeRetryInvalidJSONPolling - Long running put request, service returns a 200 to the initial request, with
@@ -1075,20 +995,16 @@ func (client *LROSADsClient) putAsyncRelativeRetryInvalidJSONPollingCreateReques
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutAsyncRelativeRetryNoStatusOptions contains the optional parameters for the LROSADsClient.BeginPutAsyncRelativeRetryNoStatus
 // method.
-func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetryNoStatusOptions) (LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse, error) {
+func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetryNoStatusOptions) (*LROSADsClientPutAsyncRelativeRetryNoStatusPoller, error) {
 	resp, err := client.putAsyncRelativeRetryNoStatus(ctx, options)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetryNoStatus", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutAsyncRelativeRetryNoStatusPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutAsyncRelativeRetryNoStatusPoller{pt: pt}, nil
 }
 
 // PutAsyncRelativeRetryNoStatus - Long running put request, service returns a 200 to the initial request, with an entity
@@ -1130,20 +1046,16 @@ func (client *LROSADsClient) putAsyncRelativeRetryNoStatusCreateRequest(ctx cont
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutAsyncRelativeRetryNoStatusPayloadOptions contains the optional parameters for the LROSADsClient.BeginPutAsyncRelativeRetryNoStatusPayload
 // method.
-func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetryNoStatusPayloadOptions) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse, error) {
+func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx context.Context, options *LROSADsClientBeginPutAsyncRelativeRetryNoStatusPayloadOptions) (*LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller, error) {
 	resp, err := client.putAsyncRelativeRetryNoStatusPayload(ctx, options)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutAsyncRelativeRetryNoStatusPayload", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller{pt: pt}, nil
 }
 
 // PutAsyncRelativeRetryNoStatusPayload - Long running put request, service returns a 200 to the initial request, with an
@@ -1184,20 +1096,16 @@ func (client *LROSADsClient) putAsyncRelativeRetryNoStatusPayloadCreateRequest(c
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutError201NoProvisioningStatePayloadOptions contains the optional parameters for the LROSADsClient.BeginPutError201NoProvisioningStatePayload
 // method.
-func (client *LROSADsClient) BeginPutError201NoProvisioningStatePayload(ctx context.Context, options *LROSADsClientBeginPutError201NoProvisioningStatePayloadOptions) (LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse, error) {
+func (client *LROSADsClient) BeginPutError201NoProvisioningStatePayload(ctx context.Context, options *LROSADsClientBeginPutError201NoProvisioningStatePayloadOptions) (*LROSADsClientPutError201NoProvisioningStatePayloadPoller, error) {
 	resp, err := client.putError201NoProvisioningStatePayload(ctx, options)
 	if err != nil {
-		return LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutError201NoProvisioningStatePayload", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutError201NoProvisioningStatePayloadPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutError201NoProvisioningStatePayloadPoller{pt: pt}, nil
 }
 
 // PutError201NoProvisioningStatePayload - Long running put request, service returns a 201 to the initial request with no
@@ -1237,20 +1145,16 @@ func (client *LROSADsClient) putError201NoProvisioningStatePayloadCreateRequest(
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutNonRetry201Creating400Options contains the optional parameters for the LROSADsClient.BeginPutNonRetry201Creating400
 // method.
-func (client *LROSADsClient) BeginPutNonRetry201Creating400(ctx context.Context, options *LROSADsClientBeginPutNonRetry201Creating400Options) (LROSADsClientPutNonRetry201Creating400PollerResponse, error) {
+func (client *LROSADsClient) BeginPutNonRetry201Creating400(ctx context.Context, options *LROSADsClientBeginPutNonRetry201Creating400Options) (*LROSADsClientPutNonRetry201Creating400Poller, error) {
 	resp, err := client.putNonRetry201Creating400(ctx, options)
 	if err != nil {
-		return LROSADsClientPutNonRetry201Creating400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutNonRetry201Creating400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutNonRetry201Creating400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutNonRetry201Creating400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutNonRetry201Creating400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutNonRetry201Creating400Poller{pt: pt}, nil
 }
 
 // PutNonRetry201Creating400 - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
@@ -1290,20 +1194,16 @@ func (client *LROSADsClient) putNonRetry201Creating400CreateRequest(ctx context.
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutNonRetry201Creating400InvalidJSONOptions contains the optional parameters for the LROSADsClient.BeginPutNonRetry201Creating400InvalidJSON
 // method.
-func (client *LROSADsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx context.Context, options *LROSADsClientBeginPutNonRetry201Creating400InvalidJSONOptions) (LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse, error) {
+func (client *LROSADsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx context.Context, options *LROSADsClientBeginPutNonRetry201Creating400InvalidJSONOptions) (*LROSADsClientPutNonRetry201Creating400InvalidJSONPoller, error) {
 	resp, err := client.putNonRetry201Creating400InvalidJSON(ctx, options)
 	if err != nil {
-		return LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutNonRetry201Creating400InvalidJSON", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutNonRetry201Creating400InvalidJSONPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutNonRetry201Creating400InvalidJSONPoller{pt: pt}, nil
 }
 
 // PutNonRetry201Creating400InvalidJSON - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating'
@@ -1342,20 +1242,16 @@ func (client *LROSADsClient) putNonRetry201Creating400InvalidJSONCreateRequest(c
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROSADsClientBeginPutNonRetry400Options contains the optional parameters for the LROSADsClient.BeginPutNonRetry400
 // method.
-func (client *LROSADsClient) BeginPutNonRetry400(ctx context.Context, options *LROSADsClientBeginPutNonRetry400Options) (LROSADsClientPutNonRetry400PollerResponse, error) {
+func (client *LROSADsClient) BeginPutNonRetry400(ctx context.Context, options *LROSADsClientBeginPutNonRetry400Options) (*LROSADsClientPutNonRetry400Poller, error) {
 	resp, err := client.putNonRetry400(ctx, options)
 	if err != nil {
-		return LROSADsClientPutNonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result := LROSADsClientPutNonRetry400PollerResponse{}
 	pt, err := armruntime.NewPoller("LROSADsClient.PutNonRetry400", "", resp, client.pl)
 	if err != nil {
-		return LROSADsClientPutNonRetry400PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROSADsClientPutNonRetry400Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROSADsClientPutNonRetry400Poller{pt: pt}, nil
 }
 
 // PutNonRetry400 - Long running put request, service returns a 400 to the initial request

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
@@ -41,20 +41,16 @@ func NewLROsCustomHeaderClient(options *azcore.ClientOptions) *LROsCustomHeaderC
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsCustomHeaderClientBeginPost202Retry200Options contains the optional parameters for the LROsCustomHeaderClient.BeginPost202Retry200
 // method.
-func (client *LROsCustomHeaderClient) BeginPost202Retry200(ctx context.Context, options *LROsCustomHeaderClientBeginPost202Retry200Options) (LROsCustomHeaderClientPost202Retry200PollerResponse, error) {
+func (client *LROsCustomHeaderClient) BeginPost202Retry200(ctx context.Context, options *LROsCustomHeaderClientBeginPost202Retry200Options) (*LROsCustomHeaderClientPost202Retry200Poller, error) {
 	resp, err := client.post202Retry200(ctx, options)
 	if err != nil {
-		return LROsCustomHeaderClientPost202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsCustomHeaderClientPost202Retry200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsCustomHeaderClient.Post202Retry200", "", resp, client.pl)
 	if err != nil {
-		return LROsCustomHeaderClientPost202Retry200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsCustomHeaderClientPost202Retry200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsCustomHeaderClientPost202Retry200Poller{pt: pt}, nil
 }
 
 // Post202Retry200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests.
@@ -96,20 +92,16 @@ func (client *LROsCustomHeaderClient) post202Retry200CreateRequest(ctx context.C
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsCustomHeaderClientBeginPostAsyncRetrySucceededOptions contains the optional parameters for the LROsCustomHeaderClient.BeginPostAsyncRetrySucceeded
 // method.
-func (client *LROsCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.Context, options *LROsCustomHeaderClientBeginPostAsyncRetrySucceededOptions) (LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse, error) {
+func (client *LROsCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.Context, options *LROsCustomHeaderClientBeginPostAsyncRetrySucceededOptions) (*LROsCustomHeaderClientPostAsyncRetrySucceededPoller, error) {
 	resp, err := client.postAsyncRetrySucceeded(ctx, options)
 	if err != nil {
-		return LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsCustomHeaderClient.PostAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsCustomHeaderClientPostAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsCustomHeaderClientPostAsyncRetrySucceededPoller{pt: pt}, nil
 }
 
 // PostAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
@@ -151,20 +143,16 @@ func (client *LROsCustomHeaderClient) postAsyncRetrySucceededCreateRequest(ctx c
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsCustomHeaderClientBeginPut201CreatingSucceeded200Options contains the optional parameters for the LROsCustomHeaderClient.BeginPut201CreatingSucceeded200
 // method.
-func (client *LROsCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LROsCustomHeaderClientBeginPut201CreatingSucceeded200Options) (LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse, error) {
+func (client *LROsCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LROsCustomHeaderClientBeginPut201CreatingSucceeded200Options) (*LROsCustomHeaderClientPut201CreatingSucceeded200Poller, error) {
 	resp, err := client.put201CreatingSucceeded200(ctx, options)
 	if err != nil {
-		return LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse{}, err
+		return nil, err
 	}
-	result := LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse{}
 	pt, err := armruntime.NewPoller("LROsCustomHeaderClient.Put201CreatingSucceeded200", "", resp, client.pl)
 	if err != nil {
-		return LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsCustomHeaderClientPut201CreatingSucceeded200Poller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsCustomHeaderClientPut201CreatingSucceeded200Poller{pt: pt}, nil
 }
 
 // Put201CreatingSucceeded200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
@@ -206,20 +194,16 @@ func (client *LROsCustomHeaderClient) put201CreatingSucceeded200CreateRequest(ct
 // If the operation fails it returns an *azcore.ResponseError type.
 // options - LROsCustomHeaderClientBeginPutAsyncRetrySucceededOptions contains the optional parameters for the LROsCustomHeaderClient.BeginPutAsyncRetrySucceeded
 // method.
-func (client *LROsCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Context, options *LROsCustomHeaderClientBeginPutAsyncRetrySucceededOptions) (LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse, error) {
+func (client *LROsCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Context, options *LROsCustomHeaderClientBeginPutAsyncRetrySucceededOptions) (*LROsCustomHeaderClientPutAsyncRetrySucceededPoller, error) {
 	resp, err := client.putAsyncRetrySucceeded(ctx, options)
 	if err != nil {
-		return LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result := LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse{}
 	pt, err := armruntime.NewPoller("LROsCustomHeaderClient.PutAsyncRetrySucceeded", "", resp, client.pl)
 	if err != nil {
-		return LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LROsCustomHeaderClientPutAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LROsCustomHeaderClientPutAsyncRetrySucceededPoller{pt: pt}, nil
 }
 
 // PutAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all

--- a/test/autorest/lrogroup/zz_generated_models.go
+++ b/test/autorest/lrogroup/zz_generated_models.go
@@ -308,6 +308,20 @@ type LROsClientBeginPatch200SucceededIgnoreHeadersOptions struct {
 	Product *Product
 }
 
+// LROsClientBeginPatch201RetryWithAsyncHeaderOptions contains the optional parameters for the LROsClient.BeginPatch201RetryWithAsyncHeader
+// method.
+type LROsClientBeginPatch201RetryWithAsyncHeaderOptions struct {
+	// Product to patch
+	Product *Product
+}
+
+// LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions contains the optional parameters for the LROsClient.BeginPatch202RetryWithAsyncAndLocationHeader
+// method.
+type LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions struct {
+	// Product to patch
+	Product *Product
+}
+
 // LROsClientBeginPost200WithPayloadOptions contains the optional parameters for the LROsClient.BeginPost200WithPayload method.
 type LROsClientBeginPost200WithPayloadOptions struct {
 	// placeholder for future optional parameters

--- a/test/autorest/lrogroup/zz_generated_models.go
+++ b/test/autorest/lrogroup/zz_generated_models.go
@@ -308,20 +308,6 @@ type LROsClientBeginPatch200SucceededIgnoreHeadersOptions struct {
 	Product *Product
 }
 
-// LROsClientBeginPatch201RetryWithAsyncHeaderOptions contains the optional parameters for the LROsClient.BeginPatch201RetryWithAsyncHeader
-// method.
-type LROsClientBeginPatch201RetryWithAsyncHeaderOptions struct {
-	// Product to patch
-	Product *Product
-}
-
-// LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions contains the optional parameters for the LROsClient.BeginPatch202RetryWithAsyncAndLocationHeader
-// method.
-type LROsClientBeginPatch202RetryWithAsyncAndLocationHeaderOptions struct {
-	// Product to patch
-	Product *Product
-}
-
 // LROsClientBeginPost200WithPayloadOptions contains the optional parameters for the LROsClient.BeginPost200WithPayload method.
 type LROsClientBeginPost200WithPayloadOptions struct {
 	// placeholder for future optional parameters

--- a/test/autorest/lrogroup/zz_generated_pollers.go
+++ b/test/autorest/lrogroup/zz_generated_pollers.go
@@ -11,7 +11,8 @@ package lrogroup
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
+	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"time"
 )
 
 // LRORetrysClientDelete202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -24,36 +25,51 @@ func (p *LRORetrysClientDelete202Retry200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LRORetrysClientDelete202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LRORetrysClientDelete202Retry200Poller) Poll(ctx context.Context) (LRORetrysClientDelete202Retry200Response, error) {
+	result := LRORetrysClientDelete202Retry200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LRORetrysClientDelete202Retry200Response will be returned.
-func (p *LRORetrysClientDelete202Retry200Poller) FinalResponse(ctx context.Context) (LRORetrysClientDelete202Retry200Response, error) {
-	respType := LRORetrysClientDelete202Retry200Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LRORetrysClientDelete202Retry200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LRORetrysClientDelete202Retry200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDelete202Retry200Response, error) {
+	result := LRORetrysClientDelete202Retry200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LRORetrysClientDelete202Retry200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LRORetrysClientDelete202Retry200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LRORetrysClientDelete202Retry200Poller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientDelete202Retry200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Delete202Retry200", token, client.pl); err != nil {
+		return LRORetrysClientDelete202Retry200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -66,36 +82,51 @@ func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
+	result := LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse will be returned.
-func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) FinalResponse(ctx context.Context) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
-	respType := LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
+	result := LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.DeleteAsyncRelativeRetrySucceeded", token, client.pl); err != nil {
+		return LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -108,36 +139,51 @@ func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Done() 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
+	result := LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse will be returned.
-func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) FinalResponse(ctx context.Context) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
-	respType := LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
+	result := LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.DeleteProvisioning202Accepted200Succeeded", token, client.pl); err != nil {
+		return LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LRORetrysClientPost202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -150,36 +196,51 @@ func (p *LRORetrysClientPost202Retry200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LRORetrysClientPost202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LRORetrysClientPost202Retry200Poller) Poll(ctx context.Context) (LRORetrysClientPost202Retry200Response, error) {
+	result := LRORetrysClientPost202Retry200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LRORetrysClientPost202Retry200Response will be returned.
-func (p *LRORetrysClientPost202Retry200Poller) FinalResponse(ctx context.Context) (LRORetrysClientPost202Retry200Response, error) {
-	respType := LRORetrysClientPost202Retry200Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LRORetrysClientPost202Retry200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LRORetrysClientPost202Retry200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPost202Retry200Response, error) {
+	result := LRORetrysClientPost202Retry200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LRORetrysClientPost202Retry200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LRORetrysClientPost202Retry200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LRORetrysClientPost202Retry200Poller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientPost202Retry200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Post202Retry200", token, client.pl); err != nil {
+		return LRORetrysClientPost202Retry200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LRORetrysClientPostAsyncRelativeRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -192,36 +253,51 @@ func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
+	result := LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LRORetrysClientPostAsyncRelativeRetrySucceededResponse will be returned.
-func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) FinalResponse(ctx context.Context) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
-	respType := LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
+	result := LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LRORetrysClientPostAsyncRelativeRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.PostAsyncRelativeRetrySucceeded", token, client.pl); err != nil {
+		return LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LRORetrysClientPut201CreatingSucceeded200Poller provides polling facilities until the operation reaches a terminal state.
@@ -234,36 +310,51 @@ func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
+	result := LRORetrysClientPut201CreatingSucceeded200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LRORetrysClientPut201CreatingSucceeded200Response will be returned.
-func (p *LRORetrysClientPut201CreatingSucceeded200Poller) FinalResponse(ctx context.Context) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
-	respType := LRORetrysClientPut201CreatingSucceeded200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LRORetrysClientPut201CreatingSucceeded200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LRORetrysClientPut201CreatingSucceeded200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
+	result := LRORetrysClientPut201CreatingSucceeded200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LRORetrysClientPut201CreatingSucceeded200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LRORetrysClientPut201CreatingSucceeded200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Put201CreatingSucceeded200", token, client.pl); err != nil {
+		return LRORetrysClientPut201CreatingSucceeded200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LRORetrysClientPutAsyncRelativeRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -276,36 +367,51 @@ func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
+	result := LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LRORetrysClientPutAsyncRelativeRetrySucceededResponse will be returned.
-func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) FinalResponse(ctx context.Context) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
-	respType := LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
+	result := LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LRORetrysClientPutAsyncRelativeRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.PutAsyncRelativeRetrySucceeded", token, client.pl); err != nil {
+		return LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientDelete202NonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -318,36 +424,51 @@ func (p *LROSADsClientDelete202NonRetry400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientDelete202NonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientDelete202NonRetry400Poller) Poll(ctx context.Context) (LROSADsClientDelete202NonRetry400Response, error) {
+	result := LROSADsClientDelete202NonRetry400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientDelete202NonRetry400Response will be returned.
-func (p *LROSADsClientDelete202NonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientDelete202NonRetry400Response, error) {
-	respType := LROSADsClientDelete202NonRetry400Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientDelete202NonRetry400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientDelete202NonRetry400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete202NonRetry400Response, error) {
+	result := LROSADsClientDelete202NonRetry400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientDelete202NonRetry400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientDelete202NonRetry400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientDelete202NonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDelete202NonRetry400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete202NonRetry400", token, client.pl); err != nil {
+		return LROSADsClientDelete202NonRetry400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientDelete202RetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -360,36 +481,51 @@ func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
+	result := LROSADsClientDelete202RetryInvalidHeaderResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientDelete202RetryInvalidHeaderResponse will be returned.
-func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientDelete202RetryInvalidHeaderResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientDelete202RetryInvalidHeaderResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
+	result := LROSADsClientDelete202RetryInvalidHeaderResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientDelete202RetryInvalidHeaderPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete202RetryInvalidHeader", token, client.pl); err != nil {
+		return LROSADsClientDelete202RetryInvalidHeaderResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientDelete204SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -402,36 +538,51 @@ func (p *LROSADsClientDelete204SucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientDelete204SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientDelete204SucceededPoller) Poll(ctx context.Context) (LROSADsClientDelete204SucceededResponse, error) {
+	result := LROSADsClientDelete204SucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientDelete204SucceededResponse will be returned.
-func (p *LROSADsClientDelete204SucceededPoller) FinalResponse(ctx context.Context) (LROSADsClientDelete204SucceededResponse, error) {
-	respType := LROSADsClientDelete204SucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientDelete204SucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientDelete204SucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete204SucceededResponse, error) {
+	result := LROSADsClientDelete204SucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientDelete204SucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientDelete204SucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientDelete204SucceededPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDelete204SucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete204Succeeded", token, client.pl); err != nil {
+		return LROSADsClientDelete204SucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientDeleteAsyncRelativeRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -444,36 +595,51 @@ func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Poll(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
+	result := LROSADsClientDeleteAsyncRelativeRetry400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientDeleteAsyncRelativeRetry400Response will be returned.
-func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
-	respType := LROSADsClientDeleteAsyncRelativeRetry400Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetry400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
+	result := LROSADsClientDeleteAsyncRelativeRetry400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetry400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetry400", token, client.pl); err != nil {
+		return LROSADsClientDeleteAsyncRelativeRetry400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -486,36 +652,51 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
+	result := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse will be returned.
-func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
+	result := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader", token, client.pl); err != nil {
+		return LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller provides polling facilities until the operation reaches a terminal state.
@@ -528,36 +709,51 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Done() b
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	result := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse will be returned.
-func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) FinalResponse(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	respType := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	result := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling", token, client.pl); err != nil {
+		return LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -570,36 +766,51 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
+	result := LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse will be returned.
-func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) FinalResponse(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
-	respType := LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
+	result := LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryNoStatus", token, client.pl); err != nil {
+		return LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientDeleteNonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -612,36 +823,51 @@ func (p *LROSADsClientDeleteNonRetry400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientDeleteNonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientDeleteNonRetry400Poller) Poll(ctx context.Context) (LROSADsClientDeleteNonRetry400Response, error) {
+	result := LROSADsClientDeleteNonRetry400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientDeleteNonRetry400Response will be returned.
-func (p *LROSADsClientDeleteNonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientDeleteNonRetry400Response, error) {
-	respType := LROSADsClientDeleteNonRetry400Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientDeleteNonRetry400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientDeleteNonRetry400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteNonRetry400Response, error) {
+	result := LROSADsClientDeleteNonRetry400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientDeleteNonRetry400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientDeleteNonRetry400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientDeleteNonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteNonRetry400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteNonRetry400", token, client.pl); err != nil {
+		return LROSADsClientDeleteNonRetry400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPost202NoLocationPoller provides polling facilities until the operation reaches a terminal state.
@@ -654,36 +880,51 @@ func (p *LROSADsClientPost202NoLocationPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPost202NoLocationPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPost202NoLocationPoller) Poll(ctx context.Context) (LROSADsClientPost202NoLocationResponse, error) {
+	result := LROSADsClientPost202NoLocationResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPost202NoLocationResponse will be returned.
-func (p *LROSADsClientPost202NoLocationPoller) FinalResponse(ctx context.Context) (LROSADsClientPost202NoLocationResponse, error) {
-	respType := LROSADsClientPost202NoLocationResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientPost202NoLocationResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPost202NoLocationPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202NoLocationResponse, error) {
+	result := LROSADsClientPost202NoLocationResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPost202NoLocationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPost202NoLocationPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPost202NoLocationPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPost202NoLocationResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202NoLocation", token, client.pl); err != nil {
+		return LROSADsClientPost202NoLocationResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPost202NonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -696,36 +937,51 @@ func (p *LROSADsClientPost202NonRetry400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPost202NonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPost202NonRetry400Poller) Poll(ctx context.Context) (LROSADsClientPost202NonRetry400Response, error) {
+	result := LROSADsClientPost202NonRetry400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPost202NonRetry400Response will be returned.
-func (p *LROSADsClientPost202NonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPost202NonRetry400Response, error) {
-	respType := LROSADsClientPost202NonRetry400Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientPost202NonRetry400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPost202NonRetry400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202NonRetry400Response, error) {
+	result := LROSADsClientPost202NonRetry400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPost202NonRetry400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPost202NonRetry400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPost202NonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPost202NonRetry400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202NonRetry400", token, client.pl); err != nil {
+		return LROSADsClientPost202NonRetry400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPost202RetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -738,36 +994,51 @@ func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
+	result := LROSADsClientPost202RetryInvalidHeaderResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPost202RetryInvalidHeaderResponse will be returned.
-func (p *LROSADsClientPost202RetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientPost202RetryInvalidHeaderResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientPost202RetryInvalidHeaderResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPost202RetryInvalidHeaderPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
+	result := LROSADsClientPost202RetryInvalidHeaderResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPost202RetryInvalidHeaderPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPost202RetryInvalidHeaderPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202RetryInvalidHeader", token, client.pl); err != nil {
+		return LROSADsClientPost202RetryInvalidHeaderResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPostAsyncRelativeRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -780,36 +1051,51 @@ func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Poll(ctx context.Context) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
+	result := LROSADsClientPostAsyncRelativeRetry400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPostAsyncRelativeRetry400Response will be returned.
-func (p *LROSADsClientPostAsyncRelativeRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
-	respType := LROSADsClientPostAsyncRelativeRetry400Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetry400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPostAsyncRelativeRetry400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
+	result := LROSADsClientPostAsyncRelativeRetry400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPostAsyncRelativeRetry400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPostAsyncRelativeRetry400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetry400", token, client.pl); err != nil {
+		return LROSADsClientPostAsyncRelativeRetry400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -822,36 +1108,51 @@ func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
+	result := LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse will be returned.
-func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
+	result := LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidHeader", token, client.pl); err != nil {
+		return LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller provides polling facilities until the operation reaches a terminal state.
@@ -864,36 +1165,51 @@ func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Done() boo
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	result := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse will be returned.
-func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) FinalResponse(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	respType := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	result := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling", token, client.pl); err != nil {
+		return LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPostAsyncRelativeRetryNoPayloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -906,36 +1222,51 @@ func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Poll(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
+	result := LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPostAsyncRelativeRetryNoPayloadResponse will be returned.
-func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) FinalResponse(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
-	respType := LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
+	result := LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPostAsyncRelativeRetryNoPayloadPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryNoPayload", token, client.pl); err != nil {
+		return LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPostNonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -948,36 +1279,51 @@ func (p *LROSADsClientPostNonRetry400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPostNonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPostNonRetry400Poller) Poll(ctx context.Context) (LROSADsClientPostNonRetry400Response, error) {
+	result := LROSADsClientPostNonRetry400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPostNonRetry400Response will be returned.
-func (p *LROSADsClientPostNonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPostNonRetry400Response, error) {
-	respType := LROSADsClientPostNonRetry400Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROSADsClientPostNonRetry400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPostNonRetry400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostNonRetry400Response, error) {
+	result := LROSADsClientPostNonRetry400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPostNonRetry400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPostNonRetry400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPostNonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostNonRetry400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostNonRetry400", token, client.pl); err != nil {
+		return LROSADsClientPostNonRetry400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPut200InvalidJSONPoller provides polling facilities until the operation reaches a terminal state.
@@ -990,36 +1336,51 @@ func (p *LROSADsClientPut200InvalidJSONPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPut200InvalidJSONPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPut200InvalidJSONPoller) Poll(ctx context.Context) (LROSADsClientPut200InvalidJSONResponse, error) {
+	result := LROSADsClientPut200InvalidJSONResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPut200InvalidJSONResponse will be returned.
-func (p *LROSADsClientPut200InvalidJSONPoller) FinalResponse(ctx context.Context) (LROSADsClientPut200InvalidJSONResponse, error) {
-	respType := LROSADsClientPut200InvalidJSONResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPut200InvalidJSONResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPut200InvalidJSONPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPut200InvalidJSONResponse, error) {
+	result := LROSADsClientPut200InvalidJSONResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPut200InvalidJSONPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPut200InvalidJSONPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPut200InvalidJSONPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPut200InvalidJSONResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Put200InvalidJSON", token, client.pl); err != nil {
+		return LROSADsClientPut200InvalidJSONResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutAsyncRelativeRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -1032,36 +1393,51 @@ func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
+	result := LROSADsClientPutAsyncRelativeRetry400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetry400Response will be returned.
-func (p *LROSADsClientPutAsyncRelativeRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
-	respType := LROSADsClientPutAsyncRelativeRetry400Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetry400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutAsyncRelativeRetry400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
+	result := LROSADsClientPutAsyncRelativeRetry400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutAsyncRelativeRetry400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutAsyncRelativeRetry400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetry400", token, client.pl); err != nil {
+		return LROSADsClientPutAsyncRelativeRetry400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -1074,36 +1450,51 @@ func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
+	result := LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse will be returned.
-func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
+	result := LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidHeader", token, client.pl); err != nil {
+		return LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller provides polling facilities until the operation reaches a terminal state.
@@ -1116,36 +1507,51 @@ func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Done() bool
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	result := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse will be returned.
-func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	respType := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	result := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling", token, client.pl); err != nil {
+		return LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -1158,36 +1564,51 @@ func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
+	result := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse will be returned.
-func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
-	respType := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
+	result := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatusPayload", token, client.pl); err != nil {
+		return LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -1200,36 +1621,51 @@ func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
+	result := LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutAsyncRelativeRetryNoStatusResponse will be returned.
-func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) FinalResponse(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
-	respType := LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
+	result := LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutAsyncRelativeRetryNoStatusPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatus", token, client.pl); err != nil {
+		return LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutError201NoProvisioningStatePayloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -1242,36 +1678,51 @@ func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Poll(ctx context.Context) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
+	result := LROSADsClientPutError201NoProvisioningStatePayloadResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutError201NoProvisioningStatePayloadResponse will be returned.
-func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) FinalResponse(ctx context.Context) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
-	respType := LROSADsClientPutError201NoProvisioningStatePayloadResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutError201NoProvisioningStatePayloadResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
+	result := LROSADsClientPutError201NoProvisioningStatePayloadResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutError201NoProvisioningStatePayloadPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutError201NoProvisioningStatePayload", token, client.pl); err != nil {
+		return LROSADsClientPutError201NoProvisioningStatePayloadResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutNonRetry201Creating400InvalidJSONPoller provides polling facilities until the operation reaches a terminal state.
@@ -1284,36 +1735,51 @@ func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Poll(ctx context.Context) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
+	result := LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutNonRetry201Creating400InvalidJSONResponse will be returned.
-func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) FinalResponse(ctx context.Context) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
-	respType := LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
+	result := LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutNonRetry201Creating400InvalidJSONPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400InvalidJSON", token, client.pl); err != nil {
+		return LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutNonRetry201Creating400Poller provides polling facilities until the operation reaches a terminal state.
@@ -1326,36 +1792,51 @@ func (p *LROSADsClientPutNonRetry201Creating400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutNonRetry201Creating400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutNonRetry201Creating400Poller) Poll(ctx context.Context) (LROSADsClientPutNonRetry201Creating400Response, error) {
+	result := LROSADsClientPutNonRetry201Creating400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutNonRetry201Creating400Response will be returned.
-func (p *LROSADsClientPutNonRetry201Creating400Poller) FinalResponse(ctx context.Context) (LROSADsClientPutNonRetry201Creating400Response, error) {
-	respType := LROSADsClientPutNonRetry201Creating400Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutNonRetry201Creating400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutNonRetry201Creating400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry201Creating400Response, error) {
+	result := LROSADsClientPutNonRetry201Creating400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutNonRetry201Creating400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutNonRetry201Creating400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutNonRetry201Creating400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutNonRetry201Creating400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400", token, client.pl); err != nil {
+		return LROSADsClientPutNonRetry201Creating400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROSADsClientPutNonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -1368,36 +1849,51 @@ func (p *LROSADsClientPutNonRetry400Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROSADsClientPutNonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROSADsClientPutNonRetry400Poller) Poll(ctx context.Context) (LROSADsClientPutNonRetry400Response, error) {
+	result := LROSADsClientPutNonRetry400Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROSADsClientPutNonRetry400Response will be returned.
-func (p *LROSADsClientPutNonRetry400Poller) FinalResponse(ctx context.Context) (LROSADsClientPutNonRetry400Response, error) {
-	respType := LROSADsClientPutNonRetry400Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROSADsClientPutNonRetry400Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROSADsClientPutNonRetry400Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry400Response, error) {
+	result := LROSADsClientPutNonRetry400Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROSADsClientPutNonRetry400Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROSADsClientPutNonRetry400Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROSADsClientPutNonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutNonRetry400Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry400", token, client.pl); err != nil {
+		return LROSADsClientPutNonRetry400Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDelete202NoRetry204Poller provides polling facilities until the operation reaches a terminal state.
@@ -1410,36 +1906,51 @@ func (p *LROsClientDelete202NoRetry204Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDelete202NoRetry204Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDelete202NoRetry204Poller) Poll(ctx context.Context) (LROsClientDelete202NoRetry204Response, error) {
+	result := LROsClientDelete202NoRetry204Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDelete202NoRetry204Response will be returned.
-func (p *LROsClientDelete202NoRetry204Poller) FinalResponse(ctx context.Context) (LROsClientDelete202NoRetry204Response, error) {
-	respType := LROsClientDelete202NoRetry204Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientDelete202NoRetry204Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDelete202NoRetry204Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete202NoRetry204Response, error) {
+	result := LROsClientDelete202NoRetry204Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDelete202NoRetry204Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDelete202NoRetry204Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDelete202NoRetry204Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDelete202NoRetry204Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete202NoRetry204", token, client.pl); err != nil {
+		return LROsClientDelete202NoRetry204Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDelete202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -1452,36 +1963,51 @@ func (p *LROsClientDelete202Retry200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDelete202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDelete202Retry200Poller) Poll(ctx context.Context) (LROsClientDelete202Retry200Response, error) {
+	result := LROsClientDelete202Retry200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDelete202Retry200Response will be returned.
-func (p *LROsClientDelete202Retry200Poller) FinalResponse(ctx context.Context) (LROsClientDelete202Retry200Response, error) {
-	respType := LROsClientDelete202Retry200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientDelete202Retry200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDelete202Retry200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete202Retry200Response, error) {
+	result := LROsClientDelete202Retry200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDelete202Retry200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDelete202Retry200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDelete202Retry200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDelete202Retry200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete202Retry200", token, client.pl); err != nil {
+		return LROsClientDelete202Retry200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDelete204SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -1494,36 +2020,51 @@ func (p *LROsClientDelete204SucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDelete204SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDelete204SucceededPoller) Poll(ctx context.Context) (LROsClientDelete204SucceededResponse, error) {
+	result := LROsClientDelete204SucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDelete204SucceededResponse will be returned.
-func (p *LROsClientDelete204SucceededPoller) FinalResponse(ctx context.Context) (LROsClientDelete204SucceededResponse, error) {
-	respType := LROsClientDelete204SucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientDelete204SucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDelete204SucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete204SucceededResponse, error) {
+	result := LROsClientDelete204SucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDelete204SucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDelete204SucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDelete204SucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDelete204SucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete204Succeeded", token, client.pl); err != nil {
+		return LROsClientDelete204SucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteAsyncNoHeaderInRetryPoller provides polling facilities until the operation reaches a terminal state.
@@ -1536,36 +2077,51 @@ func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
+	result := LROsClientDeleteAsyncNoHeaderInRetryResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteAsyncNoHeaderInRetryResponse will be returned.
-func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
-	respType := LROsClientDeleteAsyncNoHeaderInRetryResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientDeleteAsyncNoHeaderInRetryResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
+	result := LROsClientDeleteAsyncNoHeaderInRetryResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteAsyncNoHeaderInRetryPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoHeaderInRetry", token, client.pl); err != nil {
+		return LROsClientDeleteAsyncNoHeaderInRetryResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteAsyncNoRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -1578,36 +2134,51 @@ func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
+	result := LROsClientDeleteAsyncNoRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteAsyncNoRetrySucceededResponse will be returned.
-func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
-	respType := LROsClientDeleteAsyncNoRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientDeleteAsyncNoRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
+	result := LROsClientDeleteAsyncNoRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteAsyncNoRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoRetrySucceeded", token, client.pl); err != nil {
+		return LROsClientDeleteAsyncNoRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteAsyncRetryFailedPoller provides polling facilities until the operation reaches a terminal state.
@@ -1620,36 +2191,51 @@ func (p *LROsClientDeleteAsyncRetryFailedPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteAsyncRetryFailedPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteAsyncRetryFailedPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncRetryFailedResponse, error) {
+	result := LROsClientDeleteAsyncRetryFailedResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteAsyncRetryFailedResponse will be returned.
-func (p *LROsClientDeleteAsyncRetryFailedPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncRetryFailedResponse, error) {
-	respType := LROsClientDeleteAsyncRetryFailedResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientDeleteAsyncRetryFailedResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteAsyncRetryFailedPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetryFailedResponse, error) {
+	result := LROsClientDeleteAsyncRetryFailedResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteAsyncRetryFailedPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteAsyncRetryFailedPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteAsyncRetryFailedPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncRetryFailedResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetryFailed", token, client.pl); err != nil {
+		return LROsClientDeleteAsyncRetryFailedResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -1662,36 +2248,51 @@ func (p *LROsClientDeleteAsyncRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
+	result := LROsClientDeleteAsyncRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteAsyncRetrySucceededResponse will be returned.
-func (p *LROsClientDeleteAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
-	respType := LROsClientDeleteAsyncRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientDeleteAsyncRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteAsyncRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
+	result := LROsClientDeleteAsyncRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteAsyncRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrySucceeded", token, client.pl); err != nil {
+		return LROsClientDeleteAsyncRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteAsyncRetrycanceledPoller provides polling facilities until the operation reaches a terminal state.
@@ -1704,36 +2305,51 @@ func (p *LROsClientDeleteAsyncRetrycanceledPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteAsyncRetrycanceledPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteAsyncRetrycanceledPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
+	result := LROsClientDeleteAsyncRetrycanceledResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteAsyncRetrycanceledResponse will be returned.
-func (p *LROsClientDeleteAsyncRetrycanceledPoller) FinalResponse(ctx context.Context) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
-	respType := LROsClientDeleteAsyncRetrycanceledResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientDeleteAsyncRetrycanceledResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteAsyncRetrycanceledPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
+	result := LROsClientDeleteAsyncRetrycanceledResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteAsyncRetrycanceledPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteAsyncRetrycanceledPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteAsyncRetrycanceledPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrycanceled", token, client.pl); err != nil {
+		return LROsClientDeleteAsyncRetrycanceledResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteNoHeaderInRetryPoller provides polling facilities until the operation reaches a terminal state.
@@ -1746,36 +2362,51 @@ func (p *LROsClientDeleteNoHeaderInRetryPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteNoHeaderInRetryPoller) Poll(ctx context.Context) (LROsClientDeleteNoHeaderInRetryResponse, error) {
+	result := LROsClientDeleteNoHeaderInRetryResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteNoHeaderInRetryResponse will be returned.
-func (p *LROsClientDeleteNoHeaderInRetryPoller) FinalResponse(ctx context.Context) (LROsClientDeleteNoHeaderInRetryResponse, error) {
-	respType := LROsClientDeleteNoHeaderInRetryResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientDeleteNoHeaderInRetryResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteNoHeaderInRetryPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteNoHeaderInRetryResponse, error) {
+	result := LROsClientDeleteNoHeaderInRetryResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteNoHeaderInRetryPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteNoHeaderInRetryPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteNoHeaderInRetryPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteNoHeaderInRetryResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteNoHeaderInRetry", token, client.pl); err != nil {
+		return LROsClientDeleteNoHeaderInRetryResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteProvisioning202Accepted200SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -1788,36 +2419,51 @@ func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Done() bool 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
+	result := LROsClientDeleteProvisioning202Accepted200SucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteProvisioning202Accepted200SucceededResponse will be returned.
-func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) FinalResponse(ctx context.Context) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
-	respType := LROsClientDeleteProvisioning202Accepted200SucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientDeleteProvisioning202Accepted200SucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
+	result := LROsClientDeleteProvisioning202Accepted200SucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteProvisioning202Accepted200SucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Accepted200Succeeded", token, client.pl); err != nil {
+		return LROsClientDeleteProvisioning202Accepted200SucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteProvisioning202DeletingFailed200Poller provides polling facilities until the operation reaches a terminal state.
@@ -1830,36 +2476,51 @@ func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Poll(ctx context.Context) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
+	result := LROsClientDeleteProvisioning202DeletingFailed200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteProvisioning202DeletingFailed200Response will be returned.
-func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) FinalResponse(ctx context.Context) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
-	respType := LROsClientDeleteProvisioning202DeletingFailed200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientDeleteProvisioning202DeletingFailed200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
+	result := LROsClientDeleteProvisioning202DeletingFailed200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteProvisioning202DeletingFailed200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202DeletingFailed200", token, client.pl); err != nil {
+		return LROsClientDeleteProvisioning202DeletingFailed200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientDeleteProvisioning202Deletingcanceled200Poller provides polling facilities until the operation reaches a terminal state.
@@ -1872,36 +2533,51 @@ func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Poll(ctx context.Context) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
+	result := LROsClientDeleteProvisioning202Deletingcanceled200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientDeleteProvisioning202Deletingcanceled200Response will be returned.
-func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) FinalResponse(ctx context.Context) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
-	respType := LROsClientDeleteProvisioning202Deletingcanceled200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientDeleteProvisioning202Deletingcanceled200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
+	result := LROsClientDeleteProvisioning202Deletingcanceled200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientDeleteProvisioning202Deletingcanceled200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Deletingcanceled200", token, client.pl); err != nil {
+		return LROsClientDeleteProvisioning202Deletingcanceled200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPatch200SucceededIgnoreHeadersPoller provides polling facilities until the operation reaches a terminal state.
@@ -1914,120 +2590,51 @@ func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Poll(ctx context.Context) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
+	result := LROsClientPatch200SucceededIgnoreHeadersResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPatch200SucceededIgnoreHeadersResponse will be returned.
-func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) FinalResponse(ctx context.Context) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
-	respType := LROsClientPatch200SucceededIgnoreHeadersResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPatch200SucceededIgnoreHeadersResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
+	result := LROsClientPatch200SucceededIgnoreHeadersResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-// LROsClientPatch201RetryWithAsyncHeaderPoller provides polling facilities until the operation reaches a terminal state.
-type LROsClientPatch201RetryWithAsyncHeaderPoller struct {
-	pt *azcore.Poller
-}
-
-// Done returns true if the LRO has reached a terminal state.
-func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Done() bool {
-	return p.pt.Done()
-}
-
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
-// response is returned.
-// If the LRO has completed with failure or was cancelled, the poller's state is
-// updated and the error is returned.
-// If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
-// If Poll fails, the poller's state is unmodified and the error is returned.
-// Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
-}
-
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPatch201RetryWithAsyncHeaderResponse will be returned.
-func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) FinalResponse(ctx context.Context) (LROsClientPatch201RetryWithAsyncHeaderResponse, error) {
-	respType := LROsClientPatch201RetryWithAsyncHeaderResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPatch201RetryWithAsyncHeaderResponse{}, err
+// Resume rehydrates a LROsClientPatch200SucceededIgnoreHeadersPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch200SucceededIgnoreHeaders", token, client.pl); err != nil {
+		return LROsClientPatch200SucceededIgnoreHeadersResponse{}, err
 	}
-	return respType, nil
-}
-
-// ResumeToken returns a value representing the poller that can be used to resume
-// the LRO at a later time. ResumeTokens are unique per service operation.
-func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) ResumeToken() (string, error) {
-	return p.pt.ResumeToken()
-}
-
-// LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller provides polling facilities until the operation reaches a terminal state.
-type LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller struct {
-	pt *azcore.Poller
-}
-
-// Done returns true if the LRO has reached a terminal state.
-func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Done() bool {
-	return p.pt.Done()
-}
-
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
-// response is returned.
-// If the LRO has completed with failure or was cancelled, the poller's state is
-// updated and the error is returned.
-// If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
-// If Poll fails, the poller's state is unmodified and the error is returned.
-// Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
-}
-
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse will be returned.
-func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) FinalResponse(ctx context.Context) (LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse, error) {
-	respType := LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse{}, err
-	}
-	return respType, nil
-}
-
-// ResumeToken returns a value representing the poller that can be used to resume
-// the LRO at a later time. ResumeTokens are unique per service operation.
-func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) ResumeToken() (string, error) {
-	return p.pt.ResumeToken()
+	return p.Poll(ctx)
 }
 
 // LROsClientPost200WithPayloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -2040,36 +2647,51 @@ func (p *LROsClientPost200WithPayloadPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPost200WithPayloadPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPost200WithPayloadPoller) Poll(ctx context.Context) (LROsClientPost200WithPayloadResponse, error) {
+	result := LROsClientPost200WithPayloadResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SKU)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPost200WithPayloadResponse will be returned.
-func (p *LROsClientPost200WithPayloadPoller) FinalResponse(ctx context.Context) (LROsClientPost200WithPayloadResponse, error) {
-	respType := LROsClientPost200WithPayloadResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SKU)
-	if err != nil {
-		return LROsClientPost200WithPayloadResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPost200WithPayloadPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost200WithPayloadResponse, error) {
+	result := LROsClientPost200WithPayloadResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SKU)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPost200WithPayloadPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPost200WithPayloadPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPost200WithPayloadPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPost200WithPayloadResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post200WithPayload", token, client.pl); err != nil {
+		return LROsClientPost200WithPayloadResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPost202ListPoller provides polling facilities until the operation reaches a terminal state.
@@ -2082,36 +2704,51 @@ func (p *LROsClientPost202ListPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPost202ListPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPost202ListPoller) Poll(ctx context.Context) (LROsClientPost202ListResponse, error) {
+	result := LROsClientPost202ListResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ProductArray)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPost202ListResponse will be returned.
-func (p *LROsClientPost202ListPoller) FinalResponse(ctx context.Context) (LROsClientPost202ListResponse, error) {
-	respType := LROsClientPost202ListResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ProductArray)
-	if err != nil {
-		return LROsClientPost202ListResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPost202ListPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202ListResponse, error) {
+	result := LROsClientPost202ListResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ProductArray)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPost202ListPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPost202ListPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPost202ListPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPost202ListResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202List", token, client.pl); err != nil {
+		return LROsClientPost202ListResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPost202NoRetry204Poller provides polling facilities until the operation reaches a terminal state.
@@ -2124,36 +2761,51 @@ func (p *LROsClientPost202NoRetry204Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPost202NoRetry204Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPost202NoRetry204Poller) Poll(ctx context.Context) (LROsClientPost202NoRetry204Response, error) {
+	result := LROsClientPost202NoRetry204Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPost202NoRetry204Response will be returned.
-func (p *LROsClientPost202NoRetry204Poller) FinalResponse(ctx context.Context) (LROsClientPost202NoRetry204Response, error) {
-	respType := LROsClientPost202NoRetry204Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPost202NoRetry204Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPost202NoRetry204Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202NoRetry204Response, error) {
+	result := LROsClientPost202NoRetry204Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPost202NoRetry204Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPost202NoRetry204Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPost202NoRetry204Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPost202NoRetry204Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202NoRetry204", token, client.pl); err != nil {
+		return LROsClientPost202NoRetry204Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPost202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -2166,36 +2818,51 @@ func (p *LROsClientPost202Retry200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPost202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPost202Retry200Poller) Poll(ctx context.Context) (LROsClientPost202Retry200Response, error) {
+	result := LROsClientPost202Retry200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPost202Retry200Response will be returned.
-func (p *LROsClientPost202Retry200Poller) FinalResponse(ctx context.Context) (LROsClientPost202Retry200Response, error) {
-	respType := LROsClientPost202Retry200Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientPost202Retry200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPost202Retry200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202Retry200Response, error) {
+	result := LROsClientPost202Retry200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPost202Retry200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPost202Retry200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPost202Retry200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPost202Retry200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202Retry200", token, client.pl); err != nil {
+		return LROsClientPost202Retry200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPostAsyncNoRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2208,36 +2875,51 @@ func (p *LROsClientPostAsyncNoRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPostAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPostAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
+	result := LROsClientPostAsyncNoRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPostAsyncNoRetrySucceededResponse will be returned.
-func (p *LROsClientPostAsyncNoRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
-	respType := LROsClientPostAsyncNoRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPostAsyncNoRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPostAsyncNoRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
+	result := LROsClientPostAsyncNoRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPostAsyncNoRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPostAsyncNoRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPostAsyncNoRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncNoRetrySucceeded", token, client.pl); err != nil {
+		return LROsClientPostAsyncNoRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPostAsyncRetryFailedPoller provides polling facilities until the operation reaches a terminal state.
@@ -2250,36 +2932,51 @@ func (p *LROsClientPostAsyncRetryFailedPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPostAsyncRetryFailedPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPostAsyncRetryFailedPoller) Poll(ctx context.Context) (LROsClientPostAsyncRetryFailedResponse, error) {
+	result := LROsClientPostAsyncRetryFailedResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPostAsyncRetryFailedResponse will be returned.
-func (p *LROsClientPostAsyncRetryFailedPoller) FinalResponse(ctx context.Context) (LROsClientPostAsyncRetryFailedResponse, error) {
-	respType := LROsClientPostAsyncRetryFailedResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientPostAsyncRetryFailedResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPostAsyncRetryFailedPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetryFailedResponse, error) {
+	result := LROsClientPostAsyncRetryFailedResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPostAsyncRetryFailedPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPostAsyncRetryFailedPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPostAsyncRetryFailedPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostAsyncRetryFailedResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetryFailed", token, client.pl); err != nil {
+		return LROsClientPostAsyncRetryFailedResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPostAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2292,36 +2989,51 @@ func (p *LROsClientPostAsyncRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsClientPostAsyncRetrySucceededResponse, error) {
+	result := LROsClientPostAsyncRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPostAsyncRetrySucceededResponse will be returned.
-func (p *LROsClientPostAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientPostAsyncRetrySucceededResponse, error) {
-	respType := LROsClientPostAsyncRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPostAsyncRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPostAsyncRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetrySucceededResponse, error) {
+	result := LROsClientPostAsyncRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPostAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPostAsyncRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPostAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostAsyncRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetrySucceeded", token, client.pl); err != nil {
+		return LROsClientPostAsyncRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPostAsyncRetrycanceledPoller provides polling facilities until the operation reaches a terminal state.
@@ -2334,36 +3046,51 @@ func (p *LROsClientPostAsyncRetrycanceledPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPostAsyncRetrycanceledPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPostAsyncRetrycanceledPoller) Poll(ctx context.Context) (LROsClientPostAsyncRetrycanceledResponse, error) {
+	result := LROsClientPostAsyncRetrycanceledResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPostAsyncRetrycanceledResponse will be returned.
-func (p *LROsClientPostAsyncRetrycanceledPoller) FinalResponse(ctx context.Context) (LROsClientPostAsyncRetrycanceledResponse, error) {
-	respType := LROsClientPostAsyncRetrycanceledResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsClientPostAsyncRetrycanceledResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPostAsyncRetrycanceledPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetrycanceledResponse, error) {
+	result := LROsClientPostAsyncRetrycanceledResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPostAsyncRetrycanceledPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPostAsyncRetrycanceledPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPostAsyncRetrycanceledPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostAsyncRetrycanceledResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetrycanceled", token, client.pl); err != nil {
+		return LROsClientPostAsyncRetrycanceledResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller provides polling facilities until the operation reaches a terminal state.
@@ -2376,36 +3103,51 @@ func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Done() boo
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Poll(ctx context.Context) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
+	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse will be returned.
-func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) FinalResponse(ctx context.Context) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
-	respType := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
+	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault", token, client.pl); err != nil {
+		return LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller provides polling facilities until the operation reaches a terminal state.
@@ -2418,36 +3160,51 @@ func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Poll(ctx context.Context) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
+	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse will be returned.
-func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) FinalResponse(ctx context.Context) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
-	respType := LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
+	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGet", token, client.pl); err != nil {
+		return LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPostDoubleHeadersFinalLocationGetPoller provides polling facilities until the operation reaches a terminal state.
@@ -2460,36 +3217,51 @@ func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Poll(ctx context.Context) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
+	result := LROsClientPostDoubleHeadersFinalLocationGetResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPostDoubleHeadersFinalLocationGetResponse will be returned.
-func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) FinalResponse(ctx context.Context) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
-	respType := LROsClientPostDoubleHeadersFinalLocationGetResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPostDoubleHeadersFinalLocationGetResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
+	result := LROsClientPostDoubleHeadersFinalLocationGetResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPostDoubleHeadersFinalLocationGetPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalLocationGet", token, client.pl); err != nil {
+		return LROsClientPostDoubleHeadersFinalLocationGetResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPut200Acceptedcanceled200Poller provides polling facilities until the operation reaches a terminal state.
@@ -2502,36 +3274,51 @@ func (p *LROsClientPut200Acceptedcanceled200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPut200Acceptedcanceled200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPut200Acceptedcanceled200Poller) Poll(ctx context.Context) (LROsClientPut200Acceptedcanceled200Response, error) {
+	result := LROsClientPut200Acceptedcanceled200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPut200Acceptedcanceled200Response will be returned.
-func (p *LROsClientPut200Acceptedcanceled200Poller) FinalResponse(ctx context.Context) (LROsClientPut200Acceptedcanceled200Response, error) {
-	respType := LROsClientPut200Acceptedcanceled200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPut200Acceptedcanceled200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPut200Acceptedcanceled200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200Acceptedcanceled200Response, error) {
+	result := LROsClientPut200Acceptedcanceled200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPut200Acceptedcanceled200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPut200Acceptedcanceled200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPut200Acceptedcanceled200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut200Acceptedcanceled200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200Acceptedcanceled200", token, client.pl); err != nil {
+		return LROsClientPut200Acceptedcanceled200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPut200SucceededNoStatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2544,36 +3331,51 @@ func (p *LROsClientPut200SucceededNoStatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPut200SucceededNoStatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPut200SucceededNoStatePoller) Poll(ctx context.Context) (LROsClientPut200SucceededNoStateResponse, error) {
+	result := LROsClientPut200SucceededNoStateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPut200SucceededNoStateResponse will be returned.
-func (p *LROsClientPut200SucceededNoStatePoller) FinalResponse(ctx context.Context) (LROsClientPut200SucceededNoStateResponse, error) {
-	respType := LROsClientPut200SucceededNoStateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPut200SucceededNoStateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPut200SucceededNoStatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200SucceededNoStateResponse, error) {
+	result := LROsClientPut200SucceededNoStateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPut200SucceededNoStatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPut200SucceededNoStatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPut200SucceededNoStatePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut200SucceededNoStateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200SucceededNoState", token, client.pl); err != nil {
+		return LROsClientPut200SucceededNoStateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPut200SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2586,36 +3388,51 @@ func (p *LROsClientPut200SucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPut200SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPut200SucceededPoller) Poll(ctx context.Context) (LROsClientPut200SucceededResponse, error) {
+	result := LROsClientPut200SucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPut200SucceededResponse will be returned.
-func (p *LROsClientPut200SucceededPoller) FinalResponse(ctx context.Context) (LROsClientPut200SucceededResponse, error) {
-	respType := LROsClientPut200SucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPut200SucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPut200SucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200SucceededResponse, error) {
+	result := LROsClientPut200SucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPut200SucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPut200SucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPut200SucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut200SucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200Succeeded", token, client.pl); err != nil {
+		return LROsClientPut200SucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPut200UpdatingSucceeded204Poller provides polling facilities until the operation reaches a terminal state.
@@ -2628,36 +3445,51 @@ func (p *LROsClientPut200UpdatingSucceeded204Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPut200UpdatingSucceeded204Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPut200UpdatingSucceeded204Poller) Poll(ctx context.Context) (LROsClientPut200UpdatingSucceeded204Response, error) {
+	result := LROsClientPut200UpdatingSucceeded204Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPut200UpdatingSucceeded204Response will be returned.
-func (p *LROsClientPut200UpdatingSucceeded204Poller) FinalResponse(ctx context.Context) (LROsClientPut200UpdatingSucceeded204Response, error) {
-	respType := LROsClientPut200UpdatingSucceeded204Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPut200UpdatingSucceeded204Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPut200UpdatingSucceeded204Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200UpdatingSucceeded204Response, error) {
+	result := LROsClientPut200UpdatingSucceeded204Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPut200UpdatingSucceeded204Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPut200UpdatingSucceeded204Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPut200UpdatingSucceeded204Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut200UpdatingSucceeded204Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200UpdatingSucceeded204", token, client.pl); err != nil {
+		return LROsClientPut200UpdatingSucceeded204Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPut201CreatingFailed200Poller provides polling facilities until the operation reaches a terminal state.
@@ -2670,36 +3502,51 @@ func (p *LROsClientPut201CreatingFailed200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPut201CreatingFailed200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPut201CreatingFailed200Poller) Poll(ctx context.Context) (LROsClientPut201CreatingFailed200Response, error) {
+	result := LROsClientPut201CreatingFailed200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPut201CreatingFailed200Response will be returned.
-func (p *LROsClientPut201CreatingFailed200Poller) FinalResponse(ctx context.Context) (LROsClientPut201CreatingFailed200Response, error) {
-	respType := LROsClientPut201CreatingFailed200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPut201CreatingFailed200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPut201CreatingFailed200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201CreatingFailed200Response, error) {
+	result := LROsClientPut201CreatingFailed200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPut201CreatingFailed200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPut201CreatingFailed200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPut201CreatingFailed200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut201CreatingFailed200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201CreatingFailed200", token, client.pl); err != nil {
+		return LROsClientPut201CreatingFailed200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPut201CreatingSucceeded200Poller provides polling facilities until the operation reaches a terminal state.
@@ -2712,36 +3559,51 @@ func (p *LROsClientPut201CreatingSucceeded200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (LROsClientPut201CreatingSucceeded200Response, error) {
+	result := LROsClientPut201CreatingSucceeded200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPut201CreatingSucceeded200Response will be returned.
-func (p *LROsClientPut201CreatingSucceeded200Poller) FinalResponse(ctx context.Context) (LROsClientPut201CreatingSucceeded200Response, error) {
-	respType := LROsClientPut201CreatingSucceeded200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPut201CreatingSucceeded200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPut201CreatingSucceeded200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201CreatingSucceeded200Response, error) {
+	result := LROsClientPut201CreatingSucceeded200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPut201CreatingSucceeded200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPut201CreatingSucceeded200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPut201CreatingSucceeded200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut201CreatingSucceeded200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201CreatingSucceeded200", token, client.pl); err != nil {
+		return LROsClientPut201CreatingSucceeded200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPut201SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2754,36 +3616,51 @@ func (p *LROsClientPut201SucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPut201SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPut201SucceededPoller) Poll(ctx context.Context) (LROsClientPut201SucceededResponse, error) {
+	result := LROsClientPut201SucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPut201SucceededResponse will be returned.
-func (p *LROsClientPut201SucceededPoller) FinalResponse(ctx context.Context) (LROsClientPut201SucceededResponse, error) {
-	respType := LROsClientPut201SucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPut201SucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPut201SucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201SucceededResponse, error) {
+	result := LROsClientPut201SucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPut201SucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPut201SucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPut201SucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut201SucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201Succeeded", token, client.pl); err != nil {
+		return LROsClientPut201SucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPut202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -2796,36 +3673,51 @@ func (p *LROsClientPut202Retry200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPut202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPut202Retry200Poller) Poll(ctx context.Context) (LROsClientPut202Retry200Response, error) {
+	result := LROsClientPut202Retry200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPut202Retry200Response will be returned.
-func (p *LROsClientPut202Retry200Poller) FinalResponse(ctx context.Context) (LROsClientPut202Retry200Response, error) {
-	respType := LROsClientPut202Retry200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPut202Retry200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPut202Retry200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut202Retry200Response, error) {
+	result := LROsClientPut202Retry200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPut202Retry200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPut202Retry200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPut202Retry200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut202Retry200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put202Retry200", token, client.pl); err != nil {
+		return LROsClientPut202Retry200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutAsyncNoHeaderInRetryPoller provides polling facilities until the operation reaches a terminal state.
@@ -2838,36 +3730,51 @@ func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
+	result := LROsClientPutAsyncNoHeaderInRetryResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutAsyncNoHeaderInRetryResponse will be returned.
-func (p *LROsClientPutAsyncNoHeaderInRetryPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
-	respType := LROsClientPutAsyncNoHeaderInRetryResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPutAsyncNoHeaderInRetryResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutAsyncNoHeaderInRetryPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
+	result := LROsClientPutAsyncNoHeaderInRetryResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutAsyncNoHeaderInRetryPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutAsyncNoHeaderInRetryPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoHeaderInRetry", token, client.pl); err != nil {
+		return LROsClientPutAsyncNoHeaderInRetryResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutAsyncNoRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2880,36 +3787,51 @@ func (p *LROsClientPutAsyncNoRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
+	result := LROsClientPutAsyncNoRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutAsyncNoRetrySucceededResponse will be returned.
-func (p *LROsClientPutAsyncNoRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
-	respType := LROsClientPutAsyncNoRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPutAsyncNoRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutAsyncNoRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
+	result := LROsClientPutAsyncNoRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutAsyncNoRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutAsyncNoRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutAsyncNoRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrySucceeded", token, client.pl); err != nil {
+		return LROsClientPutAsyncNoRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutAsyncNoRetrycanceledPoller provides polling facilities until the operation reaches a terminal state.
@@ -2922,36 +3844,51 @@ func (p *LROsClientPutAsyncNoRetrycanceledPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutAsyncNoRetrycanceledPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutAsyncNoRetrycanceledPoller) Poll(ctx context.Context) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
+	result := LROsClientPutAsyncNoRetrycanceledResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutAsyncNoRetrycanceledResponse will be returned.
-func (p *LROsClientPutAsyncNoRetrycanceledPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
-	respType := LROsClientPutAsyncNoRetrycanceledResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPutAsyncNoRetrycanceledResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutAsyncNoRetrycanceledPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
+	result := LROsClientPutAsyncNoRetrycanceledResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutAsyncNoRetrycanceledPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutAsyncNoRetrycanceledPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutAsyncNoRetrycanceledPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrycanceled", token, client.pl); err != nil {
+		return LROsClientPutAsyncNoRetrycanceledResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutAsyncNonResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -2964,36 +3901,51 @@ func (p *LROsClientPutAsyncNonResourcePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutAsyncNonResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutAsyncNonResourcePoller) Poll(ctx context.Context) (LROsClientPutAsyncNonResourceResponse, error) {
+	result := LROsClientPutAsyncNonResourceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SKU)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutAsyncNonResourceResponse will be returned.
-func (p *LROsClientPutAsyncNonResourcePoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncNonResourceResponse, error) {
-	respType := LROsClientPutAsyncNonResourceResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SKU)
-	if err != nil {
-		return LROsClientPutAsyncNonResourceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutAsyncNonResourcePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNonResourceResponse, error) {
+	result := LROsClientPutAsyncNonResourceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SKU)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutAsyncNonResourcePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutAsyncNonResourcePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutAsyncNonResourcePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncNonResourceResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNonResource", token, client.pl); err != nil {
+		return LROsClientPutAsyncNonResourceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutAsyncRetryFailedPoller provides polling facilities until the operation reaches a terminal state.
@@ -3006,36 +3958,51 @@ func (p *LROsClientPutAsyncRetryFailedPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutAsyncRetryFailedPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutAsyncRetryFailedPoller) Poll(ctx context.Context) (LROsClientPutAsyncRetryFailedResponse, error) {
+	result := LROsClientPutAsyncRetryFailedResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutAsyncRetryFailedResponse will be returned.
-func (p *LROsClientPutAsyncRetryFailedPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncRetryFailedResponse, error) {
-	respType := LROsClientPutAsyncRetryFailedResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPutAsyncRetryFailedResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutAsyncRetryFailedPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncRetryFailedResponse, error) {
+	result := LROsClientPutAsyncRetryFailedResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutAsyncRetryFailedPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutAsyncRetryFailedPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutAsyncRetryFailedPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncRetryFailedResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncRetryFailed", token, client.pl); err != nil {
+		return LROsClientPutAsyncRetryFailedResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -3048,36 +4015,51 @@ func (p *LROsClientPutAsyncRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsClientPutAsyncRetrySucceededResponse, error) {
+	result := LROsClientPutAsyncRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutAsyncRetrySucceededResponse will be returned.
-func (p *LROsClientPutAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncRetrySucceededResponse, error) {
-	respType := LROsClientPutAsyncRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPutAsyncRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutAsyncRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncRetrySucceededResponse, error) {
+	result := LROsClientPutAsyncRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutAsyncRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncRetrySucceeded", token, client.pl); err != nil {
+		return LROsClientPutAsyncRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutAsyncSubResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -3090,36 +4072,51 @@ func (p *LROsClientPutAsyncSubResourcePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutAsyncSubResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutAsyncSubResourcePoller) Poll(ctx context.Context) (LROsClientPutAsyncSubResourceResponse, error) {
+	result := LROsClientPutAsyncSubResourceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SubProduct)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutAsyncSubResourceResponse will be returned.
-func (p *LROsClientPutAsyncSubResourcePoller) FinalResponse(ctx context.Context) (LROsClientPutAsyncSubResourceResponse, error) {
-	respType := LROsClientPutAsyncSubResourceResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SubProduct)
-	if err != nil {
-		return LROsClientPutAsyncSubResourceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutAsyncSubResourcePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncSubResourceResponse, error) {
+	result := LROsClientPutAsyncSubResourceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SubProduct)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutAsyncSubResourcePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutAsyncSubResourcePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutAsyncSubResourcePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncSubResourceResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncSubResource", token, client.pl); err != nil {
+		return LROsClientPutAsyncSubResourceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutNoHeaderInRetryPoller provides polling facilities until the operation reaches a terminal state.
@@ -3132,36 +4129,51 @@ func (p *LROsClientPutNoHeaderInRetryPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutNoHeaderInRetryPoller) Poll(ctx context.Context) (LROsClientPutNoHeaderInRetryResponse, error) {
+	result := LROsClientPutNoHeaderInRetryResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutNoHeaderInRetryResponse will be returned.
-func (p *LROsClientPutNoHeaderInRetryPoller) FinalResponse(ctx context.Context) (LROsClientPutNoHeaderInRetryResponse, error) {
-	respType := LROsClientPutNoHeaderInRetryResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsClientPutNoHeaderInRetryResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutNoHeaderInRetryPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutNoHeaderInRetryResponse, error) {
+	result := LROsClientPutNoHeaderInRetryResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutNoHeaderInRetryPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutNoHeaderInRetryPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutNoHeaderInRetryPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutNoHeaderInRetryResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutNoHeaderInRetry", token, client.pl); err != nil {
+		return LROsClientPutNoHeaderInRetryResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutNonResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -3174,36 +4186,51 @@ func (p *LROsClientPutNonResourcePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutNonResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutNonResourcePoller) Poll(ctx context.Context) (LROsClientPutNonResourceResponse, error) {
+	result := LROsClientPutNonResourceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SKU)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutNonResourceResponse will be returned.
-func (p *LROsClientPutNonResourcePoller) FinalResponse(ctx context.Context) (LROsClientPutNonResourceResponse, error) {
-	respType := LROsClientPutNonResourceResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SKU)
-	if err != nil {
-		return LROsClientPutNonResourceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutNonResourcePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutNonResourceResponse, error) {
+	result := LROsClientPutNonResourceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SKU)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutNonResourcePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutNonResourcePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutNonResourcePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutNonResourceResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutNonResource", token, client.pl); err != nil {
+		return LROsClientPutNonResourceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsClientPutSubResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -3216,36 +4243,51 @@ func (p *LROsClientPutSubResourcePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsClientPutSubResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsClientPutSubResourcePoller) Poll(ctx context.Context) (LROsClientPutSubResourceResponse, error) {
+	result := LROsClientPutSubResourceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SubProduct)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsClientPutSubResourceResponse will be returned.
-func (p *LROsClientPutSubResourcePoller) FinalResponse(ctx context.Context) (LROsClientPutSubResourceResponse, error) {
-	respType := LROsClientPutSubResourceResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SubProduct)
-	if err != nil {
-		return LROsClientPutSubResourceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPutSubResourcePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutSubResourceResponse, error) {
+	result := LROsClientPutSubResourceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SubProduct)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsClientPutSubResourcePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPutSubResourcePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPutSubResourcePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutSubResourceResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutSubResource", token, client.pl); err != nil {
+		return LROsClientPutSubResourceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsCustomHeaderClientPost202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -3258,36 +4300,51 @@ func (p *LROsCustomHeaderClientPost202Retry200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsCustomHeaderClientPost202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsCustomHeaderClientPost202Retry200Poller) Poll(ctx context.Context) (LROsCustomHeaderClientPost202Retry200Response, error) {
+	result := LROsCustomHeaderClientPost202Retry200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsCustomHeaderClientPost202Retry200Response will be returned.
-func (p *LROsCustomHeaderClientPost202Retry200Poller) FinalResponse(ctx context.Context) (LROsCustomHeaderClientPost202Retry200Response, error) {
-	respType := LROsCustomHeaderClientPost202Retry200Response{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsCustomHeaderClientPost202Retry200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsCustomHeaderClientPost202Retry200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPost202Retry200Response, error) {
+	result := LROsCustomHeaderClientPost202Retry200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsCustomHeaderClientPost202Retry200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsCustomHeaderClientPost202Retry200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsCustomHeaderClientPost202Retry200Poller) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) (LROsCustomHeaderClientPost202Retry200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.Post202Retry200", token, client.pl); err != nil {
+		return LROsCustomHeaderClientPost202Retry200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsCustomHeaderClientPostAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -3300,36 +4357,51 @@ func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
+	result := LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsCustomHeaderClientPostAsyncRetrySucceededResponse will be returned.
-func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
-	respType := LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
+	result := LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsCustomHeaderClientPostAsyncRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.PostAsyncRetrySucceeded", token, client.pl); err != nil {
+		return LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsCustomHeaderClientPut201CreatingSucceeded200Poller provides polling facilities until the operation reaches a terminal state.
@@ -3342,36 +4414,51 @@ func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
+	result := LROsCustomHeaderClientPut201CreatingSucceeded200Response{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsCustomHeaderClientPut201CreatingSucceeded200Response will be returned.
-func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) FinalResponse(ctx context.Context) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
-	respType := LROsCustomHeaderClientPut201CreatingSucceeded200Response{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsCustomHeaderClientPut201CreatingSucceeded200Response{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
+	result := LROsCustomHeaderClientPut201CreatingSucceeded200Response{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsCustomHeaderClientPut201CreatingSucceeded200Poller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.Put201CreatingSucceeded200", token, client.pl); err != nil {
+		return LROsCustomHeaderClientPut201CreatingSucceeded200Response{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LROsCustomHeaderClientPutAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -3384,34 +4471,49 @@ func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
+	result := LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LROsCustomHeaderClientPutAsyncRetrySucceededResponse will be returned.
-func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) FinalResponse(ctx context.Context) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
-	respType := LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Product)
-	if err != nil {
-		return LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
+	result := LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsCustomHeaderClientPutAsyncRetrySucceededPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.PutAsyncRetrySucceeded", token, client.pl); err != nil {
+		return LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}, err
+	}
+	return p.Poll(ctx)
 }

--- a/test/autorest/lrogroup/zz_generated_pollers.go
+++ b/test/autorest/lrogroup/zz_generated_pollers.go
@@ -2637,6 +2637,120 @@ func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Resume(ctx context.Cont
 	return p.Poll(ctx)
 }
 
+// LROsClientPatch201RetryWithAsyncHeaderPoller provides polling facilities until the operation reaches a terminal state.
+type LROsClientPatch201RetryWithAsyncHeaderPoller struct {
+	pt *azcore.Poller
+}
+
+// Done returns true if the LRO has reached a terminal state.
+func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Done() bool {
+	return p.pt.Done()
+}
+
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
+// response is returned.
+// If the LRO has completed with failure or was cancelled, the poller's state is
+// updated and the error is returned.
+// If the LRO has not reached a terminal state, the poller's state is updated and
+// a zero-value response is returned.
+// If Poll fails, the poller's state is unmodified and the error is returned.
+// Calling Poll on an LRO that has reached a terminal state will return the final
+// response or error.
+func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Poll(ctx context.Context) (LROsClientPatch201RetryWithAsyncHeaderResponse, error) {
+	result := LROsClientPatch201RetryWithAsyncHeaderResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
+}
+
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPatch201RetryWithAsyncHeaderResponse, error) {
+	result := LROsClientPatch201RetryWithAsyncHeaderResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
+}
+
+// ResumeToken returns a value representing the poller that can be used to resume
+// the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
+func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPatch201RetryWithAsyncHeaderPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPatch201RetryWithAsyncHeaderResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch201RetryWithAsyncHeader", token, client.pl); err != nil {
+		return LROsClientPatch201RetryWithAsyncHeaderResponse{}, err
+	}
+	return p.Poll(ctx)
+}
+
+// LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller provides polling facilities until the operation reaches a terminal state.
+type LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller struct {
+	pt *azcore.Poller
+}
+
+// Done returns true if the LRO has reached a terminal state.
+func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Done() bool {
+	return p.pt.Done()
+}
+
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
+// response is returned.
+// If the LRO has completed with failure or was cancelled, the poller's state is
+// updated and the error is returned.
+// If the LRO has not reached a terminal state, the poller's state is updated and
+// a zero-value response is returned.
+// If Poll fails, the poller's state is unmodified and the error is returned.
+// Calling Poll on an LRO that has reached a terminal state will return the final
+// response or error.
+func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Poll(ctx context.Context) (LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse, error) {
+	result := LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Product)
+	return result, err
+}
+
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse, error) {
+	result := LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Product)
+	return result, err
+}
+
+// ResumeToken returns a value representing the poller that can be used to resume
+// the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
+func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch202RetryWithAsyncAndLocationHeader", token, client.pl); err != nil {
+		return LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse{}, err
+	}
+	return p.Poll(ctx)
+}
+
 // LROsClientPost200WithPayloadPoller provides polling facilities until the operation reaches a terminal state.
 type LROsClientPost200WithPayloadPoller struct {
 	pt *azcore.Poller

--- a/test/autorest/lrogroup/zz_generated_pollers.go
+++ b/test/autorest/lrogroup/zz_generated_pollers.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"net/http"
 	"time"
 )
 
@@ -31,20 +32,19 @@ func (p *LRORetrysClientDelete202Retry200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LRORetrysClientDelete202Retry200Poller) Poll(ctx context.Context) (LRORetrysClientDelete202Retry200Response, error) {
-	result := LRORetrysClientDelete202Retry200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LRORetrysClientDelete202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LRORetrysClientDelete202Retry200Poller) Result(ctx context.Context) (resp LRORetrysClientDelete202Retry200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -64,12 +64,9 @@ func (p *LRORetrysClientDelete202Retry200Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LRORetrysClientDelete202Retry200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LRORetrysClientDelete202Retry200Poller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientDelete202Retry200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Delete202Retry200", token, client.pl); err != nil {
-		return LRORetrysClientDelete202Retry200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LRORetrysClientDelete202Retry200Poller) Resume(token string, client *LRORetrysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Delete202Retry200", token, client.pl)
+	return
 }
 
 // LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -88,20 +85,19 @@ func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
-	result := LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Result(ctx context.Context) (resp LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -121,12 +117,9 @@ func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) ResumeToken() (
 
 // Resume rehydrates a LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.DeleteAsyncRelativeRetrySucceeded", token, client.pl); err != nil {
-		return LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller) Resume(token string, client *LRORetrysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.DeleteAsyncRelativeRetrySucceeded", token, client.pl)
+	return
 }
 
 // LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -145,20 +138,19 @@ func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Done() 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
-	result := LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Result(ctx context.Context) (resp LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -178,12 +170,9 @@ func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) ResumeT
 
 // Resume rehydrates a LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.DeleteProvisioning202Accepted200Succeeded", token, client.pl); err != nil {
-		return LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller) Resume(token string, client *LRORetrysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.DeleteProvisioning202Accepted200Succeeded", token, client.pl)
+	return
 }
 
 // LRORetrysClientPost202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -202,20 +191,19 @@ func (p *LRORetrysClientPost202Retry200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LRORetrysClientPost202Retry200Poller) Poll(ctx context.Context) (LRORetrysClientPost202Retry200Response, error) {
-	result := LRORetrysClientPost202Retry200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LRORetrysClientPost202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LRORetrysClientPost202Retry200Poller) Result(ctx context.Context) (resp LRORetrysClientPost202Retry200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -235,12 +223,9 @@ func (p *LRORetrysClientPost202Retry200Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LRORetrysClientPost202Retry200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LRORetrysClientPost202Retry200Poller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientPost202Retry200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Post202Retry200", token, client.pl); err != nil {
-		return LRORetrysClientPost202Retry200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LRORetrysClientPost202Retry200Poller) Resume(token string, client *LRORetrysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Post202Retry200", token, client.pl)
+	return
 }
 
 // LRORetrysClientPostAsyncRelativeRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -259,20 +244,19 @@ func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
-	result := LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Result(ctx context.Context) (resp LRORetrysClientPostAsyncRelativeRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -292,12 +276,9 @@ func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) ResumeToken() (st
 
 // Resume rehydrates a LRORetrysClientPostAsyncRelativeRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.PostAsyncRelativeRetrySucceeded", token, client.pl); err != nil {
-		return LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LRORetrysClientPostAsyncRelativeRetrySucceededPoller) Resume(token string, client *LRORetrysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.PostAsyncRelativeRetrySucceeded", token, client.pl)
+	return
 }
 
 // LRORetrysClientPut201CreatingSucceeded200Poller provides polling facilities until the operation reaches a terminal state.
@@ -316,20 +297,19 @@ func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
-	result := LRORetrysClientPut201CreatingSucceeded200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Result(ctx context.Context) (resp LRORetrysClientPut201CreatingSucceeded200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -349,12 +329,9 @@ func (p *LRORetrysClientPut201CreatingSucceeded200Poller) ResumeToken() (string,
 
 // Resume rehydrates a LRORetrysClientPut201CreatingSucceeded200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Put201CreatingSucceeded200", token, client.pl); err != nil {
-		return LRORetrysClientPut201CreatingSucceeded200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LRORetrysClientPut201CreatingSucceeded200Poller) Resume(token string, client *LRORetrysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.Put201CreatingSucceeded200", token, client.pl)
+	return
 }
 
 // LRORetrysClientPutAsyncRelativeRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -373,20 +350,19 @@ func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
-	result := LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Result(ctx context.Context) (resp LRORetrysClientPutAsyncRelativeRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -406,12 +382,9 @@ func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) ResumeToken() (str
 
 // Resume rehydrates a LRORetrysClientPutAsyncRelativeRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Resume(ctx context.Context, client *LRORetrysClient, token string) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.PutAsyncRelativeRetrySucceeded", token, client.pl); err != nil {
-		return LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LRORetrysClientPutAsyncRelativeRetrySucceededPoller) Resume(token string, client *LRORetrysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LRORetrysClient.PutAsyncRelativeRetrySucceeded", token, client.pl)
+	return
 }
 
 // LROSADsClientDelete202NonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -430,20 +403,19 @@ func (p *LROSADsClientDelete202NonRetry400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientDelete202NonRetry400Poller) Poll(ctx context.Context) (LROSADsClientDelete202NonRetry400Response, error) {
-	result := LROSADsClientDelete202NonRetry400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientDelete202NonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientDelete202NonRetry400Poller) Result(ctx context.Context) (resp LROSADsClientDelete202NonRetry400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -463,12 +435,9 @@ func (p *LROSADsClientDelete202NonRetry400Poller) ResumeToken() (string, error) 
 
 // Resume rehydrates a LROSADsClientDelete202NonRetry400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientDelete202NonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDelete202NonRetry400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete202NonRetry400", token, client.pl); err != nil {
-		return LROSADsClientDelete202NonRetry400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientDelete202NonRetry400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete202NonRetry400", token, client.pl)
+	return
 }
 
 // LROSADsClientDelete202RetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -487,20 +456,19 @@ func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
-	result := LROSADsClientDelete202RetryInvalidHeaderResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Result(ctx context.Context) (resp LROSADsClientDelete202RetryInvalidHeaderResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -520,12 +488,9 @@ func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) ResumeToken() (string, 
 
 // Resume rehydrates a LROSADsClientDelete202RetryInvalidHeaderPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete202RetryInvalidHeader", token, client.pl); err != nil {
-		return LROSADsClientDelete202RetryInvalidHeaderResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientDelete202RetryInvalidHeaderPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete202RetryInvalidHeader", token, client.pl)
+	return
 }
 
 // LROSADsClientDelete204SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -544,20 +509,19 @@ func (p *LROSADsClientDelete204SucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientDelete204SucceededPoller) Poll(ctx context.Context) (LROSADsClientDelete204SucceededResponse, error) {
-	result := LROSADsClientDelete204SucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientDelete204SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientDelete204SucceededPoller) Result(ctx context.Context) (resp LROSADsClientDelete204SucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -577,12 +541,9 @@ func (p *LROSADsClientDelete204SucceededPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROSADsClientDelete204SucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientDelete204SucceededPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDelete204SucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete204Succeeded", token, client.pl); err != nil {
-		return LROSADsClientDelete204SucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientDelete204SucceededPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Delete204Succeeded", token, client.pl)
+	return
 }
 
 // LROSADsClientDeleteAsyncRelativeRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -601,20 +562,19 @@ func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Poll(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
-	result := LROSADsClientDeleteAsyncRelativeRetry400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Result(ctx context.Context) (resp LROSADsClientDeleteAsyncRelativeRetry400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -634,12 +594,9 @@ func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) ResumeToken() (string, 
 
 // Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetry400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetry400", token, client.pl); err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetry400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientDeleteAsyncRelativeRetry400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetry400", token, client.pl)
+	return
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -658,20 +615,19 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
-	result := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Result(ctx context.Context) (resp LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -691,12 +647,9 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) ResumeToken()
 
 // Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader", token, client.pl); err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader", token, client.pl)
+	return
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller provides polling facilities until the operation reaches a terminal state.
@@ -715,20 +668,19 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Done() b
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	result := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Result(ctx context.Context) (resp LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -748,12 +700,9 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) ResumeTo
 
 // Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling", token, client.pl); err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling", token, client.pl)
+	return
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -772,20 +721,19 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
-	result := LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Result(ctx context.Context) (resp LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -805,12 +753,9 @@ func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) ResumeToken() (str
 
 // Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryNoStatus", token, client.pl); err != nil {
-		return LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryNoStatus", token, client.pl)
+	return
 }
 
 // LROSADsClientDeleteNonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -829,20 +774,19 @@ func (p *LROSADsClientDeleteNonRetry400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientDeleteNonRetry400Poller) Poll(ctx context.Context) (LROSADsClientDeleteNonRetry400Response, error) {
-	result := LROSADsClientDeleteNonRetry400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientDeleteNonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientDeleteNonRetry400Poller) Result(ctx context.Context) (resp LROSADsClientDeleteNonRetry400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -862,12 +806,9 @@ func (p *LROSADsClientDeleteNonRetry400Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROSADsClientDeleteNonRetry400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientDeleteNonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientDeleteNonRetry400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteNonRetry400", token, client.pl); err != nil {
-		return LROSADsClientDeleteNonRetry400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientDeleteNonRetry400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteNonRetry400", token, client.pl)
+	return
 }
 
 // LROSADsClientPost202NoLocationPoller provides polling facilities until the operation reaches a terminal state.
@@ -886,20 +827,19 @@ func (p *LROSADsClientPost202NoLocationPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPost202NoLocationPoller) Poll(ctx context.Context) (LROSADsClientPost202NoLocationResponse, error) {
-	result := LROSADsClientPost202NoLocationResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientPost202NoLocationPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPost202NoLocationPoller) Result(ctx context.Context) (resp LROSADsClientPost202NoLocationResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -919,12 +859,9 @@ func (p *LROSADsClientPost202NoLocationPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROSADsClientPost202NoLocationPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPost202NoLocationPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPost202NoLocationResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202NoLocation", token, client.pl); err != nil {
-		return LROSADsClientPost202NoLocationResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPost202NoLocationPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202NoLocation", token, client.pl)
+	return
 }
 
 // LROSADsClientPost202NonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -943,20 +880,19 @@ func (p *LROSADsClientPost202NonRetry400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPost202NonRetry400Poller) Poll(ctx context.Context) (LROSADsClientPost202NonRetry400Response, error) {
-	result := LROSADsClientPost202NonRetry400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientPost202NonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPost202NonRetry400Poller) Result(ctx context.Context) (resp LROSADsClientPost202NonRetry400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -976,12 +912,9 @@ func (p *LROSADsClientPost202NonRetry400Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROSADsClientPost202NonRetry400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPost202NonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPost202NonRetry400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202NonRetry400", token, client.pl); err != nil {
-		return LROSADsClientPost202NonRetry400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPost202NonRetry400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202NonRetry400", token, client.pl)
+	return
 }
 
 // LROSADsClientPost202RetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -1000,20 +933,19 @@ func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
-	result := LROSADsClientPost202RetryInvalidHeaderResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Result(ctx context.Context) (resp LROSADsClientPost202RetryInvalidHeaderResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1033,12 +965,9 @@ func (p *LROSADsClientPost202RetryInvalidHeaderPoller) ResumeToken() (string, er
 
 // Resume rehydrates a LROSADsClientPost202RetryInvalidHeaderPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202RetryInvalidHeader", token, client.pl); err != nil {
-		return LROSADsClientPost202RetryInvalidHeaderResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPost202RetryInvalidHeaderPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Post202RetryInvalidHeader", token, client.pl)
+	return
 }
 
 // LROSADsClientPostAsyncRelativeRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -1057,20 +986,19 @@ func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Poll(ctx context.Context) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
-	result := LROSADsClientPostAsyncRelativeRetry400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Result(ctx context.Context) (resp LROSADsClientPostAsyncRelativeRetry400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1090,12 +1018,9 @@ func (p *LROSADsClientPostAsyncRelativeRetry400Poller) ResumeToken() (string, er
 
 // Resume rehydrates a LROSADsClientPostAsyncRelativeRetry400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetry400", token, client.pl); err != nil {
-		return LROSADsClientPostAsyncRelativeRetry400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPostAsyncRelativeRetry400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetry400", token, client.pl)
+	return
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -1114,20 +1039,19 @@ func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
-	result := LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Result(ctx context.Context) (resp LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1147,12 +1071,9 @@ func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) ResumeToken() (
 
 // Resume rehydrates a LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidHeader", token, client.pl); err != nil {
-		return LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidHeader", token, client.pl)
+	return
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller provides polling facilities until the operation reaches a terminal state.
@@ -1171,20 +1092,19 @@ func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Done() boo
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	result := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Result(ctx context.Context) (resp LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1204,12 +1124,9 @@ func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) ResumeToke
 
 // Resume rehydrates a LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling", token, client.pl); err != nil {
-		return LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling", token, client.pl)
+	return
 }
 
 // LROSADsClientPostAsyncRelativeRetryNoPayloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -1228,20 +1145,19 @@ func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Poll(ctx context.Context) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
-	result := LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Result(ctx context.Context) (resp LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1261,12 +1177,9 @@ func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) ResumeToken() (stri
 
 // Resume rehydrates a LROSADsClientPostAsyncRelativeRetryNoPayloadPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryNoPayload", token, client.pl); err != nil {
-		return LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryNoPayload", token, client.pl)
+	return
 }
 
 // LROSADsClientPostNonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -1285,20 +1198,19 @@ func (p *LROSADsClientPostNonRetry400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPostNonRetry400Poller) Poll(ctx context.Context) (LROSADsClientPostNonRetry400Response, error) {
-	result := LROSADsClientPostNonRetry400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROSADsClientPostNonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPostNonRetry400Poller) Result(ctx context.Context) (resp LROSADsClientPostNonRetry400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1318,12 +1230,9 @@ func (p *LROSADsClientPostNonRetry400Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROSADsClientPostNonRetry400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPostNonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPostNonRetry400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostNonRetry400", token, client.pl); err != nil {
-		return LROSADsClientPostNonRetry400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPostNonRetry400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PostNonRetry400", token, client.pl)
+	return
 }
 
 // LROSADsClientPut200InvalidJSONPoller provides polling facilities until the operation reaches a terminal state.
@@ -1342,20 +1251,19 @@ func (p *LROSADsClientPut200InvalidJSONPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPut200InvalidJSONPoller) Poll(ctx context.Context) (LROSADsClientPut200InvalidJSONResponse, error) {
-	result := LROSADsClientPut200InvalidJSONResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPut200InvalidJSONPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPut200InvalidJSONPoller) Result(ctx context.Context) (resp LROSADsClientPut200InvalidJSONResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1375,12 +1283,9 @@ func (p *LROSADsClientPut200InvalidJSONPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROSADsClientPut200InvalidJSONPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPut200InvalidJSONPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPut200InvalidJSONResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Put200InvalidJSON", token, client.pl); err != nil {
-		return LROSADsClientPut200InvalidJSONResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPut200InvalidJSONPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.Put200InvalidJSON", token, client.pl)
+	return
 }
 
 // LROSADsClientPutAsyncRelativeRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -1399,20 +1304,19 @@ func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
-	result := LROSADsClientPutAsyncRelativeRetry400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Result(ctx context.Context) (resp LROSADsClientPutAsyncRelativeRetry400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1432,12 +1336,9 @@ func (p *LROSADsClientPutAsyncRelativeRetry400Poller) ResumeToken() (string, err
 
 // Resume rehydrates a LROSADsClientPutAsyncRelativeRetry400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetry400", token, client.pl); err != nil {
-		return LROSADsClientPutAsyncRelativeRetry400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutAsyncRelativeRetry400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetry400", token, client.pl)
+	return
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -1456,20 +1357,19 @@ func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
-	result := LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Result(ctx context.Context) (resp LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1489,12 +1389,9 @@ func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) ResumeToken() (s
 
 // Resume rehydrates a LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidHeader", token, client.pl); err != nil {
-		return LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidHeader", token, client.pl)
+	return
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller provides polling facilities until the operation reaches a terminal state.
@@ -1513,20 +1410,19 @@ func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Done() bool
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	result := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Result(ctx context.Context) (resp LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1546,12 +1442,9 @@ func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) ResumeToken
 
 // Resume rehydrates a LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling", token, client.pl); err != nil {
-		return LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling", token, client.pl)
+	return
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -1570,20 +1463,19 @@ func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
-	result := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Result(ctx context.Context) (resp LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1603,12 +1495,9 @@ func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) ResumeToken() 
 
 // Resume rehydrates a LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatusPayload", token, client.pl); err != nil {
-		return LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatusPayload", token, client.pl)
+	return
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -1627,20 +1516,19 @@ func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
-	result := LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Result(ctx context.Context) (resp LROSADsClientPutAsyncRelativeRetryNoStatusResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1660,12 +1548,9 @@ func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) ResumeToken() (string
 
 // Resume rehydrates a LROSADsClientPutAsyncRelativeRetryNoStatusPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatus", token, client.pl); err != nil {
-		return LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutAsyncRelativeRetryNoStatusPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatus", token, client.pl)
+	return
 }
 
 // LROSADsClientPutError201NoProvisioningStatePayloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -1684,20 +1569,19 @@ func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Poll(ctx context.Context) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
-	result := LROSADsClientPutError201NoProvisioningStatePayloadResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Result(ctx context.Context) (resp LROSADsClientPutError201NoProvisioningStatePayloadResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1717,12 +1601,9 @@ func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) ResumeToken()
 
 // Resume rehydrates a LROSADsClientPutError201NoProvisioningStatePayloadPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutError201NoProvisioningStatePayload", token, client.pl); err != nil {
-		return LROSADsClientPutError201NoProvisioningStatePayloadResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutError201NoProvisioningStatePayloadPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutError201NoProvisioningStatePayload", token, client.pl)
+	return
 }
 
 // LROSADsClientPutNonRetry201Creating400InvalidJSONPoller provides polling facilities until the operation reaches a terminal state.
@@ -1741,20 +1622,19 @@ func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Poll(ctx context.Context) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
-	result := LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Result(ctx context.Context) (resp LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1774,12 +1654,9 @@ func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) ResumeToken() 
 
 // Resume rehydrates a LROSADsClientPutNonRetry201Creating400InvalidJSONPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400InvalidJSON", token, client.pl); err != nil {
-		return LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400InvalidJSON", token, client.pl)
+	return
 }
 
 // LROSADsClientPutNonRetry201Creating400Poller provides polling facilities until the operation reaches a terminal state.
@@ -1798,20 +1675,19 @@ func (p *LROSADsClientPutNonRetry201Creating400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutNonRetry201Creating400Poller) Poll(ctx context.Context) (LROSADsClientPutNonRetry201Creating400Response, error) {
-	result := LROSADsClientPutNonRetry201Creating400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutNonRetry201Creating400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutNonRetry201Creating400Poller) Result(ctx context.Context) (resp LROSADsClientPutNonRetry201Creating400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1831,12 +1707,9 @@ func (p *LROSADsClientPutNonRetry201Creating400Poller) ResumeToken() (string, er
 
 // Resume rehydrates a LROSADsClientPutNonRetry201Creating400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutNonRetry201Creating400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutNonRetry201Creating400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400", token, client.pl); err != nil {
-		return LROSADsClientPutNonRetry201Creating400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutNonRetry201Creating400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400", token, client.pl)
+	return
 }
 
 // LROSADsClientPutNonRetry400Poller provides polling facilities until the operation reaches a terminal state.
@@ -1855,20 +1728,19 @@ func (p *LROSADsClientPutNonRetry400Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROSADsClientPutNonRetry400Poller) Poll(ctx context.Context) (LROSADsClientPutNonRetry400Response, error) {
-	result := LROSADsClientPutNonRetry400Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROSADsClientPutNonRetry400Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROSADsClientPutNonRetry400Poller) Result(ctx context.Context) (resp LROSADsClientPutNonRetry400Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1888,12 +1760,9 @@ func (p *LROSADsClientPutNonRetry400Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROSADsClientPutNonRetry400Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROSADsClientPutNonRetry400Poller) Resume(ctx context.Context, client *LROSADsClient, token string) (LROSADsClientPutNonRetry400Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry400", token, client.pl); err != nil {
-		return LROSADsClientPutNonRetry400Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROSADsClientPutNonRetry400Poller) Resume(token string, client *LROSADsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry400", token, client.pl)
+	return
 }
 
 // LROsClientDelete202NoRetry204Poller provides polling facilities until the operation reaches a terminal state.
@@ -1912,20 +1781,19 @@ func (p *LROsClientDelete202NoRetry204Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDelete202NoRetry204Poller) Poll(ctx context.Context) (LROsClientDelete202NoRetry204Response, error) {
-	result := LROsClientDelete202NoRetry204Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientDelete202NoRetry204Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDelete202NoRetry204Poller) Result(ctx context.Context) (resp LROsClientDelete202NoRetry204Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1945,12 +1813,9 @@ func (p *LROsClientDelete202NoRetry204Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientDelete202NoRetry204Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDelete202NoRetry204Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDelete202NoRetry204Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete202NoRetry204", token, client.pl); err != nil {
-		return LROsClientDelete202NoRetry204Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDelete202NoRetry204Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete202NoRetry204", token, client.pl)
+	return
 }
 
 // LROsClientDelete202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -1969,20 +1834,19 @@ func (p *LROsClientDelete202Retry200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDelete202Retry200Poller) Poll(ctx context.Context) (LROsClientDelete202Retry200Response, error) {
-	result := LROsClientDelete202Retry200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientDelete202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDelete202Retry200Poller) Result(ctx context.Context) (resp LROsClientDelete202Retry200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2002,12 +1866,9 @@ func (p *LROsClientDelete202Retry200Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientDelete202Retry200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDelete202Retry200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDelete202Retry200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete202Retry200", token, client.pl); err != nil {
-		return LROsClientDelete202Retry200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDelete202Retry200Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete202Retry200", token, client.pl)
+	return
 }
 
 // LROsClientDelete204SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2026,20 +1887,19 @@ func (p *LROsClientDelete204SucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDelete204SucceededPoller) Poll(ctx context.Context) (LROsClientDelete204SucceededResponse, error) {
-	result := LROsClientDelete204SucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientDelete204SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDelete204SucceededPoller) Result(ctx context.Context) (resp LROsClientDelete204SucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2059,12 +1919,9 @@ func (p *LROsClientDelete204SucceededPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientDelete204SucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDelete204SucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDelete204SucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete204Succeeded", token, client.pl); err != nil {
-		return LROsClientDelete204SucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDelete204SucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Delete204Succeeded", token, client.pl)
+	return
 }
 
 // LROsClientDeleteAsyncNoHeaderInRetryPoller provides polling facilities until the operation reaches a terminal state.
@@ -2083,20 +1940,19 @@ func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
-	result := LROsClientDeleteAsyncNoHeaderInRetryResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Result(ctx context.Context) (resp LROsClientDeleteAsyncNoHeaderInRetryResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2116,12 +1972,9 @@ func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) ResumeToken() (string, erro
 
 // Resume rehydrates a LROsClientDeleteAsyncNoHeaderInRetryPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoHeaderInRetry", token, client.pl); err != nil {
-		return LROsClientDeleteAsyncNoHeaderInRetryResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteAsyncNoHeaderInRetryPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoHeaderInRetry", token, client.pl)
+	return
 }
 
 // LROsClientDeleteAsyncNoRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2140,20 +1993,19 @@ func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
-	result := LROsClientDeleteAsyncNoRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Result(ctx context.Context) (resp LROsClientDeleteAsyncNoRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2173,12 +2025,9 @@ func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) ResumeToken() (string, err
 
 // Resume rehydrates a LROsClientDeleteAsyncNoRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoRetrySucceeded", token, client.pl); err != nil {
-		return LROsClientDeleteAsyncNoRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteAsyncNoRetrySucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoRetrySucceeded", token, client.pl)
+	return
 }
 
 // LROsClientDeleteAsyncRetryFailedPoller provides polling facilities until the operation reaches a terminal state.
@@ -2197,20 +2046,19 @@ func (p *LROsClientDeleteAsyncRetryFailedPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteAsyncRetryFailedPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncRetryFailedResponse, error) {
-	result := LROsClientDeleteAsyncRetryFailedResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientDeleteAsyncRetryFailedPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteAsyncRetryFailedPoller) Result(ctx context.Context) (resp LROsClientDeleteAsyncRetryFailedResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2230,12 +2078,9 @@ func (p *LROsClientDeleteAsyncRetryFailedPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientDeleteAsyncRetryFailedPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteAsyncRetryFailedPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncRetryFailedResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetryFailed", token, client.pl); err != nil {
-		return LROsClientDeleteAsyncRetryFailedResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteAsyncRetryFailedPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetryFailed", token, client.pl)
+	return
 }
 
 // LROsClientDeleteAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2254,20 +2099,19 @@ func (p *LROsClientDeleteAsyncRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
-	result := LROsClientDeleteAsyncRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientDeleteAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteAsyncRetrySucceededPoller) Result(ctx context.Context) (resp LROsClientDeleteAsyncRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2287,12 +2131,9 @@ func (p *LROsClientDeleteAsyncRetrySucceededPoller) ResumeToken() (string, error
 
 // Resume rehydrates a LROsClientDeleteAsyncRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrySucceeded", token, client.pl); err != nil {
-		return LROsClientDeleteAsyncRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteAsyncRetrySucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrySucceeded", token, client.pl)
+	return
 }
 
 // LROsClientDeleteAsyncRetrycanceledPoller provides polling facilities until the operation reaches a terminal state.
@@ -2311,20 +2152,19 @@ func (p *LROsClientDeleteAsyncRetrycanceledPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteAsyncRetrycanceledPoller) Poll(ctx context.Context) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
-	result := LROsClientDeleteAsyncRetrycanceledResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientDeleteAsyncRetrycanceledPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteAsyncRetrycanceledPoller) Result(ctx context.Context) (resp LROsClientDeleteAsyncRetrycanceledResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2344,12 +2184,9 @@ func (p *LROsClientDeleteAsyncRetrycanceledPoller) ResumeToken() (string, error)
 
 // Resume rehydrates a LROsClientDeleteAsyncRetrycanceledPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteAsyncRetrycanceledPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrycanceled", token, client.pl); err != nil {
-		return LROsClientDeleteAsyncRetrycanceledResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteAsyncRetrycanceledPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrycanceled", token, client.pl)
+	return
 }
 
 // LROsClientDeleteNoHeaderInRetryPoller provides polling facilities until the operation reaches a terminal state.
@@ -2368,20 +2205,19 @@ func (p *LROsClientDeleteNoHeaderInRetryPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteNoHeaderInRetryPoller) Poll(ctx context.Context) (LROsClientDeleteNoHeaderInRetryResponse, error) {
-	result := LROsClientDeleteNoHeaderInRetryResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientDeleteNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteNoHeaderInRetryPoller) Result(ctx context.Context) (resp LROsClientDeleteNoHeaderInRetryResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2401,12 +2237,9 @@ func (p *LROsClientDeleteNoHeaderInRetryPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientDeleteNoHeaderInRetryPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteNoHeaderInRetryPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteNoHeaderInRetryResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteNoHeaderInRetry", token, client.pl); err != nil {
-		return LROsClientDeleteNoHeaderInRetryResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteNoHeaderInRetryPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteNoHeaderInRetry", token, client.pl)
+	return
 }
 
 // LROsClientDeleteProvisioning202Accepted200SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2425,20 +2258,19 @@ func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Done() bool 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
-	result := LROsClientDeleteProvisioning202Accepted200SucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Result(ctx context.Context) (resp LROsClientDeleteProvisioning202Accepted200SucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2458,12 +2290,9 @@ func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) ResumeToken(
 
 // Resume rehydrates a LROsClientDeleteProvisioning202Accepted200SucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Accepted200Succeeded", token, client.pl); err != nil {
-		return LROsClientDeleteProvisioning202Accepted200SucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteProvisioning202Accepted200SucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Accepted200Succeeded", token, client.pl)
+	return
 }
 
 // LROsClientDeleteProvisioning202DeletingFailed200Poller provides polling facilities until the operation reaches a terminal state.
@@ -2482,20 +2311,19 @@ func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Poll(ctx context.Context) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
-	result := LROsClientDeleteProvisioning202DeletingFailed200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Result(ctx context.Context) (resp LROsClientDeleteProvisioning202DeletingFailed200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2515,12 +2343,9 @@ func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) ResumeToken() (
 
 // Resume rehydrates a LROsClientDeleteProvisioning202DeletingFailed200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202DeletingFailed200", token, client.pl); err != nil {
-		return LROsClientDeleteProvisioning202DeletingFailed200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteProvisioning202DeletingFailed200Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202DeletingFailed200", token, client.pl)
+	return
 }
 
 // LROsClientDeleteProvisioning202Deletingcanceled200Poller provides polling facilities until the operation reaches a terminal state.
@@ -2539,20 +2364,19 @@ func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Poll(ctx context.Context) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
-	result := LROsClientDeleteProvisioning202Deletingcanceled200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Result(ctx context.Context) (resp LROsClientDeleteProvisioning202Deletingcanceled200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2572,12 +2396,9 @@ func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) ResumeToken()
 
 // Resume rehydrates a LROsClientDeleteProvisioning202Deletingcanceled200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Deletingcanceled200", token, client.pl); err != nil {
-		return LROsClientDeleteProvisioning202Deletingcanceled200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientDeleteProvisioning202Deletingcanceled200Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Deletingcanceled200", token, client.pl)
+	return
 }
 
 // LROsClientPatch200SucceededIgnoreHeadersPoller provides polling facilities until the operation reaches a terminal state.
@@ -2596,20 +2417,19 @@ func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Poll(ctx context.Context) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
-	result := LROsClientPatch200SucceededIgnoreHeadersResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Result(ctx context.Context) (resp LROsClientPatch200SucceededIgnoreHeadersResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2629,12 +2449,9 @@ func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) ResumeToken() (string, 
 
 // Resume rehydrates a LROsClientPatch200SucceededIgnoreHeadersPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch200SucceededIgnoreHeaders", token, client.pl); err != nil {
-		return LROsClientPatch200SucceededIgnoreHeadersResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPatch200SucceededIgnoreHeadersPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch200SucceededIgnoreHeaders", token, client.pl)
+	return
 }
 
 // LROsClientPatch201RetryWithAsyncHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -2653,20 +2470,19 @@ func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Poll(ctx context.Context) (LROsClientPatch201RetryWithAsyncHeaderResponse, error) {
-	result := LROsClientPatch201RetryWithAsyncHeaderResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Result(ctx context.Context) (resp LROsClientPatch201RetryWithAsyncHeaderResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2686,12 +2502,9 @@ func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) ResumeToken() (string, er
 
 // Resume rehydrates a LROsClientPatch201RetryWithAsyncHeaderPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPatch201RetryWithAsyncHeaderResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch201RetryWithAsyncHeader", token, client.pl); err != nil {
-		return LROsClientPatch201RetryWithAsyncHeaderResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPatch201RetryWithAsyncHeaderPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch201RetryWithAsyncHeader", token, client.pl)
+	return
 }
 
 // LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller provides polling facilities until the operation reaches a terminal state.
@@ -2710,20 +2523,19 @@ func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Poll(ctx context.Context) (LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse, error) {
-	result := LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Result(ctx context.Context) (resp LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2743,12 +2555,9 @@ func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) ResumeToken() 
 
 // Resume rehydrates a LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch202RetryWithAsyncAndLocationHeader", token, client.pl); err != nil {
-		return LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Patch202RetryWithAsyncAndLocationHeader", token, client.pl)
+	return
 }
 
 // LROsClientPost200WithPayloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -2767,20 +2576,19 @@ func (p *LROsClientPost200WithPayloadPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPost200WithPayloadPoller) Poll(ctx context.Context) (LROsClientPost200WithPayloadResponse, error) {
-	result := LROsClientPost200WithPayloadResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SKU)
-	return result, err
+func (p *LROsClientPost200WithPayloadPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPost200WithPayloadPoller) Result(ctx context.Context) (resp LROsClientPost200WithPayloadResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2800,12 +2608,9 @@ func (p *LROsClientPost200WithPayloadPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPost200WithPayloadPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPost200WithPayloadPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPost200WithPayloadResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post200WithPayload", token, client.pl); err != nil {
-		return LROsClientPost200WithPayloadResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPost200WithPayloadPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post200WithPayload", token, client.pl)
+	return
 }
 
 // LROsClientPost202ListPoller provides polling facilities until the operation reaches a terminal state.
@@ -2824,20 +2629,19 @@ func (p *LROsClientPost202ListPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPost202ListPoller) Poll(ctx context.Context) (LROsClientPost202ListResponse, error) {
-	result := LROsClientPost202ListResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ProductArray)
-	return result, err
+func (p *LROsClientPost202ListPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPost202ListPoller) Result(ctx context.Context) (resp LROsClientPost202ListResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2857,12 +2661,9 @@ func (p *LROsClientPost202ListPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPost202ListPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPost202ListPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPost202ListResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202List", token, client.pl); err != nil {
-		return LROsClientPost202ListResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPost202ListPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202List", token, client.pl)
+	return
 }
 
 // LROsClientPost202NoRetry204Poller provides polling facilities until the operation reaches a terminal state.
@@ -2881,20 +2682,19 @@ func (p *LROsClientPost202NoRetry204Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPost202NoRetry204Poller) Poll(ctx context.Context) (LROsClientPost202NoRetry204Response, error) {
-	result := LROsClientPost202NoRetry204Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPost202NoRetry204Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPost202NoRetry204Poller) Result(ctx context.Context) (resp LROsClientPost202NoRetry204Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2914,12 +2714,9 @@ func (p *LROsClientPost202NoRetry204Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPost202NoRetry204Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPost202NoRetry204Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPost202NoRetry204Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202NoRetry204", token, client.pl); err != nil {
-		return LROsClientPost202NoRetry204Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPost202NoRetry204Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202NoRetry204", token, client.pl)
+	return
 }
 
 // LROsClientPost202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -2938,20 +2735,19 @@ func (p *LROsClientPost202Retry200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPost202Retry200Poller) Poll(ctx context.Context) (LROsClientPost202Retry200Response, error) {
-	result := LROsClientPost202Retry200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientPost202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPost202Retry200Poller) Result(ctx context.Context) (resp LROsClientPost202Retry200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2971,12 +2767,9 @@ func (p *LROsClientPost202Retry200Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPost202Retry200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPost202Retry200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPost202Retry200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202Retry200", token, client.pl); err != nil {
-		return LROsClientPost202Retry200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPost202Retry200Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Post202Retry200", token, client.pl)
+	return
 }
 
 // LROsClientPostAsyncNoRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -2995,20 +2788,19 @@ func (p *LROsClientPostAsyncNoRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPostAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
-	result := LROsClientPostAsyncNoRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPostAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPostAsyncNoRetrySucceededPoller) Result(ctx context.Context) (resp LROsClientPostAsyncNoRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3028,12 +2820,9 @@ func (p *LROsClientPostAsyncNoRetrySucceededPoller) ResumeToken() (string, error
 
 // Resume rehydrates a LROsClientPostAsyncNoRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPostAsyncNoRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncNoRetrySucceeded", token, client.pl); err != nil {
-		return LROsClientPostAsyncNoRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPostAsyncNoRetrySucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncNoRetrySucceeded", token, client.pl)
+	return
 }
 
 // LROsClientPostAsyncRetryFailedPoller provides polling facilities until the operation reaches a terminal state.
@@ -3052,20 +2841,19 @@ func (p *LROsClientPostAsyncRetryFailedPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPostAsyncRetryFailedPoller) Poll(ctx context.Context) (LROsClientPostAsyncRetryFailedResponse, error) {
-	result := LROsClientPostAsyncRetryFailedResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientPostAsyncRetryFailedPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPostAsyncRetryFailedPoller) Result(ctx context.Context) (resp LROsClientPostAsyncRetryFailedResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3085,12 +2873,9 @@ func (p *LROsClientPostAsyncRetryFailedPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPostAsyncRetryFailedPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPostAsyncRetryFailedPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostAsyncRetryFailedResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetryFailed", token, client.pl); err != nil {
-		return LROsClientPostAsyncRetryFailedResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPostAsyncRetryFailedPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetryFailed", token, client.pl)
+	return
 }
 
 // LROsClientPostAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -3109,20 +2894,19 @@ func (p *LROsClientPostAsyncRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsClientPostAsyncRetrySucceededResponse, error) {
-	result := LROsClientPostAsyncRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPostAsyncRetrySucceededPoller) Result(ctx context.Context) (resp LROsClientPostAsyncRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3142,12 +2926,9 @@ func (p *LROsClientPostAsyncRetrySucceededPoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a LROsClientPostAsyncRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPostAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostAsyncRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetrySucceeded", token, client.pl); err != nil {
-		return LROsClientPostAsyncRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPostAsyncRetrySucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetrySucceeded", token, client.pl)
+	return
 }
 
 // LROsClientPostAsyncRetrycanceledPoller provides polling facilities until the operation reaches a terminal state.
@@ -3166,20 +2947,19 @@ func (p *LROsClientPostAsyncRetrycanceledPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPostAsyncRetrycanceledPoller) Poll(ctx context.Context) (LROsClientPostAsyncRetrycanceledResponse, error) {
-	result := LROsClientPostAsyncRetrycanceledResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsClientPostAsyncRetrycanceledPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPostAsyncRetrycanceledPoller) Result(ctx context.Context) (resp LROsClientPostAsyncRetrycanceledResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3199,12 +2979,9 @@ func (p *LROsClientPostAsyncRetrycanceledPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPostAsyncRetrycanceledPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPostAsyncRetrycanceledPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostAsyncRetrycanceledResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetrycanceled", token, client.pl); err != nil {
-		return LROsClientPostAsyncRetrycanceledResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPostAsyncRetrycanceledPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetrycanceled", token, client.pl)
+	return
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller provides polling facilities until the operation reaches a terminal state.
@@ -3223,20 +3000,19 @@ func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Done() boo
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Poll(ctx context.Context) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
-	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Result(ctx context.Context) (resp LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3256,12 +3032,9 @@ func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) ResumeToke
 
 // Resume rehydrates a LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault", token, client.pl); err != nil {
-		return LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault", token, client.pl)
+	return
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller provides polling facilities until the operation reaches a terminal state.
@@ -3280,20 +3053,19 @@ func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Poll(ctx context.Context) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
-	result := LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Result(ctx context.Context) (resp LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3313,12 +3085,9 @@ func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) ResumeToken() (st
 
 // Resume rehydrates a LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGet", token, client.pl); err != nil {
-		return LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGet", token, client.pl)
+	return
 }
 
 // LROsClientPostDoubleHeadersFinalLocationGetPoller provides polling facilities until the operation reaches a terminal state.
@@ -3337,20 +3106,19 @@ func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Poll(ctx context.Context) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
-	result := LROsClientPostDoubleHeadersFinalLocationGetResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Result(ctx context.Context) (resp LROsClientPostDoubleHeadersFinalLocationGetResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3370,12 +3138,9 @@ func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) ResumeToken() (strin
 
 // Resume rehydrates a LROsClientPostDoubleHeadersFinalLocationGetPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalLocationGet", token, client.pl); err != nil {
-		return LROsClientPostDoubleHeadersFinalLocationGetResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPostDoubleHeadersFinalLocationGetPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalLocationGet", token, client.pl)
+	return
 }
 
 // LROsClientPut200Acceptedcanceled200Poller provides polling facilities until the operation reaches a terminal state.
@@ -3394,20 +3159,19 @@ func (p *LROsClientPut200Acceptedcanceled200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPut200Acceptedcanceled200Poller) Poll(ctx context.Context) (LROsClientPut200Acceptedcanceled200Response, error) {
-	result := LROsClientPut200Acceptedcanceled200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPut200Acceptedcanceled200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPut200Acceptedcanceled200Poller) Result(ctx context.Context) (resp LROsClientPut200Acceptedcanceled200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3427,12 +3191,9 @@ func (p *LROsClientPut200Acceptedcanceled200Poller) ResumeToken() (string, error
 
 // Resume rehydrates a LROsClientPut200Acceptedcanceled200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPut200Acceptedcanceled200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut200Acceptedcanceled200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200Acceptedcanceled200", token, client.pl); err != nil {
-		return LROsClientPut200Acceptedcanceled200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPut200Acceptedcanceled200Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200Acceptedcanceled200", token, client.pl)
+	return
 }
 
 // LROsClientPut200SucceededNoStatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3451,20 +3212,19 @@ func (p *LROsClientPut200SucceededNoStatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPut200SucceededNoStatePoller) Poll(ctx context.Context) (LROsClientPut200SucceededNoStateResponse, error) {
-	result := LROsClientPut200SucceededNoStateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPut200SucceededNoStatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPut200SucceededNoStatePoller) Result(ctx context.Context) (resp LROsClientPut200SucceededNoStateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3484,12 +3244,9 @@ func (p *LROsClientPut200SucceededNoStatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPut200SucceededNoStatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPut200SucceededNoStatePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut200SucceededNoStateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200SucceededNoState", token, client.pl); err != nil {
-		return LROsClientPut200SucceededNoStateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPut200SucceededNoStatePoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200SucceededNoState", token, client.pl)
+	return
 }
 
 // LROsClientPut200SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -3508,20 +3265,19 @@ func (p *LROsClientPut200SucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPut200SucceededPoller) Poll(ctx context.Context) (LROsClientPut200SucceededResponse, error) {
-	result := LROsClientPut200SucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPut200SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPut200SucceededPoller) Result(ctx context.Context) (resp LROsClientPut200SucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3541,12 +3297,9 @@ func (p *LROsClientPut200SucceededPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPut200SucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPut200SucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut200SucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200Succeeded", token, client.pl); err != nil {
-		return LROsClientPut200SucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPut200SucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200Succeeded", token, client.pl)
+	return
 }
 
 // LROsClientPut200UpdatingSucceeded204Poller provides polling facilities until the operation reaches a terminal state.
@@ -3565,20 +3318,19 @@ func (p *LROsClientPut200UpdatingSucceeded204Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPut200UpdatingSucceeded204Poller) Poll(ctx context.Context) (LROsClientPut200UpdatingSucceeded204Response, error) {
-	result := LROsClientPut200UpdatingSucceeded204Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPut200UpdatingSucceeded204Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPut200UpdatingSucceeded204Poller) Result(ctx context.Context) (resp LROsClientPut200UpdatingSucceeded204Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3598,12 +3350,9 @@ func (p *LROsClientPut200UpdatingSucceeded204Poller) ResumeToken() (string, erro
 
 // Resume rehydrates a LROsClientPut200UpdatingSucceeded204Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPut200UpdatingSucceeded204Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut200UpdatingSucceeded204Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200UpdatingSucceeded204", token, client.pl); err != nil {
-		return LROsClientPut200UpdatingSucceeded204Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPut200UpdatingSucceeded204Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put200UpdatingSucceeded204", token, client.pl)
+	return
 }
 
 // LROsClientPut201CreatingFailed200Poller provides polling facilities until the operation reaches a terminal state.
@@ -3622,20 +3371,19 @@ func (p *LROsClientPut201CreatingFailed200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPut201CreatingFailed200Poller) Poll(ctx context.Context) (LROsClientPut201CreatingFailed200Response, error) {
-	result := LROsClientPut201CreatingFailed200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPut201CreatingFailed200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPut201CreatingFailed200Poller) Result(ctx context.Context) (resp LROsClientPut201CreatingFailed200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3655,12 +3403,9 @@ func (p *LROsClientPut201CreatingFailed200Poller) ResumeToken() (string, error) 
 
 // Resume rehydrates a LROsClientPut201CreatingFailed200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPut201CreatingFailed200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut201CreatingFailed200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201CreatingFailed200", token, client.pl); err != nil {
-		return LROsClientPut201CreatingFailed200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPut201CreatingFailed200Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201CreatingFailed200", token, client.pl)
+	return
 }
 
 // LROsClientPut201CreatingSucceeded200Poller provides polling facilities until the operation reaches a terminal state.
@@ -3679,20 +3424,19 @@ func (p *LROsClientPut201CreatingSucceeded200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (LROsClientPut201CreatingSucceeded200Response, error) {
-	result := LROsClientPut201CreatingSucceeded200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPut201CreatingSucceeded200Poller) Result(ctx context.Context) (resp LROsClientPut201CreatingSucceeded200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3712,12 +3456,9 @@ func (p *LROsClientPut201CreatingSucceeded200Poller) ResumeToken() (string, erro
 
 // Resume rehydrates a LROsClientPut201CreatingSucceeded200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPut201CreatingSucceeded200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut201CreatingSucceeded200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201CreatingSucceeded200", token, client.pl); err != nil {
-		return LROsClientPut201CreatingSucceeded200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPut201CreatingSucceeded200Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201CreatingSucceeded200", token, client.pl)
+	return
 }
 
 // LROsClientPut201SucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -3736,20 +3477,19 @@ func (p *LROsClientPut201SucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPut201SucceededPoller) Poll(ctx context.Context) (LROsClientPut201SucceededResponse, error) {
-	result := LROsClientPut201SucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPut201SucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPut201SucceededPoller) Result(ctx context.Context) (resp LROsClientPut201SucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3769,12 +3509,9 @@ func (p *LROsClientPut201SucceededPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPut201SucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPut201SucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut201SucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201Succeeded", token, client.pl); err != nil {
-		return LROsClientPut201SucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPut201SucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put201Succeeded", token, client.pl)
+	return
 }
 
 // LROsClientPut202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -3793,20 +3530,19 @@ func (p *LROsClientPut202Retry200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPut202Retry200Poller) Poll(ctx context.Context) (LROsClientPut202Retry200Response, error) {
-	result := LROsClientPut202Retry200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPut202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPut202Retry200Poller) Result(ctx context.Context) (resp LROsClientPut202Retry200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3826,12 +3562,9 @@ func (p *LROsClientPut202Retry200Poller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPut202Retry200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPut202Retry200Poller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPut202Retry200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put202Retry200", token, client.pl); err != nil {
-		return LROsClientPut202Retry200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPut202Retry200Poller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.Put202Retry200", token, client.pl)
+	return
 }
 
 // LROsClientPutAsyncNoHeaderInRetryPoller provides polling facilities until the operation reaches a terminal state.
@@ -3850,20 +3583,19 @@ func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
-	result := LROsClientPutAsyncNoHeaderInRetryResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Result(ctx context.Context) (resp LROsClientPutAsyncNoHeaderInRetryResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3883,12 +3615,9 @@ func (p *LROsClientPutAsyncNoHeaderInRetryPoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a LROsClientPutAsyncNoHeaderInRetryPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoHeaderInRetry", token, client.pl); err != nil {
-		return LROsClientPutAsyncNoHeaderInRetryResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutAsyncNoHeaderInRetryPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoHeaderInRetry", token, client.pl)
+	return
 }
 
 // LROsClientPutAsyncNoRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -3907,20 +3636,19 @@ func (p *LROsClientPutAsyncNoRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
-	result := LROsClientPutAsyncNoRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPutAsyncNoRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutAsyncNoRetrySucceededPoller) Result(ctx context.Context) (resp LROsClientPutAsyncNoRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3940,12 +3668,9 @@ func (p *LROsClientPutAsyncNoRetrySucceededPoller) ResumeToken() (string, error)
 
 // Resume rehydrates a LROsClientPutAsyncNoRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutAsyncNoRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrySucceeded", token, client.pl); err != nil {
-		return LROsClientPutAsyncNoRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutAsyncNoRetrySucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrySucceeded", token, client.pl)
+	return
 }
 
 // LROsClientPutAsyncNoRetrycanceledPoller provides polling facilities until the operation reaches a terminal state.
@@ -3964,20 +3689,19 @@ func (p *LROsClientPutAsyncNoRetrycanceledPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutAsyncNoRetrycanceledPoller) Poll(ctx context.Context) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
-	result := LROsClientPutAsyncNoRetrycanceledResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPutAsyncNoRetrycanceledPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutAsyncNoRetrycanceledPoller) Result(ctx context.Context) (resp LROsClientPutAsyncNoRetrycanceledResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3997,12 +3721,9 @@ func (p *LROsClientPutAsyncNoRetrycanceledPoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a LROsClientPutAsyncNoRetrycanceledPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutAsyncNoRetrycanceledPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrycanceled", token, client.pl); err != nil {
-		return LROsClientPutAsyncNoRetrycanceledResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutAsyncNoRetrycanceledPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrycanceled", token, client.pl)
+	return
 }
 
 // LROsClientPutAsyncNonResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -4021,20 +3742,19 @@ func (p *LROsClientPutAsyncNonResourcePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutAsyncNonResourcePoller) Poll(ctx context.Context) (LROsClientPutAsyncNonResourceResponse, error) {
-	result := LROsClientPutAsyncNonResourceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SKU)
-	return result, err
+func (p *LROsClientPutAsyncNonResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutAsyncNonResourcePoller) Result(ctx context.Context) (resp LROsClientPutAsyncNonResourceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4054,12 +3774,9 @@ func (p *LROsClientPutAsyncNonResourcePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPutAsyncNonResourcePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutAsyncNonResourcePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncNonResourceResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNonResource", token, client.pl); err != nil {
-		return LROsClientPutAsyncNonResourceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutAsyncNonResourcePoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNonResource", token, client.pl)
+	return
 }
 
 // LROsClientPutAsyncRetryFailedPoller provides polling facilities until the operation reaches a terminal state.
@@ -4078,20 +3795,19 @@ func (p *LROsClientPutAsyncRetryFailedPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutAsyncRetryFailedPoller) Poll(ctx context.Context) (LROsClientPutAsyncRetryFailedResponse, error) {
-	result := LROsClientPutAsyncRetryFailedResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPutAsyncRetryFailedPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutAsyncRetryFailedPoller) Result(ctx context.Context) (resp LROsClientPutAsyncRetryFailedResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4111,12 +3827,9 @@ func (p *LROsClientPutAsyncRetryFailedPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPutAsyncRetryFailedPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutAsyncRetryFailedPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncRetryFailedResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncRetryFailed", token, client.pl); err != nil {
-		return LROsClientPutAsyncRetryFailedResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutAsyncRetryFailedPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncRetryFailed", token, client.pl)
+	return
 }
 
 // LROsClientPutAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -4135,20 +3848,19 @@ func (p *LROsClientPutAsyncRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsClientPutAsyncRetrySucceededResponse, error) {
-	result := LROsClientPutAsyncRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutAsyncRetrySucceededPoller) Result(ctx context.Context) (resp LROsClientPutAsyncRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4168,12 +3880,9 @@ func (p *LROsClientPutAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPutAsyncRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncRetrySucceeded", token, client.pl); err != nil {
-		return LROsClientPutAsyncRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutAsyncRetrySucceededPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncRetrySucceeded", token, client.pl)
+	return
 }
 
 // LROsClientPutAsyncSubResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -4192,20 +3901,19 @@ func (p *LROsClientPutAsyncSubResourcePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutAsyncSubResourcePoller) Poll(ctx context.Context) (LROsClientPutAsyncSubResourceResponse, error) {
-	result := LROsClientPutAsyncSubResourceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SubProduct)
-	return result, err
+func (p *LROsClientPutAsyncSubResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutAsyncSubResourcePoller) Result(ctx context.Context) (resp LROsClientPutAsyncSubResourceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4225,12 +3933,9 @@ func (p *LROsClientPutAsyncSubResourcePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPutAsyncSubResourcePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutAsyncSubResourcePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutAsyncSubResourceResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncSubResource", token, client.pl); err != nil {
-		return LROsClientPutAsyncSubResourceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutAsyncSubResourcePoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncSubResource", token, client.pl)
+	return
 }
 
 // LROsClientPutNoHeaderInRetryPoller provides polling facilities until the operation reaches a terminal state.
@@ -4249,20 +3954,19 @@ func (p *LROsClientPutNoHeaderInRetryPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutNoHeaderInRetryPoller) Poll(ctx context.Context) (LROsClientPutNoHeaderInRetryResponse, error) {
-	result := LROsClientPutNoHeaderInRetryResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsClientPutNoHeaderInRetryPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutNoHeaderInRetryPoller) Result(ctx context.Context) (resp LROsClientPutNoHeaderInRetryResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4282,12 +3986,9 @@ func (p *LROsClientPutNoHeaderInRetryPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPutNoHeaderInRetryPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutNoHeaderInRetryPoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutNoHeaderInRetryResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutNoHeaderInRetry", token, client.pl); err != nil {
-		return LROsClientPutNoHeaderInRetryResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutNoHeaderInRetryPoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutNoHeaderInRetry", token, client.pl)
+	return
 }
 
 // LROsClientPutNonResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -4306,20 +4007,19 @@ func (p *LROsClientPutNonResourcePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutNonResourcePoller) Poll(ctx context.Context) (LROsClientPutNonResourceResponse, error) {
-	result := LROsClientPutNonResourceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SKU)
-	return result, err
+func (p *LROsClientPutNonResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutNonResourcePoller) Result(ctx context.Context) (resp LROsClientPutNonResourceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4339,12 +4039,9 @@ func (p *LROsClientPutNonResourcePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPutNonResourcePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutNonResourcePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutNonResourceResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutNonResource", token, client.pl); err != nil {
-		return LROsClientPutNonResourceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutNonResourcePoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutNonResource", token, client.pl)
+	return
 }
 
 // LROsClientPutSubResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -4363,20 +4060,19 @@ func (p *LROsClientPutSubResourcePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsClientPutSubResourcePoller) Poll(ctx context.Context) (LROsClientPutSubResourceResponse, error) {
-	result := LROsClientPutSubResourceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SubProduct)
-	return result, err
+func (p *LROsClientPutSubResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsClientPutSubResourcePoller) Result(ctx context.Context) (resp LROsClientPutSubResourceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4396,12 +4092,9 @@ func (p *LROsClientPutSubResourcePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LROsClientPutSubResourcePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsClientPutSubResourcePoller) Resume(ctx context.Context, client *LROsClient, token string) (LROsClientPutSubResourceResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutSubResource", token, client.pl); err != nil {
-		return LROsClientPutSubResourceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsClientPutSubResourcePoller) Resume(token string, client *LROsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsClient.PutSubResource", token, client.pl)
+	return
 }
 
 // LROsCustomHeaderClientPost202Retry200Poller provides polling facilities until the operation reaches a terminal state.
@@ -4420,20 +4113,19 @@ func (p *LROsCustomHeaderClientPost202Retry200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsCustomHeaderClientPost202Retry200Poller) Poll(ctx context.Context) (LROsCustomHeaderClientPost202Retry200Response, error) {
-	result := LROsCustomHeaderClientPost202Retry200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsCustomHeaderClientPost202Retry200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsCustomHeaderClientPost202Retry200Poller) Result(ctx context.Context) (resp LROsCustomHeaderClientPost202Retry200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4453,12 +4145,9 @@ func (p *LROsCustomHeaderClientPost202Retry200Poller) ResumeToken() (string, err
 
 // Resume rehydrates a LROsCustomHeaderClientPost202Retry200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsCustomHeaderClientPost202Retry200Poller) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) (LROsCustomHeaderClientPost202Retry200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.Post202Retry200", token, client.pl); err != nil {
-		return LROsCustomHeaderClientPost202Retry200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsCustomHeaderClientPost202Retry200Poller) Resume(token string, client *LROsCustomHeaderClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.Post202Retry200", token, client.pl)
+	return
 }
 
 // LROsCustomHeaderClientPostAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -4477,20 +4166,19 @@ func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
-	result := LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Result(ctx context.Context) (resp LROsCustomHeaderClientPostAsyncRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4510,12 +4198,9 @@ func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) ResumeToken() (str
 
 // Resume rehydrates a LROsCustomHeaderClientPostAsyncRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.PostAsyncRetrySucceeded", token, client.pl); err != nil {
-		return LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsCustomHeaderClientPostAsyncRetrySucceededPoller) Resume(token string, client *LROsCustomHeaderClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.PostAsyncRetrySucceeded", token, client.pl)
+	return
 }
 
 // LROsCustomHeaderClientPut201CreatingSucceeded200Poller provides polling facilities until the operation reaches a terminal state.
@@ -4534,20 +4219,19 @@ func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
-	result := LROsCustomHeaderClientPut201CreatingSucceeded200Response{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Result(ctx context.Context) (resp LROsCustomHeaderClientPut201CreatingSucceeded200Response, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4567,12 +4251,9 @@ func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) ResumeToken() (
 
 // Resume rehydrates a LROsCustomHeaderClientPut201CreatingSucceeded200Poller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.Put201CreatingSucceeded200", token, client.pl); err != nil {
-		return LROsCustomHeaderClientPut201CreatingSucceeded200Response{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsCustomHeaderClientPut201CreatingSucceeded200Poller) Resume(token string, client *LROsCustomHeaderClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.Put201CreatingSucceeded200", token, client.pl)
+	return
 }
 
 // LROsCustomHeaderClientPutAsyncRetrySucceededPoller provides polling facilities until the operation reaches a terminal state.
@@ -4591,20 +4272,19 @@ func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
-	result := LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Product)
-	return result, err
+func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Result(ctx context.Context) (resp LROsCustomHeaderClientPutAsyncRetrySucceededResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4624,10 +4304,7 @@ func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) ResumeToken() (stri
 
 // Resume rehydrates a LROsCustomHeaderClientPutAsyncRetrySucceededPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.PutAsyncRetrySucceeded", token, client.pl); err != nil {
-		return LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LROsCustomHeaderClientPutAsyncRetrySucceededPoller) Resume(token string, client *LROsCustomHeaderClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.PutAsyncRetrySucceeded", token, client.pl)
+	return
 }

--- a/test/autorest/lrogroup/zz_generated_response_types.go
+++ b/test/autorest/lrogroup/zz_generated_response_types.go
@@ -8,84 +8,9 @@
 
 package lrogroup
 
-import (
-	"context"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"time"
-)
-
-// LRORetrysClientDelete202Retry200PollerResponse contains the response from method LRORetrysClient.Delete202Retry200.
-type LRORetrysClientDelete202Retry200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LRORetrysClientDelete202Retry200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LRORetrysClientDelete202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDelete202Retry200Response, error) {
-	respType := LRORetrysClientDelete202Retry200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LRORetrysClientDelete202Retry200PollerResponse from the provided client and resume token.
-func (l *LRORetrysClientDelete202Retry200PollerResponse) Resume(ctx context.Context, client *LRORetrysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LRORetrysClient.Delete202Retry200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LRORetrysClientDelete202Retry200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LRORetrysClientDelete202Retry200Response contains the response from method LRORetrysClient.Delete202Retry200.
 type LRORetrysClientDelete202Retry200Response struct {
 	// placeholder for future response values
-}
-
-// LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse contains the response from method LRORetrysClient.DeleteAsyncRelativeRetrySucceeded.
-type LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse, error) {
-	respType := LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse from the provided client and resume
-// token.
-func (l *LRORetrysClientDeleteAsyncRelativeRetrySucceededPollerResponse) Resume(ctx context.Context, client *LRORetrysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LRORetrysClient.DeleteAsyncRelativeRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LRORetrysClientDeleteAsyncRelativeRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse contains the response from method LRORetrysClient.DeleteAsyncRelativeRetrySucceeded.
@@ -93,78 +18,9 @@ type LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse struct {
 	// placeholder for future response values
 }
 
-// LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse contains the response from method LRORetrysClient.DeleteProvisioning202Accepted200Succeeded.
-type LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse, error) {
-	respType := LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse from the provided client and
-// resume token.
-func (l *LRORetrysClientDeleteProvisioning202Accepted200SucceededPollerResponse) Resume(ctx context.Context, client *LRORetrysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LRORetrysClient.DeleteProvisioning202Accepted200Succeeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LRORetrysClientDeleteProvisioning202Accepted200SucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse contains the response from method LRORetrysClient.DeleteProvisioning202Accepted200Succeeded.
 type LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse struct {
 	Product
-}
-
-// LRORetrysClientPost202Retry200PollerResponse contains the response from method LRORetrysClient.Post202Retry200.
-type LRORetrysClientPost202Retry200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LRORetrysClientPost202Retry200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LRORetrysClientPost202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPost202Retry200Response, error) {
-	respType := LRORetrysClientPost202Retry200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LRORetrysClientPost202Retry200PollerResponse from the provided client and resume token.
-func (l *LRORetrysClientPost202Retry200PollerResponse) Resume(ctx context.Context, client *LRORetrysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LRORetrysClient.Post202Retry200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LRORetrysClientPost202Retry200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LRORetrysClientPost202Retry200Response contains the response from method LRORetrysClient.Post202Retry200.
@@ -172,77 +28,9 @@ type LRORetrysClientPost202Retry200Response struct {
 	// placeholder for future response values
 }
 
-// LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse contains the response from method LRORetrysClient.PostAsyncRelativeRetrySucceeded.
-type LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LRORetrysClientPostAsyncRelativeRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPostAsyncRelativeRetrySucceededResponse, error) {
-	respType := LRORetrysClientPostAsyncRelativeRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LRORetrysClientPostAsyncRelativeRetrySucceededPollerResponse) Resume(ctx context.Context, client *LRORetrysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LRORetrysClient.PostAsyncRelativeRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LRORetrysClientPostAsyncRelativeRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LRORetrysClientPostAsyncRelativeRetrySucceededResponse contains the response from method LRORetrysClient.PostAsyncRelativeRetrySucceeded.
 type LRORetrysClientPostAsyncRelativeRetrySucceededResponse struct {
 	// placeholder for future response values
-}
-
-// LRORetrysClientPut201CreatingSucceeded200PollerResponse contains the response from method LRORetrysClient.Put201CreatingSucceeded200.
-type LRORetrysClientPut201CreatingSucceeded200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LRORetrysClientPut201CreatingSucceeded200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LRORetrysClientPut201CreatingSucceeded200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPut201CreatingSucceeded200Response, error) {
-	respType := LRORetrysClientPut201CreatingSucceeded200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LRORetrysClientPut201CreatingSucceeded200PollerResponse from the provided client and resume token.
-func (l *LRORetrysClientPut201CreatingSucceeded200PollerResponse) Resume(ctx context.Context, client *LRORetrysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LRORetrysClient.Put201CreatingSucceeded200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LRORetrysClientPut201CreatingSucceeded200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LRORetrysClientPut201CreatingSucceeded200Response contains the response from method LRORetrysClient.Put201CreatingSucceeded200.
@@ -250,77 +38,9 @@ type LRORetrysClientPut201CreatingSucceeded200Response struct {
 	Product
 }
 
-// LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse contains the response from method LRORetrysClient.PutAsyncRelativeRetrySucceeded.
-type LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LRORetrysClientPutAsyncRelativeRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LRORetrysClientPutAsyncRelativeRetrySucceededResponse, error) {
-	respType := LRORetrysClientPutAsyncRelativeRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LRORetrysClientPutAsyncRelativeRetrySucceededPollerResponse) Resume(ctx context.Context, client *LRORetrysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LRORetrysClient.PutAsyncRelativeRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LRORetrysClientPutAsyncRelativeRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LRORetrysClientPutAsyncRelativeRetrySucceededResponse contains the response from method LRORetrysClient.PutAsyncRelativeRetrySucceeded.
 type LRORetrysClientPutAsyncRelativeRetrySucceededResponse struct {
 	Product
-}
-
-// LROSADsClientDelete202NonRetry400PollerResponse contains the response from method LROSADsClient.Delete202NonRetry400.
-type LROSADsClientDelete202NonRetry400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientDelete202NonRetry400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientDelete202NonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete202NonRetry400Response, error) {
-	respType := LROSADsClientDelete202NonRetry400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientDelete202NonRetry400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientDelete202NonRetry400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.Delete202NonRetry400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientDelete202NonRetry400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientDelete202NonRetry400Response contains the response from method LROSADsClient.Delete202NonRetry400.
@@ -328,77 +48,9 @@ type LROSADsClientDelete202NonRetry400Response struct {
 	// placeholder for future response values
 }
 
-// LROSADsClientDelete202RetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.Delete202RetryInvalidHeader.
-type LROSADsClientDelete202RetryInvalidHeaderPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientDelete202RetryInvalidHeaderPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientDelete202RetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete202RetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientDelete202RetryInvalidHeaderResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientDelete202RetryInvalidHeaderPollerResponse from the provided client and resume token.
-func (l *LROSADsClientDelete202RetryInvalidHeaderPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.Delete202RetryInvalidHeader", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientDelete202RetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientDelete202RetryInvalidHeaderResponse contains the response from method LROSADsClient.Delete202RetryInvalidHeader.
 type LROSADsClientDelete202RetryInvalidHeaderResponse struct {
 	// placeholder for future response values
-}
-
-// LROSADsClientDelete204SucceededPollerResponse contains the response from method LROSADsClient.Delete204Succeeded.
-type LROSADsClientDelete204SucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientDelete204SucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientDelete204SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDelete204SucceededResponse, error) {
-	respType := LROSADsClientDelete204SucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientDelete204SucceededPollerResponse from the provided client and resume token.
-func (l *LROSADsClientDelete204SucceededPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.Delete204Succeeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientDelete204SucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientDelete204SucceededResponse contains the response from method LROSADsClient.Delete204Succeeded.
@@ -406,78 +58,9 @@ type LROSADsClientDelete204SucceededResponse struct {
 	// placeholder for future response values
 }
 
-// LROSADsClientDeleteAsyncRelativeRetry400PollerResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetry400.
-type LROSADsClientDeleteAsyncRelativeRetry400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientDeleteAsyncRelativeRetry400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientDeleteAsyncRelativeRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetry400Response, error) {
-	respType := LROSADsClientDeleteAsyncRelativeRetry400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetry400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientDeleteAsyncRelativeRetry400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetry400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientDeleteAsyncRelativeRetry400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientDeleteAsyncRelativeRetry400Response contains the response from method LROSADsClient.DeleteAsyncRelativeRetry400.
 type LROSADsClientDeleteAsyncRelativeRetry400Response struct {
 	// placeholder for future response values
-}
-
-// LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader.
-type LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse from the provided client and resume
-// token.
-func (l *LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader.
@@ -485,78 +68,9 @@ type LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse struct {
 	// placeholder for future response values
 }
 
-// LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling.
-type LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	respType := LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse from the provided client and
-// resume token.
-func (l *LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse struct {
 	// placeholder for future response values
-}
-
-// LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryNoStatus.
-type LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse, error) {
-	respType := LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse from the provided client and resume token.
-func (l *LROSADsClientDeleteAsyncRelativeRetryNoStatusPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryNoStatus", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientDeleteAsyncRelativeRetryNoStatusPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse contains the response from method LROSADsClient.DeleteAsyncRelativeRetryNoStatus.
@@ -564,77 +78,9 @@ type LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse struct {
 	// placeholder for future response values
 }
 
-// LROSADsClientDeleteNonRetry400PollerResponse contains the response from method LROSADsClient.DeleteNonRetry400.
-type LROSADsClientDeleteNonRetry400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientDeleteNonRetry400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientDeleteNonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientDeleteNonRetry400Response, error) {
-	respType := LROSADsClientDeleteNonRetry400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientDeleteNonRetry400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientDeleteNonRetry400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.DeleteNonRetry400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientDeleteNonRetry400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientDeleteNonRetry400Response contains the response from method LROSADsClient.DeleteNonRetry400.
 type LROSADsClientDeleteNonRetry400Response struct {
 	// placeholder for future response values
-}
-
-// LROSADsClientPost202NoLocationPollerResponse contains the response from method LROSADsClient.Post202NoLocation.
-type LROSADsClientPost202NoLocationPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPost202NoLocationPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPost202NoLocationPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202NoLocationResponse, error) {
-	respType := LROSADsClientPost202NoLocationResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPost202NoLocationPollerResponse from the provided client and resume token.
-func (l *LROSADsClientPost202NoLocationPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.Post202NoLocation", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPost202NoLocationPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPost202NoLocationResponse contains the response from method LROSADsClient.Post202NoLocation.
@@ -642,77 +88,9 @@ type LROSADsClientPost202NoLocationResponse struct {
 	// placeholder for future response values
 }
 
-// LROSADsClientPost202NonRetry400PollerResponse contains the response from method LROSADsClient.Post202NonRetry400.
-type LROSADsClientPost202NonRetry400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPost202NonRetry400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPost202NonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202NonRetry400Response, error) {
-	respType := LROSADsClientPost202NonRetry400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPost202NonRetry400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientPost202NonRetry400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.Post202NonRetry400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPost202NonRetry400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPost202NonRetry400Response contains the response from method LROSADsClient.Post202NonRetry400.
 type LROSADsClientPost202NonRetry400Response struct {
 	// placeholder for future response values
-}
-
-// LROSADsClientPost202RetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.Post202RetryInvalidHeader.
-type LROSADsClientPost202RetryInvalidHeaderPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPost202RetryInvalidHeaderPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPost202RetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPost202RetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientPost202RetryInvalidHeaderResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPost202RetryInvalidHeaderPollerResponse from the provided client and resume token.
-func (l *LROSADsClientPost202RetryInvalidHeaderPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.Post202RetryInvalidHeader", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPost202RetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPost202RetryInvalidHeaderResponse contains the response from method LROSADsClient.Post202RetryInvalidHeader.
@@ -720,78 +98,9 @@ type LROSADsClientPost202RetryInvalidHeaderResponse struct {
 	// placeholder for future response values
 }
 
-// LROSADsClientPostAsyncRelativeRetry400PollerResponse contains the response from method LROSADsClient.PostAsyncRelativeRetry400.
-type LROSADsClientPostAsyncRelativeRetry400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPostAsyncRelativeRetry400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPostAsyncRelativeRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetry400Response, error) {
-	respType := LROSADsClientPostAsyncRelativeRetry400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPostAsyncRelativeRetry400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientPostAsyncRelativeRetry400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetry400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPostAsyncRelativeRetry400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPostAsyncRelativeRetry400Response contains the response from method LROSADsClient.PostAsyncRelativeRetry400.
 type LROSADsClientPostAsyncRelativeRetry400Response struct {
 	// placeholder for future response values
-}
-
-// LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryInvalidHeader.
-type LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse from the provided client and resume
-// token.
-func (l *LROSADsClientPostAsyncRelativeRetryInvalidHeaderPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidHeader", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPostAsyncRelativeRetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryInvalidHeader.
@@ -799,78 +108,9 @@ type LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse struct {
 	// placeholder for future response values
 }
 
-// LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling.
-type LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	respType := LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse from the provided client and resume
-// token.
-func (l *LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse struct {
 	// placeholder for future response values
-}
-
-// LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryNoPayload.
-type LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPostAsyncRelativeRetryNoPayloadPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostAsyncRelativeRetryNoPayloadResponse, error) {
-	respType := LROSADsClientPostAsyncRelativeRetryNoPayloadResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse from the provided client and resume token.
-func (l *LROSADsClientPostAsyncRelativeRetryNoPayloadPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryNoPayload", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPostAsyncRelativeRetryNoPayloadPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPostAsyncRelativeRetryNoPayloadResponse contains the response from method LROSADsClient.PostAsyncRelativeRetryNoPayload.
@@ -878,77 +118,9 @@ type LROSADsClientPostAsyncRelativeRetryNoPayloadResponse struct {
 	// placeholder for future response values
 }
 
-// LROSADsClientPostNonRetry400PollerResponse contains the response from method LROSADsClient.PostNonRetry400.
-type LROSADsClientPostNonRetry400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPostNonRetry400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPostNonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPostNonRetry400Response, error) {
-	respType := LROSADsClientPostNonRetry400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPostNonRetry400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientPostNonRetry400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PostNonRetry400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPostNonRetry400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPostNonRetry400Response contains the response from method LROSADsClient.PostNonRetry400.
 type LROSADsClientPostNonRetry400Response struct {
 	// placeholder for future response values
-}
-
-// LROSADsClientPut200InvalidJSONPollerResponse contains the response from method LROSADsClient.Put200InvalidJSON.
-type LROSADsClientPut200InvalidJSONPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPut200InvalidJSONPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPut200InvalidJSONPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPut200InvalidJSONResponse, error) {
-	respType := LROSADsClientPut200InvalidJSONResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPut200InvalidJSONPollerResponse from the provided client and resume token.
-func (l *LROSADsClientPut200InvalidJSONPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.Put200InvalidJSON", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPut200InvalidJSONPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPut200InvalidJSONResponse contains the response from method LROSADsClient.Put200InvalidJSON.
@@ -956,77 +128,9 @@ type LROSADsClientPut200InvalidJSONResponse struct {
 	Product
 }
 
-// LROSADsClientPutAsyncRelativeRetry400PollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetry400.
-type LROSADsClientPutAsyncRelativeRetry400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutAsyncRelativeRetry400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutAsyncRelativeRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetry400Response, error) {
-	respType := LROSADsClientPutAsyncRelativeRetry400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutAsyncRelativeRetry400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientPutAsyncRelativeRetry400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetry400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutAsyncRelativeRetry400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPutAsyncRelativeRetry400Response contains the response from method LROSADsClient.PutAsyncRelativeRetry400.
 type LROSADsClientPutAsyncRelativeRetry400Response struct {
 	Product
-}
-
-// LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidHeader.
-type LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse, error) {
-	respType := LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse from the provided client and resume token.
-func (l *LROSADsClientPutAsyncRelativeRetryInvalidHeaderPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidHeader", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutAsyncRelativeRetryInvalidHeaderPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidHeader.
@@ -1034,79 +138,9 @@ type LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse struct {
 	Product
 }
 
-// LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling.
-type LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	respType := LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse from the provided client and resume
-// token.
-func (l *LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling.
 type LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse struct {
 	Product
-}
-
-// LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatusPayload.
-type LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse, error) {
-	respType := LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse from the provided client and resume
-// token.
-func (l *LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatusPayload", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutAsyncRelativeRetryNoStatusPayloadPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatusPayload.
@@ -1114,78 +148,9 @@ type LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse struct {
 	Product
 }
 
-// LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatus.
-type LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutAsyncRelativeRetryNoStatusPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutAsyncRelativeRetryNoStatusResponse, error) {
-	respType := LROSADsClientPutAsyncRelativeRetryNoStatusResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse from the provided client and resume token.
-func (l *LROSADsClientPutAsyncRelativeRetryNoStatusPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatus", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutAsyncRelativeRetryNoStatusPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPutAsyncRelativeRetryNoStatusResponse contains the response from method LROSADsClient.PutAsyncRelativeRetryNoStatus.
 type LROSADsClientPutAsyncRelativeRetryNoStatusResponse struct {
 	Product
-}
-
-// LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse contains the response from method LROSADsClient.PutError201NoProvisioningStatePayload.
-type LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutError201NoProvisioningStatePayloadPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutError201NoProvisioningStatePayloadResponse, error) {
-	respType := LROSADsClientPutError201NoProvisioningStatePayloadResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse from the provided client and resume
-// token.
-func (l *LROSADsClientPutError201NoProvisioningStatePayloadPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutError201NoProvisioningStatePayload", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutError201NoProvisioningStatePayloadPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPutError201NoProvisioningStatePayloadResponse contains the response from method LROSADsClient.PutError201NoProvisioningStatePayload.
@@ -1193,78 +158,9 @@ type LROSADsClientPutError201NoProvisioningStatePayloadResponse struct {
 	Product
 }
 
-// LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse contains the response from method LROSADsClient.PutNonRetry201Creating400InvalidJSON.
-type LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutNonRetry201Creating400InvalidJSONPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry201Creating400InvalidJSONResponse, error) {
-	respType := LROSADsClientPutNonRetry201Creating400InvalidJSONResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse from the provided client and resume
-// token.
-func (l *LROSADsClientPutNonRetry201Creating400InvalidJSONPollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400InvalidJSON", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutNonRetry201Creating400InvalidJSONPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPutNonRetry201Creating400InvalidJSONResponse contains the response from method LROSADsClient.PutNonRetry201Creating400InvalidJSON.
 type LROSADsClientPutNonRetry201Creating400InvalidJSONResponse struct {
 	Product
-}
-
-// LROSADsClientPutNonRetry201Creating400PollerResponse contains the response from method LROSADsClient.PutNonRetry201Creating400.
-type LROSADsClientPutNonRetry201Creating400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutNonRetry201Creating400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutNonRetry201Creating400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry201Creating400Response, error) {
-	respType := LROSADsClientPutNonRetry201Creating400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutNonRetry201Creating400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientPutNonRetry201Creating400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutNonRetry201Creating400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROSADsClientPutNonRetry201Creating400Response contains the response from method LROSADsClient.PutNonRetry201Creating400.
@@ -1272,77 +168,9 @@ type LROSADsClientPutNonRetry201Creating400Response struct {
 	Product
 }
 
-// LROSADsClientPutNonRetry400PollerResponse contains the response from method LROSADsClient.PutNonRetry400.
-type LROSADsClientPutNonRetry400PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROSADsClientPutNonRetry400Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROSADsClientPutNonRetry400PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROSADsClientPutNonRetry400Response, error) {
-	respType := LROSADsClientPutNonRetry400Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROSADsClientPutNonRetry400PollerResponse from the provided client and resume token.
-func (l *LROSADsClientPutNonRetry400PollerResponse) Resume(ctx context.Context, client *LROSADsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROSADsClient.PutNonRetry400", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROSADsClientPutNonRetry400Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROSADsClientPutNonRetry400Response contains the response from method LROSADsClient.PutNonRetry400.
 type LROSADsClientPutNonRetry400Response struct {
 	Product
-}
-
-// LROsClientDelete202NoRetry204PollerResponse contains the response from method LROsClient.Delete202NoRetry204.
-type LROsClientDelete202NoRetry204PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDelete202NoRetry204Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDelete202NoRetry204PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete202NoRetry204Response, error) {
-	respType := LROsClientDelete202NoRetry204Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDelete202NoRetry204PollerResponse from the provided client and resume token.
-func (l *LROsClientDelete202NoRetry204PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Delete202NoRetry204", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDelete202NoRetry204Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientDelete202NoRetry204Response contains the response from method LROsClient.Delete202NoRetry204.
@@ -1350,77 +178,9 @@ type LROsClientDelete202NoRetry204Response struct {
 	Product
 }
 
-// LROsClientDelete202Retry200PollerResponse contains the response from method LROsClient.Delete202Retry200.
-type LROsClientDelete202Retry200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDelete202Retry200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDelete202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete202Retry200Response, error) {
-	respType := LROsClientDelete202Retry200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDelete202Retry200PollerResponse from the provided client and resume token.
-func (l *LROsClientDelete202Retry200PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Delete202Retry200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDelete202Retry200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientDelete202Retry200Response contains the response from method LROsClient.Delete202Retry200.
 type LROsClientDelete202Retry200Response struct {
 	Product
-}
-
-// LROsClientDelete204SucceededPollerResponse contains the response from method LROsClient.Delete204Succeeded.
-type LROsClientDelete204SucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDelete204SucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDelete204SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDelete204SucceededResponse, error) {
-	respType := LROsClientDelete204SucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDelete204SucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientDelete204SucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Delete204Succeeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDelete204SucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientDelete204SucceededResponse contains the response from method LROsClient.Delete204Succeeded.
@@ -1428,77 +188,9 @@ type LROsClientDelete204SucceededResponse struct {
 	// placeholder for future response values
 }
 
-// LROsClientDeleteAsyncNoHeaderInRetryPollerResponse contains the response from method LROsClient.DeleteAsyncNoHeaderInRetry.
-type LROsClientDeleteAsyncNoHeaderInRetryPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteAsyncNoHeaderInRetryPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteAsyncNoHeaderInRetryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncNoHeaderInRetryResponse, error) {
-	respType := LROsClientDeleteAsyncNoHeaderInRetryResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteAsyncNoHeaderInRetryPollerResponse from the provided client and resume token.
-func (l *LROsClientDeleteAsyncNoHeaderInRetryPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoHeaderInRetry", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteAsyncNoHeaderInRetryPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientDeleteAsyncNoHeaderInRetryResponse contains the response from method LROsClient.DeleteAsyncNoHeaderInRetry.
 type LROsClientDeleteAsyncNoHeaderInRetryResponse struct {
 	// placeholder for future response values
-}
-
-// LROsClientDeleteAsyncNoRetrySucceededPollerResponse contains the response from method LROsClient.DeleteAsyncNoRetrySucceeded.
-type LROsClientDeleteAsyncNoRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteAsyncNoRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteAsyncNoRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncNoRetrySucceededResponse, error) {
-	respType := LROsClientDeleteAsyncNoRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteAsyncNoRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientDeleteAsyncNoRetrySucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteAsyncNoRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientDeleteAsyncNoRetrySucceededResponse contains the response from method LROsClient.DeleteAsyncNoRetrySucceeded.
@@ -1506,77 +198,9 @@ type LROsClientDeleteAsyncNoRetrySucceededResponse struct {
 	// placeholder for future response values
 }
 
-// LROsClientDeleteAsyncRetryFailedPollerResponse contains the response from method LROsClient.DeleteAsyncRetryFailed.
-type LROsClientDeleteAsyncRetryFailedPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteAsyncRetryFailedPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteAsyncRetryFailedPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetryFailedResponse, error) {
-	respType := LROsClientDeleteAsyncRetryFailedResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteAsyncRetryFailedPollerResponse from the provided client and resume token.
-func (l *LROsClientDeleteAsyncRetryFailedPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetryFailed", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteAsyncRetryFailedPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientDeleteAsyncRetryFailedResponse contains the response from method LROsClient.DeleteAsyncRetryFailed.
 type LROsClientDeleteAsyncRetryFailedResponse struct {
 	// placeholder for future response values
-}
-
-// LROsClientDeleteAsyncRetrySucceededPollerResponse contains the response from method LROsClient.DeleteAsyncRetrySucceeded.
-type LROsClientDeleteAsyncRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteAsyncRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetrySucceededResponse, error) {
-	respType := LROsClientDeleteAsyncRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteAsyncRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientDeleteAsyncRetrySucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientDeleteAsyncRetrySucceededResponse contains the response from method LROsClient.DeleteAsyncRetrySucceeded.
@@ -1584,77 +208,9 @@ type LROsClientDeleteAsyncRetrySucceededResponse struct {
 	// placeholder for future response values
 }
 
-// LROsClientDeleteAsyncRetrycanceledPollerResponse contains the response from method LROsClient.DeleteAsyncRetrycanceled.
-type LROsClientDeleteAsyncRetrycanceledPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteAsyncRetrycanceledPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteAsyncRetrycanceledPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteAsyncRetrycanceledResponse, error) {
-	respType := LROsClientDeleteAsyncRetrycanceledResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteAsyncRetrycanceledPollerResponse from the provided client and resume token.
-func (l *LROsClientDeleteAsyncRetrycanceledPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrycanceled", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteAsyncRetrycanceledPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientDeleteAsyncRetrycanceledResponse contains the response from method LROsClient.DeleteAsyncRetrycanceled.
 type LROsClientDeleteAsyncRetrycanceledResponse struct {
 	// placeholder for future response values
-}
-
-// LROsClientDeleteNoHeaderInRetryPollerResponse contains the response from method LROsClient.DeleteNoHeaderInRetry.
-type LROsClientDeleteNoHeaderInRetryPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteNoHeaderInRetryPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteNoHeaderInRetryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteNoHeaderInRetryResponse, error) {
-	respType := LROsClientDeleteNoHeaderInRetryResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteNoHeaderInRetryPollerResponse from the provided client and resume token.
-func (l *LROsClientDeleteNoHeaderInRetryPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteNoHeaderInRetry", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteNoHeaderInRetryPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientDeleteNoHeaderInRetryResponse contains the response from method LROsClient.DeleteNoHeaderInRetry.
@@ -1662,79 +218,9 @@ type LROsClientDeleteNoHeaderInRetryResponse struct {
 	// placeholder for future response values
 }
 
-// LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse contains the response from method LROsClient.DeleteProvisioning202Accepted200Succeeded.
-type LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteProvisioning202Accepted200SucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202Accepted200SucceededResponse, error) {
-	respType := LROsClientDeleteProvisioning202Accepted200SucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse from the provided client and resume
-// token.
-func (l *LROsClientDeleteProvisioning202Accepted200SucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Accepted200Succeeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteProvisioning202Accepted200SucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientDeleteProvisioning202Accepted200SucceededResponse contains the response from method LROsClient.DeleteProvisioning202Accepted200Succeeded.
 type LROsClientDeleteProvisioning202Accepted200SucceededResponse struct {
 	Product
-}
-
-// LROsClientDeleteProvisioning202DeletingFailed200PollerResponse contains the response from method LROsClient.DeleteProvisioning202DeletingFailed200.
-type LROsClientDeleteProvisioning202DeletingFailed200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteProvisioning202DeletingFailed200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteProvisioning202DeletingFailed200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202DeletingFailed200Response, error) {
-	respType := LROsClientDeleteProvisioning202DeletingFailed200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteProvisioning202DeletingFailed200PollerResponse from the provided client and resume
-// token.
-func (l *LROsClientDeleteProvisioning202DeletingFailed200PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202DeletingFailed200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteProvisioning202DeletingFailed200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientDeleteProvisioning202DeletingFailed200Response contains the response from method LROsClient.DeleteProvisioning202DeletingFailed200.
@@ -1742,78 +228,9 @@ type LROsClientDeleteProvisioning202DeletingFailed200Response struct {
 	Product
 }
 
-// LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse contains the response from method LROsClient.DeleteProvisioning202Deletingcanceled200.
-type LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientDeleteProvisioning202Deletingcanceled200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientDeleteProvisioning202Deletingcanceled200Response, error) {
-	respType := LROsClientDeleteProvisioning202Deletingcanceled200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse from the provided client and resume
-// token.
-func (l *LROsClientDeleteProvisioning202Deletingcanceled200PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Deletingcanceled200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientDeleteProvisioning202Deletingcanceled200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientDeleteProvisioning202Deletingcanceled200Response contains the response from method LROsClient.DeleteProvisioning202Deletingcanceled200.
 type LROsClientDeleteProvisioning202Deletingcanceled200Response struct {
 	Product
-}
-
-// LROsClientPatch200SucceededIgnoreHeadersPollerResponse contains the response from method LROsClient.Patch200SucceededIgnoreHeaders.
-type LROsClientPatch200SucceededIgnoreHeadersPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPatch200SucceededIgnoreHeadersPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPatch200SucceededIgnoreHeadersPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPatch200SucceededIgnoreHeadersResponse, error) {
-	respType := LROsClientPatch200SucceededIgnoreHeadersResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPatch200SucceededIgnoreHeadersPollerResponse from the provided client and resume token.
-func (l *LROsClientPatch200SucceededIgnoreHeadersPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Patch200SucceededIgnoreHeaders", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPatch200SucceededIgnoreHeadersPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPatch200SucceededIgnoreHeadersResponse contains the response from method LROsClient.Patch200SucceededIgnoreHeaders.
@@ -1821,156 +238,9 @@ type LROsClientPatch200SucceededIgnoreHeadersResponse struct {
 	Product
 }
 
-// LROsClientPatch201RetryWithAsyncHeaderPollerResponse contains the response from method LROsClient.Patch201RetryWithAsyncHeader.
-type LROsClientPatch201RetryWithAsyncHeaderPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPatch201RetryWithAsyncHeaderPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPatch201RetryWithAsyncHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPatch201RetryWithAsyncHeaderResponse, error) {
-	respType := LROsClientPatch201RetryWithAsyncHeaderResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPatch201RetryWithAsyncHeaderPollerResponse from the provided client and resume token.
-func (l *LROsClientPatch201RetryWithAsyncHeaderPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Patch201RetryWithAsyncHeader", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPatch201RetryWithAsyncHeaderPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
-// LROsClientPatch201RetryWithAsyncHeaderResponse contains the response from method LROsClient.Patch201RetryWithAsyncHeader.
-type LROsClientPatch201RetryWithAsyncHeaderResponse struct {
-	Product
-}
-
-// LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse contains the response from method LROsClient.Patch202RetryWithAsyncAndLocationHeader.
-type LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse, error) {
-	respType := LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse from the provided client and resume
-// token.
-func (l *LROsClientPatch202RetryWithAsyncAndLocationHeaderPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Patch202RetryWithAsyncAndLocationHeader", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPatch202RetryWithAsyncAndLocationHeaderPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
-// LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse contains the response from method LROsClient.Patch202RetryWithAsyncAndLocationHeader.
-type LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse struct {
-	Product
-}
-
-// LROsClientPost200WithPayloadPollerResponse contains the response from method LROsClient.Post200WithPayload.
-type LROsClientPost200WithPayloadPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPost200WithPayloadPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPost200WithPayloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost200WithPayloadResponse, error) {
-	respType := LROsClientPost200WithPayloadResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPost200WithPayloadPollerResponse from the provided client and resume token.
-func (l *LROsClientPost200WithPayloadPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Post200WithPayload", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPost200WithPayloadPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPost200WithPayloadResponse contains the response from method LROsClient.Post200WithPayload.
 type LROsClientPost200WithPayloadResponse struct {
 	SKU
-}
-
-// LROsClientPost202ListPollerResponse contains the response from method LROsClient.Post202List.
-type LROsClientPost202ListPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPost202ListPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPost202ListPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202ListResponse, error) {
-	respType := LROsClientPost202ListResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ProductArray)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPost202ListPollerResponse from the provided client and resume token.
-func (l *LROsClientPost202ListPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Post202List", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPost202ListPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPost202ListResponse contains the response from method LROsClient.Post202List.
@@ -1979,77 +249,9 @@ type LROsClientPost202ListResponse struct {
 	ProductArray []*Product
 }
 
-// LROsClientPost202NoRetry204PollerResponse contains the response from method LROsClient.Post202NoRetry204.
-type LROsClientPost202NoRetry204PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPost202NoRetry204Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPost202NoRetry204PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202NoRetry204Response, error) {
-	respType := LROsClientPost202NoRetry204Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPost202NoRetry204PollerResponse from the provided client and resume token.
-func (l *LROsClientPost202NoRetry204PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Post202NoRetry204", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPost202NoRetry204Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPost202NoRetry204Response contains the response from method LROsClient.Post202NoRetry204.
 type LROsClientPost202NoRetry204Response struct {
 	Product
-}
-
-// LROsClientPost202Retry200PollerResponse contains the response from method LROsClient.Post202Retry200.
-type LROsClientPost202Retry200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPost202Retry200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPost202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPost202Retry200Response, error) {
-	respType := LROsClientPost202Retry200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPost202Retry200PollerResponse from the provided client and resume token.
-func (l *LROsClientPost202Retry200PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Post202Retry200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPost202Retry200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPost202Retry200Response contains the response from method LROsClient.Post202Retry200.
@@ -2057,77 +259,9 @@ type LROsClientPost202Retry200Response struct {
 	// placeholder for future response values
 }
 
-// LROsClientPostAsyncNoRetrySucceededPollerResponse contains the response from method LROsClient.PostAsyncNoRetrySucceeded.
-type LROsClientPostAsyncNoRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPostAsyncNoRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPostAsyncNoRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncNoRetrySucceededResponse, error) {
-	respType := LROsClientPostAsyncNoRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPostAsyncNoRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientPostAsyncNoRetrySucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncNoRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPostAsyncNoRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPostAsyncNoRetrySucceededResponse contains the response from method LROsClient.PostAsyncNoRetrySucceeded.
 type LROsClientPostAsyncNoRetrySucceededResponse struct {
 	Product
-}
-
-// LROsClientPostAsyncRetryFailedPollerResponse contains the response from method LROsClient.PostAsyncRetryFailed.
-type LROsClientPostAsyncRetryFailedPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPostAsyncRetryFailedPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPostAsyncRetryFailedPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetryFailedResponse, error) {
-	respType := LROsClientPostAsyncRetryFailedResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPostAsyncRetryFailedPollerResponse from the provided client and resume token.
-func (l *LROsClientPostAsyncRetryFailedPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetryFailed", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPostAsyncRetryFailedPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPostAsyncRetryFailedResponse contains the response from method LROsClient.PostAsyncRetryFailed.
@@ -2135,77 +269,9 @@ type LROsClientPostAsyncRetryFailedResponse struct {
 	// placeholder for future response values
 }
 
-// LROsClientPostAsyncRetrySucceededPollerResponse contains the response from method LROsClient.PostAsyncRetrySucceeded.
-type LROsClientPostAsyncRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPostAsyncRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPostAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetrySucceededResponse, error) {
-	respType := LROsClientPostAsyncRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPostAsyncRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientPostAsyncRetrySucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPostAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPostAsyncRetrySucceededResponse contains the response from method LROsClient.PostAsyncRetrySucceeded.
 type LROsClientPostAsyncRetrySucceededResponse struct {
 	Product
-}
-
-// LROsClientPostAsyncRetrycanceledPollerResponse contains the response from method LROsClient.PostAsyncRetrycanceled.
-type LROsClientPostAsyncRetrycanceledPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPostAsyncRetrycanceledPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPostAsyncRetrycanceledPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostAsyncRetrycanceledResponse, error) {
-	respType := LROsClientPostAsyncRetrycanceledResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPostAsyncRetrycanceledPollerResponse from the provided client and resume token.
-func (l *LROsClientPostAsyncRetrycanceledPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PostAsyncRetrycanceled", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPostAsyncRetrycanceledPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPostAsyncRetrycanceledResponse contains the response from method LROsClient.PostAsyncRetrycanceled.
@@ -2213,78 +279,9 @@ type LROsClientPostAsyncRetrycanceledResponse struct {
 	// placeholder for future response values
 }
 
-// LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault.
-type LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse, error) {
-	respType := LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse from the provided client and resume
-// token.
-func (l *LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault.
 type LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse struct {
 	Product
-}
-
-// LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGet.
-type LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse, error) {
-	respType := LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse from the provided client and resume token.
-func (l *LROsClientPostDoubleHeadersFinalAzureHeaderGetPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGet", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPostDoubleHeadersFinalAzureHeaderGetPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse contains the response from method LROsClient.PostDoubleHeadersFinalAzureHeaderGet.
@@ -2292,77 +289,9 @@ type LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse struct {
 	Product
 }
 
-// LROsClientPostDoubleHeadersFinalLocationGetPollerResponse contains the response from method LROsClient.PostDoubleHeadersFinalLocationGet.
-type LROsClientPostDoubleHeadersFinalLocationGetPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPostDoubleHeadersFinalLocationGetPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPostDoubleHeadersFinalLocationGetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPostDoubleHeadersFinalLocationGetResponse, error) {
-	respType := LROsClientPostDoubleHeadersFinalLocationGetResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPostDoubleHeadersFinalLocationGetPollerResponse from the provided client and resume token.
-func (l *LROsClientPostDoubleHeadersFinalLocationGetPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalLocationGet", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPostDoubleHeadersFinalLocationGetPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPostDoubleHeadersFinalLocationGetResponse contains the response from method LROsClient.PostDoubleHeadersFinalLocationGet.
 type LROsClientPostDoubleHeadersFinalLocationGetResponse struct {
 	Product
-}
-
-// LROsClientPut200Acceptedcanceled200PollerResponse contains the response from method LROsClient.Put200Acceptedcanceled200.
-type LROsClientPut200Acceptedcanceled200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPut200Acceptedcanceled200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPut200Acceptedcanceled200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200Acceptedcanceled200Response, error) {
-	respType := LROsClientPut200Acceptedcanceled200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPut200Acceptedcanceled200PollerResponse from the provided client and resume token.
-func (l *LROsClientPut200Acceptedcanceled200PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Put200Acceptedcanceled200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPut200Acceptedcanceled200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPut200Acceptedcanceled200Response contains the response from method LROsClient.Put200Acceptedcanceled200.
@@ -2370,77 +299,9 @@ type LROsClientPut200Acceptedcanceled200Response struct {
 	Product
 }
 
-// LROsClientPut200SucceededNoStatePollerResponse contains the response from method LROsClient.Put200SucceededNoState.
-type LROsClientPut200SucceededNoStatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPut200SucceededNoStatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPut200SucceededNoStatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200SucceededNoStateResponse, error) {
-	respType := LROsClientPut200SucceededNoStateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPut200SucceededNoStatePollerResponse from the provided client and resume token.
-func (l *LROsClientPut200SucceededNoStatePollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Put200SucceededNoState", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPut200SucceededNoStatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPut200SucceededNoStateResponse contains the response from method LROsClient.Put200SucceededNoState.
 type LROsClientPut200SucceededNoStateResponse struct {
 	Product
-}
-
-// LROsClientPut200SucceededPollerResponse contains the response from method LROsClient.Put200Succeeded.
-type LROsClientPut200SucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPut200SucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPut200SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200SucceededResponse, error) {
-	respType := LROsClientPut200SucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPut200SucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientPut200SucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Put200Succeeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPut200SucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPut200SucceededResponse contains the response from method LROsClient.Put200Succeeded.
@@ -2448,77 +309,9 @@ type LROsClientPut200SucceededResponse struct {
 	Product
 }
 
-// LROsClientPut200UpdatingSucceeded204PollerResponse contains the response from method LROsClient.Put200UpdatingSucceeded204.
-type LROsClientPut200UpdatingSucceeded204PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPut200UpdatingSucceeded204Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPut200UpdatingSucceeded204PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut200UpdatingSucceeded204Response, error) {
-	respType := LROsClientPut200UpdatingSucceeded204Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPut200UpdatingSucceeded204PollerResponse from the provided client and resume token.
-func (l *LROsClientPut200UpdatingSucceeded204PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Put200UpdatingSucceeded204", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPut200UpdatingSucceeded204Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPut200UpdatingSucceeded204Response contains the response from method LROsClient.Put200UpdatingSucceeded204.
 type LROsClientPut200UpdatingSucceeded204Response struct {
 	Product
-}
-
-// LROsClientPut201CreatingFailed200PollerResponse contains the response from method LROsClient.Put201CreatingFailed200.
-type LROsClientPut201CreatingFailed200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPut201CreatingFailed200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPut201CreatingFailed200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201CreatingFailed200Response, error) {
-	respType := LROsClientPut201CreatingFailed200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPut201CreatingFailed200PollerResponse from the provided client and resume token.
-func (l *LROsClientPut201CreatingFailed200PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Put201CreatingFailed200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPut201CreatingFailed200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPut201CreatingFailed200Response contains the response from method LROsClient.Put201CreatingFailed200.
@@ -2526,77 +319,9 @@ type LROsClientPut201CreatingFailed200Response struct {
 	Product
 }
 
-// LROsClientPut201CreatingSucceeded200PollerResponse contains the response from method LROsClient.Put201CreatingSucceeded200.
-type LROsClientPut201CreatingSucceeded200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPut201CreatingSucceeded200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPut201CreatingSucceeded200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201CreatingSucceeded200Response, error) {
-	respType := LROsClientPut201CreatingSucceeded200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPut201CreatingSucceeded200PollerResponse from the provided client and resume token.
-func (l *LROsClientPut201CreatingSucceeded200PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Put201CreatingSucceeded200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPut201CreatingSucceeded200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPut201CreatingSucceeded200Response contains the response from method LROsClient.Put201CreatingSucceeded200.
 type LROsClientPut201CreatingSucceeded200Response struct {
 	Product
-}
-
-// LROsClientPut201SucceededPollerResponse contains the response from method LROsClient.Put201Succeeded.
-type LROsClientPut201SucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPut201SucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPut201SucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut201SucceededResponse, error) {
-	respType := LROsClientPut201SucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPut201SucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientPut201SucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Put201Succeeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPut201SucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPut201SucceededResponse contains the response from method LROsClient.Put201Succeeded.
@@ -2604,77 +329,9 @@ type LROsClientPut201SucceededResponse struct {
 	Product
 }
 
-// LROsClientPut202Retry200PollerResponse contains the response from method LROsClient.Put202Retry200.
-type LROsClientPut202Retry200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPut202Retry200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPut202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPut202Retry200Response, error) {
-	respType := LROsClientPut202Retry200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPut202Retry200PollerResponse from the provided client and resume token.
-func (l *LROsClientPut202Retry200PollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.Put202Retry200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPut202Retry200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPut202Retry200Response contains the response from method LROsClient.Put202Retry200.
 type LROsClientPut202Retry200Response struct {
 	Product
-}
-
-// LROsClientPutAsyncNoHeaderInRetryPollerResponse contains the response from method LROsClient.PutAsyncNoHeaderInRetry.
-type LROsClientPutAsyncNoHeaderInRetryPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutAsyncNoHeaderInRetryPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutAsyncNoHeaderInRetryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoHeaderInRetryResponse, error) {
-	respType := LROsClientPutAsyncNoHeaderInRetryResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutAsyncNoHeaderInRetryPollerResponse from the provided client and resume token.
-func (l *LROsClientPutAsyncNoHeaderInRetryPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoHeaderInRetry", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutAsyncNoHeaderInRetryPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPutAsyncNoHeaderInRetryResponse contains the response from method LROsClient.PutAsyncNoHeaderInRetry.
@@ -2682,77 +339,9 @@ type LROsClientPutAsyncNoHeaderInRetryResponse struct {
 	Product
 }
 
-// LROsClientPutAsyncNoRetrySucceededPollerResponse contains the response from method LROsClient.PutAsyncNoRetrySucceeded.
-type LROsClientPutAsyncNoRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutAsyncNoRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutAsyncNoRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoRetrySucceededResponse, error) {
-	respType := LROsClientPutAsyncNoRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutAsyncNoRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientPutAsyncNoRetrySucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutAsyncNoRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPutAsyncNoRetrySucceededResponse contains the response from method LROsClient.PutAsyncNoRetrySucceeded.
 type LROsClientPutAsyncNoRetrySucceededResponse struct {
 	Product
-}
-
-// LROsClientPutAsyncNoRetrycanceledPollerResponse contains the response from method LROsClient.PutAsyncNoRetrycanceled.
-type LROsClientPutAsyncNoRetrycanceledPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutAsyncNoRetrycanceledPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutAsyncNoRetrycanceledPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNoRetrycanceledResponse, error) {
-	respType := LROsClientPutAsyncNoRetrycanceledResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutAsyncNoRetrycanceledPollerResponse from the provided client and resume token.
-func (l *LROsClientPutAsyncNoRetrycanceledPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrycanceled", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutAsyncNoRetrycanceledPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPutAsyncNoRetrycanceledResponse contains the response from method LROsClient.PutAsyncNoRetrycanceled.
@@ -2760,77 +349,9 @@ type LROsClientPutAsyncNoRetrycanceledResponse struct {
 	Product
 }
 
-// LROsClientPutAsyncNonResourcePollerResponse contains the response from method LROsClient.PutAsyncNonResource.
-type LROsClientPutAsyncNonResourcePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutAsyncNonResourcePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutAsyncNonResourcePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncNonResourceResponse, error) {
-	respType := LROsClientPutAsyncNonResourceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutAsyncNonResourcePollerResponse from the provided client and resume token.
-func (l *LROsClientPutAsyncNonResourcePollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncNonResource", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutAsyncNonResourcePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPutAsyncNonResourceResponse contains the response from method LROsClient.PutAsyncNonResource.
 type LROsClientPutAsyncNonResourceResponse struct {
 	SKU
-}
-
-// LROsClientPutAsyncRetryFailedPollerResponse contains the response from method LROsClient.PutAsyncRetryFailed.
-type LROsClientPutAsyncRetryFailedPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutAsyncRetryFailedPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutAsyncRetryFailedPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncRetryFailedResponse, error) {
-	respType := LROsClientPutAsyncRetryFailedResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutAsyncRetryFailedPollerResponse from the provided client and resume token.
-func (l *LROsClientPutAsyncRetryFailedPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncRetryFailed", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutAsyncRetryFailedPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPutAsyncRetryFailedResponse contains the response from method LROsClient.PutAsyncRetryFailed.
@@ -2838,77 +359,9 @@ type LROsClientPutAsyncRetryFailedResponse struct {
 	Product
 }
 
-// LROsClientPutAsyncRetrySucceededPollerResponse contains the response from method LROsClient.PutAsyncRetrySucceeded.
-type LROsClientPutAsyncRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutAsyncRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncRetrySucceededResponse, error) {
-	respType := LROsClientPutAsyncRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutAsyncRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LROsClientPutAsyncRetrySucceededPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPutAsyncRetrySucceededResponse contains the response from method LROsClient.PutAsyncRetrySucceeded.
 type LROsClientPutAsyncRetrySucceededResponse struct {
 	Product
-}
-
-// LROsClientPutAsyncSubResourcePollerResponse contains the response from method LROsClient.PutAsyncSubResource.
-type LROsClientPutAsyncSubResourcePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutAsyncSubResourcePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutAsyncSubResourcePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutAsyncSubResourceResponse, error) {
-	respType := LROsClientPutAsyncSubResourceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SubProduct)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutAsyncSubResourcePollerResponse from the provided client and resume token.
-func (l *LROsClientPutAsyncSubResourcePollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutAsyncSubResource", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutAsyncSubResourcePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPutAsyncSubResourceResponse contains the response from method LROsClient.PutAsyncSubResource.
@@ -2916,77 +369,9 @@ type LROsClientPutAsyncSubResourceResponse struct {
 	SubProduct
 }
 
-// LROsClientPutNoHeaderInRetryPollerResponse contains the response from method LROsClient.PutNoHeaderInRetry.
-type LROsClientPutNoHeaderInRetryPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutNoHeaderInRetryPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutNoHeaderInRetryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutNoHeaderInRetryResponse, error) {
-	respType := LROsClientPutNoHeaderInRetryResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutNoHeaderInRetryPollerResponse from the provided client and resume token.
-func (l *LROsClientPutNoHeaderInRetryPollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutNoHeaderInRetry", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutNoHeaderInRetryPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPutNoHeaderInRetryResponse contains the response from method LROsClient.PutNoHeaderInRetry.
 type LROsClientPutNoHeaderInRetryResponse struct {
 	Product
-}
-
-// LROsClientPutNonResourcePollerResponse contains the response from method LROsClient.PutNonResource.
-type LROsClientPutNonResourcePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutNonResourcePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutNonResourcePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutNonResourceResponse, error) {
-	respType := LROsClientPutNonResourceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SKU)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutNonResourcePollerResponse from the provided client and resume token.
-func (l *LROsClientPutNonResourcePollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutNonResource", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutNonResourcePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsClientPutNonResourceResponse contains the response from method LROsClient.PutNonResource.
@@ -2994,77 +379,9 @@ type LROsClientPutNonResourceResponse struct {
 	SKU
 }
 
-// LROsClientPutSubResourcePollerResponse contains the response from method LROsClient.PutSubResource.
-type LROsClientPutSubResourcePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsClientPutSubResourcePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsClientPutSubResourcePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsClientPutSubResourceResponse, error) {
-	respType := LROsClientPutSubResourceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SubProduct)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsClientPutSubResourcePollerResponse from the provided client and resume token.
-func (l *LROsClientPutSubResourcePollerResponse) Resume(ctx context.Context, client *LROsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsClient.PutSubResource", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsClientPutSubResourcePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsClientPutSubResourceResponse contains the response from method LROsClient.PutSubResource.
 type LROsClientPutSubResourceResponse struct {
 	SubProduct
-}
-
-// LROsCustomHeaderClientPost202Retry200PollerResponse contains the response from method LROsCustomHeaderClient.Post202Retry200.
-type LROsCustomHeaderClientPost202Retry200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsCustomHeaderClientPost202Retry200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsCustomHeaderClientPost202Retry200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPost202Retry200Response, error) {
-	respType := LROsCustomHeaderClientPost202Retry200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsCustomHeaderClientPost202Retry200PollerResponse from the provided client and resume token.
-func (l *LROsCustomHeaderClientPost202Retry200PollerResponse) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.Post202Retry200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsCustomHeaderClientPost202Retry200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsCustomHeaderClientPost202Retry200Response contains the response from method LROsCustomHeaderClient.Post202Retry200.
@@ -3072,117 +389,14 @@ type LROsCustomHeaderClientPost202Retry200Response struct {
 	// placeholder for future response values
 }
 
-// LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse contains the response from method LROsCustomHeaderClient.PostAsyncRetrySucceeded.
-type LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsCustomHeaderClientPostAsyncRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPostAsyncRetrySucceededResponse, error) {
-	respType := LROsCustomHeaderClientPostAsyncRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LROsCustomHeaderClientPostAsyncRetrySucceededPollerResponse) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.PostAsyncRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsCustomHeaderClientPostAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsCustomHeaderClientPostAsyncRetrySucceededResponse contains the response from method LROsCustomHeaderClient.PostAsyncRetrySucceeded.
 type LROsCustomHeaderClientPostAsyncRetrySucceededResponse struct {
 	// placeholder for future response values
 }
 
-// LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse contains the response from method LROsCustomHeaderClient.Put201CreatingSucceeded200.
-type LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsCustomHeaderClientPut201CreatingSucceeded200Poller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPut201CreatingSucceeded200Response, error) {
-	respType := LROsCustomHeaderClientPut201CreatingSucceeded200Response{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse from the provided client and resume
-// token.
-func (l *LROsCustomHeaderClientPut201CreatingSucceeded200PollerResponse) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.Put201CreatingSucceeded200", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsCustomHeaderClientPut201CreatingSucceeded200Poller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LROsCustomHeaderClientPut201CreatingSucceeded200Response contains the response from method LROsCustomHeaderClient.Put201CreatingSucceeded200.
 type LROsCustomHeaderClientPut201CreatingSucceeded200Response struct {
 	Product
-}
-
-// LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse contains the response from method LROsCustomHeaderClient.PutAsyncRetrySucceeded.
-type LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LROsCustomHeaderClientPutAsyncRetrySucceededPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LROsCustomHeaderClientPutAsyncRetrySucceededResponse, error) {
-	respType := LROsCustomHeaderClientPutAsyncRetrySucceededResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Product)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse from the provided client and resume token.
-func (l *LROsCustomHeaderClientPutAsyncRetrySucceededPollerResponse) Resume(ctx context.Context, client *LROsCustomHeaderClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LROsCustomHeaderClient.PutAsyncRetrySucceeded", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LROsCustomHeaderClientPutAsyncRetrySucceededPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LROsCustomHeaderClientPutAsyncRetrySucceededResponse contains the response from method LROsCustomHeaderClient.PutAsyncRetrySucceeded.

--- a/test/autorest/lrogroup/zz_generated_response_types.go
+++ b/test/autorest/lrogroup/zz_generated_response_types.go
@@ -238,6 +238,16 @@ type LROsClientPatch200SucceededIgnoreHeadersResponse struct {
 	Product
 }
 
+// LROsClientPatch201RetryWithAsyncHeaderResponse contains the response from method LROsClient.Patch201RetryWithAsyncHeader.
+type LROsClientPatch201RetryWithAsyncHeaderResponse struct {
+	Product
+}
+
+// LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse contains the response from method LROsClient.Patch202RetryWithAsyncAndLocationHeader.
+type LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse struct {
+	Product
+}
+
 // LROsClientPost200WithPayloadResponse contains the response from method LROsClient.Post200WithPayload.
 type LROsClientPost200WithPayloadResponse struct {
 	SKU

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -154,9 +154,8 @@ func TestGetMultiplePagesLro(t *testing.T) {
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
 	poller = &PagingClientGetMultiplePagesLROPoller{}
-	pager, err := poller.Resume(context.Background(), client, rt)
-	require.NoError(t, err)
-	pager, err = poller.PollUntilDone(context.Background(), time.Second)
+	require.NoError(t, poller.Resume(rt, client))
+	pager, err := poller.PollUntilDone(context.Background(), time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -149,17 +149,17 @@ func TestGetMultiplePagesFragmentWithGroupingNextLink(t *testing.T) {
 // GetMultiplePagesLro - A long-running paging operation that includes a nextLink that has 10 pages
 func TestGetMultiplePagesLro(t *testing.T) {
 	client := newPagingClient()
-	resp, err := client.BeginGetMultiplePagesLRO(context.Background(), nil)
+	poller, err := client.BeginGetMultiplePagesLRO(context.Background(), nil)
 	require.NoError(t, err)
-	poller := resp.Poller
 	rt, err := poller.ResumeToken()
 	require.NoError(t, err)
-	resp = PagingClientGetMultiplePagesLROPollerResponse{}
-	if err = resp.Resume(context.Background(), client, rt); err != nil {
+	poller = &PagingClientGetMultiplePagesLROPoller{}
+	pager, err := poller.Resume(context.Background(), client, rt)
+	require.NoError(t, err)
+	pager, err = poller.PollUntilDone(context.Background(), time.Second)
+	if err != nil {
 		t.Fatal(err)
 	}
-	pager, err := resp.PollUntilDone(context.Background(), time.Second)
-	require.NoError(t, err)
 	count := 0
 	for pager.More() {
 		page, err := pager.NextPage(context.Background())

--- a/test/autorest/paginggroup/zz_generated_models.go
+++ b/test/autorest/paginggroup/zz_generated_models.go
@@ -36,6 +36,12 @@ type PagingClientBeginGetMultiplePagesLROOptions struct {
 	Timeout *int32
 }
 
+// PagingClientDuplicateParamsOptions contains the optional parameters for the PagingClient.DuplicateParams method.
+type PagingClientDuplicateParamsOptions struct {
+	// OData filter options. Pass in 'foo'
+	Filter *string
+}
+
 // PagingClientFirstResponseEmptyOptions contains the optional parameters for the PagingClient.FirstResponseEmpty method.
 type PagingClientFirstResponseEmptyOptions struct {
 	// placeholder for future optional parameters

--- a/test/autorest/paginggroup/zz_generated_models.go
+++ b/test/autorest/paginggroup/zz_generated_models.go
@@ -36,12 +36,6 @@ type PagingClientBeginGetMultiplePagesLROOptions struct {
 	Timeout *int32
 }
 
-// PagingClientDuplicateParamsOptions contains the optional parameters for the PagingClient.DuplicateParams method.
-type PagingClientDuplicateParamsOptions struct {
-	// OData filter options. Pass in 'foo'
-	Filter *string
-}
-
 // PagingClientFirstResponseEmptyOptions contains the optional parameters for the PagingClient.FirstResponseEmpty method.
 type PagingClientFirstResponseEmptyOptions struct {
 	// placeholder for future optional parameters

--- a/test/autorest/paginggroup/zz_generated_pagers.go
+++ b/test/autorest/paginggroup/zz_generated_pagers.go
@@ -17,55 +17,6 @@ import (
 	"reflect"
 )
 
-// PagingClientDuplicateParamsPager provides operations for iterating over paged responses.
-type PagingClientDuplicateParamsPager struct {
-	client    *PagingClient
-	current   PagingClientDuplicateParamsResponse
-	requester func(context.Context) (*policy.Request, error)
-	advancer  func(context.Context, PagingClientDuplicateParamsResponse) (*policy.Request, error)
-}
-
-// More returns true if there are more pages to retrieve.
-func (p *PagingClientDuplicateParamsPager) More() bool {
-	if !reflect.ValueOf(p.current).IsZero() {
-		if p.current.ProductResult.NextLink == nil || len(*p.current.ProductResult.NextLink) == 0 {
-			return false
-		}
-	}
-	return true
-}
-
-// NextPage advances the pager to the next page.
-func (p *PagingClientDuplicateParamsPager) NextPage(ctx context.Context) (PagingClientDuplicateParamsResponse, error) {
-	var req *policy.Request
-	var err error
-	if !reflect.ValueOf(p.current).IsZero() {
-		if !p.More() {
-			return PagingClientDuplicateParamsResponse{}, errors.New("no more pages")
-		}
-		req, err = p.advancer(ctx, p.current)
-	} else {
-		req, err = p.requester(ctx)
-	}
-	if err != nil {
-		return PagingClientDuplicateParamsResponse{}, err
-	}
-	resp, err := p.client.pl.Do(req)
-	if err != nil {
-		return PagingClientDuplicateParamsResponse{}, err
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-
-		return PagingClientDuplicateParamsResponse{}, runtime.NewResponseError(resp)
-	}
-	result, err := p.client.duplicateParamsHandleResponse(resp)
-	if err != nil {
-		return PagingClientDuplicateParamsResponse{}, err
-	}
-	p.current = result
-	return p.current, nil
-}
-
 // PagingClientFirstResponseEmptyPager provides operations for iterating over paged responses.
 type PagingClientFirstResponseEmptyPager struct {
 	client    *PagingClient

--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -39,6 +39,47 @@ func NewPagingClient(options *azcore.ClientOptions) *PagingClient {
 	return client
 }
 
+// DuplicateParams - Define filter as a query param for all calls. However, the returned next link will also include the filter
+// as part of it. Make sure you don't end up duplicating the filter param in the url sent.
+// If the operation fails it returns an *azcore.ResponseError type.
+// options - PagingClientDuplicateParamsOptions contains the optional parameters for the PagingClient.DuplicateParams method.
+func (client *PagingClient) DuplicateParams(options *PagingClientDuplicateParamsOptions) *PagingClientDuplicateParamsPager {
+	return &PagingClientDuplicateParamsPager{
+		client: client,
+		requester: func(ctx context.Context) (*policy.Request, error) {
+			return client.duplicateParamsCreateRequest(ctx, options)
+		},
+		advancer: func(ctx context.Context, resp PagingClientDuplicateParamsResponse) (*policy.Request, error) {
+			return runtime.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
+		},
+	}
+}
+
+// duplicateParamsCreateRequest creates the DuplicateParams request.
+func (client *PagingClient) duplicateParamsCreateRequest(ctx context.Context, options *PagingClientDuplicateParamsOptions) (*policy.Request, error) {
+	urlPath := "/paging/multiple/duplicateParams/1"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	if options != nil && options.Filter != nil {
+		reqQP.Set("$filter", *options.Filter)
+	}
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// duplicateParamsHandleResponse handles the DuplicateParams response.
+func (client *PagingClient) duplicateParamsHandleResponse(resp *http.Response) (PagingClientDuplicateParamsResponse, error) {
+	result := PagingClientDuplicateParamsResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
+		return PagingClientDuplicateParamsResponse{}, err
+	}
+	return result, nil
+}
+
 // FirstResponseEmpty - A paging operation whose first response's items list is empty, but still returns a next link. Second
 // (and final) call, will give you an items list of 1.
 // If the operation fails it returns an *azcore.ResponseError type.

--- a/test/autorest/paginggroup/zz_generated_response_types.go
+++ b/test/autorest/paginggroup/zz_generated_response_types.go
@@ -8,17 +8,6 @@
 
 package paginggroup
 
-import (
-	"context"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"time"
-)
-
-// PagingClientDuplicateParamsResponse contains the response from method PagingClient.DuplicateParams.
-type PagingClientDuplicateParamsResponse struct {
-	ProductResult
-}
-
 // PagingClientFirstResponseEmptyResponse contains the response from method PagingClient.FirstResponseEmpty.
 type PagingClientFirstResponseEmptyResponse struct {
 	ProductResultValue
@@ -42,42 +31,6 @@ type PagingClientGetMultiplePagesFragmentNextLinkResponse struct {
 // PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse contains the response from method PagingClient.GetMultiplePagesFragmentWithGroupingNextLink.
 type PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse struct {
 	ODataProductResult
-}
-
-// PagingClientGetMultiplePagesLROPollerResponse contains the response from method PagingClient.GetMultiplePagesLRO.
-type PagingClientGetMultiplePagesLROPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PagingClientGetMultiplePagesLROPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l PagingClientGetMultiplePagesLROPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (*PagingClientGetMultiplePagesLROPager, error) {
-	respType := &PagingClientGetMultiplePagesLROPager{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.ProductResult)
-	if err != nil {
-		return respType, err
-	}
-	respType.client = l.Poller.client
-	return respType, nil
-}
-
-// Resume rehydrates a PagingClientGetMultiplePagesLROPollerResponse from the provided client and resume token.
-func (l *PagingClientGetMultiplePagesLROPollerResponse) Resume(ctx context.Context, client *PagingClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PagingClient.GetMultiplePagesLRO", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PagingClientGetMultiplePagesLROPoller{
-		pt:     pt,
-		client: client,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PagingClientGetMultiplePagesLROResponse contains the response from method PagingClient.GetMultiplePagesLRO.

--- a/test/autorest/paginggroup/zz_generated_response_types.go
+++ b/test/autorest/paginggroup/zz_generated_response_types.go
@@ -8,6 +8,11 @@
 
 package paginggroup
 
+// PagingClientDuplicateParamsResponse contains the response from method PagingClient.DuplicateParams.
+type PagingClientDuplicateParamsResponse struct {
+	ProductResult
+}
+
 // PagingClientFirstResponseEmptyResponse contains the response from method PagingClient.FirstResponseEmpty.
 type PagingClientFirstResponseEmptyResponse struct {
 	ProductResultValue

--- a/test/compute/2019-12-01/armcompute/go.mod
+++ b/test/compute/2019-12-01/armcompute/go.mod
@@ -2,4 +2,4 @@ module armcompute
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/compute/2019-12-01/armcompute/go.sum
+++ b/test/compute/2019-12-01/armcompute/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
@@ -58,20 +58,16 @@ func NewContainerServicesClient(subscriptionID string, credential azcore.TokenCr
 // parameters - Parameters supplied to the Create or Update a Container Service operation.
 // options - ContainerServicesClientBeginCreateOrUpdateOptions contains the optional parameters for the ContainerServicesClient.BeginCreateOrUpdate
 // method.
-func (client *ContainerServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService, options *ContainerServicesClientBeginCreateOrUpdateOptions) (ContainerServicesClientCreateOrUpdatePollerResponse, error) {
+func (client *ContainerServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService, options *ContainerServicesClientBeginCreateOrUpdateOptions) (*ContainerServicesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, containerServiceName, parameters, options)
 	if err != nil {
-		return ContainerServicesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ContainerServicesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ContainerServicesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return ContainerServicesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ContainerServicesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ContainerServicesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a container service with the specified configuration of orchestrator, masters, and
@@ -127,20 +123,16 @@ func (client *ContainerServicesClient) createOrUpdateCreateRequest(ctx context.C
 // containerServiceName - The name of the container service in the specified subscription and resource group.
 // options - ContainerServicesClientBeginDeleteOptions contains the optional parameters for the ContainerServicesClient.BeginDelete
 // method.
-func (client *ContainerServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesClientBeginDeleteOptions) (ContainerServicesClientDeletePollerResponse, error) {
+func (client *ContainerServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesClientBeginDeleteOptions) (*ContainerServicesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, containerServiceName, options)
 	if err != nil {
-		return ContainerServicesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ContainerServicesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ContainerServicesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return ContainerServicesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ContainerServicesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ContainerServicesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified container service in the specified subscription and resource group. The operation does not

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
@@ -58,20 +58,16 @@ func NewDedicatedHostsClient(subscriptionID string, credential azcore.TokenCrede
 // parameters - Parameters supplied to the Create Dedicated Host.
 // options - DedicatedHostsClientBeginCreateOrUpdateOptions contains the optional parameters for the DedicatedHostsClient.BeginCreateOrUpdate
 // method.
-func (client *DedicatedHostsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost, options *DedicatedHostsClientBeginCreateOrUpdateOptions) (DedicatedHostsClientCreateOrUpdatePollerResponse, error) {
+func (client *DedicatedHostsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost, options *DedicatedHostsClientBeginCreateOrUpdateOptions) (*DedicatedHostsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, hostGroupName, hostName, parameters, options)
 	if err != nil {
-		return DedicatedHostsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := DedicatedHostsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DedicatedHostsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return DedicatedHostsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DedicatedHostsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DedicatedHostsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a dedicated host .
@@ -128,20 +124,16 @@ func (client *DedicatedHostsClient) createOrUpdateCreateRequest(ctx context.Cont
 // hostName - The name of the dedicated host.
 // options - DedicatedHostsClientBeginDeleteOptions contains the optional parameters for the DedicatedHostsClient.BeginDelete
 // method.
-func (client *DedicatedHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsClientBeginDeleteOptions) (DedicatedHostsClientDeletePollerResponse, error) {
+func (client *DedicatedHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsClientBeginDeleteOptions) (*DedicatedHostsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, hostGroupName, hostName, options)
 	if err != nil {
-		return DedicatedHostsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := DedicatedHostsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DedicatedHostsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return DedicatedHostsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DedicatedHostsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DedicatedHostsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Delete a dedicated host.
@@ -315,20 +307,16 @@ func (client *DedicatedHostsClient) listByHostGroupHandleResponse(resp *http.Res
 // parameters - Parameters supplied to the Update Dedicated Host operation.
 // options - DedicatedHostsClientBeginUpdateOptions contains the optional parameters for the DedicatedHostsClient.BeginUpdate
 // method.
-func (client *DedicatedHostsClient) BeginUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate, options *DedicatedHostsClientBeginUpdateOptions) (DedicatedHostsClientUpdatePollerResponse, error) {
+func (client *DedicatedHostsClient) BeginUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate, options *DedicatedHostsClientBeginUpdateOptions) (*DedicatedHostsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, hostGroupName, hostName, parameters, options)
 	if err != nil {
-		return DedicatedHostsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := DedicatedHostsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DedicatedHostsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return DedicatedHostsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DedicatedHostsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DedicatedHostsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Update an dedicated host .

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
@@ -59,20 +59,16 @@ func NewDiskEncryptionSetsClient(subscriptionID string, credential azcore.TokenC
 // diskEncryptionSet - disk encryption set object supplied in the body of the Put disk encryption set operation.
 // options - DiskEncryptionSetsClientBeginCreateOrUpdateOptions contains the optional parameters for the DiskEncryptionSetsClient.BeginCreateOrUpdate
 // method.
-func (client *DiskEncryptionSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet, options *DiskEncryptionSetsClientBeginCreateOrUpdateOptions) (DiskEncryptionSetsClientCreateOrUpdatePollerResponse, error) {
+func (client *DiskEncryptionSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet, options *DiskEncryptionSetsClientBeginCreateOrUpdateOptions) (*DiskEncryptionSetsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet, options)
 	if err != nil {
-		return DiskEncryptionSetsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := DiskEncryptionSetsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DiskEncryptionSetsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return DiskEncryptionSetsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DiskEncryptionSetsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DiskEncryptionSetsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a disk encryption set
@@ -126,20 +122,16 @@ func (client *DiskEncryptionSetsClient) createOrUpdateCreateRequest(ctx context.
 // name length is 80 characters.
 // options - DiskEncryptionSetsClientBeginDeleteOptions contains the optional parameters for the DiskEncryptionSetsClient.BeginDelete
 // method.
-func (client *DiskEncryptionSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsClientBeginDeleteOptions) (DiskEncryptionSetsClientDeletePollerResponse, error) {
+func (client *DiskEncryptionSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsClientBeginDeleteOptions) (*DiskEncryptionSetsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, diskEncryptionSetName, options)
 	if err != nil {
-		return DiskEncryptionSetsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := DiskEncryptionSetsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DiskEncryptionSetsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return DiskEncryptionSetsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DiskEncryptionSetsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DiskEncryptionSetsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a disk encryption set.
@@ -341,20 +333,16 @@ func (client *DiskEncryptionSetsClient) listByResourceGroupHandleResponse(resp *
 // diskEncryptionSet - disk encryption set object supplied in the body of the Patch disk encryption set operation.
 // options - DiskEncryptionSetsClientBeginUpdateOptions contains the optional parameters for the DiskEncryptionSetsClient.BeginUpdate
 // method.
-func (client *DiskEncryptionSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate, options *DiskEncryptionSetsClientBeginUpdateOptions) (DiskEncryptionSetsClientUpdatePollerResponse, error) {
+func (client *DiskEncryptionSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate, options *DiskEncryptionSetsClientBeginUpdateOptions) (*DiskEncryptionSetsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet, options)
 	if err != nil {
-		return DiskEncryptionSetsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := DiskEncryptionSetsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DiskEncryptionSetsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return DiskEncryptionSetsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DiskEncryptionSetsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DiskEncryptionSetsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Updates (patches) a disk encryption set.

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
@@ -59,20 +59,16 @@ func NewDisksClient(subscriptionID string, credential azcore.TokenCredential, op
 // disk - Disk object supplied in the body of the Put disk operation.
 // options - DisksClientBeginCreateOrUpdateOptions contains the optional parameters for the DisksClient.BeginCreateOrUpdate
 // method.
-func (client *DisksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, disk Disk, options *DisksClientBeginCreateOrUpdateOptions) (DisksClientCreateOrUpdatePollerResponse, error) {
+func (client *DisksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, disk Disk, options *DisksClientBeginCreateOrUpdateOptions) (*DisksClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, diskName, disk, options)
 	if err != nil {
-		return DisksClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := DisksClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return DisksClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DisksClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DisksClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a disk.
@@ -125,20 +121,16 @@ func (client *DisksClient) createOrUpdateCreateRequest(ctx context.Context, reso
 // characters for the name are a-z, A-Z, 0-9 and _. The maximum name length is 80
 // characters.
 // options - DisksClientBeginDeleteOptions contains the optional parameters for the DisksClient.BeginDelete method.
-func (client *DisksClient) BeginDelete(ctx context.Context, resourceGroupName string, diskName string, options *DisksClientBeginDeleteOptions) (DisksClientDeletePollerResponse, error) {
+func (client *DisksClient) BeginDelete(ctx context.Context, resourceGroupName string, diskName string, options *DisksClientBeginDeleteOptions) (*DisksClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, diskName, options)
 	if err != nil {
-		return DisksClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := DisksClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return DisksClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DisksClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DisksClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a disk.
@@ -248,20 +240,16 @@ func (client *DisksClient) getHandleResponse(resp *http.Response) (DisksClientGe
 // characters.
 // grantAccessData - Access data object supplied in the body of the get disk access operation.
 // options - DisksClientBeginGrantAccessOptions contains the optional parameters for the DisksClient.BeginGrantAccess method.
-func (client *DisksClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData, options *DisksClientBeginGrantAccessOptions) (DisksClientGrantAccessPollerResponse, error) {
+func (client *DisksClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData, options *DisksClientBeginGrantAccessOptions) (*DisksClientGrantAccessPoller, error) {
 	resp, err := client.grantAccess(ctx, resourceGroupName, diskName, grantAccessData, options)
 	if err != nil {
-		return DisksClientGrantAccessPollerResponse{}, err
+		return nil, err
 	}
-	result := DisksClientGrantAccessPollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.GrantAccess", "location", resp, client.pl)
 	if err != nil {
-		return DisksClientGrantAccessPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DisksClientGrantAccessPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DisksClientGrantAccessPoller{pt: pt}, nil
 }
 
 // GrantAccess - Grants access to a disk.
@@ -404,20 +392,16 @@ func (client *DisksClient) listByResourceGroupHandleResponse(resp *http.Response
 // characters for the name are a-z, A-Z, 0-9 and _. The maximum name length is 80
 // characters.
 // options - DisksClientBeginRevokeAccessOptions contains the optional parameters for the DisksClient.BeginRevokeAccess method.
-func (client *DisksClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, diskName string, options *DisksClientBeginRevokeAccessOptions) (DisksClientRevokeAccessPollerResponse, error) {
+func (client *DisksClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, diskName string, options *DisksClientBeginRevokeAccessOptions) (*DisksClientRevokeAccessPoller, error) {
 	resp, err := client.revokeAccess(ctx, resourceGroupName, diskName, options)
 	if err != nil {
-		return DisksClientRevokeAccessPollerResponse{}, err
+		return nil, err
 	}
-	result := DisksClientRevokeAccessPollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.RevokeAccess", "location", resp, client.pl)
 	if err != nil {
-		return DisksClientRevokeAccessPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DisksClientRevokeAccessPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DisksClientRevokeAccessPoller{pt: pt}, nil
 }
 
 // RevokeAccess - Revokes access to a disk.
@@ -470,20 +454,16 @@ func (client *DisksClient) revokeAccessCreateRequest(ctx context.Context, resour
 // characters.
 // disk - Disk object supplied in the body of the Patch disk operation.
 // options - DisksClientBeginUpdateOptions contains the optional parameters for the DisksClient.BeginUpdate method.
-func (client *DisksClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate, options *DisksClientBeginUpdateOptions) (DisksClientUpdatePollerResponse, error) {
+func (client *DisksClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate, options *DisksClientBeginUpdateOptions) (*DisksClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, diskName, disk, options)
 	if err != nil {
-		return DisksClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := DisksClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DisksClient.Update", "", resp, client.pl)
 	if err != nil {
-		return DisksClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DisksClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DisksClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Updates (patches) a disk.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
@@ -58,20 +58,16 @@ func NewGalleriesClient(subscriptionID string, credential azcore.TokenCredential
 // gallery - Parameters supplied to the create or update Shared Image Gallery operation.
 // options - GalleriesClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleriesClient.BeginCreateOrUpdate
 // method.
-func (client *GalleriesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery, options *GalleriesClientBeginCreateOrUpdateOptions) (GalleriesClientCreateOrUpdatePollerResponse, error) {
+func (client *GalleriesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery, options *GalleriesClientBeginCreateOrUpdateOptions) (*GalleriesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, galleryName, gallery, options)
 	if err != nil {
-		return GalleriesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleriesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleriesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return GalleriesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleriesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleriesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a Shared Image Gallery.
@@ -122,20 +118,16 @@ func (client *GalleriesClient) createOrUpdateCreateRequest(ctx context.Context, 
 // resourceGroupName - The name of the resource group.
 // galleryName - The name of the Shared Image Gallery to be deleted.
 // options - GalleriesClientBeginDeleteOptions contains the optional parameters for the GalleriesClient.BeginDelete method.
-func (client *GalleriesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesClientBeginDeleteOptions) (GalleriesClientDeletePollerResponse, error) {
+func (client *GalleriesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesClientBeginDeleteOptions) (*GalleriesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, galleryName, options)
 	if err != nil {
-		return GalleriesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleriesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleriesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return GalleriesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleriesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleriesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Delete a Shared Image Gallery.
@@ -333,20 +325,16 @@ func (client *GalleriesClient) listByResourceGroupHandleResponse(resp *http.Resp
 // allowed in the middle. The maximum length is 80 characters.
 // gallery - Parameters supplied to the update Shared Image Gallery operation.
 // options - GalleriesClientBeginUpdateOptions contains the optional parameters for the GalleriesClient.BeginUpdate method.
-func (client *GalleriesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate, options *GalleriesClientBeginUpdateOptions) (GalleriesClientUpdatePollerResponse, error) {
+func (client *GalleriesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate, options *GalleriesClientBeginUpdateOptions) (*GalleriesClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, galleryName, gallery, options)
 	if err != nil {
-		return GalleriesClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleriesClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleriesClient.Update", "", resp, client.pl)
 	if err != nil {
-		return GalleriesClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleriesClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleriesClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Update a Shared Image Gallery.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
@@ -60,20 +60,16 @@ func NewGalleryApplicationsClient(subscriptionID string, credential azcore.Token
 // galleryApplication - Parameters supplied to the create or update gallery Application operation.
 // options - GalleryApplicationsClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryApplicationsClient.BeginCreateOrUpdate
 // method.
-func (client *GalleryApplicationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication, options *GalleryApplicationsClientBeginCreateOrUpdateOptions) (GalleryApplicationsClientCreateOrUpdatePollerResponse, error) {
+func (client *GalleryApplicationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication, options *GalleryApplicationsClientBeginCreateOrUpdateOptions) (*GalleryApplicationsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication, options)
 	if err != nil {
-		return GalleryApplicationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryApplicationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return GalleryApplicationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryApplicationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryApplicationsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a gallery Application Definition.
@@ -130,20 +126,16 @@ func (client *GalleryApplicationsClient) createOrUpdateCreateRequest(ctx context
 // galleryApplicationName - The name of the gallery Application Definition to be deleted.
 // options - GalleryApplicationsClientBeginDeleteOptions contains the optional parameters for the GalleryApplicationsClient.BeginDelete
 // method.
-func (client *GalleryApplicationsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsClientBeginDeleteOptions) (GalleryApplicationsClientDeletePollerResponse, error) {
+func (client *GalleryApplicationsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsClientBeginDeleteOptions) (*GalleryApplicationsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, galleryName, galleryApplicationName, options)
 	if err != nil {
-		return GalleryApplicationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryApplicationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return GalleryApplicationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryApplicationsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryApplicationsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Delete a gallery Application.
@@ -316,20 +308,16 @@ func (client *GalleryApplicationsClient) listByGalleryHandleResponse(resp *http.
 // galleryApplication - Parameters supplied to the update gallery Application operation.
 // options - GalleryApplicationsClientBeginUpdateOptions contains the optional parameters for the GalleryApplicationsClient.BeginUpdate
 // method.
-func (client *GalleryApplicationsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate, options *GalleryApplicationsClientBeginUpdateOptions) (GalleryApplicationsClientUpdatePollerResponse, error) {
+func (client *GalleryApplicationsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate, options *GalleryApplicationsClientBeginUpdateOptions) (*GalleryApplicationsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication, options)
 	if err != nil {
-		return GalleryApplicationsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryApplicationsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return GalleryApplicationsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryApplicationsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryApplicationsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Update a gallery Application Definition.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
@@ -61,20 +61,16 @@ func NewGalleryApplicationVersionsClient(subscriptionID string, credential azcor
 // galleryApplicationVersion - Parameters supplied to the create or update gallery Application Version operation.
 // options - GalleryApplicationVersionsClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryApplicationVersionsClient.BeginCreateOrUpdate
 // method.
-func (client *GalleryApplicationVersionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion, options *GalleryApplicationVersionsClientBeginCreateOrUpdateOptions) (GalleryApplicationVersionsClientCreateOrUpdatePollerResponse, error) {
+func (client *GalleryApplicationVersionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion, options *GalleryApplicationVersionsClientBeginCreateOrUpdateOptions) (*GalleryApplicationVersionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion, options)
 	if err != nil {
-		return GalleryApplicationVersionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryApplicationVersionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationVersionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return GalleryApplicationVersionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryApplicationVersionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryApplicationVersionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a gallery Application Version.
@@ -136,20 +132,16 @@ func (client *GalleryApplicationVersionsClient) createOrUpdateCreateRequest(ctx 
 // galleryApplicationVersionName - The name of the gallery Application Version to be deleted.
 // options - GalleryApplicationVersionsClientBeginDeleteOptions contains the optional parameters for the GalleryApplicationVersionsClient.BeginDelete
 // method.
-func (client *GalleryApplicationVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsClientBeginDeleteOptions) (GalleryApplicationVersionsClientDeletePollerResponse, error) {
+func (client *GalleryApplicationVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsClientBeginDeleteOptions) (*GalleryApplicationVersionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, options)
 	if err != nil {
-		return GalleryApplicationVersionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryApplicationVersionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationVersionsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return GalleryApplicationVersionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryApplicationVersionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryApplicationVersionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Delete a gallery Application Version.
@@ -342,20 +334,16 @@ func (client *GalleryApplicationVersionsClient) listByGalleryApplicationHandleRe
 // galleryApplicationVersion - Parameters supplied to the update gallery Application Version operation.
 // options - GalleryApplicationVersionsClientBeginUpdateOptions contains the optional parameters for the GalleryApplicationVersionsClient.BeginUpdate
 // method.
-func (client *GalleryApplicationVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate, options *GalleryApplicationVersionsClientBeginUpdateOptions) (GalleryApplicationVersionsClientUpdatePollerResponse, error) {
+func (client *GalleryApplicationVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate, options *GalleryApplicationVersionsClientBeginUpdateOptions) (*GalleryApplicationVersionsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion, options)
 	if err != nil {
-		return GalleryApplicationVersionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryApplicationVersionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryApplicationVersionsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return GalleryApplicationVersionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryApplicationVersionsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryApplicationVersionsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Update a gallery Application Version.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
@@ -60,20 +60,16 @@ func NewGalleryImagesClient(subscriptionID string, credential azcore.TokenCreden
 // galleryImage - Parameters supplied to the create or update gallery image operation.
 // options - GalleryImagesClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryImagesClient.BeginCreateOrUpdate
 // method.
-func (client *GalleryImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage, options *GalleryImagesClientBeginCreateOrUpdateOptions) (GalleryImagesClientCreateOrUpdatePollerResponse, error) {
+func (client *GalleryImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage, options *GalleryImagesClientBeginCreateOrUpdateOptions) (*GalleryImagesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage, options)
 	if err != nil {
-		return GalleryImagesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryImagesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImagesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return GalleryImagesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryImagesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryImagesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a gallery Image Definition.
@@ -130,20 +126,16 @@ func (client *GalleryImagesClient) createOrUpdateCreateRequest(ctx context.Conte
 // galleryImageName - The name of the gallery Image Definition to be deleted.
 // options - GalleryImagesClientBeginDeleteOptions contains the optional parameters for the GalleryImagesClient.BeginDelete
 // method.
-func (client *GalleryImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesClientBeginDeleteOptions) (GalleryImagesClientDeletePollerResponse, error) {
+func (client *GalleryImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesClientBeginDeleteOptions) (*GalleryImagesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, galleryName, galleryImageName, options)
 	if err != nil {
-		return GalleryImagesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryImagesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImagesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return GalleryImagesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryImagesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryImagesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Delete a gallery image.
@@ -315,20 +307,16 @@ func (client *GalleryImagesClient) listByGalleryHandleResponse(resp *http.Respon
 // galleryImage - Parameters supplied to the update gallery image operation.
 // options - GalleryImagesClientBeginUpdateOptions contains the optional parameters for the GalleryImagesClient.BeginUpdate
 // method.
-func (client *GalleryImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate, options *GalleryImagesClientBeginUpdateOptions) (GalleryImagesClientUpdatePollerResponse, error) {
+func (client *GalleryImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate, options *GalleryImagesClientBeginUpdateOptions) (*GalleryImagesClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage, options)
 	if err != nil {
-		return GalleryImagesClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryImagesClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImagesClient.Update", "", resp, client.pl)
 	if err != nil {
-		return GalleryImagesClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryImagesClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryImagesClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Update a gallery Image Definition.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
@@ -61,20 +61,16 @@ func NewGalleryImageVersionsClient(subscriptionID string, credential azcore.Toke
 // galleryImageVersion - Parameters supplied to the create or update gallery Image Version operation.
 // options - GalleryImageVersionsClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryImageVersionsClient.BeginCreateOrUpdate
 // method.
-func (client *GalleryImageVersionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion, options *GalleryImageVersionsClientBeginCreateOrUpdateOptions) (GalleryImageVersionsClientCreateOrUpdatePollerResponse, error) {
+func (client *GalleryImageVersionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion, options *GalleryImageVersionsClientBeginCreateOrUpdateOptions) (*GalleryImageVersionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion, options)
 	if err != nil {
-		return GalleryImageVersionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryImageVersionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImageVersionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return GalleryImageVersionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryImageVersionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryImageVersionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a gallery Image Version.
@@ -136,20 +132,16 @@ func (client *GalleryImageVersionsClient) createOrUpdateCreateRequest(ctx contex
 // galleryImageVersionName - The name of the gallery Image Version to be deleted.
 // options - GalleryImageVersionsClientBeginDeleteOptions contains the optional parameters for the GalleryImageVersionsClient.BeginDelete
 // method.
-func (client *GalleryImageVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsClientBeginDeleteOptions) (GalleryImageVersionsClientDeletePollerResponse, error) {
+func (client *GalleryImageVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsClientBeginDeleteOptions) (*GalleryImageVersionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, options)
 	if err != nil {
-		return GalleryImageVersionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryImageVersionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImageVersionsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return GalleryImageVersionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryImageVersionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryImageVersionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Delete a gallery Image Version.
@@ -341,20 +333,16 @@ func (client *GalleryImageVersionsClient) listByGalleryImageHandleResponse(resp 
 // galleryImageVersion - Parameters supplied to the update gallery Image Version operation.
 // options - GalleryImageVersionsClientBeginUpdateOptions contains the optional parameters for the GalleryImageVersionsClient.BeginUpdate
 // method.
-func (client *GalleryImageVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate, options *GalleryImageVersionsClientBeginUpdateOptions) (GalleryImageVersionsClientUpdatePollerResponse, error) {
+func (client *GalleryImageVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate, options *GalleryImageVersionsClientBeginUpdateOptions) (*GalleryImageVersionsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion, options)
 	if err != nil {
-		return GalleryImageVersionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := GalleryImageVersionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("GalleryImageVersionsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return GalleryImageVersionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &GalleryImageVersionsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &GalleryImageVersionsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Update a gallery Image Version.

--- a/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
@@ -57,20 +57,16 @@ func NewImagesClient(subscriptionID string, credential azcore.TokenCredential, o
 // parameters - Parameters supplied to the Create Image operation.
 // options - ImagesClientBeginCreateOrUpdateOptions contains the optional parameters for the ImagesClient.BeginCreateOrUpdate
 // method.
-func (client *ImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters Image, options *ImagesClientBeginCreateOrUpdateOptions) (ImagesClientCreateOrUpdatePollerResponse, error) {
+func (client *ImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters Image, options *ImagesClientBeginCreateOrUpdateOptions) (*ImagesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, imageName, parameters, options)
 	if err != nil {
-		return ImagesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ImagesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ImagesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return ImagesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ImagesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ImagesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update an image.
@@ -121,20 +117,16 @@ func (client *ImagesClient) createOrUpdateCreateRequest(ctx context.Context, res
 // resourceGroupName - The name of the resource group.
 // imageName - The name of the image.
 // options - ImagesClientBeginDeleteOptions contains the optional parameters for the ImagesClient.BeginDelete method.
-func (client *ImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, imageName string, options *ImagesClientBeginDeleteOptions) (ImagesClientDeletePollerResponse, error) {
+func (client *ImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, imageName string, options *ImagesClientBeginDeleteOptions) (*ImagesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, imageName, options)
 	if err != nil {
-		return ImagesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ImagesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ImagesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return ImagesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ImagesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ImagesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes an Image.
@@ -334,20 +326,16 @@ func (client *ImagesClient) listByResourceGroupHandleResponse(resp *http.Respons
 // imageName - The name of the image.
 // parameters - Parameters supplied to the Update Image operation.
 // options - ImagesClientBeginUpdateOptions contains the optional parameters for the ImagesClient.BeginUpdate method.
-func (client *ImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate, options *ImagesClientBeginUpdateOptions) (ImagesClientUpdatePollerResponse, error) {
+func (client *ImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate, options *ImagesClientBeginUpdateOptions) (*ImagesClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, imageName, parameters, options)
 	if err != nil {
-		return ImagesClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ImagesClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ImagesClient.Update", "", resp, client.pl)
 	if err != nil {
-		return ImagesClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ImagesClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ImagesClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Update an image.

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
@@ -57,20 +57,16 @@ func NewLogAnalyticsClient(subscriptionID string, credential azcore.TokenCredent
 // parameters - Parameters supplied to the LogAnalytics getRequestRateByInterval Api.
 // options - LogAnalyticsClientBeginExportRequestRateByIntervalOptions contains the optional parameters for the LogAnalyticsClient.BeginExportRequestRateByInterval
 // method.
-func (client *LogAnalyticsClient) BeginExportRequestRateByInterval(ctx context.Context, location string, parameters RequestRateByIntervalInput, options *LogAnalyticsClientBeginExportRequestRateByIntervalOptions) (LogAnalyticsClientExportRequestRateByIntervalPollerResponse, error) {
+func (client *LogAnalyticsClient) BeginExportRequestRateByInterval(ctx context.Context, location string, parameters RequestRateByIntervalInput, options *LogAnalyticsClientBeginExportRequestRateByIntervalOptions) (*LogAnalyticsClientExportRequestRateByIntervalPoller, error) {
 	resp, err := client.exportRequestRateByInterval(ctx, location, parameters, options)
 	if err != nil {
-		return LogAnalyticsClientExportRequestRateByIntervalPollerResponse{}, err
+		return nil, err
 	}
-	result := LogAnalyticsClientExportRequestRateByIntervalPollerResponse{}
 	pt, err := armruntime.NewPoller("LogAnalyticsClient.ExportRequestRateByInterval", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return LogAnalyticsClientExportRequestRateByIntervalPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LogAnalyticsClientExportRequestRateByIntervalPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LogAnalyticsClientExportRequestRateByIntervalPoller{pt: pt}, nil
 }
 
 // ExportRequestRateByInterval - Export logs that show Api requests made by this subscription in the given time window to
@@ -120,20 +116,16 @@ func (client *LogAnalyticsClient) exportRequestRateByIntervalCreateRequest(ctx c
 // parameters - Parameters supplied to the LogAnalytics getThrottledRequests Api.
 // options - LogAnalyticsClientBeginExportThrottledRequestsOptions contains the optional parameters for the LogAnalyticsClient.BeginExportThrottledRequests
 // method.
-func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Context, location string, parameters ThrottledRequestsInput, options *LogAnalyticsClientBeginExportThrottledRequestsOptions) (LogAnalyticsClientExportThrottledRequestsPollerResponse, error) {
+func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Context, location string, parameters ThrottledRequestsInput, options *LogAnalyticsClientBeginExportThrottledRequestsOptions) (*LogAnalyticsClientExportThrottledRequestsPoller, error) {
 	resp, err := client.exportThrottledRequests(ctx, location, parameters, options)
 	if err != nil {
-		return LogAnalyticsClientExportThrottledRequestsPollerResponse{}, err
+		return nil, err
 	}
-	result := LogAnalyticsClientExportThrottledRequestsPollerResponse{}
 	pt, err := armruntime.NewPoller("LogAnalyticsClient.ExportThrottledRequests", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return LogAnalyticsClientExportThrottledRequestsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LogAnalyticsClientExportThrottledRequestsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LogAnalyticsClientExportThrottledRequestsPoller{pt: pt}, nil
 }
 
 // ExportThrottledRequests - Export logs that show total throttled Api requests for this subscription in the given time window.

--- a/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"net/http"
 	"time"
 )
 
@@ -31,20 +32,19 @@ func (p *ContainerServicesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ContainerServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) (ContainerServicesClientCreateOrUpdateResponse, error) {
-	result := ContainerServicesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ContainerService)
-	return result, err
+func (p *ContainerServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ContainerServicesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ContainerServicesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -65,12 +65,9 @@ func (p *ContainerServicesClientCreateOrUpdatePoller) ResumeToken() (string, err
 
 // Resume rehydrates a ContainerServicesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ContainerServicesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ContainerServicesClient, token string) (ContainerServicesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainerServicesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ContainerServicesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ContainerServicesClientCreateOrUpdatePoller) Resume(token string, client *ContainerServicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ContainerServicesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ContainerServicesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -89,20 +86,19 @@ func (p *ContainerServicesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ContainerServicesClientDeletePoller) Poll(ctx context.Context) (ContainerServicesClientDeleteResponse, error) {
-	result := ContainerServicesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ContainerServicesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ContainerServicesClientDeletePoller) Result(ctx context.Context) (resp ContainerServicesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -123,12 +119,9 @@ func (p *ContainerServicesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ContainerServicesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ContainerServicesClientDeletePoller) Resume(ctx context.Context, client *ContainerServicesClient, token string) (ContainerServicesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainerServicesClient.Delete", token, client.pl); err != nil {
-		return ContainerServicesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ContainerServicesClientDeletePoller) Resume(token string, client *ContainerServicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ContainerServicesClient.Delete", token, client.pl)
+	return
 }
 
 // DedicatedHostsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -147,20 +140,19 @@ func (p *DedicatedHostsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DedicatedHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (DedicatedHostsClientCreateOrUpdateResponse, error) {
-	result := DedicatedHostsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DedicatedHost)
-	return result, err
+func (p *DedicatedHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DedicatedHostsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp DedicatedHostsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -181,12 +173,9 @@ func (p *DedicatedHostsClientCreateOrUpdatePoller) ResumeToken() (string, error)
 
 // Resume rehydrates a DedicatedHostsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DedicatedHostsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DedicatedHostsClient, token string) (DedicatedHostsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return DedicatedHostsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DedicatedHostsClientCreateOrUpdatePoller) Resume(token string, client *DedicatedHostsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // DedicatedHostsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -205,20 +194,19 @@ func (p *DedicatedHostsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DedicatedHostsClientDeletePoller) Poll(ctx context.Context) (DedicatedHostsClientDeleteResponse, error) {
-	result := DedicatedHostsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DedicatedHostsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DedicatedHostsClientDeletePoller) Result(ctx context.Context) (resp DedicatedHostsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -239,12 +227,9 @@ func (p *DedicatedHostsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DedicatedHostsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DedicatedHostsClientDeletePoller) Resume(ctx context.Context, client *DedicatedHostsClient, token string) (DedicatedHostsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.Delete", token, client.pl); err != nil {
-		return DedicatedHostsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DedicatedHostsClientDeletePoller) Resume(token string, client *DedicatedHostsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.Delete", token, client.pl)
+	return
 }
 
 // DedicatedHostsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -263,20 +248,19 @@ func (p *DedicatedHostsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DedicatedHostsClientUpdatePoller) Poll(ctx context.Context) (DedicatedHostsClientUpdateResponse, error) {
-	result := DedicatedHostsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DedicatedHost)
-	return result, err
+func (p *DedicatedHostsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DedicatedHostsClientUpdatePoller) Result(ctx context.Context) (resp DedicatedHostsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -297,12 +281,9 @@ func (p *DedicatedHostsClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DedicatedHostsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DedicatedHostsClientUpdatePoller) Resume(ctx context.Context, client *DedicatedHostsClient, token string) (DedicatedHostsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.Update", token, client.pl); err != nil {
-		return DedicatedHostsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DedicatedHostsClientUpdatePoller) Resume(token string, client *DedicatedHostsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.Update", token, client.pl)
+	return
 }
 
 // DiskEncryptionSetsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -321,20 +302,19 @@ func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
-	result := DiskEncryptionSetsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DiskEncryptionSet)
-	return result, err
+func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp DiskEncryptionSetsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -355,12 +335,9 @@ func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) ResumeToken() (string, er
 
 // Resume rehydrates a DiskEncryptionSetsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return DiskEncryptionSetsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Resume(token string, client *DiskEncryptionSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // DiskEncryptionSetsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -379,20 +356,19 @@ func (p *DiskEncryptionSetsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DiskEncryptionSetsClientDeletePoller) Poll(ctx context.Context) (DiskEncryptionSetsClientDeleteResponse, error) {
-	result := DiskEncryptionSetsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DiskEncryptionSetsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DiskEncryptionSetsClientDeletePoller) Result(ctx context.Context) (resp DiskEncryptionSetsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -413,12 +389,9 @@ func (p *DiskEncryptionSetsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DiskEncryptionSetsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DiskEncryptionSetsClientDeletePoller) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) (DiskEncryptionSetsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.Delete", token, client.pl); err != nil {
-		return DiskEncryptionSetsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DiskEncryptionSetsClientDeletePoller) Resume(token string, client *DiskEncryptionSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.Delete", token, client.pl)
+	return
 }
 
 // DiskEncryptionSetsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -437,20 +410,19 @@ func (p *DiskEncryptionSetsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DiskEncryptionSetsClientUpdatePoller) Poll(ctx context.Context) (DiskEncryptionSetsClientUpdateResponse, error) {
-	result := DiskEncryptionSetsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DiskEncryptionSet)
-	return result, err
+func (p *DiskEncryptionSetsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DiskEncryptionSetsClientUpdatePoller) Result(ctx context.Context) (resp DiskEncryptionSetsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -471,12 +443,9 @@ func (p *DiskEncryptionSetsClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DiskEncryptionSetsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DiskEncryptionSetsClientUpdatePoller) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) (DiskEncryptionSetsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.Update", token, client.pl); err != nil {
-		return DiskEncryptionSetsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DiskEncryptionSetsClientUpdatePoller) Resume(token string, client *DiskEncryptionSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.Update", token, client.pl)
+	return
 }
 
 // DisksClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -495,20 +464,19 @@ func (p *DisksClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DisksClientCreateOrUpdatePoller) Poll(ctx context.Context) (DisksClientCreateOrUpdateResponse, error) {
-	result := DisksClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Disk)
-	return result, err
+func (p *DisksClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DisksClientCreateOrUpdatePoller) Result(ctx context.Context) (resp DisksClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -529,12 +497,9 @@ func (p *DisksClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DisksClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DisksClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.CreateOrUpdate", token, client.pl); err != nil {
-		return DisksClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DisksClientCreateOrUpdatePoller) Resume(token string, client *DisksClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // DisksClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -553,20 +518,19 @@ func (p *DisksClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DisksClientDeletePoller) Poll(ctx context.Context) (DisksClientDeleteResponse, error) {
-	result := DisksClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DisksClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DisksClientDeletePoller) Result(ctx context.Context) (resp DisksClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -587,12 +551,9 @@ func (p *DisksClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DisksClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DisksClientDeletePoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.Delete", token, client.pl); err != nil {
-		return DisksClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DisksClientDeletePoller) Resume(token string, client *DisksClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.Delete", token, client.pl)
+	return
 }
 
 // DisksClientGrantAccessPoller provides polling facilities until the operation reaches a terminal state.
@@ -611,20 +572,19 @@ func (p *DisksClientGrantAccessPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DisksClientGrantAccessPoller) Poll(ctx context.Context) (DisksClientGrantAccessResponse, error) {
-	result := DisksClientGrantAccessResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.AccessURI)
-	return result, err
+func (p *DisksClientGrantAccessPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DisksClientGrantAccessPoller) Result(ctx context.Context) (resp DisksClientGrantAccessResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -645,12 +605,9 @@ func (p *DisksClientGrantAccessPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DisksClientGrantAccessPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DisksClientGrantAccessPoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientGrantAccessResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.GrantAccess", token, client.pl); err != nil {
-		return DisksClientGrantAccessResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DisksClientGrantAccessPoller) Resume(token string, client *DisksClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.GrantAccess", token, client.pl)
+	return
 }
 
 // DisksClientRevokeAccessPoller provides polling facilities until the operation reaches a terminal state.
@@ -669,20 +626,19 @@ func (p *DisksClientRevokeAccessPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DisksClientRevokeAccessPoller) Poll(ctx context.Context) (DisksClientRevokeAccessResponse, error) {
-	result := DisksClientRevokeAccessResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DisksClientRevokeAccessPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DisksClientRevokeAccessPoller) Result(ctx context.Context) (resp DisksClientRevokeAccessResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -703,12 +659,9 @@ func (p *DisksClientRevokeAccessPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DisksClientRevokeAccessPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DisksClientRevokeAccessPoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientRevokeAccessResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.RevokeAccess", token, client.pl); err != nil {
-		return DisksClientRevokeAccessResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DisksClientRevokeAccessPoller) Resume(token string, client *DisksClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.RevokeAccess", token, client.pl)
+	return
 }
 
 // DisksClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -727,20 +680,19 @@ func (p *DisksClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DisksClientUpdatePoller) Poll(ctx context.Context) (DisksClientUpdateResponse, error) {
-	result := DisksClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Disk)
-	return result, err
+func (p *DisksClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DisksClientUpdatePoller) Result(ctx context.Context) (resp DisksClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -761,12 +713,9 @@ func (p *DisksClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DisksClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DisksClientUpdatePoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.Update", token, client.pl); err != nil {
-		return DisksClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DisksClientUpdatePoller) Resume(token string, client *DisksClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.Update", token, client.pl)
+	return
 }
 
 // GalleriesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -785,20 +734,19 @@ func (p *GalleriesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleriesClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleriesClientCreateOrUpdateResponse, error) {
-	result := GalleriesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Gallery)
-	return result, err
+func (p *GalleriesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleriesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp GalleriesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -819,12 +767,9 @@ func (p *GalleriesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleriesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleriesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleriesClient, token string) (GalleriesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return GalleriesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleriesClientCreateOrUpdatePoller) Resume(token string, client *GalleriesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // GalleriesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -843,20 +788,19 @@ func (p *GalleriesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleriesClientDeletePoller) Poll(ctx context.Context) (GalleriesClientDeleteResponse, error) {
-	result := GalleriesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *GalleriesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleriesClientDeletePoller) Result(ctx context.Context) (resp GalleriesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -877,12 +821,9 @@ func (p *GalleriesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleriesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleriesClientDeletePoller) Resume(ctx context.Context, client *GalleriesClient, token string) (GalleriesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.Delete", token, client.pl); err != nil {
-		return GalleriesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleriesClientDeletePoller) Resume(token string, client *GalleriesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.Delete", token, client.pl)
+	return
 }
 
 // GalleriesClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -901,20 +842,19 @@ func (p *GalleriesClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleriesClientUpdatePoller) Poll(ctx context.Context) (GalleriesClientUpdateResponse, error) {
-	result := GalleriesClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Gallery)
-	return result, err
+func (p *GalleriesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleriesClientUpdatePoller) Result(ctx context.Context) (resp GalleriesClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -935,12 +875,9 @@ func (p *GalleriesClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleriesClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleriesClientUpdatePoller) Resume(ctx context.Context, client *GalleriesClient, token string) (GalleriesClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.Update", token, client.pl); err != nil {
-		return GalleriesClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleriesClientUpdatePoller) Resume(token string, client *GalleriesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.Update", token, client.pl)
+	return
 }
 
 // GalleryApplicationVersionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -959,20 +896,19 @@ func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
-	result := GalleryApplicationVersionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GalleryApplicationVersion)
-	return result, err
+func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp GalleryApplicationVersionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -993,12 +929,9 @@ func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) ResumeToken() (st
 
 // Resume rehydrates a GalleryApplicationVersionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return GalleryApplicationVersionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Resume(token string, client *GalleryApplicationVersionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // GalleryApplicationVersionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1017,20 +950,19 @@ func (p *GalleryApplicationVersionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryApplicationVersionsClientDeletePoller) Poll(ctx context.Context) (GalleryApplicationVersionsClientDeleteResponse, error) {
-	result := GalleryApplicationVersionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *GalleryApplicationVersionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryApplicationVersionsClientDeletePoller) Result(ctx context.Context) (resp GalleryApplicationVersionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1051,12 +983,9 @@ func (p *GalleryApplicationVersionsClientDeletePoller) ResumeToken() (string, er
 
 // Resume rehydrates a GalleryApplicationVersionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryApplicationVersionsClientDeletePoller) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) (GalleryApplicationVersionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Delete", token, client.pl); err != nil {
-		return GalleryApplicationVersionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryApplicationVersionsClientDeletePoller) Resume(token string, client *GalleryApplicationVersionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Delete", token, client.pl)
+	return
 }
 
 // GalleryApplicationVersionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1075,20 +1004,19 @@ func (p *GalleryApplicationVersionsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryApplicationVersionsClientUpdatePoller) Poll(ctx context.Context) (GalleryApplicationVersionsClientUpdateResponse, error) {
-	result := GalleryApplicationVersionsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GalleryApplicationVersion)
-	return result, err
+func (p *GalleryApplicationVersionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryApplicationVersionsClientUpdatePoller) Result(ctx context.Context) (resp GalleryApplicationVersionsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1109,12 +1037,9 @@ func (p *GalleryApplicationVersionsClientUpdatePoller) ResumeToken() (string, er
 
 // Resume rehydrates a GalleryApplicationVersionsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryApplicationVersionsClientUpdatePoller) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) (GalleryApplicationVersionsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Update", token, client.pl); err != nil {
-		return GalleryApplicationVersionsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryApplicationVersionsClientUpdatePoller) Resume(token string, client *GalleryApplicationVersionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Update", token, client.pl)
+	return
 }
 
 // GalleryApplicationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1133,20 +1058,19 @@ func (p *GalleryApplicationsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryApplicationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
-	result := GalleryApplicationsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GalleryApplication)
-	return result, err
+func (p *GalleryApplicationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryApplicationsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp GalleryApplicationsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1167,12 +1091,9 @@ func (p *GalleryApplicationsClientCreateOrUpdatePoller) ResumeToken() (string, e
 
 // Resume rehydrates a GalleryApplicationsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryApplicationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return GalleryApplicationsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryApplicationsClientCreateOrUpdatePoller) Resume(token string, client *GalleryApplicationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // GalleryApplicationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1191,20 +1112,19 @@ func (p *GalleryApplicationsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryApplicationsClientDeletePoller) Poll(ctx context.Context) (GalleryApplicationsClientDeleteResponse, error) {
-	result := GalleryApplicationsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *GalleryApplicationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryApplicationsClientDeletePoller) Result(ctx context.Context) (resp GalleryApplicationsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1225,12 +1145,9 @@ func (p *GalleryApplicationsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleryApplicationsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryApplicationsClientDeletePoller) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) (GalleryApplicationsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.Delete", token, client.pl); err != nil {
-		return GalleryApplicationsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryApplicationsClientDeletePoller) Resume(token string, client *GalleryApplicationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.Delete", token, client.pl)
+	return
 }
 
 // GalleryApplicationsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1249,20 +1166,19 @@ func (p *GalleryApplicationsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryApplicationsClientUpdatePoller) Poll(ctx context.Context) (GalleryApplicationsClientUpdateResponse, error) {
-	result := GalleryApplicationsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GalleryApplication)
-	return result, err
+func (p *GalleryApplicationsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryApplicationsClientUpdatePoller) Result(ctx context.Context) (resp GalleryApplicationsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1283,12 +1199,9 @@ func (p *GalleryApplicationsClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleryApplicationsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryApplicationsClientUpdatePoller) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) (GalleryApplicationsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.Update", token, client.pl); err != nil {
-		return GalleryApplicationsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryApplicationsClientUpdatePoller) Resume(token string, client *GalleryApplicationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.Update", token, client.pl)
+	return
 }
 
 // GalleryImageVersionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1307,20 +1220,19 @@ func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
-	result := GalleryImageVersionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GalleryImageVersion)
-	return result, err
+func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp GalleryImageVersionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1341,12 +1253,9 @@ func (p *GalleryImageVersionsClientCreateOrUpdatePoller) ResumeToken() (string, 
 
 // Resume rehydrates a GalleryImageVersionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return GalleryImageVersionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Resume(token string, client *GalleryImageVersionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // GalleryImageVersionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1365,20 +1274,19 @@ func (p *GalleryImageVersionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryImageVersionsClientDeletePoller) Poll(ctx context.Context) (GalleryImageVersionsClientDeleteResponse, error) {
-	result := GalleryImageVersionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *GalleryImageVersionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryImageVersionsClientDeletePoller) Result(ctx context.Context) (resp GalleryImageVersionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1399,12 +1307,9 @@ func (p *GalleryImageVersionsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleryImageVersionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryImageVersionsClientDeletePoller) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) (GalleryImageVersionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.Delete", token, client.pl); err != nil {
-		return GalleryImageVersionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryImageVersionsClientDeletePoller) Resume(token string, client *GalleryImageVersionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.Delete", token, client.pl)
+	return
 }
 
 // GalleryImageVersionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1423,20 +1328,19 @@ func (p *GalleryImageVersionsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryImageVersionsClientUpdatePoller) Poll(ctx context.Context) (GalleryImageVersionsClientUpdateResponse, error) {
-	result := GalleryImageVersionsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GalleryImageVersion)
-	return result, err
+func (p *GalleryImageVersionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryImageVersionsClientUpdatePoller) Result(ctx context.Context) (resp GalleryImageVersionsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1457,12 +1361,9 @@ func (p *GalleryImageVersionsClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleryImageVersionsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryImageVersionsClientUpdatePoller) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) (GalleryImageVersionsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.Update", token, client.pl); err != nil {
-		return GalleryImageVersionsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryImageVersionsClientUpdatePoller) Resume(token string, client *GalleryImageVersionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.Update", token, client.pl)
+	return
 }
 
 // GalleryImagesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1481,20 +1382,19 @@ func (p *GalleryImagesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleryImagesClientCreateOrUpdateResponse, error) {
-	result := GalleryImagesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GalleryImage)
-	return result, err
+func (p *GalleryImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryImagesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp GalleryImagesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1515,12 +1415,9 @@ func (p *GalleryImagesClientCreateOrUpdatePoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a GalleryImagesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryImagesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleryImagesClient, token string) (GalleryImagesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return GalleryImagesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryImagesClientCreateOrUpdatePoller) Resume(token string, client *GalleryImagesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // GalleryImagesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1539,20 +1436,19 @@ func (p *GalleryImagesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryImagesClientDeletePoller) Poll(ctx context.Context) (GalleryImagesClientDeleteResponse, error) {
-	result := GalleryImagesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *GalleryImagesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryImagesClientDeletePoller) Result(ctx context.Context) (resp GalleryImagesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1573,12 +1469,9 @@ func (p *GalleryImagesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleryImagesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryImagesClientDeletePoller) Resume(ctx context.Context, client *GalleryImagesClient, token string) (GalleryImagesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.Delete", token, client.pl); err != nil {
-		return GalleryImagesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryImagesClientDeletePoller) Resume(token string, client *GalleryImagesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.Delete", token, client.pl)
+	return
 }
 
 // GalleryImagesClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1597,20 +1490,19 @@ func (p *GalleryImagesClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *GalleryImagesClientUpdatePoller) Poll(ctx context.Context) (GalleryImagesClientUpdateResponse, error) {
-	result := GalleryImagesClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GalleryImage)
-	return result, err
+func (p *GalleryImagesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *GalleryImagesClientUpdatePoller) Result(ctx context.Context) (resp GalleryImagesClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1631,12 +1523,9 @@ func (p *GalleryImagesClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a GalleryImagesClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *GalleryImagesClientUpdatePoller) Resume(ctx context.Context, client *GalleryImagesClient, token string) (GalleryImagesClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.Update", token, client.pl); err != nil {
-		return GalleryImagesClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *GalleryImagesClientUpdatePoller) Resume(token string, client *GalleryImagesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.Update", token, client.pl)
+	return
 }
 
 // ImagesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1655,20 +1544,19 @@ func (p *ImagesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (ImagesClientCreateOrUpdateResponse, error) {
-	result := ImagesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Image)
-	return result, err
+func (p *ImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ImagesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ImagesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1689,12 +1577,9 @@ func (p *ImagesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ImagesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ImagesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ImagesClient, token string) (ImagesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ImagesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ImagesClientCreateOrUpdatePoller) Resume(token string, client *ImagesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ImagesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1713,20 +1598,19 @@ func (p *ImagesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ImagesClientDeletePoller) Poll(ctx context.Context) (ImagesClientDeleteResponse, error) {
-	result := ImagesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ImagesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ImagesClientDeletePoller) Result(ctx context.Context) (resp ImagesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1747,12 +1631,9 @@ func (p *ImagesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ImagesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ImagesClientDeletePoller) Resume(ctx context.Context, client *ImagesClient, token string) (ImagesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.Delete", token, client.pl); err != nil {
-		return ImagesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ImagesClientDeletePoller) Resume(token string, client *ImagesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.Delete", token, client.pl)
+	return
 }
 
 // ImagesClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1771,20 +1652,19 @@ func (p *ImagesClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ImagesClientUpdatePoller) Poll(ctx context.Context) (ImagesClientUpdateResponse, error) {
-	result := ImagesClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Image)
-	return result, err
+func (p *ImagesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ImagesClientUpdatePoller) Result(ctx context.Context) (resp ImagesClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1805,12 +1685,9 @@ func (p *ImagesClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ImagesClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ImagesClientUpdatePoller) Resume(ctx context.Context, client *ImagesClient, token string) (ImagesClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.Update", token, client.pl); err != nil {
-		return ImagesClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ImagesClientUpdatePoller) Resume(token string, client *ImagesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.Update", token, client.pl)
+	return
 }
 
 // LogAnalyticsClientExportRequestRateByIntervalPoller provides polling facilities until the operation reaches a terminal state.
@@ -1829,20 +1706,19 @@ func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Poll(ctx context.Context) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
-	result := LogAnalyticsClientExportRequestRateByIntervalResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.LogAnalyticsOperationResult)
-	return result, err
+func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Result(ctx context.Context) (resp LogAnalyticsClientExportRequestRateByIntervalResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1863,12 +1739,9 @@ func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) ResumeToken() (str
 
 // Resume rehydrates a LogAnalyticsClientExportRequestRateByIntervalPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Resume(ctx context.Context, client *LogAnalyticsClient, token string) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LogAnalyticsClient.ExportRequestRateByInterval", token, client.pl); err != nil {
-		return LogAnalyticsClientExportRequestRateByIntervalResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Resume(token string, client *LogAnalyticsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LogAnalyticsClient.ExportRequestRateByInterval", token, client.pl)
+	return
 }
 
 // LogAnalyticsClientExportThrottledRequestsPoller provides polling facilities until the operation reaches a terminal state.
@@ -1887,20 +1760,19 @@ func (p *LogAnalyticsClientExportThrottledRequestsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LogAnalyticsClientExportThrottledRequestsPoller) Poll(ctx context.Context) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
-	result := LogAnalyticsClientExportThrottledRequestsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.LogAnalyticsOperationResult)
-	return result, err
+func (p *LogAnalyticsClientExportThrottledRequestsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LogAnalyticsClientExportThrottledRequestsPoller) Result(ctx context.Context) (resp LogAnalyticsClientExportThrottledRequestsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1921,12 +1793,9 @@ func (p *LogAnalyticsClientExportThrottledRequestsPoller) ResumeToken() (string,
 
 // Resume rehydrates a LogAnalyticsClientExportThrottledRequestsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LogAnalyticsClientExportThrottledRequestsPoller) Resume(ctx context.Context, client *LogAnalyticsClient, token string) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LogAnalyticsClient.ExportThrottledRequests", token, client.pl); err != nil {
-		return LogAnalyticsClientExportThrottledRequestsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LogAnalyticsClientExportThrottledRequestsPoller) Resume(token string, client *LogAnalyticsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LogAnalyticsClient.ExportThrottledRequests", token, client.pl)
+	return
 }
 
 // SnapshotsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1945,20 +1814,19 @@ func (p *SnapshotsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SnapshotsClientCreateOrUpdatePoller) Poll(ctx context.Context) (SnapshotsClientCreateOrUpdateResponse, error) {
-	result := SnapshotsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Snapshot)
-	return result, err
+func (p *SnapshotsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SnapshotsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp SnapshotsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1979,12 +1847,9 @@ func (p *SnapshotsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SnapshotsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SnapshotsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return SnapshotsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SnapshotsClientCreateOrUpdatePoller) Resume(token string, client *SnapshotsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // SnapshotsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2003,20 +1868,19 @@ func (p *SnapshotsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SnapshotsClientDeletePoller) Poll(ctx context.Context) (SnapshotsClientDeleteResponse, error) {
-	result := SnapshotsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SnapshotsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SnapshotsClientDeletePoller) Result(ctx context.Context) (resp SnapshotsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2037,12 +1901,9 @@ func (p *SnapshotsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SnapshotsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SnapshotsClientDeletePoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.Delete", token, client.pl); err != nil {
-		return SnapshotsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SnapshotsClientDeletePoller) Resume(token string, client *SnapshotsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.Delete", token, client.pl)
+	return
 }
 
 // SnapshotsClientGrantAccessPoller provides polling facilities until the operation reaches a terminal state.
@@ -2061,20 +1922,19 @@ func (p *SnapshotsClientGrantAccessPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SnapshotsClientGrantAccessPoller) Poll(ctx context.Context) (SnapshotsClientGrantAccessResponse, error) {
-	result := SnapshotsClientGrantAccessResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.AccessURI)
-	return result, err
+func (p *SnapshotsClientGrantAccessPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SnapshotsClientGrantAccessPoller) Result(ctx context.Context) (resp SnapshotsClientGrantAccessResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2095,12 +1955,9 @@ func (p *SnapshotsClientGrantAccessPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SnapshotsClientGrantAccessPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SnapshotsClientGrantAccessPoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientGrantAccessResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.GrantAccess", token, client.pl); err != nil {
-		return SnapshotsClientGrantAccessResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SnapshotsClientGrantAccessPoller) Resume(token string, client *SnapshotsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.GrantAccess", token, client.pl)
+	return
 }
 
 // SnapshotsClientRevokeAccessPoller provides polling facilities until the operation reaches a terminal state.
@@ -2119,20 +1976,19 @@ func (p *SnapshotsClientRevokeAccessPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SnapshotsClientRevokeAccessPoller) Poll(ctx context.Context) (SnapshotsClientRevokeAccessResponse, error) {
-	result := SnapshotsClientRevokeAccessResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SnapshotsClientRevokeAccessPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SnapshotsClientRevokeAccessPoller) Result(ctx context.Context) (resp SnapshotsClientRevokeAccessResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2153,12 +2009,9 @@ func (p *SnapshotsClientRevokeAccessPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SnapshotsClientRevokeAccessPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SnapshotsClientRevokeAccessPoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientRevokeAccessResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.RevokeAccess", token, client.pl); err != nil {
-		return SnapshotsClientRevokeAccessResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SnapshotsClientRevokeAccessPoller) Resume(token string, client *SnapshotsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.RevokeAccess", token, client.pl)
+	return
 }
 
 // SnapshotsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2177,20 +2030,19 @@ func (p *SnapshotsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SnapshotsClientUpdatePoller) Poll(ctx context.Context) (SnapshotsClientUpdateResponse, error) {
-	result := SnapshotsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Snapshot)
-	return result, err
+func (p *SnapshotsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SnapshotsClientUpdatePoller) Result(ctx context.Context) (resp SnapshotsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2211,12 +2063,9 @@ func (p *SnapshotsClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SnapshotsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SnapshotsClientUpdatePoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.Update", token, client.pl); err != nil {
-		return SnapshotsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SnapshotsClientUpdatePoller) Resume(token string, client *SnapshotsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.Update", token, client.pl)
+	return
 }
 
 // VirtualMachineExtensionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2235,20 +2084,19 @@ func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
-	result := VirtualMachineExtensionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineExtension)
-	return result, err
+func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualMachineExtensionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2269,12 +2117,9 @@ func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) ResumeToken() (stri
 
 // Resume rehydrates a VirtualMachineExtensionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualMachineExtensionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Resume(token string, client *VirtualMachineExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualMachineExtensionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2293,20 +2138,19 @@ func (p *VirtualMachineExtensionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineExtensionsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineExtensionsClientDeleteResponse, error) {
-	result := VirtualMachineExtensionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineExtensionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineExtensionsClientDeletePoller) Result(ctx context.Context) (resp VirtualMachineExtensionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2327,12 +2171,9 @@ func (p *VirtualMachineExtensionsClientDeletePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a VirtualMachineExtensionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineExtensionsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) (VirtualMachineExtensionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Delete", token, client.pl); err != nil {
-		return VirtualMachineExtensionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineExtensionsClientDeletePoller) Resume(token string, client *VirtualMachineExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualMachineExtensionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2351,20 +2192,19 @@ func (p *VirtualMachineExtensionsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineExtensionsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineExtensionsClientUpdateResponse, error) {
-	result := VirtualMachineExtensionsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineExtension)
-	return result, err
+func (p *VirtualMachineExtensionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineExtensionsClientUpdatePoller) Result(ctx context.Context) (resp VirtualMachineExtensionsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2385,12 +2225,9 @@ func (p *VirtualMachineExtensionsClientUpdatePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a VirtualMachineExtensionsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineExtensionsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) (VirtualMachineExtensionsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Update", token, client.pl); err != nil {
-		return VirtualMachineExtensionsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineExtensionsClientUpdatePoller) Resume(token string, client *VirtualMachineExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Update", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2409,20 +2246,19 @@ func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Done() bool
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
-	result := VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSetExtension)
-	return result, err
+func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2443,12 +2279,9 @@ func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) ResumeToken
 
 // Resume rehydrates a VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Resume(token string, client *VirtualMachineScaleSetExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetExtensionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2467,20 +2300,19 @@ func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
-	result := VirtualMachineScaleSetExtensionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetExtensionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2501,12 +2333,9 @@ func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) ResumeToken() (stri
 
 // Resume rehydrates a VirtualMachineScaleSetExtensionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Delete", token, client.pl); err != nil {
-		return VirtualMachineScaleSetExtensionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Resume(token string, client *VirtualMachineScaleSetExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetExtensionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2525,20 +2354,19 @@ func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
-	result := VirtualMachineScaleSetExtensionsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSetExtension)
-	return result, err
+func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetExtensionsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2559,12 +2387,9 @@ func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) ResumeToken() (stri
 
 // Resume rehydrates a VirtualMachineScaleSetExtensionsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Update", token, client.pl); err != nil {
-		return VirtualMachineScaleSetExtensionsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Resume(token string, client *VirtualMachineScaleSetExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Update", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientCancelPoller provides polling facilities until the operation reaches a terminal state.
@@ -2583,20 +2408,19 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Poll(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
-	result := VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetRollingUpgradesClientCancelResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2617,12 +2441,9 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) ResumeToken() 
 
 // Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientCancelPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.Cancel", token, client.pl); err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Resume(token string, client *VirtualMachineScaleSetRollingUpgradesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.Cancel", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller provides polling facilities until the operation reaches a terminal state.
@@ -2641,20 +2462,19 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller)
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) Poll(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
-	result := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2675,12 +2495,9 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller)
 
 // Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade", token, client.pl); err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) Resume(token string, client *VirtualMachineScaleSetRollingUpgradesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller provides polling facilities until the operation reaches a terminal state.
@@ -2699,20 +2516,19 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Done()
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Poll(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
-	result := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2733,12 +2549,9 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Resume
 
 // Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade", token, client.pl); err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Resume(token string, client *VirtualMachineScaleSetRollingUpgradesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2757,20 +2570,19 @@ func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Done() bo
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
-	result := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineExtension)
-	return result, err
+func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2791,12 +2603,9 @@ func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) ResumeTok
 
 // Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Resume(token string, client *VirtualMachineScaleSetVMExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMExtensionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2815,20 +2624,19 @@ func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
-	result := VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMExtensionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2849,12 +2657,9 @@ func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) ResumeToken() (st
 
 // Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Delete", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Resume(token string, client *VirtualMachineScaleSetVMExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMExtensionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2873,20 +2678,19 @@ func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
-	result := VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineExtension)
-	return result, err
+func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMExtensionsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2907,12 +2711,9 @@ func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) ResumeToken() (st
 
 // Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Update", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Resume(token string, client *VirtualMachineScaleSetVMExtensionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Update", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientDeallocatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2931,20 +2732,19 @@ func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
-	result := VirtualMachineScaleSetVMsClientDeallocateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientDeallocateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2965,12 +2765,9 @@ func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) ResumeToken() (string,
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientDeallocatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Deallocate", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientDeallocateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Deallocate", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2989,20 +2786,19 @@ func (p *VirtualMachineScaleSetVMsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
-	result := VirtualMachineScaleSetVMsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientDeletePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3023,12 +2819,9 @@ func (p *VirtualMachineScaleSetVMsClientDeletePoller) ResumeToken() (string, err
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Delete", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientDeletePoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientPerformMaintenancePoller provides polling facilities until the operation reaches a terminal state.
@@ -3047,20 +2840,19 @@ func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
-	result := VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3081,12 +2873,9 @@ func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) ResumeToken() 
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientPerformMaintenancePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PerformMaintenance", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PerformMaintenance", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientPowerOffPoller provides polling facilities until the operation reaches a terminal state.
@@ -3105,20 +2894,19 @@ func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
-	result := VirtualMachineScaleSetVMsClientPowerOffResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientPowerOffResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3139,12 +2927,9 @@ func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) ResumeToken() (string, e
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientPowerOffPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PowerOff", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientPowerOffResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PowerOff", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientRedeployPoller provides polling facilities until the operation reaches a terminal state.
@@ -3163,20 +2948,19 @@ func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
-	result := VirtualMachineScaleSetVMsClientRedeployResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientRedeployResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3197,12 +2981,9 @@ func (p *VirtualMachineScaleSetVMsClientRedeployPoller) ResumeToken() (string, e
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientRedeployPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Redeploy", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientRedeployResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Redeploy", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientReimageAllPoller provides polling facilities until the operation reaches a terminal state.
@@ -3221,20 +3002,19 @@ func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
-	result := VirtualMachineScaleSetVMsClientReimageAllResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientReimageAllResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3255,12 +3035,9 @@ func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) ResumeToken() (string,
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientReimageAllPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.ReimageAll", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientReimageAllResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.ReimageAll", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientReimagePoller provides polling facilities until the operation reaches a terminal state.
@@ -3279,20 +3056,19 @@ func (p *VirtualMachineScaleSetVMsClientReimagePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientReimagePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
-	result := VirtualMachineScaleSetVMsClientReimageResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientReimagePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientReimagePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientReimageResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3313,12 +3089,9 @@ func (p *VirtualMachineScaleSetVMsClientReimagePoller) ResumeToken() (string, er
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientReimagePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientReimagePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Reimage", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientReimageResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientReimagePoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Reimage", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientRestartPoller provides polling facilities until the operation reaches a terminal state.
@@ -3337,20 +3110,19 @@ func (p *VirtualMachineScaleSetVMsClientRestartPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientRestartPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
-	result := VirtualMachineScaleSetVMsClientRestartResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientRestartPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientRestartPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientRestartResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3371,12 +3143,9 @@ func (p *VirtualMachineScaleSetVMsClientRestartPoller) ResumeToken() (string, er
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientRestartPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientRestartPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Restart", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientRestartResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientRestartPoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Restart", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientRunCommandPoller provides polling facilities until the operation reaches a terminal state.
@@ -3395,20 +3164,19 @@ func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
-	result := VirtualMachineScaleSetVMsClientRunCommandResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.RunCommandResult)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientRunCommandResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3429,12 +3197,9 @@ func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) ResumeToken() (string,
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientRunCommandPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.RunCommand", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientRunCommandResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.RunCommand", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -3453,20 +3218,19 @@ func (p *VirtualMachineScaleSetVMsClientStartPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientStartPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientStartResponse, error) {
-	result := VirtualMachineScaleSetVMsClientStartResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientStartPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientStartResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3487,12 +3251,9 @@ func (p *VirtualMachineScaleSetVMsClientStartPoller) ResumeToken() (string, erro
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientStartPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientStartPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientStartResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Start", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientStartResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientStartPoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Start", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetVMsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3511,20 +3272,19 @@ func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
-	result := VirtualMachineScaleSetVMsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSetVM)
-	return result, err
+func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetVMsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3545,12 +3305,9 @@ func (p *VirtualMachineScaleSetVMsClientUpdatePoller) ResumeToken() (string, err
 
 // Resume rehydrates a VirtualMachineScaleSetVMsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Update", token, client.pl); err != nil {
-		return VirtualMachineScaleSetVMsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Resume(token string, client *VirtualMachineScaleSetVMsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Update", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3569,20 +3326,19 @@ func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
-	result := VirtualMachineScaleSetsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSet)
-	return result, err
+func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3603,12 +3359,9 @@ func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) ResumeToken() (strin
 
 // Resume rehydrates a VirtualMachineScaleSetsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientDeallocatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3627,20 +3380,19 @@ func (p *VirtualMachineScaleSetsClientDeallocatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientDeallocatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
-	result := VirtualMachineScaleSetsClientDeallocateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientDeallocatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientDeallocatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientDeallocateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3661,12 +3413,9 @@ func (p *VirtualMachineScaleSetsClientDeallocatePoller) ResumeToken() (string, e
 
 // Resume rehydrates a VirtualMachineScaleSetsClientDeallocatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientDeallocatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Deallocate", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientDeallocateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientDeallocatePoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Deallocate", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientDeleteInstancesPoller provides polling facilities until the operation reaches a terminal state.
@@ -3685,20 +3434,19 @@ func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
-	result := VirtualMachineScaleSetsClientDeleteInstancesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientDeleteInstancesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3719,12 +3467,9 @@ func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) ResumeToken() (stri
 
 // Resume rehydrates a VirtualMachineScaleSetsClientDeleteInstancesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.DeleteInstances", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientDeleteInstancesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.DeleteInstances", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3743,20 +3488,19 @@ func (p *VirtualMachineScaleSetsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientDeleteResponse, error) {
-	result := VirtualMachineScaleSetsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientDeletePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3777,12 +3521,9 @@ func (p *VirtualMachineScaleSetsClientDeletePoller) ResumeToken() (string, error
 
 // Resume rehydrates a VirtualMachineScaleSetsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Delete", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientDeletePoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientPerformMaintenancePoller provides polling facilities until the operation reaches a terminal state.
@@ -3801,20 +3542,19 @@ func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
-	result := VirtualMachineScaleSetsClientPerformMaintenanceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientPerformMaintenanceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3835,12 +3575,9 @@ func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) ResumeToken() (s
 
 // Resume rehydrates a VirtualMachineScaleSetsClientPerformMaintenancePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PerformMaintenance", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientPerformMaintenanceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PerformMaintenance", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientPowerOffPoller provides polling facilities until the operation reaches a terminal state.
@@ -3859,20 +3596,19 @@ func (p *VirtualMachineScaleSetsClientPowerOffPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientPowerOffPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
-	result := VirtualMachineScaleSetsClientPowerOffResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientPowerOffPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientPowerOffPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientPowerOffResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3893,12 +3629,9 @@ func (p *VirtualMachineScaleSetsClientPowerOffPoller) ResumeToken() (string, err
 
 // Resume rehydrates a VirtualMachineScaleSetsClientPowerOffPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientPowerOffPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PowerOff", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientPowerOffResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientPowerOffPoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PowerOff", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientRedeployPoller provides polling facilities until the operation reaches a terminal state.
@@ -3917,20 +3650,19 @@ func (p *VirtualMachineScaleSetsClientRedeployPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientRedeployPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientRedeployResponse, error) {
-	result := VirtualMachineScaleSetsClientRedeployResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientRedeployPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientRedeployPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientRedeployResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3951,12 +3683,9 @@ func (p *VirtualMachineScaleSetsClientRedeployPoller) ResumeToken() (string, err
 
 // Resume rehydrates a VirtualMachineScaleSetsClientRedeployPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientRedeployPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientRedeployResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Redeploy", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientRedeployResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientRedeployPoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Redeploy", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientReimageAllPoller provides polling facilities until the operation reaches a terminal state.
@@ -3975,20 +3704,19 @@ func (p *VirtualMachineScaleSetsClientReimageAllPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientReimageAllPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
-	result := VirtualMachineScaleSetsClientReimageAllResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientReimageAllPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientReimageAllPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientReimageAllResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4009,12 +3737,9 @@ func (p *VirtualMachineScaleSetsClientReimageAllPoller) ResumeToken() (string, e
 
 // Resume rehydrates a VirtualMachineScaleSetsClientReimageAllPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientReimageAllPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.ReimageAll", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientReimageAllResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientReimageAllPoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.ReimageAll", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientReimagePoller provides polling facilities until the operation reaches a terminal state.
@@ -4033,20 +3758,19 @@ func (p *VirtualMachineScaleSetsClientReimagePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientReimagePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientReimageResponse, error) {
-	result := VirtualMachineScaleSetsClientReimageResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientReimagePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientReimagePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientReimageResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4067,12 +3791,9 @@ func (p *VirtualMachineScaleSetsClientReimagePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a VirtualMachineScaleSetsClientReimagePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientReimagePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientReimageResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Reimage", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientReimageResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientReimagePoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Reimage", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientRestartPoller provides polling facilities until the operation reaches a terminal state.
@@ -4091,20 +3812,19 @@ func (p *VirtualMachineScaleSetsClientRestartPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientRestartPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientRestartResponse, error) {
-	result := VirtualMachineScaleSetsClientRestartResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientRestartPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientRestartPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientRestartResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4125,12 +3845,9 @@ func (p *VirtualMachineScaleSetsClientRestartPoller) ResumeToken() (string, erro
 
 // Resume rehydrates a VirtualMachineScaleSetsClientRestartPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientRestartPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientRestartResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Restart", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientRestartResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientRestartPoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Restart", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4149,20 +3866,19 @@ func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Done()
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
-	result := VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4183,12 +3899,9 @@ func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Resume
 
 // Resume rehydrates a VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.SetOrchestrationServiceState", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.SetOrchestrationServiceState", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -4207,20 +3920,19 @@ func (p *VirtualMachineScaleSetsClientStartPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientStartPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientStartResponse, error) {
-	result := VirtualMachineScaleSetsClientStartResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientStartPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientStartResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4241,12 +3953,9 @@ func (p *VirtualMachineScaleSetsClientStartPoller) ResumeToken() (string, error)
 
 // Resume rehydrates a VirtualMachineScaleSetsClientStartPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientStartPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientStartResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Start", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientStartResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientStartPoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Start", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientUpdateInstancesPoller provides polling facilities until the operation reaches a terminal state.
@@ -4265,20 +3974,19 @@ func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
-	result := VirtualMachineScaleSetsClientUpdateInstancesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientUpdateInstancesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4299,12 +4007,9 @@ func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) ResumeToken() (stri
 
 // Resume rehydrates a VirtualMachineScaleSetsClientUpdateInstancesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.UpdateInstances", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientUpdateInstancesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.UpdateInstances", token, client.pl)
+	return
 }
 
 // VirtualMachineScaleSetsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4323,20 +4028,19 @@ func (p *VirtualMachineScaleSetsClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachineScaleSetsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientUpdateResponse, error) {
-	result := VirtualMachineScaleSetsClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSet)
-	return result, err
+func (p *VirtualMachineScaleSetsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachineScaleSetsClientUpdatePoller) Result(ctx context.Context) (resp VirtualMachineScaleSetsClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4357,12 +4061,9 @@ func (p *VirtualMachineScaleSetsClientUpdatePoller) ResumeToken() (string, error
 
 // Resume rehydrates a VirtualMachineScaleSetsClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachineScaleSetsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Update", token, client.pl); err != nil {
-		return VirtualMachineScaleSetsClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachineScaleSetsClientUpdatePoller) Resume(token string, client *VirtualMachineScaleSetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Update", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -4381,20 +4082,19 @@ func (p *VirtualMachinesClientCapturePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientCapturePoller) Poll(ctx context.Context) (VirtualMachinesClientCaptureResponse, error) {
-	result := VirtualMachinesClientCaptureResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineCaptureResult)
-	return result, err
+func (p *VirtualMachinesClientCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientCapturePoller) Result(ctx context.Context) (resp VirtualMachinesClientCaptureResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4415,12 +4115,9 @@ func (p *VirtualMachinesClientCapturePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientCapturePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientCapturePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientCaptureResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Capture", token, client.pl); err != nil {
-		return VirtualMachinesClientCaptureResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientCapturePoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Capture", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientConvertToManagedDisksPoller provides polling facilities until the operation reaches a terminal state.
@@ -4439,20 +4136,19 @@ func (p *VirtualMachinesClientConvertToManagedDisksPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientConvertToManagedDisksPoller) Poll(ctx context.Context) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
-	result := VirtualMachinesClientConvertToManagedDisksResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientConvertToManagedDisksPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientConvertToManagedDisksPoller) Result(ctx context.Context) (resp VirtualMachinesClientConvertToManagedDisksResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4473,12 +4169,9 @@ func (p *VirtualMachinesClientConvertToManagedDisksPoller) ResumeToken() (string
 
 // Resume rehydrates a VirtualMachinesClientConvertToManagedDisksPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientConvertToManagedDisksPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.ConvertToManagedDisks", token, client.pl); err != nil {
-		return VirtualMachinesClientConvertToManagedDisksResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientConvertToManagedDisksPoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.ConvertToManagedDisks", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4497,20 +4190,19 @@ func (p *VirtualMachinesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachinesClientCreateOrUpdateResponse, error) {
-	result := VirtualMachinesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachine)
-	return result, err
+func (p *VirtualMachinesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualMachinesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4531,12 +4223,9 @@ func (p *VirtualMachinesClientCreateOrUpdatePoller) ResumeToken() (string, error
 
 // Resume rehydrates a VirtualMachinesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualMachinesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientCreateOrUpdatePoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientDeallocatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4555,20 +4244,19 @@ func (p *VirtualMachinesClientDeallocatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientDeallocatePoller) Poll(ctx context.Context) (VirtualMachinesClientDeallocateResponse, error) {
-	result := VirtualMachinesClientDeallocateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientDeallocatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientDeallocatePoller) Result(ctx context.Context) (resp VirtualMachinesClientDeallocateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4589,12 +4277,9 @@ func (p *VirtualMachinesClientDeallocatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientDeallocatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientDeallocatePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientDeallocateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Deallocate", token, client.pl); err != nil {
-		return VirtualMachinesClientDeallocateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientDeallocatePoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Deallocate", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4613,20 +4298,19 @@ func (p *VirtualMachinesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientDeletePoller) Poll(ctx context.Context) (VirtualMachinesClientDeleteResponse, error) {
-	result := VirtualMachinesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientDeletePoller) Result(ctx context.Context) (resp VirtualMachinesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4647,12 +4331,9 @@ func (p *VirtualMachinesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientDeletePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Delete", token, client.pl); err != nil {
-		return VirtualMachinesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientDeletePoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientPerformMaintenancePoller provides polling facilities until the operation reaches a terminal state.
@@ -4671,20 +4352,19 @@ func (p *VirtualMachinesClientPerformMaintenancePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientPerformMaintenancePoller) Poll(ctx context.Context) (VirtualMachinesClientPerformMaintenanceResponse, error) {
-	result := VirtualMachinesClientPerformMaintenanceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientPerformMaintenancePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientPerformMaintenancePoller) Result(ctx context.Context) (resp VirtualMachinesClientPerformMaintenanceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4705,12 +4385,9 @@ func (p *VirtualMachinesClientPerformMaintenancePoller) ResumeToken() (string, e
 
 // Resume rehydrates a VirtualMachinesClientPerformMaintenancePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientPerformMaintenancePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientPerformMaintenanceResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.PerformMaintenance", token, client.pl); err != nil {
-		return VirtualMachinesClientPerformMaintenanceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientPerformMaintenancePoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.PerformMaintenance", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientPowerOffPoller provides polling facilities until the operation reaches a terminal state.
@@ -4729,20 +4406,19 @@ func (p *VirtualMachinesClientPowerOffPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientPowerOffPoller) Poll(ctx context.Context) (VirtualMachinesClientPowerOffResponse, error) {
-	result := VirtualMachinesClientPowerOffResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientPowerOffPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientPowerOffPoller) Result(ctx context.Context) (resp VirtualMachinesClientPowerOffResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4763,12 +4439,9 @@ func (p *VirtualMachinesClientPowerOffPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientPowerOffPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientPowerOffPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientPowerOffResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.PowerOff", token, client.pl); err != nil {
-		return VirtualMachinesClientPowerOffResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientPowerOffPoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.PowerOff", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientReapplyPoller provides polling facilities until the operation reaches a terminal state.
@@ -4787,20 +4460,19 @@ func (p *VirtualMachinesClientReapplyPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientReapplyPoller) Poll(ctx context.Context) (VirtualMachinesClientReapplyResponse, error) {
-	result := VirtualMachinesClientReapplyResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientReapplyPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientReapplyPoller) Result(ctx context.Context) (resp VirtualMachinesClientReapplyResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4821,12 +4493,9 @@ func (p *VirtualMachinesClientReapplyPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientReapplyPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientReapplyPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientReapplyResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Reapply", token, client.pl); err != nil {
-		return VirtualMachinesClientReapplyResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientReapplyPoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Reapply", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientRedeployPoller provides polling facilities until the operation reaches a terminal state.
@@ -4845,20 +4514,19 @@ func (p *VirtualMachinesClientRedeployPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientRedeployPoller) Poll(ctx context.Context) (VirtualMachinesClientRedeployResponse, error) {
-	result := VirtualMachinesClientRedeployResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientRedeployPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientRedeployPoller) Result(ctx context.Context) (resp VirtualMachinesClientRedeployResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4879,12 +4547,9 @@ func (p *VirtualMachinesClientRedeployPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientRedeployPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientRedeployPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientRedeployResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Redeploy", token, client.pl); err != nil {
-		return VirtualMachinesClientRedeployResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientRedeployPoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Redeploy", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientReimagePoller provides polling facilities until the operation reaches a terminal state.
@@ -4903,20 +4568,19 @@ func (p *VirtualMachinesClientReimagePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientReimagePoller) Poll(ctx context.Context) (VirtualMachinesClientReimageResponse, error) {
-	result := VirtualMachinesClientReimageResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientReimagePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientReimagePoller) Result(ctx context.Context) (resp VirtualMachinesClientReimageResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4937,12 +4601,9 @@ func (p *VirtualMachinesClientReimagePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientReimagePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientReimagePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientReimageResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Reimage", token, client.pl); err != nil {
-		return VirtualMachinesClientReimageResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientReimagePoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Reimage", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientRestartPoller provides polling facilities until the operation reaches a terminal state.
@@ -4961,20 +4622,19 @@ func (p *VirtualMachinesClientRestartPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientRestartPoller) Poll(ctx context.Context) (VirtualMachinesClientRestartResponse, error) {
-	result := VirtualMachinesClientRestartResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientRestartPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientRestartPoller) Result(ctx context.Context) (resp VirtualMachinesClientRestartResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4995,12 +4655,9 @@ func (p *VirtualMachinesClientRestartPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientRestartPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientRestartPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientRestartResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Restart", token, client.pl); err != nil {
-		return VirtualMachinesClientRestartResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientRestartPoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Restart", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientRunCommandPoller provides polling facilities until the operation reaches a terminal state.
@@ -5019,20 +4676,19 @@ func (p *VirtualMachinesClientRunCommandPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientRunCommandPoller) Poll(ctx context.Context) (VirtualMachinesClientRunCommandResponse, error) {
-	result := VirtualMachinesClientRunCommandResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.RunCommandResult)
-	return result, err
+func (p *VirtualMachinesClientRunCommandPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientRunCommandPoller) Result(ctx context.Context) (resp VirtualMachinesClientRunCommandResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5053,12 +4709,9 @@ func (p *VirtualMachinesClientRunCommandPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientRunCommandPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientRunCommandPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientRunCommandResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.RunCommand", token, client.pl); err != nil {
-		return VirtualMachinesClientRunCommandResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientRunCommandPoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.RunCommand", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -5077,20 +4730,19 @@ func (p *VirtualMachinesClientStartPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientStartPoller) Poll(ctx context.Context) (VirtualMachinesClientStartResponse, error) {
-	result := VirtualMachinesClientStartResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualMachinesClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientStartPoller) Result(ctx context.Context) (resp VirtualMachinesClientStartResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5111,12 +4763,9 @@ func (p *VirtualMachinesClientStartPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientStartPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientStartPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientStartResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Start", token, client.pl); err != nil {
-		return VirtualMachinesClientStartResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientStartPoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Start", token, client.pl)
+	return
 }
 
 // VirtualMachinesClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5135,20 +4784,19 @@ func (p *VirtualMachinesClientUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualMachinesClientUpdatePoller) Poll(ctx context.Context) (VirtualMachinesClientUpdateResponse, error) {
-	result := VirtualMachinesClientUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachine)
-	return result, err
+func (p *VirtualMachinesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualMachinesClientUpdatePoller) Result(ctx context.Context) (resp VirtualMachinesClientUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5169,10 +4817,7 @@ func (p *VirtualMachinesClientUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualMachinesClientUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualMachinesClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Update", token, client.pl); err != nil {
-		return VirtualMachinesClientUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualMachinesClientUpdatePoller) Resume(token string, client *VirtualMachinesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Update", token, client.pl)
+	return
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
@@ -11,7 +11,8 @@ package armcompute
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
+	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"time"
 )
 
 // ContainerServicesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -24,36 +25,52 @@ func (p *ContainerServicesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ContainerServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ContainerServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) (ContainerServicesClientCreateOrUpdateResponse, error) {
+	result := ContainerServicesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ContainerService)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ContainerServicesClientCreateOrUpdateResponse will be returned.
-func (p *ContainerServicesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ContainerServicesClientCreateOrUpdateResponse, error) {
-	respType := ContainerServicesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ContainerService)
-	if err != nil {
-		return ContainerServicesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ContainerServicesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ContainerServicesClientCreateOrUpdateResponse, error) {
+	result := ContainerServicesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ContainerService)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ContainerServicesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ContainerServicesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ContainerServicesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ContainerServicesClient, token string) (ContainerServicesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainerServicesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ContainerServicesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ContainerServicesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -66,36 +83,52 @@ func (p *ContainerServicesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ContainerServicesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ContainerServicesClientDeletePoller) Poll(ctx context.Context) (ContainerServicesClientDeleteResponse, error) {
+	result := ContainerServicesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ContainerServicesClientDeleteResponse will be returned.
-func (p *ContainerServicesClientDeletePoller) FinalResponse(ctx context.Context) (ContainerServicesClientDeleteResponse, error) {
-	respType := ContainerServicesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ContainerServicesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ContainerServicesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ContainerServicesClientDeleteResponse, error) {
+	result := ContainerServicesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ContainerServicesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ContainerServicesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ContainerServicesClientDeletePoller) Resume(ctx context.Context, client *ContainerServicesClient, token string) (ContainerServicesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainerServicesClient.Delete", token, client.pl); err != nil {
+		return ContainerServicesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DedicatedHostsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -108,36 +141,52 @@ func (p *DedicatedHostsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DedicatedHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DedicatedHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (DedicatedHostsClientCreateOrUpdateResponse, error) {
+	result := DedicatedHostsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DedicatedHost)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DedicatedHostsClientCreateOrUpdateResponse will be returned.
-func (p *DedicatedHostsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DedicatedHostsClientCreateOrUpdateResponse, error) {
-	respType := DedicatedHostsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DedicatedHost)
-	if err != nil {
-		return DedicatedHostsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DedicatedHostsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientCreateOrUpdateResponse, error) {
+	result := DedicatedHostsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DedicatedHost)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DedicatedHostsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DedicatedHostsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DedicatedHostsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DedicatedHostsClient, token string) (DedicatedHostsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return DedicatedHostsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DedicatedHostsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -150,36 +199,52 @@ func (p *DedicatedHostsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DedicatedHostsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DedicatedHostsClientDeletePoller) Poll(ctx context.Context) (DedicatedHostsClientDeleteResponse, error) {
+	result := DedicatedHostsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DedicatedHostsClientDeleteResponse will be returned.
-func (p *DedicatedHostsClientDeletePoller) FinalResponse(ctx context.Context) (DedicatedHostsClientDeleteResponse, error) {
-	respType := DedicatedHostsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DedicatedHostsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DedicatedHostsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientDeleteResponse, error) {
+	result := DedicatedHostsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DedicatedHostsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DedicatedHostsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DedicatedHostsClientDeletePoller) Resume(ctx context.Context, client *DedicatedHostsClient, token string) (DedicatedHostsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.Delete", token, client.pl); err != nil {
+		return DedicatedHostsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DedicatedHostsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -192,36 +257,52 @@ func (p *DedicatedHostsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DedicatedHostsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DedicatedHostsClientUpdatePoller) Poll(ctx context.Context) (DedicatedHostsClientUpdateResponse, error) {
+	result := DedicatedHostsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DedicatedHost)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DedicatedHostsClientUpdateResponse will be returned.
-func (p *DedicatedHostsClientUpdatePoller) FinalResponse(ctx context.Context) (DedicatedHostsClientUpdateResponse, error) {
-	respType := DedicatedHostsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DedicatedHost)
-	if err != nil {
-		return DedicatedHostsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DedicatedHostsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientUpdateResponse, error) {
+	result := DedicatedHostsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DedicatedHost)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DedicatedHostsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DedicatedHostsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DedicatedHostsClientUpdatePoller) Resume(ctx context.Context, client *DedicatedHostsClient, token string) (DedicatedHostsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DedicatedHostsClient.Update", token, client.pl); err != nil {
+		return DedicatedHostsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DiskEncryptionSetsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -234,36 +315,52 @@ func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
+	result := DiskEncryptionSetsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DiskEncryptionSet)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DiskEncryptionSetsClientCreateOrUpdateResponse will be returned.
-func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
-	respType := DiskEncryptionSetsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DiskEncryptionSet)
-	if err != nil {
-		return DiskEncryptionSetsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
+	result := DiskEncryptionSetsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DiskEncryptionSet)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DiskEncryptionSetsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DiskEncryptionSetsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return DiskEncryptionSetsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DiskEncryptionSetsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -276,36 +373,52 @@ func (p *DiskEncryptionSetsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DiskEncryptionSetsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DiskEncryptionSetsClientDeletePoller) Poll(ctx context.Context) (DiskEncryptionSetsClientDeleteResponse, error) {
+	result := DiskEncryptionSetsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DiskEncryptionSetsClientDeleteResponse will be returned.
-func (p *DiskEncryptionSetsClientDeletePoller) FinalResponse(ctx context.Context) (DiskEncryptionSetsClientDeleteResponse, error) {
-	respType := DiskEncryptionSetsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DiskEncryptionSetsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DiskEncryptionSetsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientDeleteResponse, error) {
+	result := DiskEncryptionSetsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DiskEncryptionSetsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DiskEncryptionSetsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DiskEncryptionSetsClientDeletePoller) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) (DiskEncryptionSetsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.Delete", token, client.pl); err != nil {
+		return DiskEncryptionSetsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DiskEncryptionSetsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -318,36 +431,52 @@ func (p *DiskEncryptionSetsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DiskEncryptionSetsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DiskEncryptionSetsClientUpdatePoller) Poll(ctx context.Context) (DiskEncryptionSetsClientUpdateResponse, error) {
+	result := DiskEncryptionSetsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DiskEncryptionSet)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DiskEncryptionSetsClientUpdateResponse will be returned.
-func (p *DiskEncryptionSetsClientUpdatePoller) FinalResponse(ctx context.Context) (DiskEncryptionSetsClientUpdateResponse, error) {
-	respType := DiskEncryptionSetsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DiskEncryptionSet)
-	if err != nil {
-		return DiskEncryptionSetsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DiskEncryptionSetsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientUpdateResponse, error) {
+	result := DiskEncryptionSetsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DiskEncryptionSet)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DiskEncryptionSetsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DiskEncryptionSetsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DiskEncryptionSetsClientUpdatePoller) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) (DiskEncryptionSetsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.Update", token, client.pl); err != nil {
+		return DiskEncryptionSetsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DisksClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -360,36 +489,52 @@ func (p *DisksClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DisksClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DisksClientCreateOrUpdatePoller) Poll(ctx context.Context) (DisksClientCreateOrUpdateResponse, error) {
+	result := DisksClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Disk)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DisksClientCreateOrUpdateResponse will be returned.
-func (p *DisksClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DisksClientCreateOrUpdateResponse, error) {
-	respType := DisksClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Disk)
-	if err != nil {
-		return DisksClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DisksClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientCreateOrUpdateResponse, error) {
+	result := DisksClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Disk)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DisksClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DisksClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DisksClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.CreateOrUpdate", token, client.pl); err != nil {
+		return DisksClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DisksClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -402,36 +547,52 @@ func (p *DisksClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DisksClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DisksClientDeletePoller) Poll(ctx context.Context) (DisksClientDeleteResponse, error) {
+	result := DisksClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DisksClientDeleteResponse will be returned.
-func (p *DisksClientDeletePoller) FinalResponse(ctx context.Context) (DisksClientDeleteResponse, error) {
-	respType := DisksClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DisksClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DisksClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientDeleteResponse, error) {
+	result := DisksClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DisksClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DisksClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DisksClientDeletePoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.Delete", token, client.pl); err != nil {
+		return DisksClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DisksClientGrantAccessPoller provides polling facilities until the operation reaches a terminal state.
@@ -444,36 +605,52 @@ func (p *DisksClientGrantAccessPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DisksClientGrantAccessPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DisksClientGrantAccessPoller) Poll(ctx context.Context) (DisksClientGrantAccessResponse, error) {
+	result := DisksClientGrantAccessResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.AccessURI)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DisksClientGrantAccessResponse will be returned.
-func (p *DisksClientGrantAccessPoller) FinalResponse(ctx context.Context) (DisksClientGrantAccessResponse, error) {
-	respType := DisksClientGrantAccessResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.AccessURI)
-	if err != nil {
-		return DisksClientGrantAccessResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DisksClientGrantAccessPoller) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientGrantAccessResponse, error) {
+	result := DisksClientGrantAccessResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.AccessURI)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DisksClientGrantAccessPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DisksClientGrantAccessPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DisksClientGrantAccessPoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientGrantAccessResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.GrantAccess", token, client.pl); err != nil {
+		return DisksClientGrantAccessResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DisksClientRevokeAccessPoller provides polling facilities until the operation reaches a terminal state.
@@ -486,36 +663,52 @@ func (p *DisksClientRevokeAccessPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DisksClientRevokeAccessPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DisksClientRevokeAccessPoller) Poll(ctx context.Context) (DisksClientRevokeAccessResponse, error) {
+	result := DisksClientRevokeAccessResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DisksClientRevokeAccessResponse will be returned.
-func (p *DisksClientRevokeAccessPoller) FinalResponse(ctx context.Context) (DisksClientRevokeAccessResponse, error) {
-	respType := DisksClientRevokeAccessResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DisksClientRevokeAccessResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DisksClientRevokeAccessPoller) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientRevokeAccessResponse, error) {
+	result := DisksClientRevokeAccessResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DisksClientRevokeAccessPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DisksClientRevokeAccessPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DisksClientRevokeAccessPoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientRevokeAccessResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.RevokeAccess", token, client.pl); err != nil {
+		return DisksClientRevokeAccessResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DisksClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -528,36 +721,52 @@ func (p *DisksClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DisksClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DisksClientUpdatePoller) Poll(ctx context.Context) (DisksClientUpdateResponse, error) {
+	result := DisksClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Disk)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DisksClientUpdateResponse will be returned.
-func (p *DisksClientUpdatePoller) FinalResponse(ctx context.Context) (DisksClientUpdateResponse, error) {
-	respType := DisksClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Disk)
-	if err != nil {
-		return DisksClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DisksClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientUpdateResponse, error) {
+	result := DisksClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Disk)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DisksClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DisksClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DisksClientUpdatePoller) Resume(ctx context.Context, client *DisksClient, token string) (DisksClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DisksClient.Update", token, client.pl); err != nil {
+		return DisksClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleriesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -570,36 +779,52 @@ func (p *GalleriesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleriesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleriesClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleriesClientCreateOrUpdateResponse, error) {
+	result := GalleriesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Gallery)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleriesClientCreateOrUpdateResponse will be returned.
-func (p *GalleriesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleriesClientCreateOrUpdateResponse, error) {
-	respType := GalleriesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Gallery)
-	if err != nil {
-		return GalleriesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleriesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientCreateOrUpdateResponse, error) {
+	result := GalleriesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Gallery)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleriesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleriesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleriesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleriesClient, token string) (GalleriesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return GalleriesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleriesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -612,36 +837,52 @@ func (p *GalleriesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleriesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleriesClientDeletePoller) Poll(ctx context.Context) (GalleriesClientDeleteResponse, error) {
+	result := GalleriesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleriesClientDeleteResponse will be returned.
-func (p *GalleriesClientDeletePoller) FinalResponse(ctx context.Context) (GalleriesClientDeleteResponse, error) {
-	respType := GalleriesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return GalleriesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleriesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientDeleteResponse, error) {
+	result := GalleriesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleriesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleriesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleriesClientDeletePoller) Resume(ctx context.Context, client *GalleriesClient, token string) (GalleriesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.Delete", token, client.pl); err != nil {
+		return GalleriesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleriesClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -654,36 +895,52 @@ func (p *GalleriesClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleriesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleriesClientUpdatePoller) Poll(ctx context.Context) (GalleriesClientUpdateResponse, error) {
+	result := GalleriesClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Gallery)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleriesClientUpdateResponse will be returned.
-func (p *GalleriesClientUpdatePoller) FinalResponse(ctx context.Context) (GalleriesClientUpdateResponse, error) {
-	respType := GalleriesClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Gallery)
-	if err != nil {
-		return GalleriesClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleriesClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientUpdateResponse, error) {
+	result := GalleriesClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Gallery)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleriesClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleriesClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleriesClientUpdatePoller) Resume(ctx context.Context, client *GalleriesClient, token string) (GalleriesClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleriesClient.Update", token, client.pl); err != nil {
+		return GalleriesClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryApplicationVersionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -696,36 +953,52 @@ func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
+	result := GalleryApplicationVersionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GalleryApplicationVersion)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryApplicationVersionsClientCreateOrUpdateResponse will be returned.
-func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
-	respType := GalleryApplicationVersionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GalleryApplicationVersion)
-	if err != nil {
-		return GalleryApplicationVersionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
+	result := GalleryApplicationVersionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GalleryApplicationVersion)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryApplicationVersionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryApplicationVersionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return GalleryApplicationVersionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryApplicationVersionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -738,36 +1011,52 @@ func (p *GalleryApplicationVersionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryApplicationVersionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryApplicationVersionsClientDeletePoller) Poll(ctx context.Context) (GalleryApplicationVersionsClientDeleteResponse, error) {
+	result := GalleryApplicationVersionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryApplicationVersionsClientDeleteResponse will be returned.
-func (p *GalleryApplicationVersionsClientDeletePoller) FinalResponse(ctx context.Context) (GalleryApplicationVersionsClientDeleteResponse, error) {
-	respType := GalleryApplicationVersionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return GalleryApplicationVersionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryApplicationVersionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientDeleteResponse, error) {
+	result := GalleryApplicationVersionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryApplicationVersionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryApplicationVersionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryApplicationVersionsClientDeletePoller) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) (GalleryApplicationVersionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Delete", token, client.pl); err != nil {
+		return GalleryApplicationVersionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryApplicationVersionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -780,36 +1069,52 @@ func (p *GalleryApplicationVersionsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryApplicationVersionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryApplicationVersionsClientUpdatePoller) Poll(ctx context.Context) (GalleryApplicationVersionsClientUpdateResponse, error) {
+	result := GalleryApplicationVersionsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GalleryApplicationVersion)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryApplicationVersionsClientUpdateResponse will be returned.
-func (p *GalleryApplicationVersionsClientUpdatePoller) FinalResponse(ctx context.Context) (GalleryApplicationVersionsClientUpdateResponse, error) {
-	respType := GalleryApplicationVersionsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GalleryApplicationVersion)
-	if err != nil {
-		return GalleryApplicationVersionsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryApplicationVersionsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientUpdateResponse, error) {
+	result := GalleryApplicationVersionsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GalleryApplicationVersion)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryApplicationVersionsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryApplicationVersionsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryApplicationVersionsClientUpdatePoller) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) (GalleryApplicationVersionsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Update", token, client.pl); err != nil {
+		return GalleryApplicationVersionsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryApplicationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -822,36 +1127,52 @@ func (p *GalleryApplicationsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryApplicationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryApplicationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
+	result := GalleryApplicationsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GalleryApplication)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryApplicationsClientCreateOrUpdateResponse will be returned.
-func (p *GalleryApplicationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
-	respType := GalleryApplicationsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GalleryApplication)
-	if err != nil {
-		return GalleryApplicationsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryApplicationsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
+	result := GalleryApplicationsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GalleryApplication)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryApplicationsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryApplicationsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryApplicationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return GalleryApplicationsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryApplicationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -864,36 +1185,52 @@ func (p *GalleryApplicationsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryApplicationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryApplicationsClientDeletePoller) Poll(ctx context.Context) (GalleryApplicationsClientDeleteResponse, error) {
+	result := GalleryApplicationsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryApplicationsClientDeleteResponse will be returned.
-func (p *GalleryApplicationsClientDeletePoller) FinalResponse(ctx context.Context) (GalleryApplicationsClientDeleteResponse, error) {
-	respType := GalleryApplicationsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return GalleryApplicationsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryApplicationsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientDeleteResponse, error) {
+	result := GalleryApplicationsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryApplicationsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryApplicationsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryApplicationsClientDeletePoller) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) (GalleryApplicationsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.Delete", token, client.pl); err != nil {
+		return GalleryApplicationsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryApplicationsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -906,36 +1243,52 @@ func (p *GalleryApplicationsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryApplicationsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryApplicationsClientUpdatePoller) Poll(ctx context.Context) (GalleryApplicationsClientUpdateResponse, error) {
+	result := GalleryApplicationsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GalleryApplication)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryApplicationsClientUpdateResponse will be returned.
-func (p *GalleryApplicationsClientUpdatePoller) FinalResponse(ctx context.Context) (GalleryApplicationsClientUpdateResponse, error) {
-	respType := GalleryApplicationsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GalleryApplication)
-	if err != nil {
-		return GalleryApplicationsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryApplicationsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientUpdateResponse, error) {
+	result := GalleryApplicationsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GalleryApplication)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryApplicationsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryApplicationsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryApplicationsClientUpdatePoller) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) (GalleryApplicationsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.Update", token, client.pl); err != nil {
+		return GalleryApplicationsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryImageVersionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -948,36 +1301,52 @@ func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
+	result := GalleryImageVersionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GalleryImageVersion)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryImageVersionsClientCreateOrUpdateResponse will be returned.
-func (p *GalleryImageVersionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
-	respType := GalleryImageVersionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GalleryImageVersion)
-	if err != nil {
-		return GalleryImageVersionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryImageVersionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
+	result := GalleryImageVersionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GalleryImageVersion)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryImageVersionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryImageVersionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryImageVersionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return GalleryImageVersionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryImageVersionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -990,36 +1359,52 @@ func (p *GalleryImageVersionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryImageVersionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryImageVersionsClientDeletePoller) Poll(ctx context.Context) (GalleryImageVersionsClientDeleteResponse, error) {
+	result := GalleryImageVersionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryImageVersionsClientDeleteResponse will be returned.
-func (p *GalleryImageVersionsClientDeletePoller) FinalResponse(ctx context.Context) (GalleryImageVersionsClientDeleteResponse, error) {
-	respType := GalleryImageVersionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return GalleryImageVersionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryImageVersionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientDeleteResponse, error) {
+	result := GalleryImageVersionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryImageVersionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryImageVersionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryImageVersionsClientDeletePoller) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) (GalleryImageVersionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.Delete", token, client.pl); err != nil {
+		return GalleryImageVersionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryImageVersionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1032,36 +1417,52 @@ func (p *GalleryImageVersionsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryImageVersionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryImageVersionsClientUpdatePoller) Poll(ctx context.Context) (GalleryImageVersionsClientUpdateResponse, error) {
+	result := GalleryImageVersionsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GalleryImageVersion)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryImageVersionsClientUpdateResponse will be returned.
-func (p *GalleryImageVersionsClientUpdatePoller) FinalResponse(ctx context.Context) (GalleryImageVersionsClientUpdateResponse, error) {
-	respType := GalleryImageVersionsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GalleryImageVersion)
-	if err != nil {
-		return GalleryImageVersionsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryImageVersionsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientUpdateResponse, error) {
+	result := GalleryImageVersionsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GalleryImageVersion)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryImageVersionsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryImageVersionsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryImageVersionsClientUpdatePoller) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) (GalleryImageVersionsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.Update", token, client.pl); err != nil {
+		return GalleryImageVersionsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryImagesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1074,36 +1475,52 @@ func (p *GalleryImagesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (GalleryImagesClientCreateOrUpdateResponse, error) {
+	result := GalleryImagesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GalleryImage)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryImagesClientCreateOrUpdateResponse will be returned.
-func (p *GalleryImagesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (GalleryImagesClientCreateOrUpdateResponse, error) {
-	respType := GalleryImagesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GalleryImage)
-	if err != nil {
-		return GalleryImagesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryImagesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientCreateOrUpdateResponse, error) {
+	result := GalleryImagesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GalleryImage)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryImagesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryImagesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryImagesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *GalleryImagesClient, token string) (GalleryImagesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return GalleryImagesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryImagesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1116,36 +1533,52 @@ func (p *GalleryImagesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryImagesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryImagesClientDeletePoller) Poll(ctx context.Context) (GalleryImagesClientDeleteResponse, error) {
+	result := GalleryImagesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryImagesClientDeleteResponse will be returned.
-func (p *GalleryImagesClientDeletePoller) FinalResponse(ctx context.Context) (GalleryImagesClientDeleteResponse, error) {
-	respType := GalleryImagesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return GalleryImagesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryImagesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientDeleteResponse, error) {
+	result := GalleryImagesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryImagesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryImagesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryImagesClientDeletePoller) Resume(ctx context.Context, client *GalleryImagesClient, token string) (GalleryImagesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.Delete", token, client.pl); err != nil {
+		return GalleryImagesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // GalleryImagesClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1158,36 +1591,52 @@ func (p *GalleryImagesClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *GalleryImagesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *GalleryImagesClientUpdatePoller) Poll(ctx context.Context) (GalleryImagesClientUpdateResponse, error) {
+	result := GalleryImagesClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GalleryImage)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final GalleryImagesClientUpdateResponse will be returned.
-func (p *GalleryImagesClientUpdatePoller) FinalResponse(ctx context.Context) (GalleryImagesClientUpdateResponse, error) {
-	respType := GalleryImagesClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GalleryImage)
-	if err != nil {
-		return GalleryImagesClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *GalleryImagesClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientUpdateResponse, error) {
+	result := GalleryImagesClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GalleryImage)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *GalleryImagesClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a GalleryImagesClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *GalleryImagesClientUpdatePoller) Resume(ctx context.Context, client *GalleryImagesClient, token string) (GalleryImagesClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("GalleryImagesClient.Update", token, client.pl); err != nil {
+		return GalleryImagesClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ImagesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1200,36 +1649,52 @@ func (p *ImagesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ImagesClientCreateOrUpdatePoller) Poll(ctx context.Context) (ImagesClientCreateOrUpdateResponse, error) {
+	result := ImagesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Image)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ImagesClientCreateOrUpdateResponse will be returned.
-func (p *ImagesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ImagesClientCreateOrUpdateResponse, error) {
-	respType := ImagesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Image)
-	if err != nil {
-		return ImagesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ImagesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientCreateOrUpdateResponse, error) {
+	result := ImagesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Image)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ImagesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ImagesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ImagesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ImagesClient, token string) (ImagesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ImagesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ImagesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1242,36 +1707,52 @@ func (p *ImagesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ImagesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ImagesClientDeletePoller) Poll(ctx context.Context) (ImagesClientDeleteResponse, error) {
+	result := ImagesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ImagesClientDeleteResponse will be returned.
-func (p *ImagesClientDeletePoller) FinalResponse(ctx context.Context) (ImagesClientDeleteResponse, error) {
-	respType := ImagesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ImagesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ImagesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientDeleteResponse, error) {
+	result := ImagesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ImagesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ImagesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ImagesClientDeletePoller) Resume(ctx context.Context, client *ImagesClient, token string) (ImagesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.Delete", token, client.pl); err != nil {
+		return ImagesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ImagesClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1284,36 +1765,52 @@ func (p *ImagesClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ImagesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ImagesClientUpdatePoller) Poll(ctx context.Context) (ImagesClientUpdateResponse, error) {
+	result := ImagesClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Image)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ImagesClientUpdateResponse will be returned.
-func (p *ImagesClientUpdatePoller) FinalResponse(ctx context.Context) (ImagesClientUpdateResponse, error) {
-	respType := ImagesClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Image)
-	if err != nil {
-		return ImagesClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ImagesClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientUpdateResponse, error) {
+	result := ImagesClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Image)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ImagesClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ImagesClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ImagesClientUpdatePoller) Resume(ctx context.Context, client *ImagesClient, token string) (ImagesClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ImagesClient.Update", token, client.pl); err != nil {
+		return ImagesClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LogAnalyticsClientExportRequestRateByIntervalPoller provides polling facilities until the operation reaches a terminal state.
@@ -1326,36 +1823,52 @@ func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Poll(ctx context.Context) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
+	result := LogAnalyticsClientExportRequestRateByIntervalResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.LogAnalyticsOperationResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LogAnalyticsClientExportRequestRateByIntervalResponse will be returned.
-func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) FinalResponse(ctx context.Context) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
-	respType := LogAnalyticsClientExportRequestRateByIntervalResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.LogAnalyticsOperationResult)
-	if err != nil {
-		return LogAnalyticsClientExportRequestRateByIntervalResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
+	result := LogAnalyticsClientExportRequestRateByIntervalResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.LogAnalyticsOperationResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LogAnalyticsClientExportRequestRateByIntervalPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LogAnalyticsClientExportRequestRateByIntervalPoller) Resume(ctx context.Context, client *LogAnalyticsClient, token string) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LogAnalyticsClient.ExportRequestRateByInterval", token, client.pl); err != nil {
+		return LogAnalyticsClientExportRequestRateByIntervalResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LogAnalyticsClientExportThrottledRequestsPoller provides polling facilities until the operation reaches a terminal state.
@@ -1368,36 +1881,52 @@ func (p *LogAnalyticsClientExportThrottledRequestsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LogAnalyticsClientExportThrottledRequestsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LogAnalyticsClientExportThrottledRequestsPoller) Poll(ctx context.Context) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
+	result := LogAnalyticsClientExportThrottledRequestsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.LogAnalyticsOperationResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LogAnalyticsClientExportThrottledRequestsResponse will be returned.
-func (p *LogAnalyticsClientExportThrottledRequestsPoller) FinalResponse(ctx context.Context) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
-	respType := LogAnalyticsClientExportThrottledRequestsResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.LogAnalyticsOperationResult)
-	if err != nil {
-		return LogAnalyticsClientExportThrottledRequestsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *LogAnalyticsClientExportThrottledRequestsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
+	result := LogAnalyticsClientExportThrottledRequestsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.LogAnalyticsOperationResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LogAnalyticsClientExportThrottledRequestsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LogAnalyticsClientExportThrottledRequestsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LogAnalyticsClientExportThrottledRequestsPoller) Resume(ctx context.Context, client *LogAnalyticsClient, token string) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LogAnalyticsClient.ExportThrottledRequests", token, client.pl); err != nil {
+		return LogAnalyticsClientExportThrottledRequestsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SnapshotsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1410,36 +1939,52 @@ func (p *SnapshotsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SnapshotsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SnapshotsClientCreateOrUpdatePoller) Poll(ctx context.Context) (SnapshotsClientCreateOrUpdateResponse, error) {
+	result := SnapshotsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Snapshot)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SnapshotsClientCreateOrUpdateResponse will be returned.
-func (p *SnapshotsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SnapshotsClientCreateOrUpdateResponse, error) {
-	respType := SnapshotsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Snapshot)
-	if err != nil {
-		return SnapshotsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SnapshotsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientCreateOrUpdateResponse, error) {
+	result := SnapshotsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Snapshot)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SnapshotsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SnapshotsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SnapshotsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return SnapshotsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SnapshotsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1452,36 +1997,52 @@ func (p *SnapshotsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SnapshotsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SnapshotsClientDeletePoller) Poll(ctx context.Context) (SnapshotsClientDeleteResponse, error) {
+	result := SnapshotsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SnapshotsClientDeleteResponse will be returned.
-func (p *SnapshotsClientDeletePoller) FinalResponse(ctx context.Context) (SnapshotsClientDeleteResponse, error) {
-	respType := SnapshotsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SnapshotsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SnapshotsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientDeleteResponse, error) {
+	result := SnapshotsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SnapshotsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SnapshotsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SnapshotsClientDeletePoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.Delete", token, client.pl); err != nil {
+		return SnapshotsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SnapshotsClientGrantAccessPoller provides polling facilities until the operation reaches a terminal state.
@@ -1494,36 +2055,52 @@ func (p *SnapshotsClientGrantAccessPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SnapshotsClientGrantAccessPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SnapshotsClientGrantAccessPoller) Poll(ctx context.Context) (SnapshotsClientGrantAccessResponse, error) {
+	result := SnapshotsClientGrantAccessResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.AccessURI)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SnapshotsClientGrantAccessResponse will be returned.
-func (p *SnapshotsClientGrantAccessPoller) FinalResponse(ctx context.Context) (SnapshotsClientGrantAccessResponse, error) {
-	respType := SnapshotsClientGrantAccessResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.AccessURI)
-	if err != nil {
-		return SnapshotsClientGrantAccessResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SnapshotsClientGrantAccessPoller) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientGrantAccessResponse, error) {
+	result := SnapshotsClientGrantAccessResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.AccessURI)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SnapshotsClientGrantAccessPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SnapshotsClientGrantAccessPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SnapshotsClientGrantAccessPoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientGrantAccessResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.GrantAccess", token, client.pl); err != nil {
+		return SnapshotsClientGrantAccessResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SnapshotsClientRevokeAccessPoller provides polling facilities until the operation reaches a terminal state.
@@ -1536,36 +2113,52 @@ func (p *SnapshotsClientRevokeAccessPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SnapshotsClientRevokeAccessPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SnapshotsClientRevokeAccessPoller) Poll(ctx context.Context) (SnapshotsClientRevokeAccessResponse, error) {
+	result := SnapshotsClientRevokeAccessResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SnapshotsClientRevokeAccessResponse will be returned.
-func (p *SnapshotsClientRevokeAccessPoller) FinalResponse(ctx context.Context) (SnapshotsClientRevokeAccessResponse, error) {
-	respType := SnapshotsClientRevokeAccessResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SnapshotsClientRevokeAccessResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SnapshotsClientRevokeAccessPoller) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientRevokeAccessResponse, error) {
+	result := SnapshotsClientRevokeAccessResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SnapshotsClientRevokeAccessPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SnapshotsClientRevokeAccessPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SnapshotsClientRevokeAccessPoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientRevokeAccessResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.RevokeAccess", token, client.pl); err != nil {
+		return SnapshotsClientRevokeAccessResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SnapshotsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1578,36 +2171,52 @@ func (p *SnapshotsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SnapshotsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SnapshotsClientUpdatePoller) Poll(ctx context.Context) (SnapshotsClientUpdateResponse, error) {
+	result := SnapshotsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Snapshot)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SnapshotsClientUpdateResponse will be returned.
-func (p *SnapshotsClientUpdatePoller) FinalResponse(ctx context.Context) (SnapshotsClientUpdateResponse, error) {
-	respType := SnapshotsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Snapshot)
-	if err != nil {
-		return SnapshotsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SnapshotsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientUpdateResponse, error) {
+	result := SnapshotsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Snapshot)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SnapshotsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SnapshotsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SnapshotsClientUpdatePoller) Resume(ctx context.Context, client *SnapshotsClient, token string) (SnapshotsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SnapshotsClient.Update", token, client.pl); err != nil {
+		return SnapshotsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineExtensionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1620,36 +2229,52 @@ func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
+	result := VirtualMachineExtensionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineExtension)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineExtensionsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachineExtensionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
-	if err != nil {
-		return VirtualMachineExtensionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
+	result := VirtualMachineExtensionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineExtension)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineExtensionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineExtensionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualMachineExtensionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineExtensionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1662,36 +2287,52 @@ func (p *VirtualMachineExtensionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineExtensionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineExtensionsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineExtensionsClientDeleteResponse, error) {
+	result := VirtualMachineExtensionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineExtensionsClientDeleteResponse will be returned.
-func (p *VirtualMachineExtensionsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineExtensionsClientDeleteResponse, error) {
-	respType := VirtualMachineExtensionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineExtensionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineExtensionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientDeleteResponse, error) {
+	result := VirtualMachineExtensionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineExtensionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineExtensionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineExtensionsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) (VirtualMachineExtensionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Delete", token, client.pl); err != nil {
+		return VirtualMachineExtensionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineExtensionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1704,36 +2345,52 @@ func (p *VirtualMachineExtensionsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineExtensionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineExtensionsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineExtensionsClientUpdateResponse, error) {
+	result := VirtualMachineExtensionsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineExtension)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineExtensionsClientUpdateResponse will be returned.
-func (p *VirtualMachineExtensionsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineExtensionsClientUpdateResponse, error) {
-	respType := VirtualMachineExtensionsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
-	if err != nil {
-		return VirtualMachineExtensionsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineExtensionsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientUpdateResponse, error) {
+	result := VirtualMachineExtensionsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineExtension)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineExtensionsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineExtensionsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineExtensionsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) (VirtualMachineExtensionsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Update", token, client.pl); err != nil {
+		return VirtualMachineExtensionsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1746,36 +2403,52 @@ func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Done() bool
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
+	result := VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSetExtension)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetExtension)
-	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
+	result := VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineScaleSetExtension)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetExtensionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1788,36 +2461,52 @@ func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
+	result := VirtualMachineScaleSetExtensionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetExtensionsClientDeleteResponse will be returned.
-func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
-	respType := VirtualMachineScaleSetExtensionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
+	result := VirtualMachineScaleSetExtensionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetExtensionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetExtensionsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Delete", token, client.pl); err != nil {
+		return VirtualMachineScaleSetExtensionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetExtensionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1830,36 +2519,52 @@ func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
+	result := VirtualMachineScaleSetExtensionsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSetExtension)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetExtensionsClientUpdateResponse will be returned.
-func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
-	respType := VirtualMachineScaleSetExtensionsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetExtension)
-	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
+	result := VirtualMachineScaleSetExtensionsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineScaleSetExtension)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetExtensionsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetExtensionsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Update", token, client.pl); err != nil {
+		return VirtualMachineScaleSetExtensionsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientCancelPoller provides polling facilities until the operation reaches a terminal state.
@@ -1872,36 +2577,52 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Poll(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
+	result := VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetRollingUpgradesClientCancelResponse will be returned.
-func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
-	respType := VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
+	result := VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientCancelPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetRollingUpgradesClientCancelPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.Cancel", token, client.pl); err != nil {
+		return VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller provides polling facilities until the operation reaches a terminal state.
@@ -1914,36 +2635,52 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller)
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) Poll(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
+	result := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse will be returned.
-func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
-	respType := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
+	result := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade", token, client.pl); err != nil {
+		return VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller provides polling facilities until the operation reaches a terminal state.
@@ -1956,36 +2693,52 @@ func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Done()
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Poll(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
+	result := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse will be returned.
-func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
-	respType := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
+	result := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade", token, client.pl); err != nil {
+		return VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1998,36 +2751,52 @@ func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Done() bo
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
+	result := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineExtension)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
-	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
+	result := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineExtension)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMExtensionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2040,36 +2809,52 @@ func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
+	result := VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMExtensionsClientDeleteResponse will be returned.
-func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
-	respType := VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
+	result := VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMExtensionsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Delete", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMExtensionsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2082,36 +2867,52 @@ func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
+	result := VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineExtension)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMExtensionsClientUpdateResponse will be returned.
-func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
-	respType := VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineExtension)
-	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
+	result := VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineExtension)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMExtensionsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Update", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientDeallocatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2124,36 +2925,52 @@ func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
+	result := VirtualMachineScaleSetVMsClientDeallocateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientDeallocateResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientDeallocateResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientDeallocateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
+	result := VirtualMachineScaleSetVMsClientDeallocateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientDeallocatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientDeallocatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Deallocate", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientDeallocateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2166,36 +2983,52 @@ func (p *VirtualMachineScaleSetVMsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
+	result := VirtualMachineScaleSetVMsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientDeleteResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
+	result := VirtualMachineScaleSetVMsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Delete", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientPerformMaintenancePoller provides polling facilities until the operation reaches a terminal state.
@@ -2208,36 +3041,52 @@ func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
+	result := VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientPerformMaintenanceResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
+	result := VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientPerformMaintenancePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientPerformMaintenancePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PerformMaintenance", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientPowerOffPoller provides polling facilities until the operation reaches a terminal state.
@@ -2250,36 +3099,52 @@ func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
+	result := VirtualMachineScaleSetVMsClientPowerOffResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientPowerOffResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientPowerOffResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientPowerOffResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
+	result := VirtualMachineScaleSetVMsClientPowerOffResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientPowerOffPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientPowerOffPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PowerOff", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientPowerOffResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientRedeployPoller provides polling facilities until the operation reaches a terminal state.
@@ -2292,36 +3157,52 @@ func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
+	result := VirtualMachineScaleSetVMsClientRedeployResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientRedeployResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientRedeployPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientRedeployResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientRedeployResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientRedeployPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
+	result := VirtualMachineScaleSetVMsClientRedeployResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientRedeployPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientRedeployPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientRedeployPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Redeploy", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientRedeployResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientReimageAllPoller provides polling facilities until the operation reaches a terminal state.
@@ -2334,36 +3215,52 @@ func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
+	result := VirtualMachineScaleSetVMsClientReimageAllResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientReimageAllResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientReimageAllResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientReimageAllResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
+	result := VirtualMachineScaleSetVMsClientReimageAllResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientReimageAllPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientReimageAllPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.ReimageAll", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientReimageAllResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientReimagePoller provides polling facilities until the operation reaches a terminal state.
@@ -2376,36 +3273,52 @@ func (p *VirtualMachineScaleSetVMsClientReimagePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientReimagePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientReimagePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
+	result := VirtualMachineScaleSetVMsClientReimageResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientReimageResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientReimagePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientReimageResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientReimageResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientReimagePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
+	result := VirtualMachineScaleSetVMsClientReimageResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientReimagePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientReimagePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientReimagePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Reimage", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientReimageResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientRestartPoller provides polling facilities until the operation reaches a terminal state.
@@ -2418,36 +3331,52 @@ func (p *VirtualMachineScaleSetVMsClientRestartPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientRestartPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientRestartPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
+	result := VirtualMachineScaleSetVMsClientRestartResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientRestartResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientRestartPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientRestartResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientRestartResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientRestartPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
+	result := VirtualMachineScaleSetVMsClientRestartResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientRestartPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientRestartPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientRestartPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Restart", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientRestartResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientRunCommandPoller provides polling facilities until the operation reaches a terminal state.
@@ -2460,36 +3389,52 @@ func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
+	result := VirtualMachineScaleSetVMsClientRunCommandResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.RunCommandResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientRunCommandResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientRunCommandResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.RunCommandResult)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientRunCommandResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
+	result := VirtualMachineScaleSetVMsClientRunCommandResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.RunCommandResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientRunCommandPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientRunCommandPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.RunCommand", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientRunCommandResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -2502,36 +3447,52 @@ func (p *VirtualMachineScaleSetVMsClientStartPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientStartPoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientStartResponse, error) {
+	result := VirtualMachineScaleSetVMsClientStartResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientStartResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientStartPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientStartResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientStartResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientStartResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientStartPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientStartResponse, error) {
+	result := VirtualMachineScaleSetVMsClientStartResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientStartPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientStartPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientStartPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientStartResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Start", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientStartResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetVMsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2544,36 +3505,52 @@ func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
+	result := VirtualMachineScaleSetVMsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSetVM)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetVMsClientUpdateResponse will be returned.
-func (p *VirtualMachineScaleSetVMsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSetVM)
-	if err != nil {
-		return VirtualMachineScaleSetVMsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetVMsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
+	result := VirtualMachineScaleSetVMsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineScaleSetVM)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetVMsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetVMsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetVMsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Update", token, client.pl); err != nil {
+		return VirtualMachineScaleSetVMsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2586,36 +3563,52 @@ func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
+	result := VirtualMachineScaleSetsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSet)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachineScaleSetsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSet)
-	if err != nil {
-		return VirtualMachineScaleSetsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
+	result := VirtualMachineScaleSetsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineScaleSet)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientDeallocatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2628,36 +3621,52 @@ func (p *VirtualMachineScaleSetsClientDeallocatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientDeallocatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientDeallocatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
+	result := VirtualMachineScaleSetsClientDeallocateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientDeallocateResponse will be returned.
-func (p *VirtualMachineScaleSetsClientDeallocatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
-	respType := VirtualMachineScaleSetsClientDeallocateResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientDeallocateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientDeallocatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
+	result := VirtualMachineScaleSetsClientDeallocateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientDeallocatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientDeallocatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientDeallocatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Deallocate", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientDeallocateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientDeleteInstancesPoller provides polling facilities until the operation reaches a terminal state.
@@ -2670,36 +3679,52 @@ func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
+	result := VirtualMachineScaleSetsClientDeleteInstancesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientDeleteInstancesResponse will be returned.
-func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
-	respType := VirtualMachineScaleSetsClientDeleteInstancesResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientDeleteInstancesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
+	result := VirtualMachineScaleSetsClientDeleteInstancesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientDeleteInstancesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientDeleteInstancesPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.DeleteInstances", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientDeleteInstancesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2712,36 +3737,52 @@ func (p *VirtualMachineScaleSetsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientDeletePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientDeleteResponse, error) {
+	result := VirtualMachineScaleSetsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientDeleteResponse will be returned.
-func (p *VirtualMachineScaleSetsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientDeleteResponse, error) {
-	respType := VirtualMachineScaleSetsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeleteResponse, error) {
+	result := VirtualMachineScaleSetsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientDeletePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Delete", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientPerformMaintenancePoller provides polling facilities until the operation reaches a terminal state.
@@ -2754,36 +3795,52 @@ func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
+	result := VirtualMachineScaleSetsClientPerformMaintenanceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientPerformMaintenanceResponse will be returned.
-func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
-	respType := VirtualMachineScaleSetsClientPerformMaintenanceResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientPerformMaintenanceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
+	result := VirtualMachineScaleSetsClientPerformMaintenanceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientPerformMaintenancePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientPerformMaintenancePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PerformMaintenance", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientPerformMaintenanceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientPowerOffPoller provides polling facilities until the operation reaches a terminal state.
@@ -2796,36 +3853,52 @@ func (p *VirtualMachineScaleSetsClientPowerOffPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientPowerOffPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientPowerOffPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
+	result := VirtualMachineScaleSetsClientPowerOffResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientPowerOffResponse will be returned.
-func (p *VirtualMachineScaleSetsClientPowerOffPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
-	respType := VirtualMachineScaleSetsClientPowerOffResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientPowerOffResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientPowerOffPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
+	result := VirtualMachineScaleSetsClientPowerOffResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientPowerOffPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientPowerOffPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientPowerOffPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PowerOff", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientPowerOffResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientRedeployPoller provides polling facilities until the operation reaches a terminal state.
@@ -2838,36 +3911,52 @@ func (p *VirtualMachineScaleSetsClientRedeployPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientRedeployPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientRedeployPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientRedeployResponse, error) {
+	result := VirtualMachineScaleSetsClientRedeployResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientRedeployResponse will be returned.
-func (p *VirtualMachineScaleSetsClientRedeployPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientRedeployResponse, error) {
-	respType := VirtualMachineScaleSetsClientRedeployResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientRedeployResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientRedeployPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientRedeployResponse, error) {
+	result := VirtualMachineScaleSetsClientRedeployResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientRedeployPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientRedeployPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientRedeployPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientRedeployResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Redeploy", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientRedeployResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientReimageAllPoller provides polling facilities until the operation reaches a terminal state.
@@ -2880,36 +3969,52 @@ func (p *VirtualMachineScaleSetsClientReimageAllPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientReimageAllPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientReimageAllPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
+	result := VirtualMachineScaleSetsClientReimageAllResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientReimageAllResponse will be returned.
-func (p *VirtualMachineScaleSetsClientReimageAllPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
-	respType := VirtualMachineScaleSetsClientReimageAllResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientReimageAllResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientReimageAllPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
+	result := VirtualMachineScaleSetsClientReimageAllResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientReimageAllPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientReimageAllPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientReimageAllPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.ReimageAll", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientReimageAllResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientReimagePoller provides polling facilities until the operation reaches a terminal state.
@@ -2922,36 +4027,52 @@ func (p *VirtualMachineScaleSetsClientReimagePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientReimagePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientReimagePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientReimageResponse, error) {
+	result := VirtualMachineScaleSetsClientReimageResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientReimageResponse will be returned.
-func (p *VirtualMachineScaleSetsClientReimagePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientReimageResponse, error) {
-	respType := VirtualMachineScaleSetsClientReimageResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientReimageResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientReimagePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientReimageResponse, error) {
+	result := VirtualMachineScaleSetsClientReimageResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientReimagePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientReimagePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientReimagePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientReimageResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Reimage", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientReimageResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientRestartPoller provides polling facilities until the operation reaches a terminal state.
@@ -2964,36 +4085,52 @@ func (p *VirtualMachineScaleSetsClientRestartPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientRestartPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientRestartPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientRestartResponse, error) {
+	result := VirtualMachineScaleSetsClientRestartResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientRestartResponse will be returned.
-func (p *VirtualMachineScaleSetsClientRestartPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientRestartResponse, error) {
-	respType := VirtualMachineScaleSetsClientRestartResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientRestartResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientRestartPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientRestartResponse, error) {
+	result := VirtualMachineScaleSetsClientRestartResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientRestartPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientRestartPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientRestartPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientRestartResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Restart", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientRestartResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3006,36 +4143,52 @@ func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Done()
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
+	result := VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse will be returned.
-func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
-	respType := VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
+	result := VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.SetOrchestrationServiceState", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -3048,36 +4201,52 @@ func (p *VirtualMachineScaleSetsClientStartPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientStartPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientStartResponse, error) {
+	result := VirtualMachineScaleSetsClientStartResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientStartResponse will be returned.
-func (p *VirtualMachineScaleSetsClientStartPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientStartResponse, error) {
-	respType := VirtualMachineScaleSetsClientStartResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientStartResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientStartPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientStartResponse, error) {
+	result := VirtualMachineScaleSetsClientStartResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientStartPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientStartPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientStartPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientStartResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Start", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientStartResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientUpdateInstancesPoller provides polling facilities until the operation reaches a terminal state.
@@ -3090,36 +4259,52 @@ func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
+	result := VirtualMachineScaleSetsClientUpdateInstancesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientUpdateInstancesResponse will be returned.
-func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
-	respType := VirtualMachineScaleSetsClientUpdateInstancesResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachineScaleSetsClientUpdateInstancesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
+	result := VirtualMachineScaleSetsClientUpdateInstancesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientUpdateInstancesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientUpdateInstancesPoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.UpdateInstances", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientUpdateInstancesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachineScaleSetsClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3132,36 +4317,52 @@ func (p *VirtualMachineScaleSetsClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachineScaleSetsClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachineScaleSetsClientUpdatePoller) Poll(ctx context.Context) (VirtualMachineScaleSetsClientUpdateResponse, error) {
+	result := VirtualMachineScaleSetsClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineScaleSet)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachineScaleSetsClientUpdateResponse will be returned.
-func (p *VirtualMachineScaleSetsClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachineScaleSetsClientUpdateResponse, error) {
-	respType := VirtualMachineScaleSetsClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineScaleSet)
-	if err != nil {
-		return VirtualMachineScaleSetsClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachineScaleSetsClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientUpdateResponse, error) {
+	result := VirtualMachineScaleSetsClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineScaleSet)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachineScaleSetsClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachineScaleSetsClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachineScaleSetsClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) (VirtualMachineScaleSetsClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Update", token, client.pl); err != nil {
+		return VirtualMachineScaleSetsClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -3174,36 +4375,52 @@ func (p *VirtualMachinesClientCapturePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientCapturePoller) Poll(ctx context.Context) (VirtualMachinesClientCaptureResponse, error) {
+	result := VirtualMachinesClientCaptureResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachineCaptureResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientCaptureResponse will be returned.
-func (p *VirtualMachinesClientCapturePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientCaptureResponse, error) {
-	respType := VirtualMachinesClientCaptureResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachineCaptureResult)
-	if err != nil {
-		return VirtualMachinesClientCaptureResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientCapturePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientCaptureResponse, error) {
+	result := VirtualMachinesClientCaptureResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachineCaptureResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientCapturePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientCapturePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientCapturePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientCaptureResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Capture", token, client.pl); err != nil {
+		return VirtualMachinesClientCaptureResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientConvertToManagedDisksPoller provides polling facilities until the operation reaches a terminal state.
@@ -3216,36 +4433,52 @@ func (p *VirtualMachinesClientConvertToManagedDisksPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientConvertToManagedDisksPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientConvertToManagedDisksPoller) Poll(ctx context.Context) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
+	result := VirtualMachinesClientConvertToManagedDisksResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientConvertToManagedDisksResponse will be returned.
-func (p *VirtualMachinesClientConvertToManagedDisksPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
-	respType := VirtualMachinesClientConvertToManagedDisksResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientConvertToManagedDisksResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientConvertToManagedDisksPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
+	result := VirtualMachinesClientConvertToManagedDisksResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientConvertToManagedDisksPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientConvertToManagedDisksPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientConvertToManagedDisksPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.ConvertToManagedDisks", token, client.pl); err != nil {
+		return VirtualMachinesClientConvertToManagedDisksResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3258,36 +4491,52 @@ func (p *VirtualMachinesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualMachinesClientCreateOrUpdateResponse, error) {
+	result := VirtualMachinesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachine)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientCreateOrUpdateResponse will be returned.
-func (p *VirtualMachinesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachinesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachine)
-	if err != nil {
-		return VirtualMachinesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientCreateOrUpdateResponse, error) {
+	result := VirtualMachinesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachine)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualMachinesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientDeallocatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3300,36 +4549,52 @@ func (p *VirtualMachinesClientDeallocatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientDeallocatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientDeallocatePoller) Poll(ctx context.Context) (VirtualMachinesClientDeallocateResponse, error) {
+	result := VirtualMachinesClientDeallocateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientDeallocateResponse will be returned.
-func (p *VirtualMachinesClientDeallocatePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientDeallocateResponse, error) {
-	respType := VirtualMachinesClientDeallocateResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientDeallocateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientDeallocatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientDeallocateResponse, error) {
+	result := VirtualMachinesClientDeallocateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientDeallocatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientDeallocatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientDeallocatePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientDeallocateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Deallocate", token, client.pl); err != nil {
+		return VirtualMachinesClientDeallocateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3342,36 +4607,52 @@ func (p *VirtualMachinesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientDeletePoller) Poll(ctx context.Context) (VirtualMachinesClientDeleteResponse, error) {
+	result := VirtualMachinesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientDeleteResponse will be returned.
-func (p *VirtualMachinesClientDeletePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientDeleteResponse, error) {
-	respType := VirtualMachinesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientDeleteResponse, error) {
+	result := VirtualMachinesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientDeletePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Delete", token, client.pl); err != nil {
+		return VirtualMachinesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientPerformMaintenancePoller provides polling facilities until the operation reaches a terminal state.
@@ -3384,36 +4665,52 @@ func (p *VirtualMachinesClientPerformMaintenancePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientPerformMaintenancePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientPerformMaintenancePoller) Poll(ctx context.Context) (VirtualMachinesClientPerformMaintenanceResponse, error) {
+	result := VirtualMachinesClientPerformMaintenanceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientPerformMaintenanceResponse will be returned.
-func (p *VirtualMachinesClientPerformMaintenancePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientPerformMaintenanceResponse, error) {
-	respType := VirtualMachinesClientPerformMaintenanceResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientPerformMaintenanceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientPerformMaintenancePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientPerformMaintenanceResponse, error) {
+	result := VirtualMachinesClientPerformMaintenanceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientPerformMaintenancePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientPerformMaintenancePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientPerformMaintenancePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientPerformMaintenanceResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.PerformMaintenance", token, client.pl); err != nil {
+		return VirtualMachinesClientPerformMaintenanceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientPowerOffPoller provides polling facilities until the operation reaches a terminal state.
@@ -3426,36 +4723,52 @@ func (p *VirtualMachinesClientPowerOffPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientPowerOffPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientPowerOffPoller) Poll(ctx context.Context) (VirtualMachinesClientPowerOffResponse, error) {
+	result := VirtualMachinesClientPowerOffResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientPowerOffResponse will be returned.
-func (p *VirtualMachinesClientPowerOffPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientPowerOffResponse, error) {
-	respType := VirtualMachinesClientPowerOffResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientPowerOffResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientPowerOffPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientPowerOffResponse, error) {
+	result := VirtualMachinesClientPowerOffResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientPowerOffPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientPowerOffPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientPowerOffPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientPowerOffResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.PowerOff", token, client.pl); err != nil {
+		return VirtualMachinesClientPowerOffResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientReapplyPoller provides polling facilities until the operation reaches a terminal state.
@@ -3468,36 +4781,52 @@ func (p *VirtualMachinesClientReapplyPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientReapplyPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientReapplyPoller) Poll(ctx context.Context) (VirtualMachinesClientReapplyResponse, error) {
+	result := VirtualMachinesClientReapplyResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientReapplyResponse will be returned.
-func (p *VirtualMachinesClientReapplyPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientReapplyResponse, error) {
-	respType := VirtualMachinesClientReapplyResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientReapplyResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientReapplyPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientReapplyResponse, error) {
+	result := VirtualMachinesClientReapplyResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientReapplyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientReapplyPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientReapplyPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientReapplyResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Reapply", token, client.pl); err != nil {
+		return VirtualMachinesClientReapplyResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientRedeployPoller provides polling facilities until the operation reaches a terminal state.
@@ -3510,36 +4839,52 @@ func (p *VirtualMachinesClientRedeployPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientRedeployPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientRedeployPoller) Poll(ctx context.Context) (VirtualMachinesClientRedeployResponse, error) {
+	result := VirtualMachinesClientRedeployResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientRedeployResponse will be returned.
-func (p *VirtualMachinesClientRedeployPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientRedeployResponse, error) {
-	respType := VirtualMachinesClientRedeployResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientRedeployResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientRedeployPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRedeployResponse, error) {
+	result := VirtualMachinesClientRedeployResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientRedeployPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientRedeployPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientRedeployPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientRedeployResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Redeploy", token, client.pl); err != nil {
+		return VirtualMachinesClientRedeployResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientReimagePoller provides polling facilities until the operation reaches a terminal state.
@@ -3552,36 +4897,52 @@ func (p *VirtualMachinesClientReimagePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientReimagePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientReimagePoller) Poll(ctx context.Context) (VirtualMachinesClientReimageResponse, error) {
+	result := VirtualMachinesClientReimageResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientReimageResponse will be returned.
-func (p *VirtualMachinesClientReimagePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientReimageResponse, error) {
-	respType := VirtualMachinesClientReimageResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientReimageResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientReimagePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientReimageResponse, error) {
+	result := VirtualMachinesClientReimageResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientReimagePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientReimagePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientReimagePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientReimageResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Reimage", token, client.pl); err != nil {
+		return VirtualMachinesClientReimageResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientRestartPoller provides polling facilities until the operation reaches a terminal state.
@@ -3594,36 +4955,52 @@ func (p *VirtualMachinesClientRestartPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientRestartPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientRestartPoller) Poll(ctx context.Context) (VirtualMachinesClientRestartResponse, error) {
+	result := VirtualMachinesClientRestartResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientRestartResponse will be returned.
-func (p *VirtualMachinesClientRestartPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientRestartResponse, error) {
-	respType := VirtualMachinesClientRestartResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientRestartResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientRestartPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRestartResponse, error) {
+	result := VirtualMachinesClientRestartResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientRestartPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientRestartPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientRestartPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientRestartResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Restart", token, client.pl); err != nil {
+		return VirtualMachinesClientRestartResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientRunCommandPoller provides polling facilities until the operation reaches a terminal state.
@@ -3636,36 +5013,52 @@ func (p *VirtualMachinesClientRunCommandPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientRunCommandPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientRunCommandPoller) Poll(ctx context.Context) (VirtualMachinesClientRunCommandResponse, error) {
+	result := VirtualMachinesClientRunCommandResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.RunCommandResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientRunCommandResponse will be returned.
-func (p *VirtualMachinesClientRunCommandPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientRunCommandResponse, error) {
-	respType := VirtualMachinesClientRunCommandResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.RunCommandResult)
-	if err != nil {
-		return VirtualMachinesClientRunCommandResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientRunCommandPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRunCommandResponse, error) {
+	result := VirtualMachinesClientRunCommandResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.RunCommandResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientRunCommandPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientRunCommandPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientRunCommandPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientRunCommandResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.RunCommand", token, client.pl); err != nil {
+		return VirtualMachinesClientRunCommandResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -3678,36 +5071,52 @@ func (p *VirtualMachinesClientStartPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientStartPoller) Poll(ctx context.Context) (VirtualMachinesClientStartResponse, error) {
+	result := VirtualMachinesClientStartResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientStartResponse will be returned.
-func (p *VirtualMachinesClientStartPoller) FinalResponse(ctx context.Context) (VirtualMachinesClientStartResponse, error) {
-	respType := VirtualMachinesClientStartResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualMachinesClientStartResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientStartPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientStartResponse, error) {
+	result := VirtualMachinesClientStartResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientStartPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientStartPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientStartPoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientStartResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Start", token, client.pl); err != nil {
+		return VirtualMachinesClientStartResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualMachinesClientUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3720,34 +5129,50 @@ func (p *VirtualMachinesClientUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualMachinesClientUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualMachinesClientUpdatePoller) Poll(ctx context.Context) (VirtualMachinesClientUpdateResponse, error) {
+	result := VirtualMachinesClientUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualMachine)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualMachinesClientUpdateResponse will be returned.
-func (p *VirtualMachinesClientUpdatePoller) FinalResponse(ctx context.Context) (VirtualMachinesClientUpdateResponse, error) {
-	respType := VirtualMachinesClientUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualMachine)
-	if err != nil {
-		return VirtualMachinesClientUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualMachinesClientUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientUpdateResponse, error) {
+	result := VirtualMachinesClientUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualMachine)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualMachinesClientUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualMachinesClientUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualMachinesClientUpdatePoller) Resume(ctx context.Context, client *VirtualMachinesClient, token string) (VirtualMachinesClientUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Update", token, client.pl); err != nil {
+		return VirtualMachinesClientUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
@@ -8,12 +8,6 @@
 
 package armcompute
 
-import (
-	"context"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"time"
-)
-
 // AvailabilitySetsClientCreateOrUpdateResponse contains the response from method AvailabilitySetsClient.CreateOrUpdate.
 type AvailabilitySetsClientCreateOrUpdateResponse struct {
 	AvailabilitySet
@@ -49,79 +43,9 @@ type AvailabilitySetsClientUpdateResponse struct {
 	AvailabilitySet
 }
 
-// ContainerServicesClientCreateOrUpdatePollerResponse contains the response from method ContainerServicesClient.CreateOrUpdate.
-type ContainerServicesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ContainerServicesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ContainerServicesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainerServicesClientCreateOrUpdateResponse, error) {
-	respType := ContainerServicesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ContainerService)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ContainerServicesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ContainerServicesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ContainerServicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ContainerServicesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ContainerServicesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ContainerServicesClientCreateOrUpdateResponse contains the response from method ContainerServicesClient.CreateOrUpdate.
 type ContainerServicesClientCreateOrUpdateResponse struct {
 	ContainerService
-}
-
-// ContainerServicesClientDeletePollerResponse contains the response from method ContainerServicesClient.Delete.
-type ContainerServicesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ContainerServicesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ContainerServicesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainerServicesClientDeleteResponse, error) {
-	respType := ContainerServicesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ContainerServicesClientDeletePollerResponse from the provided client and resume token.
-func (l *ContainerServicesClientDeletePollerResponse) Resume(ctx context.Context, client *ContainerServicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ContainerServicesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ContainerServicesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ContainerServicesClientDeleteResponse contains the response from method ContainerServicesClient.Delete.
@@ -174,79 +98,9 @@ type DedicatedHostGroupsClientUpdateResponse struct {
 	DedicatedHostGroup
 }
 
-// DedicatedHostsClientCreateOrUpdatePollerResponse contains the response from method DedicatedHostsClient.CreateOrUpdate.
-type DedicatedHostsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DedicatedHostsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DedicatedHostsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientCreateOrUpdateResponse, error) {
-	respType := DedicatedHostsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DedicatedHost)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DedicatedHostsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *DedicatedHostsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *DedicatedHostsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DedicatedHostsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DedicatedHostsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DedicatedHostsClientCreateOrUpdateResponse contains the response from method DedicatedHostsClient.CreateOrUpdate.
 type DedicatedHostsClientCreateOrUpdateResponse struct {
 	DedicatedHost
-}
-
-// DedicatedHostsClientDeletePollerResponse contains the response from method DedicatedHostsClient.Delete.
-type DedicatedHostsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DedicatedHostsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DedicatedHostsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientDeleteResponse, error) {
-	respType := DedicatedHostsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DedicatedHostsClientDeletePollerResponse from the provided client and resume token.
-func (l *DedicatedHostsClientDeletePollerResponse) Resume(ctx context.Context, client *DedicatedHostsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DedicatedHostsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DedicatedHostsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DedicatedHostsClientDeleteResponse contains the response from method DedicatedHostsClient.Delete.
@@ -264,119 +118,14 @@ type DedicatedHostsClientListByHostGroupResponse struct {
 	DedicatedHostListResult
 }
 
-// DedicatedHostsClientUpdatePollerResponse contains the response from method DedicatedHostsClient.Update.
-type DedicatedHostsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DedicatedHostsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DedicatedHostsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostsClientUpdateResponse, error) {
-	respType := DedicatedHostsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DedicatedHost)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DedicatedHostsClientUpdatePollerResponse from the provided client and resume token.
-func (l *DedicatedHostsClientUpdatePollerResponse) Resume(ctx context.Context, client *DedicatedHostsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DedicatedHostsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DedicatedHostsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DedicatedHostsClientUpdateResponse contains the response from method DedicatedHostsClient.Update.
 type DedicatedHostsClientUpdateResponse struct {
 	DedicatedHost
 }
 
-// DiskEncryptionSetsClientCreateOrUpdatePollerResponse contains the response from method DiskEncryptionSetsClient.CreateOrUpdate.
-type DiskEncryptionSetsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DiskEncryptionSetsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DiskEncryptionSetsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientCreateOrUpdateResponse, error) {
-	respType := DiskEncryptionSetsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DiskEncryptionSet)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DiskEncryptionSetsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *DiskEncryptionSetsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DiskEncryptionSetsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DiskEncryptionSetsClientCreateOrUpdateResponse contains the response from method DiskEncryptionSetsClient.CreateOrUpdate.
 type DiskEncryptionSetsClientCreateOrUpdateResponse struct {
 	DiskEncryptionSet
-}
-
-// DiskEncryptionSetsClientDeletePollerResponse contains the response from method DiskEncryptionSetsClient.Delete.
-type DiskEncryptionSetsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DiskEncryptionSetsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DiskEncryptionSetsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientDeleteResponse, error) {
-	respType := DiskEncryptionSetsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DiskEncryptionSetsClientDeletePollerResponse from the provided client and resume token.
-func (l *DiskEncryptionSetsClientDeletePollerResponse) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DiskEncryptionSetsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DiskEncryptionSetsClientDeleteResponse contains the response from method DiskEncryptionSetsClient.Delete.
@@ -399,119 +148,14 @@ type DiskEncryptionSetsClientListResponse struct {
 	DiskEncryptionSetList
 }
 
-// DiskEncryptionSetsClientUpdatePollerResponse contains the response from method DiskEncryptionSetsClient.Update.
-type DiskEncryptionSetsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DiskEncryptionSetsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DiskEncryptionSetsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetsClientUpdateResponse, error) {
-	respType := DiskEncryptionSetsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DiskEncryptionSet)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DiskEncryptionSetsClientUpdatePollerResponse from the provided client and resume token.
-func (l *DiskEncryptionSetsClientUpdatePollerResponse) Resume(ctx context.Context, client *DiskEncryptionSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DiskEncryptionSetsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DiskEncryptionSetsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DiskEncryptionSetsClientUpdateResponse contains the response from method DiskEncryptionSetsClient.Update.
 type DiskEncryptionSetsClientUpdateResponse struct {
 	DiskEncryptionSet
 }
 
-// DisksClientCreateOrUpdatePollerResponse contains the response from method DisksClient.CreateOrUpdate.
-type DisksClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DisksClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DisksClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientCreateOrUpdateResponse, error) {
-	respType := DisksClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Disk)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DisksClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *DisksClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *DisksClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DisksClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DisksClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DisksClientCreateOrUpdateResponse contains the response from method DisksClient.CreateOrUpdate.
 type DisksClientCreateOrUpdateResponse struct {
 	Disk
-}
-
-// DisksClientDeletePollerResponse contains the response from method DisksClient.Delete.
-type DisksClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DisksClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DisksClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientDeleteResponse, error) {
-	respType := DisksClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DisksClientDeletePollerResponse from the provided client and resume token.
-func (l *DisksClientDeletePollerResponse) Resume(ctx context.Context, client *DisksClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DisksClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DisksClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DisksClientDeleteResponse contains the response from method DisksClient.Delete.
@@ -522,41 +166,6 @@ type DisksClientDeleteResponse struct {
 // DisksClientGetResponse contains the response from method DisksClient.Get.
 type DisksClientGetResponse struct {
 	Disk
-}
-
-// DisksClientGrantAccessPollerResponse contains the response from method DisksClient.GrantAccess.
-type DisksClientGrantAccessPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DisksClientGrantAccessPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DisksClientGrantAccessPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientGrantAccessResponse, error) {
-	respType := DisksClientGrantAccessResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AccessURI)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DisksClientGrantAccessPollerResponse from the provided client and resume token.
-func (l *DisksClientGrantAccessPollerResponse) Resume(ctx context.Context, client *DisksClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DisksClient.GrantAccess", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DisksClientGrantAccessPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DisksClientGrantAccessResponse contains the response from method DisksClient.GrantAccess.
@@ -574,79 +183,9 @@ type DisksClientListResponse struct {
 	DiskList
 }
 
-// DisksClientRevokeAccessPollerResponse contains the response from method DisksClient.RevokeAccess.
-type DisksClientRevokeAccessPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DisksClientRevokeAccessPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DisksClientRevokeAccessPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientRevokeAccessResponse, error) {
-	respType := DisksClientRevokeAccessResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DisksClientRevokeAccessPollerResponse from the provided client and resume token.
-func (l *DisksClientRevokeAccessPollerResponse) Resume(ctx context.Context, client *DisksClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DisksClient.RevokeAccess", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DisksClientRevokeAccessPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DisksClientRevokeAccessResponse contains the response from method DisksClient.RevokeAccess.
 type DisksClientRevokeAccessResponse struct {
 	// placeholder for future response values
-}
-
-// DisksClientUpdatePollerResponse contains the response from method DisksClient.Update.
-type DisksClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DisksClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DisksClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DisksClientUpdateResponse, error) {
-	respType := DisksClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Disk)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DisksClientUpdatePollerResponse from the provided client and resume token.
-func (l *DisksClientUpdatePollerResponse) Resume(ctx context.Context, client *DisksClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DisksClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DisksClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DisksClientUpdateResponse contains the response from method DisksClient.Update.
@@ -654,79 +193,9 @@ type DisksClientUpdateResponse struct {
 	Disk
 }
 
-// GalleriesClientCreateOrUpdatePollerResponse contains the response from method GalleriesClient.CreateOrUpdate.
-type GalleriesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleriesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleriesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientCreateOrUpdateResponse, error) {
-	respType := GalleriesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Gallery)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleriesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *GalleriesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *GalleriesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleriesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleriesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleriesClientCreateOrUpdateResponse contains the response from method GalleriesClient.CreateOrUpdate.
 type GalleriesClientCreateOrUpdateResponse struct {
 	Gallery
-}
-
-// GalleriesClientDeletePollerResponse contains the response from method GalleriesClient.Delete.
-type GalleriesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleriesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleriesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientDeleteResponse, error) {
-	respType := GalleriesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleriesClientDeletePollerResponse from the provided client and resume token.
-func (l *GalleriesClientDeletePollerResponse) Resume(ctx context.Context, client *GalleriesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleriesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleriesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // GalleriesClientDeleteResponse contains the response from method GalleriesClient.Delete.
@@ -749,119 +218,14 @@ type GalleriesClientListResponse struct {
 	GalleryList
 }
 
-// GalleriesClientUpdatePollerResponse contains the response from method GalleriesClient.Update.
-type GalleriesClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleriesClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleriesClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleriesClientUpdateResponse, error) {
-	respType := GalleriesClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Gallery)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleriesClientUpdatePollerResponse from the provided client and resume token.
-func (l *GalleriesClientUpdatePollerResponse) Resume(ctx context.Context, client *GalleriesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleriesClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleriesClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleriesClientUpdateResponse contains the response from method GalleriesClient.Update.
 type GalleriesClientUpdateResponse struct {
 	Gallery
 }
 
-// GalleryApplicationVersionsClientCreateOrUpdatePollerResponse contains the response from method GalleryApplicationVersionsClient.CreateOrUpdate.
-type GalleryApplicationVersionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryApplicationVersionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryApplicationVersionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientCreateOrUpdateResponse, error) {
-	respType := GalleryApplicationVersionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplicationVersion)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryApplicationVersionsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *GalleryApplicationVersionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryApplicationVersionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleryApplicationVersionsClientCreateOrUpdateResponse contains the response from method GalleryApplicationVersionsClient.CreateOrUpdate.
 type GalleryApplicationVersionsClientCreateOrUpdateResponse struct {
 	GalleryApplicationVersion
-}
-
-// GalleryApplicationVersionsClientDeletePollerResponse contains the response from method GalleryApplicationVersionsClient.Delete.
-type GalleryApplicationVersionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryApplicationVersionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryApplicationVersionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientDeleteResponse, error) {
-	respType := GalleryApplicationVersionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryApplicationVersionsClientDeletePollerResponse from the provided client and resume token.
-func (l *GalleryApplicationVersionsClientDeletePollerResponse) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryApplicationVersionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // GalleryApplicationVersionsClientDeleteResponse contains the response from method GalleryApplicationVersionsClient.Delete.
@@ -879,119 +243,14 @@ type GalleryApplicationVersionsClientListByGalleryApplicationResponse struct {
 	GalleryApplicationVersionList
 }
 
-// GalleryApplicationVersionsClientUpdatePollerResponse contains the response from method GalleryApplicationVersionsClient.Update.
-type GalleryApplicationVersionsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryApplicationVersionsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryApplicationVersionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionsClientUpdateResponse, error) {
-	respType := GalleryApplicationVersionsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplicationVersion)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryApplicationVersionsClientUpdatePollerResponse from the provided client and resume token.
-func (l *GalleryApplicationVersionsClientUpdatePollerResponse) Resume(ctx context.Context, client *GalleryApplicationVersionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryApplicationVersionsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleryApplicationVersionsClientUpdateResponse contains the response from method GalleryApplicationVersionsClient.Update.
 type GalleryApplicationVersionsClientUpdateResponse struct {
 	GalleryApplicationVersion
 }
 
-// GalleryApplicationsClientCreateOrUpdatePollerResponse contains the response from method GalleryApplicationsClient.CreateOrUpdate.
-type GalleryApplicationsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryApplicationsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryApplicationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientCreateOrUpdateResponse, error) {
-	respType := GalleryApplicationsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplication)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryApplicationsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *GalleryApplicationsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryApplicationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleryApplicationsClientCreateOrUpdateResponse contains the response from method GalleryApplicationsClient.CreateOrUpdate.
 type GalleryApplicationsClientCreateOrUpdateResponse struct {
 	GalleryApplication
-}
-
-// GalleryApplicationsClientDeletePollerResponse contains the response from method GalleryApplicationsClient.Delete.
-type GalleryApplicationsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryApplicationsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryApplicationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientDeleteResponse, error) {
-	respType := GalleryApplicationsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryApplicationsClientDeletePollerResponse from the provided client and resume token.
-func (l *GalleryApplicationsClientDeletePollerResponse) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryApplicationsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // GalleryApplicationsClientDeleteResponse contains the response from method GalleryApplicationsClient.Delete.
@@ -1009,119 +268,14 @@ type GalleryApplicationsClientListByGalleryResponse struct {
 	GalleryApplicationList
 }
 
-// GalleryApplicationsClientUpdatePollerResponse contains the response from method GalleryApplicationsClient.Update.
-type GalleryApplicationsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryApplicationsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryApplicationsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationsClientUpdateResponse, error) {
-	respType := GalleryApplicationsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryApplication)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryApplicationsClientUpdatePollerResponse from the provided client and resume token.
-func (l *GalleryApplicationsClientUpdatePollerResponse) Resume(ctx context.Context, client *GalleryApplicationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryApplicationsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryApplicationsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleryApplicationsClientUpdateResponse contains the response from method GalleryApplicationsClient.Update.
 type GalleryApplicationsClientUpdateResponse struct {
 	GalleryApplication
 }
 
-// GalleryImageVersionsClientCreateOrUpdatePollerResponse contains the response from method GalleryImageVersionsClient.CreateOrUpdate.
-type GalleryImageVersionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryImageVersionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryImageVersionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientCreateOrUpdateResponse, error) {
-	respType := GalleryImageVersionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImageVersion)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryImageVersionsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *GalleryImageVersionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryImageVersionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleryImageVersionsClientCreateOrUpdateResponse contains the response from method GalleryImageVersionsClient.CreateOrUpdate.
 type GalleryImageVersionsClientCreateOrUpdateResponse struct {
 	GalleryImageVersion
-}
-
-// GalleryImageVersionsClientDeletePollerResponse contains the response from method GalleryImageVersionsClient.Delete.
-type GalleryImageVersionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryImageVersionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryImageVersionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientDeleteResponse, error) {
-	respType := GalleryImageVersionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryImageVersionsClientDeletePollerResponse from the provided client and resume token.
-func (l *GalleryImageVersionsClientDeletePollerResponse) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryImageVersionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // GalleryImageVersionsClientDeleteResponse contains the response from method GalleryImageVersionsClient.Delete.
@@ -1139,119 +293,14 @@ type GalleryImageVersionsClientListByGalleryImageResponse struct {
 	GalleryImageVersionList
 }
 
-// GalleryImageVersionsClientUpdatePollerResponse contains the response from method GalleryImageVersionsClient.Update.
-type GalleryImageVersionsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryImageVersionsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryImageVersionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionsClientUpdateResponse, error) {
-	respType := GalleryImageVersionsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImageVersion)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryImageVersionsClientUpdatePollerResponse from the provided client and resume token.
-func (l *GalleryImageVersionsClientUpdatePollerResponse) Resume(ctx context.Context, client *GalleryImageVersionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryImageVersionsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryImageVersionsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleryImageVersionsClientUpdateResponse contains the response from method GalleryImageVersionsClient.Update.
 type GalleryImageVersionsClientUpdateResponse struct {
 	GalleryImageVersion
 }
 
-// GalleryImagesClientCreateOrUpdatePollerResponse contains the response from method GalleryImagesClient.CreateOrUpdate.
-type GalleryImagesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryImagesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryImagesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientCreateOrUpdateResponse, error) {
-	respType := GalleryImagesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImage)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryImagesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *GalleryImagesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *GalleryImagesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryImagesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryImagesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleryImagesClientCreateOrUpdateResponse contains the response from method GalleryImagesClient.CreateOrUpdate.
 type GalleryImagesClientCreateOrUpdateResponse struct {
 	GalleryImage
-}
-
-// GalleryImagesClientDeletePollerResponse contains the response from method GalleryImagesClient.Delete.
-type GalleryImagesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryImagesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryImagesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientDeleteResponse, error) {
-	respType := GalleryImagesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryImagesClientDeletePollerResponse from the provided client and resume token.
-func (l *GalleryImagesClientDeletePollerResponse) Resume(ctx context.Context, client *GalleryImagesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryImagesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryImagesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // GalleryImagesClientDeleteResponse contains the response from method GalleryImagesClient.Delete.
@@ -1269,119 +318,14 @@ type GalleryImagesClientListByGalleryResponse struct {
 	GalleryImageList
 }
 
-// GalleryImagesClientUpdatePollerResponse contains the response from method GalleryImagesClient.Update.
-type GalleryImagesClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *GalleryImagesClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l GalleryImagesClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (GalleryImagesClientUpdateResponse, error) {
-	respType := GalleryImagesClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GalleryImage)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a GalleryImagesClientUpdatePollerResponse from the provided client and resume token.
-func (l *GalleryImagesClientUpdatePollerResponse) Resume(ctx context.Context, client *GalleryImagesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("GalleryImagesClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &GalleryImagesClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // GalleryImagesClientUpdateResponse contains the response from method GalleryImagesClient.Update.
 type GalleryImagesClientUpdateResponse struct {
 	GalleryImage
 }
 
-// ImagesClientCreateOrUpdatePollerResponse contains the response from method ImagesClient.CreateOrUpdate.
-type ImagesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ImagesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ImagesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientCreateOrUpdateResponse, error) {
-	respType := ImagesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Image)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ImagesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ImagesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ImagesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ImagesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ImagesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ImagesClientCreateOrUpdateResponse contains the response from method ImagesClient.CreateOrUpdate.
 type ImagesClientCreateOrUpdateResponse struct {
 	Image
-}
-
-// ImagesClientDeletePollerResponse contains the response from method ImagesClient.Delete.
-type ImagesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ImagesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ImagesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientDeleteResponse, error) {
-	respType := ImagesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ImagesClientDeletePollerResponse from the provided client and resume token.
-func (l *ImagesClientDeletePollerResponse) Resume(ctx context.Context, client *ImagesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ImagesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ImagesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ImagesClientDeleteResponse contains the response from method ImagesClient.Delete.
@@ -1404,119 +348,14 @@ type ImagesClientListResponse struct {
 	ImageListResult
 }
 
-// ImagesClientUpdatePollerResponse contains the response from method ImagesClient.Update.
-type ImagesClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ImagesClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ImagesClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ImagesClientUpdateResponse, error) {
-	respType := ImagesClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Image)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ImagesClientUpdatePollerResponse from the provided client and resume token.
-func (l *ImagesClientUpdatePollerResponse) Resume(ctx context.Context, client *ImagesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ImagesClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ImagesClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ImagesClientUpdateResponse contains the response from method ImagesClient.Update.
 type ImagesClientUpdateResponse struct {
 	Image
 }
 
-// LogAnalyticsClientExportRequestRateByIntervalPollerResponse contains the response from method LogAnalyticsClient.ExportRequestRateByInterval.
-type LogAnalyticsClientExportRequestRateByIntervalPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LogAnalyticsClientExportRequestRateByIntervalPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l LogAnalyticsClientExportRequestRateByIntervalPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LogAnalyticsClientExportRequestRateByIntervalResponse, error) {
-	respType := LogAnalyticsClientExportRequestRateByIntervalResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LogAnalyticsOperationResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LogAnalyticsClientExportRequestRateByIntervalPollerResponse from the provided client and resume token.
-func (l *LogAnalyticsClientExportRequestRateByIntervalPollerResponse) Resume(ctx context.Context, client *LogAnalyticsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LogAnalyticsClient.ExportRequestRateByInterval", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LogAnalyticsClientExportRequestRateByIntervalPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LogAnalyticsClientExportRequestRateByIntervalResponse contains the response from method LogAnalyticsClient.ExportRequestRateByInterval.
 type LogAnalyticsClientExportRequestRateByIntervalResponse struct {
 	LogAnalyticsOperationResult
-}
-
-// LogAnalyticsClientExportThrottledRequestsPollerResponse contains the response from method LogAnalyticsClient.ExportThrottledRequests.
-type LogAnalyticsClientExportThrottledRequestsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LogAnalyticsClientExportThrottledRequestsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l LogAnalyticsClientExportThrottledRequestsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LogAnalyticsClientExportThrottledRequestsResponse, error) {
-	respType := LogAnalyticsClientExportThrottledRequestsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LogAnalyticsOperationResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LogAnalyticsClientExportThrottledRequestsPollerResponse from the provided client and resume token.
-func (l *LogAnalyticsClientExportThrottledRequestsPollerResponse) Resume(ctx context.Context, client *LogAnalyticsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LogAnalyticsClient.ExportThrottledRequests", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LogAnalyticsClientExportThrottledRequestsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LogAnalyticsClientExportThrottledRequestsResponse contains the response from method LogAnalyticsClient.ExportThrottledRequests.
@@ -1599,79 +438,9 @@ type SSHPublicKeysClientUpdateResponse struct {
 	SSHPublicKeyResource
 }
 
-// SnapshotsClientCreateOrUpdatePollerResponse contains the response from method SnapshotsClient.CreateOrUpdate.
-type SnapshotsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SnapshotsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SnapshotsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientCreateOrUpdateResponse, error) {
-	respType := SnapshotsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Snapshot)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SnapshotsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *SnapshotsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *SnapshotsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SnapshotsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SnapshotsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SnapshotsClientCreateOrUpdateResponse contains the response from method SnapshotsClient.CreateOrUpdate.
 type SnapshotsClientCreateOrUpdateResponse struct {
 	Snapshot
-}
-
-// SnapshotsClientDeletePollerResponse contains the response from method SnapshotsClient.Delete.
-type SnapshotsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SnapshotsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SnapshotsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientDeleteResponse, error) {
-	respType := SnapshotsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SnapshotsClientDeletePollerResponse from the provided client and resume token.
-func (l *SnapshotsClientDeletePollerResponse) Resume(ctx context.Context, client *SnapshotsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SnapshotsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SnapshotsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SnapshotsClientDeleteResponse contains the response from method SnapshotsClient.Delete.
@@ -1682,41 +451,6 @@ type SnapshotsClientDeleteResponse struct {
 // SnapshotsClientGetResponse contains the response from method SnapshotsClient.Get.
 type SnapshotsClientGetResponse struct {
 	Snapshot
-}
-
-// SnapshotsClientGrantAccessPollerResponse contains the response from method SnapshotsClient.GrantAccess.
-type SnapshotsClientGrantAccessPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SnapshotsClientGrantAccessPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SnapshotsClientGrantAccessPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientGrantAccessResponse, error) {
-	respType := SnapshotsClientGrantAccessResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AccessURI)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SnapshotsClientGrantAccessPollerResponse from the provided client and resume token.
-func (l *SnapshotsClientGrantAccessPollerResponse) Resume(ctx context.Context, client *SnapshotsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SnapshotsClient.GrantAccess", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SnapshotsClientGrantAccessPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SnapshotsClientGrantAccessResponse contains the response from method SnapshotsClient.GrantAccess.
@@ -1734,79 +468,9 @@ type SnapshotsClientListResponse struct {
 	SnapshotList
 }
 
-// SnapshotsClientRevokeAccessPollerResponse contains the response from method SnapshotsClient.RevokeAccess.
-type SnapshotsClientRevokeAccessPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SnapshotsClientRevokeAccessPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SnapshotsClientRevokeAccessPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientRevokeAccessResponse, error) {
-	respType := SnapshotsClientRevokeAccessResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SnapshotsClientRevokeAccessPollerResponse from the provided client and resume token.
-func (l *SnapshotsClientRevokeAccessPollerResponse) Resume(ctx context.Context, client *SnapshotsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SnapshotsClient.RevokeAccess", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SnapshotsClientRevokeAccessPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SnapshotsClientRevokeAccessResponse contains the response from method SnapshotsClient.RevokeAccess.
 type SnapshotsClientRevokeAccessResponse struct {
 	// placeholder for future response values
-}
-
-// SnapshotsClientUpdatePollerResponse contains the response from method SnapshotsClient.Update.
-type SnapshotsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SnapshotsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SnapshotsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SnapshotsClientUpdateResponse, error) {
-	respType := SnapshotsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Snapshot)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SnapshotsClientUpdatePollerResponse from the provided client and resume token.
-func (l *SnapshotsClientUpdatePollerResponse) Resume(ctx context.Context, client *SnapshotsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SnapshotsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SnapshotsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SnapshotsClientUpdateResponse contains the response from method SnapshotsClient.Update.
@@ -1836,79 +500,9 @@ type VirtualMachineExtensionImagesClientListVersionsResponse struct {
 	VirtualMachineExtensionImageArray []*VirtualMachineExtensionImage
 }
 
-// VirtualMachineExtensionsClientCreateOrUpdatePollerResponse contains the response from method VirtualMachineExtensionsClient.CreateOrUpdate.
-type VirtualMachineExtensionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineExtensionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineExtensionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachineExtensionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineExtensionsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineExtensionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineExtensionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineExtensionsClient.CreateOrUpdate.
 type VirtualMachineExtensionsClientCreateOrUpdateResponse struct {
 	VirtualMachineExtension
-}
-
-// VirtualMachineExtensionsClientDeletePollerResponse contains the response from method VirtualMachineExtensionsClient.Delete.
-type VirtualMachineExtensionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineExtensionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineExtensionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientDeleteResponse, error) {
-	respType := VirtualMachineExtensionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineExtensionsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualMachineExtensionsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineExtensionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineExtensionsClientDeleteResponse contains the response from method VirtualMachineExtensionsClient.Delete.
@@ -1924,41 +518,6 @@ type VirtualMachineExtensionsClientGetResponse struct {
 // VirtualMachineExtensionsClientListResponse contains the response from method VirtualMachineExtensionsClient.List.
 type VirtualMachineExtensionsClientListResponse struct {
 	VirtualMachineExtensionsListResult
-}
-
-// VirtualMachineExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineExtensionsClient.Update.
-type VirtualMachineExtensionsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineExtensionsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineExtensionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionsClientUpdateResponse, error) {
-	respType := VirtualMachineExtensionsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineExtensionsClientUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineExtensionsClientUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineExtensionsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineExtensionsClientUpdateResponse contains the response from method VirtualMachineExtensionsClient.Update.
@@ -2005,80 +564,9 @@ type VirtualMachineRunCommandsClientListResponse struct {
 	RunCommandListResult
 }
 
-// VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.CreateOrUpdate.
-type VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetExtension)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse from the provided client and resume
-// token.
-func (l *VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetExtensionsClient.CreateOrUpdate.
 type VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse struct {
 	VirtualMachineScaleSetExtension
-}
-
-// VirtualMachineScaleSetExtensionsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Delete.
-type VirtualMachineScaleSetExtensionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetExtensionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetExtensionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientDeleteResponse, error) {
-	respType := VirtualMachineScaleSetExtensionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetExtensionsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetExtensionsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetExtensionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetExtensionsClientDeleteResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Delete.
@@ -2096,80 +584,9 @@ type VirtualMachineScaleSetExtensionsClientListResponse struct {
 	VirtualMachineScaleSetExtensionListResult
 }
 
-// VirtualMachineScaleSetExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Update.
-type VirtualMachineScaleSetExtensionsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetExtensionsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetExtensionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionsClientUpdateResponse, error) {
-	respType := VirtualMachineScaleSetExtensionsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetExtension)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetExtensionsClientUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetExtensionsClientUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetExtensionsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetExtensionsClientUpdateResponse contains the response from method VirtualMachineScaleSetExtensionsClient.Update.
 type VirtualMachineScaleSetExtensionsClientUpdateResponse struct {
 	VirtualMachineScaleSetExtension
-}
-
-// VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.Cancel.
-type VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetRollingUpgradesClientCancelPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientCancelResponse, error) {
-	respType := VirtualMachineScaleSetRollingUpgradesClientCancelResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse from the provided client and resume
-// token.
-func (l *VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.Cancel", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetRollingUpgradesClientCancelPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientCancelResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.Cancel.
@@ -2182,81 +599,9 @@ type VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse struct {
 	RollingUpgradeStatusInfo
 }
 
-// VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade.
-type VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse, error) {
-	respType := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse from the provided client
-// and resume token.
-func (l *VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade.
 type VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade.
-type VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse, error) {
-	respType := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse from the provided client and
-// resume token.
-func (l *VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetRollingUpgradesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse contains the response from method VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade.
@@ -2264,80 +609,9 @@ type VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate.
-type VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse from the provided client and resume
-// token.
-func (l *VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate.
 type VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse struct {
 	VirtualMachineExtension
-}
-
-// VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Delete.
-type VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMExtensionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientDeleteResponse, error) {
-	respType := VirtualMachineScaleSetVMExtensionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMExtensionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetVMExtensionsClientDeleteResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Delete.
@@ -2355,119 +629,14 @@ type VirtualMachineScaleSetVMExtensionsClientListResponse struct {
 	VirtualMachineExtensionsListResult
 }
 
-// VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Update.
-type VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMExtensionsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMExtensionsClientUpdateResponse, error) {
-	respType := VirtualMachineScaleSetVMExtensionsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineExtension)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMExtensionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMExtensionsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetVMExtensionsClientUpdateResponse contains the response from method VirtualMachineScaleSetVMExtensionsClient.Update.
 type VirtualMachineScaleSetVMExtensionsClientUpdateResponse struct {
 	VirtualMachineExtension
 }
 
-// VirtualMachineScaleSetVMsClientDeallocatePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Deallocate.
-type VirtualMachineScaleSetVMsClientDeallocatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientDeallocatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientDeallocatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientDeallocateResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientDeallocateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientDeallocatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientDeallocatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Deallocate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientDeallocatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetVMsClientDeallocateResponse contains the response from method VirtualMachineScaleSetVMsClient.Deallocate.
 type VirtualMachineScaleSetVMsClientDeallocateResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetVMsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Delete.
-type VirtualMachineScaleSetVMsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientDeleteResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetVMsClientDeleteResponse contains the response from method VirtualMachineScaleSetVMsClient.Delete.
@@ -2490,80 +659,9 @@ type VirtualMachineScaleSetVMsClientListResponse struct {
 	VirtualMachineScaleSetVMListResult
 }
 
-// VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.PerformMaintenance.
-type VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientPerformMaintenancePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientPerformMaintenanceResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientPerformMaintenanceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse from the provided client and resume
-// token.
-func (l *VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PerformMaintenance", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientPerformMaintenancePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetVMsClientPerformMaintenanceResponse contains the response from method VirtualMachineScaleSetVMsClient.PerformMaintenance.
 type VirtualMachineScaleSetVMsClientPerformMaintenanceResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetVMsClientPowerOffPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.PowerOff.
-type VirtualMachineScaleSetVMsClientPowerOffPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientPowerOffPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientPowerOffPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientPowerOffResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientPowerOffResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientPowerOffPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientPowerOffPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PowerOff", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientPowerOffPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetVMsClientPowerOffResponse contains the response from method VirtualMachineScaleSetVMsClient.PowerOff.
@@ -2571,79 +669,9 @@ type VirtualMachineScaleSetVMsClientPowerOffResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetVMsClientRedeployPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Redeploy.
-type VirtualMachineScaleSetVMsClientRedeployPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientRedeployPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientRedeployPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRedeployResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientRedeployResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientRedeployPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientRedeployPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Redeploy", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientRedeployPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetVMsClientRedeployResponse contains the response from method VirtualMachineScaleSetVMsClient.Redeploy.
 type VirtualMachineScaleSetVMsClientRedeployResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetVMsClientReimageAllPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.ReimageAll.
-type VirtualMachineScaleSetVMsClientReimageAllPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientReimageAllPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientReimageAllPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientReimageAllResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientReimageAllResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientReimageAllPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientReimageAllPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.ReimageAll", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientReimageAllPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetVMsClientReimageAllResponse contains the response from method VirtualMachineScaleSetVMsClient.ReimageAll.
@@ -2651,119 +679,14 @@ type VirtualMachineScaleSetVMsClientReimageAllResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetVMsClientReimagePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Reimage.
-type VirtualMachineScaleSetVMsClientReimagePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientReimagePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientReimagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientReimageResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientReimageResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientReimagePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientReimagePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Reimage", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientReimagePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetVMsClientReimageResponse contains the response from method VirtualMachineScaleSetVMsClient.Reimage.
 type VirtualMachineScaleSetVMsClientReimageResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetVMsClientRestartPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Restart.
-type VirtualMachineScaleSetVMsClientRestartPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientRestartPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientRestartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRestartResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientRestartResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientRestartPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientRestartPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Restart", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientRestartPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetVMsClientRestartResponse contains the response from method VirtualMachineScaleSetVMsClient.Restart.
 type VirtualMachineScaleSetVMsClientRestartResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetVMsClientRunCommandPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.RunCommand.
-type VirtualMachineScaleSetVMsClientRunCommandPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientRunCommandPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientRunCommandPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientRunCommandResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientRunCommandResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RunCommandResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientRunCommandPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientRunCommandPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.RunCommand", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientRunCommandPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetVMsClientRunCommandResponse contains the response from method VirtualMachineScaleSetVMsClient.RunCommand.
@@ -2776,79 +699,9 @@ type VirtualMachineScaleSetVMsClientSimulateEvictionResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetVMsClientStartPollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Start.
-type VirtualMachineScaleSetVMsClientStartPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientStartPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientStartResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientStartResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientStartPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientStartPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Start", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientStartPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetVMsClientStartResponse contains the response from method VirtualMachineScaleSetVMsClient.Start.
 type VirtualMachineScaleSetVMsClientStartResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetVMsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetVMsClient.Update.
-type VirtualMachineScaleSetVMsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetVMsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetVMsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMsClientUpdateResponse, error) {
-	respType := VirtualMachineScaleSetVMsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSetVM)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetVMsClientUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetVMsClientUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetVMsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetVMsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetVMsClientUpdateResponse contains the response from method VirtualMachineScaleSetVMsClient.Update.
@@ -2861,79 +714,9 @@ type VirtualMachineScaleSetsClientConvertToSinglePlacementGroupResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse contains the response from method VirtualMachineScaleSetsClient.CreateOrUpdate.
-type VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachineScaleSetsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSet)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetsClientCreateOrUpdateResponse contains the response from method VirtualMachineScaleSetsClient.CreateOrUpdate.
 type VirtualMachineScaleSetsClientCreateOrUpdateResponse struct {
 	VirtualMachineScaleSet
-}
-
-// VirtualMachineScaleSetsClientDeallocatePollerResponse contains the response from method VirtualMachineScaleSetsClient.Deallocate.
-type VirtualMachineScaleSetsClientDeallocatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientDeallocatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientDeallocatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeallocateResponse, error) {
-	respType := VirtualMachineScaleSetsClientDeallocateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientDeallocatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientDeallocatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Deallocate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientDeallocatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetsClientDeallocateResponse contains the response from method VirtualMachineScaleSetsClient.Deallocate.
@@ -2941,79 +724,9 @@ type VirtualMachineScaleSetsClientDeallocateResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetsClientDeleteInstancesPollerResponse contains the response from method VirtualMachineScaleSetsClient.DeleteInstances.
-type VirtualMachineScaleSetsClientDeleteInstancesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientDeleteInstancesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientDeleteInstancesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
-	respType := VirtualMachineScaleSetsClientDeleteInstancesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientDeleteInstancesPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientDeleteInstancesPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.DeleteInstances", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientDeleteInstancesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetsClientDeleteInstancesResponse contains the response from method VirtualMachineScaleSetsClient.DeleteInstances.
 type VirtualMachineScaleSetsClientDeleteInstancesResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetsClientDeletePollerResponse contains the response from method VirtualMachineScaleSetsClient.Delete.
-type VirtualMachineScaleSetsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientDeleteResponse, error) {
-	respType := VirtualMachineScaleSetsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetsClientDeleteResponse contains the response from method VirtualMachineScaleSetsClient.Delete.
@@ -3057,79 +770,9 @@ type VirtualMachineScaleSetsClientListSKUsResponse struct {
 	VirtualMachineScaleSetListSKUsResult
 }
 
-// VirtualMachineScaleSetsClientPerformMaintenancePollerResponse contains the response from method VirtualMachineScaleSetsClient.PerformMaintenance.
-type VirtualMachineScaleSetsClientPerformMaintenancePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientPerformMaintenancePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientPerformMaintenancePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientPerformMaintenanceResponse, error) {
-	respType := VirtualMachineScaleSetsClientPerformMaintenanceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientPerformMaintenancePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientPerformMaintenancePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PerformMaintenance", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientPerformMaintenancePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetsClientPerformMaintenanceResponse contains the response from method VirtualMachineScaleSetsClient.PerformMaintenance.
 type VirtualMachineScaleSetsClientPerformMaintenanceResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetsClientPowerOffPollerResponse contains the response from method VirtualMachineScaleSetsClient.PowerOff.
-type VirtualMachineScaleSetsClientPowerOffPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientPowerOffPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientPowerOffPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientPowerOffResponse, error) {
-	respType := VirtualMachineScaleSetsClientPowerOffResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientPowerOffPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientPowerOffPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PowerOff", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientPowerOffPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetsClientPowerOffResponse contains the response from method VirtualMachineScaleSetsClient.PowerOff.
@@ -3137,79 +780,9 @@ type VirtualMachineScaleSetsClientPowerOffResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetsClientRedeployPollerResponse contains the response from method VirtualMachineScaleSetsClient.Redeploy.
-type VirtualMachineScaleSetsClientRedeployPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientRedeployPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientRedeployPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientRedeployResponse, error) {
-	respType := VirtualMachineScaleSetsClientRedeployResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientRedeployPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientRedeployPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Redeploy", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientRedeployPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetsClientRedeployResponse contains the response from method VirtualMachineScaleSetsClient.Redeploy.
 type VirtualMachineScaleSetsClientRedeployResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetsClientReimageAllPollerResponse contains the response from method VirtualMachineScaleSetsClient.ReimageAll.
-type VirtualMachineScaleSetsClientReimageAllPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientReimageAllPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientReimageAllPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientReimageAllResponse, error) {
-	respType := VirtualMachineScaleSetsClientReimageAllResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientReimageAllPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientReimageAllPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.ReimageAll", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientReimageAllPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetsClientReimageAllResponse contains the response from method VirtualMachineScaleSetsClient.ReimageAll.
@@ -3217,79 +790,9 @@ type VirtualMachineScaleSetsClientReimageAllResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetsClientReimagePollerResponse contains the response from method VirtualMachineScaleSetsClient.Reimage.
-type VirtualMachineScaleSetsClientReimagePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientReimagePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientReimagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientReimageResponse, error) {
-	respType := VirtualMachineScaleSetsClientReimageResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientReimagePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientReimagePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Reimage", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientReimagePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetsClientReimageResponse contains the response from method VirtualMachineScaleSetsClient.Reimage.
 type VirtualMachineScaleSetsClientReimageResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetsClientRestartPollerResponse contains the response from method VirtualMachineScaleSetsClient.Restart.
-type VirtualMachineScaleSetsClientRestartPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientRestartPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientRestartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientRestartResponse, error) {
-	respType := VirtualMachineScaleSetsClientRestartResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientRestartPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientRestartPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Restart", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientRestartPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetsClientRestartResponse contains the response from method VirtualMachineScaleSetsClient.Restart.
@@ -3297,80 +800,9 @@ type VirtualMachineScaleSetsClientRestartResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse contains the response from method VirtualMachineScaleSetsClient.SetOrchestrationServiceState.
-type VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse, error) {
-	respType := VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse from the provided client and
-// resume token.
-func (l *VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.SetOrchestrationServiceState", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse contains the response from method VirtualMachineScaleSetsClient.SetOrchestrationServiceState.
 type VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetsClientStartPollerResponse contains the response from method VirtualMachineScaleSetsClient.Start.
-type VirtualMachineScaleSetsClientStartPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientStartPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientStartResponse, error) {
-	respType := VirtualMachineScaleSetsClientStartResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientStartPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientStartPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Start", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientStartPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetsClientStartResponse contains the response from method VirtualMachineScaleSetsClient.Start.
@@ -3378,79 +810,9 @@ type VirtualMachineScaleSetsClientStartResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachineScaleSetsClientUpdateInstancesPollerResponse contains the response from method VirtualMachineScaleSetsClient.UpdateInstances.
-type VirtualMachineScaleSetsClientUpdateInstancesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientUpdateInstancesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientUpdateInstancesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientUpdateInstancesResponse, error) {
-	respType := VirtualMachineScaleSetsClientUpdateInstancesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientUpdateInstancesPollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientUpdateInstancesPollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.UpdateInstances", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientUpdateInstancesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachineScaleSetsClientUpdateInstancesResponse contains the response from method VirtualMachineScaleSetsClient.UpdateInstances.
 type VirtualMachineScaleSetsClientUpdateInstancesResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachineScaleSetsClientUpdatePollerResponse contains the response from method VirtualMachineScaleSetsClient.Update.
-type VirtualMachineScaleSetsClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachineScaleSetsClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachineScaleSetsClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetsClientUpdateResponse, error) {
-	respType := VirtualMachineScaleSetsClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineScaleSet)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachineScaleSetsClientUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachineScaleSetsClientUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachineScaleSetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachineScaleSetsClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachineScaleSetsClientUpdateResponse contains the response from method VirtualMachineScaleSetsClient.Update.
@@ -3463,79 +825,9 @@ type VirtualMachineSizesClientListResponse struct {
 	VirtualMachineSizeListResult
 }
 
-// VirtualMachinesClientCapturePollerResponse contains the response from method VirtualMachinesClient.Capture.
-type VirtualMachinesClientCapturePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientCapturePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientCaptureResponse, error) {
-	respType := VirtualMachinesClientCaptureResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachineCaptureResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientCapturePollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientCapturePollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Capture", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientCapturePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachinesClientCaptureResponse contains the response from method VirtualMachinesClient.Capture.
 type VirtualMachinesClientCaptureResponse struct {
 	VirtualMachineCaptureResult
-}
-
-// VirtualMachinesClientConvertToManagedDisksPollerResponse contains the response from method VirtualMachinesClient.ConvertToManagedDisks.
-type VirtualMachinesClientConvertToManagedDisksPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientConvertToManagedDisksPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientConvertToManagedDisksPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientConvertToManagedDisksResponse, error) {
-	respType := VirtualMachinesClientConvertToManagedDisksResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientConvertToManagedDisksPollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientConvertToManagedDisksPollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.ConvertToManagedDisks", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientConvertToManagedDisksPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachinesClientConvertToManagedDisksResponse contains the response from method VirtualMachinesClient.ConvertToManagedDisks.
@@ -3543,119 +835,14 @@ type VirtualMachinesClientConvertToManagedDisksResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachinesClientCreateOrUpdatePollerResponse contains the response from method VirtualMachinesClient.CreateOrUpdate.
-type VirtualMachinesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientCreateOrUpdateResponse, error) {
-	respType := VirtualMachinesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachine)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachinesClientCreateOrUpdateResponse contains the response from method VirtualMachinesClient.CreateOrUpdate.
 type VirtualMachinesClientCreateOrUpdateResponse struct {
 	VirtualMachine
 }
 
-// VirtualMachinesClientDeallocatePollerResponse contains the response from method VirtualMachinesClient.Deallocate.
-type VirtualMachinesClientDeallocatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientDeallocatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientDeallocatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientDeallocateResponse, error) {
-	respType := VirtualMachinesClientDeallocateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientDeallocatePollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientDeallocatePollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Deallocate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientDeallocatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachinesClientDeallocateResponse contains the response from method VirtualMachinesClient.Deallocate.
 type VirtualMachinesClientDeallocateResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachinesClientDeletePollerResponse contains the response from method VirtualMachinesClient.Delete.
-type VirtualMachinesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientDeleteResponse, error) {
-	respType := VirtualMachinesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachinesClientDeleteResponse contains the response from method VirtualMachinesClient.Delete.
@@ -3698,79 +885,9 @@ type VirtualMachinesClientListResponse struct {
 	VirtualMachineListResult
 }
 
-// VirtualMachinesClientPerformMaintenancePollerResponse contains the response from method VirtualMachinesClient.PerformMaintenance.
-type VirtualMachinesClientPerformMaintenancePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientPerformMaintenancePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientPerformMaintenancePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientPerformMaintenanceResponse, error) {
-	respType := VirtualMachinesClientPerformMaintenanceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientPerformMaintenancePollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientPerformMaintenancePollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.PerformMaintenance", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientPerformMaintenancePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachinesClientPerformMaintenanceResponse contains the response from method VirtualMachinesClient.PerformMaintenance.
 type VirtualMachinesClientPerformMaintenanceResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachinesClientPowerOffPollerResponse contains the response from method VirtualMachinesClient.PowerOff.
-type VirtualMachinesClientPowerOffPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientPowerOffPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientPowerOffPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientPowerOffResponse, error) {
-	respType := VirtualMachinesClientPowerOffResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientPowerOffPollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientPowerOffPollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.PowerOff", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientPowerOffPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachinesClientPowerOffResponse contains the response from method VirtualMachinesClient.PowerOff.
@@ -3778,79 +895,9 @@ type VirtualMachinesClientPowerOffResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachinesClientReapplyPollerResponse contains the response from method VirtualMachinesClient.Reapply.
-type VirtualMachinesClientReapplyPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientReapplyPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientReapplyPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientReapplyResponse, error) {
-	respType := VirtualMachinesClientReapplyResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientReapplyPollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientReapplyPollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Reapply", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientReapplyPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachinesClientReapplyResponse contains the response from method VirtualMachinesClient.Reapply.
 type VirtualMachinesClientReapplyResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachinesClientRedeployPollerResponse contains the response from method VirtualMachinesClient.Redeploy.
-type VirtualMachinesClientRedeployPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientRedeployPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientRedeployPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRedeployResponse, error) {
-	respType := VirtualMachinesClientRedeployResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientRedeployPollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientRedeployPollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Redeploy", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientRedeployPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachinesClientRedeployResponse contains the response from method VirtualMachinesClient.Redeploy.
@@ -3858,119 +905,14 @@ type VirtualMachinesClientRedeployResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachinesClientReimagePollerResponse contains the response from method VirtualMachinesClient.Reimage.
-type VirtualMachinesClientReimagePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientReimagePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientReimagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientReimageResponse, error) {
-	respType := VirtualMachinesClientReimageResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientReimagePollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientReimagePollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Reimage", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientReimagePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachinesClientReimageResponse contains the response from method VirtualMachinesClient.Reimage.
 type VirtualMachinesClientReimageResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachinesClientRestartPollerResponse contains the response from method VirtualMachinesClient.Restart.
-type VirtualMachinesClientRestartPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientRestartPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientRestartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRestartResponse, error) {
-	respType := VirtualMachinesClientRestartResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientRestartPollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientRestartPollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Restart", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientRestartPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachinesClientRestartResponse contains the response from method VirtualMachinesClient.Restart.
 type VirtualMachinesClientRestartResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachinesClientRunCommandPollerResponse contains the response from method VirtualMachinesClient.RunCommand.
-type VirtualMachinesClientRunCommandPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientRunCommandPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientRunCommandPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientRunCommandResponse, error) {
-	respType := VirtualMachinesClientRunCommandResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RunCommandResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientRunCommandPollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientRunCommandPollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.RunCommand", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientRunCommandPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachinesClientRunCommandResponse contains the response from method VirtualMachinesClient.RunCommand.
@@ -3983,79 +925,9 @@ type VirtualMachinesClientSimulateEvictionResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualMachinesClientStartPollerResponse contains the response from method VirtualMachinesClient.Start.
-type VirtualMachinesClientStartPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientStartPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientStartResponse, error) {
-	respType := VirtualMachinesClientStartResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientStartPollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientStartPollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Start", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientStartPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualMachinesClientStartResponse contains the response from method VirtualMachinesClient.Start.
 type VirtualMachinesClientStartResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualMachinesClientUpdatePollerResponse contains the response from method VirtualMachinesClient.Update.
-type VirtualMachinesClientUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualMachinesClientUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualMachinesClientUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachinesClientUpdateResponse, error) {
-	respType := VirtualMachinesClientUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualMachine)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualMachinesClientUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualMachinesClientUpdatePollerResponse) Resume(ctx context.Context, client *VirtualMachinesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualMachinesClient.Update", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualMachinesClientUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualMachinesClientUpdateResponse contains the response from method VirtualMachinesClient.Update.

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
@@ -59,20 +59,16 @@ func NewSnapshotsClient(subscriptionID string, credential azcore.TokenCredential
 // snapshot - Snapshot object supplied in the body of the Put disk operation.
 // options - SnapshotsClientBeginCreateOrUpdateOptions contains the optional parameters for the SnapshotsClient.BeginCreateOrUpdate
 // method.
-func (client *SnapshotsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot, options *SnapshotsClientBeginCreateOrUpdateOptions) (SnapshotsClientCreateOrUpdatePollerResponse, error) {
+func (client *SnapshotsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot, options *SnapshotsClientBeginCreateOrUpdateOptions) (*SnapshotsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, snapshotName, snapshot, options)
 	if err != nil {
-		return SnapshotsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := SnapshotsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return SnapshotsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SnapshotsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SnapshotsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a snapshot.
@@ -125,20 +121,16 @@ func (client *SnapshotsClient) createOrUpdateCreateRequest(ctx context.Context, 
 // Supported characters for the name are a-z, A-Z, 0-9 and _. The max name length is 80
 // characters.
 // options - SnapshotsClientBeginDeleteOptions contains the optional parameters for the SnapshotsClient.BeginDelete method.
-func (client *SnapshotsClient) BeginDelete(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsClientBeginDeleteOptions) (SnapshotsClientDeletePollerResponse, error) {
+func (client *SnapshotsClient) BeginDelete(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsClientBeginDeleteOptions) (*SnapshotsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, snapshotName, options)
 	if err != nil {
-		return SnapshotsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := SnapshotsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return SnapshotsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SnapshotsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SnapshotsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a snapshot.
@@ -249,20 +241,16 @@ func (client *SnapshotsClient) getHandleResponse(resp *http.Response) (Snapshots
 // grantAccessData - Access data object supplied in the body of the get snapshot access operation.
 // options - SnapshotsClientBeginGrantAccessOptions contains the optional parameters for the SnapshotsClient.BeginGrantAccess
 // method.
-func (client *SnapshotsClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData, options *SnapshotsClientBeginGrantAccessOptions) (SnapshotsClientGrantAccessPollerResponse, error) {
+func (client *SnapshotsClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData, options *SnapshotsClientBeginGrantAccessOptions) (*SnapshotsClientGrantAccessPoller, error) {
 	resp, err := client.grantAccess(ctx, resourceGroupName, snapshotName, grantAccessData, options)
 	if err != nil {
-		return SnapshotsClientGrantAccessPollerResponse{}, err
+		return nil, err
 	}
-	result := SnapshotsClientGrantAccessPollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.GrantAccess", "location", resp, client.pl)
 	if err != nil {
-		return SnapshotsClientGrantAccessPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SnapshotsClientGrantAccessPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SnapshotsClientGrantAccessPoller{pt: pt}, nil
 }
 
 // GrantAccess - Grants access to a snapshot.
@@ -406,20 +394,16 @@ func (client *SnapshotsClient) listByResourceGroupHandleResponse(resp *http.Resp
 // characters.
 // options - SnapshotsClientBeginRevokeAccessOptions contains the optional parameters for the SnapshotsClient.BeginRevokeAccess
 // method.
-func (client *SnapshotsClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsClientBeginRevokeAccessOptions) (SnapshotsClientRevokeAccessPollerResponse, error) {
+func (client *SnapshotsClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsClientBeginRevokeAccessOptions) (*SnapshotsClientRevokeAccessPoller, error) {
 	resp, err := client.revokeAccess(ctx, resourceGroupName, snapshotName, options)
 	if err != nil {
-		return SnapshotsClientRevokeAccessPollerResponse{}, err
+		return nil, err
 	}
-	result := SnapshotsClientRevokeAccessPollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.RevokeAccess", "location", resp, client.pl)
 	if err != nil {
-		return SnapshotsClientRevokeAccessPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SnapshotsClientRevokeAccessPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SnapshotsClientRevokeAccessPoller{pt: pt}, nil
 }
 
 // RevokeAccess - Revokes access to a snapshot.
@@ -472,20 +456,16 @@ func (client *SnapshotsClient) revokeAccessCreateRequest(ctx context.Context, re
 // characters.
 // snapshot - Snapshot object supplied in the body of the Patch snapshot operation.
 // options - SnapshotsClientBeginUpdateOptions contains the optional parameters for the SnapshotsClient.BeginUpdate method.
-func (client *SnapshotsClient) BeginUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate, options *SnapshotsClientBeginUpdateOptions) (SnapshotsClientUpdatePollerResponse, error) {
+func (client *SnapshotsClient) BeginUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate, options *SnapshotsClientBeginUpdateOptions) (*SnapshotsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, snapshotName, snapshot, options)
 	if err != nil {
-		return SnapshotsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := SnapshotsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SnapshotsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return SnapshotsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SnapshotsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SnapshotsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Updates (patches) a snapshot.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
@@ -58,20 +58,16 @@ func NewVirtualMachineExtensionsClient(subscriptionID string, credential azcore.
 // extensionParameters - Parameters supplied to the Create Virtual Machine Extension operation.
 // options - VirtualMachineExtensionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineExtensionsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualMachineExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineExtensionsClientBeginCreateOrUpdateOptions) (VirtualMachineExtensionsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualMachineExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineExtensionsClientBeginCreateOrUpdateOptions) (*VirtualMachineExtensionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters, options)
 	if err != nil {
-		return VirtualMachineExtensionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineExtensionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineExtensionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineExtensionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineExtensionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineExtensionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - The operation to create or update the extension.
@@ -128,20 +124,16 @@ func (client *VirtualMachineExtensionsClient) createOrUpdateCreateRequest(ctx co
 // vmExtensionName - The name of the virtual machine extension.
 // options - VirtualMachineExtensionsClientBeginDeleteOptions contains the optional parameters for the VirtualMachineExtensionsClient.BeginDelete
 // method.
-func (client *VirtualMachineExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsClientBeginDeleteOptions) (VirtualMachineExtensionsClientDeletePollerResponse, error) {
+func (client *VirtualMachineExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsClientBeginDeleteOptions) (*VirtualMachineExtensionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, vmName, vmExtensionName, options)
 	if err != nil {
-		return VirtualMachineExtensionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineExtensionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineExtensionsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineExtensionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineExtensionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineExtensionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - The operation to delete the extension.
@@ -321,20 +313,16 @@ func (client *VirtualMachineExtensionsClient) listHandleResponse(resp *http.Resp
 // extensionParameters - Parameters supplied to the Update Virtual Machine Extension operation.
 // options - VirtualMachineExtensionsClientBeginUpdateOptions contains the optional parameters for the VirtualMachineExtensionsClient.BeginUpdate
 // method.
-func (client *VirtualMachineExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineExtensionsClientBeginUpdateOptions) (VirtualMachineExtensionsClientUpdatePollerResponse, error) {
+func (client *VirtualMachineExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineExtensionsClientBeginUpdateOptions) (*VirtualMachineExtensionsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters, options)
 	if err != nil {
-		return VirtualMachineExtensionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineExtensionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineExtensionsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineExtensionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineExtensionsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineExtensionsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - The operation to update the extension.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
@@ -59,20 +59,16 @@ func NewVirtualMachinesClient(subscriptionID string, credential azcore.TokenCred
 // parameters - Parameters supplied to the Capture Virtual Machine operation.
 // options - VirtualMachinesClientBeginCaptureOptions contains the optional parameters for the VirtualMachinesClient.BeginCapture
 // method.
-func (client *VirtualMachinesClient) BeginCapture(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, options *VirtualMachinesClientBeginCaptureOptions) (VirtualMachinesClientCapturePollerResponse, error) {
+func (client *VirtualMachinesClient) BeginCapture(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, options *VirtualMachinesClientBeginCaptureOptions) (*VirtualMachinesClientCapturePoller, error) {
 	resp, err := client.capture(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
-		return VirtualMachinesClientCapturePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Capture", "location", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientCapturePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientCapturePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientCapturePoller{pt: pt}, nil
 }
 
 // Capture - Captures the VM by copying virtual hard disks of the VM and outputs a template that can be used to create similar
@@ -129,20 +125,16 @@ func (client *VirtualMachinesClient) captureCreateRequest(ctx context.Context, r
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginConvertToManagedDisksOptions contains the optional parameters for the VirtualMachinesClient.BeginConvertToManagedDisks
 // method.
-func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginConvertToManagedDisksOptions) (VirtualMachinesClientConvertToManagedDisksPollerResponse, error) {
+func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginConvertToManagedDisksOptions) (*VirtualMachinesClientConvertToManagedDisksPoller, error) {
 	resp, err := client.convertToManagedDisks(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientConvertToManagedDisksPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientConvertToManagedDisksPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.ConvertToManagedDisks", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientConvertToManagedDisksPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientConvertToManagedDisksPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientConvertToManagedDisksPoller{pt: pt}, nil
 }
 
 // ConvertToManagedDisks - Converts virtual machine disks from blob-based to managed disks. Virtual machine must be stop-deallocated
@@ -199,20 +191,16 @@ func (client *VirtualMachinesClient) convertToManagedDisksCreateRequest(ctx cont
 // parameters - Parameters supplied to the Create Virtual Machine operation.
 // options - VirtualMachinesClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachinesClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualMachinesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine, options *VirtualMachinesClientBeginCreateOrUpdateOptions) (VirtualMachinesClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualMachinesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine, options *VirtualMachinesClientBeginCreateOrUpdateOptions) (*VirtualMachinesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
-		return VirtualMachinesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - The operation to create or update a virtual machine. Please note some properties can be set only during
@@ -266,20 +254,16 @@ func (client *VirtualMachinesClient) createOrUpdateCreateRequest(ctx context.Con
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginDeallocateOptions contains the optional parameters for the VirtualMachinesClient.BeginDeallocate
 // method.
-func (client *VirtualMachinesClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginDeallocateOptions) (VirtualMachinesClientDeallocatePollerResponse, error) {
+func (client *VirtualMachinesClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginDeallocateOptions) (*VirtualMachinesClientDeallocatePoller, error) {
 	resp, err := client.deallocate(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientDeallocatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientDeallocatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Deallocate", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientDeallocatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientDeallocatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientDeallocatePoller{pt: pt}, nil
 }
 
 // Deallocate - Shuts down the virtual machine and releases the compute resources. You are not billed for the compute resources
@@ -331,20 +315,16 @@ func (client *VirtualMachinesClient) deallocateCreateRequest(ctx context.Context
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginDeleteOptions contains the optional parameters for the VirtualMachinesClient.BeginDelete
 // method.
-func (client *VirtualMachinesClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginDeleteOptions) (VirtualMachinesClientDeletePollerResponse, error) {
+func (client *VirtualMachinesClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginDeleteOptions) (*VirtualMachinesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - The operation to delete a virtual machine.
@@ -752,20 +732,16 @@ func (client *VirtualMachinesClient) listByLocationHandleResponse(resp *http.Res
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginPerformMaintenanceOptions contains the optional parameters for the VirtualMachinesClient.BeginPerformMaintenance
 // method.
-func (client *VirtualMachinesClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginPerformMaintenanceOptions) (VirtualMachinesClientPerformMaintenancePollerResponse, error) {
+func (client *VirtualMachinesClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginPerformMaintenanceOptions) (*VirtualMachinesClientPerformMaintenancePoller, error) {
 	resp, err := client.performMaintenance(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientPerformMaintenancePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientPerformMaintenancePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.PerformMaintenance", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientPerformMaintenancePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientPerformMaintenancePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientPerformMaintenancePoller{pt: pt}, nil
 }
 
 // PerformMaintenance - Shuts down the virtual machine, moves it to an already updated node, and powers it back on during
@@ -818,20 +794,16 @@ func (client *VirtualMachinesClient) performMaintenanceCreateRequest(ctx context
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginPowerOffOptions contains the optional parameters for the VirtualMachinesClient.BeginPowerOff
 // method.
-func (client *VirtualMachinesClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginPowerOffOptions) (VirtualMachinesClientPowerOffPollerResponse, error) {
+func (client *VirtualMachinesClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginPowerOffOptions) (*VirtualMachinesClientPowerOffPoller, error) {
 	resp, err := client.powerOff(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientPowerOffPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientPowerOffPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.PowerOff", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientPowerOffPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientPowerOffPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientPowerOffPoller{pt: pt}, nil
 }
 
 // PowerOff - The operation to power off (stop) a virtual machine. The virtual machine can be restarted with the same provisioned
@@ -886,20 +858,16 @@ func (client *VirtualMachinesClient) powerOffCreateRequest(ctx context.Context, 
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginReapplyOptions contains the optional parameters for the VirtualMachinesClient.BeginReapply
 // method.
-func (client *VirtualMachinesClient) BeginReapply(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginReapplyOptions) (VirtualMachinesClientReapplyPollerResponse, error) {
+func (client *VirtualMachinesClient) BeginReapply(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginReapplyOptions) (*VirtualMachinesClientReapplyPoller, error) {
 	resp, err := client.reapply(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientReapplyPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientReapplyPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Reapply", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientReapplyPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientReapplyPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientReapplyPoller{pt: pt}, nil
 }
 
 // Reapply - The operation to reapply a virtual machine's state.
@@ -951,20 +919,16 @@ func (client *VirtualMachinesClient) reapplyCreateRequest(ctx context.Context, r
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginRedeployOptions contains the optional parameters for the VirtualMachinesClient.BeginRedeploy
 // method.
-func (client *VirtualMachinesClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginRedeployOptions) (VirtualMachinesClientRedeployPollerResponse, error) {
+func (client *VirtualMachinesClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginRedeployOptions) (*VirtualMachinesClientRedeployPoller, error) {
 	resp, err := client.redeploy(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientRedeployPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientRedeployPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Redeploy", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientRedeployPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientRedeployPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientRedeployPoller{pt: pt}, nil
 }
 
 // Redeploy - Shuts down the virtual machine, moves it to a new node, and powers it back on.
@@ -1015,20 +979,16 @@ func (client *VirtualMachinesClient) redeployCreateRequest(ctx context.Context, 
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginReimageOptions contains the optional parameters for the VirtualMachinesClient.BeginReimage
 // method.
-func (client *VirtualMachinesClient) BeginReimage(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginReimageOptions) (VirtualMachinesClientReimagePollerResponse, error) {
+func (client *VirtualMachinesClient) BeginReimage(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginReimageOptions) (*VirtualMachinesClientReimagePoller, error) {
 	resp, err := client.reimage(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientReimagePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientReimagePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Reimage", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientReimagePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientReimagePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientReimagePoller{pt: pt}, nil
 }
 
 // Reimage - Reimages the virtual machine which has an ephemeral OS disk back to its initial state.
@@ -1082,20 +1042,16 @@ func (client *VirtualMachinesClient) reimageCreateRequest(ctx context.Context, r
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginRestartOptions contains the optional parameters for the VirtualMachinesClient.BeginRestart
 // method.
-func (client *VirtualMachinesClient) BeginRestart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginRestartOptions) (VirtualMachinesClientRestartPollerResponse, error) {
+func (client *VirtualMachinesClient) BeginRestart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginRestartOptions) (*VirtualMachinesClientRestartPoller, error) {
 	resp, err := client.restart(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientRestartPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientRestartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Restart", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientRestartPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientRestartPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientRestartPoller{pt: pt}, nil
 }
 
 // Restart - The operation to restart a virtual machine.
@@ -1147,20 +1103,16 @@ func (client *VirtualMachinesClient) restartCreateRequest(ctx context.Context, r
 // parameters - Parameters supplied to the Run command operation.
 // options - VirtualMachinesClientBeginRunCommandOptions contains the optional parameters for the VirtualMachinesClient.BeginRunCommand
 // method.
-func (client *VirtualMachinesClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput, options *VirtualMachinesClientBeginRunCommandOptions) (VirtualMachinesClientRunCommandPollerResponse, error) {
+func (client *VirtualMachinesClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput, options *VirtualMachinesClientBeginRunCommandOptions) (*VirtualMachinesClientRunCommandPoller, error) {
 	resp, err := client.runCommand(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
-		return VirtualMachinesClientRunCommandPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientRunCommandPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.RunCommand", "location", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientRunCommandPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientRunCommandPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientRunCommandPoller{pt: pt}, nil
 }
 
 // RunCommand - Run command on the VM.
@@ -1259,20 +1211,16 @@ func (client *VirtualMachinesClient) simulateEvictionCreateRequest(ctx context.C
 // vmName - The name of the virtual machine.
 // options - VirtualMachinesClientBeginStartOptions contains the optional parameters for the VirtualMachinesClient.BeginStart
 // method.
-func (client *VirtualMachinesClient) BeginStart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginStartOptions) (VirtualMachinesClientStartPollerResponse, error) {
+func (client *VirtualMachinesClient) BeginStart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesClientBeginStartOptions) (*VirtualMachinesClientStartPoller, error) {
 	resp, err := client.start(ctx, resourceGroupName, vmName, options)
 	if err != nil {
-		return VirtualMachinesClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Start", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientStartPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientStartPoller{pt: pt}, nil
 }
 
 // Start - The operation to start a virtual machine.
@@ -1324,20 +1272,16 @@ func (client *VirtualMachinesClient) startCreateRequest(ctx context.Context, res
 // parameters - Parameters supplied to the Update Virtual Machine operation.
 // options - VirtualMachinesClientBeginUpdateOptions contains the optional parameters for the VirtualMachinesClient.BeginUpdate
 // method.
-func (client *VirtualMachinesClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate, options *VirtualMachinesClientBeginUpdateOptions) (VirtualMachinesClientUpdatePollerResponse, error) {
+func (client *VirtualMachinesClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate, options *VirtualMachinesClientBeginUpdateOptions) (*VirtualMachinesClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
-		return VirtualMachinesClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachinesClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachinesClient.Update", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachinesClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachinesClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachinesClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - The operation to update a virtual machine.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
@@ -58,20 +58,16 @@ func NewVirtualMachineScaleSetExtensionsClient(subscriptionID string, credential
 // extensionParameters - Parameters supplied to the Create VM scale set Extension operation.
 // options - VirtualMachineScaleSetExtensionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetExtensionsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualMachineScaleSetExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension, options *VirtualMachineScaleSetExtensionsClientBeginCreateOrUpdateOptions) (VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension, options *VirtualMachineScaleSetExtensionsClientBeginCreateOrUpdateOptions) (*VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetExtensionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetExtensionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - The operation to create or update an extension.
@@ -128,20 +124,16 @@ func (client *VirtualMachineScaleSetExtensionsClient) createOrUpdateCreateReques
 // vmssExtensionName - The name of the VM scale set extension.
 // options - VirtualMachineScaleSetExtensionsClientBeginDeleteOptions contains the optional parameters for the VirtualMachineScaleSetExtensionsClient.BeginDelete
 // method.
-func (client *VirtualMachineScaleSetExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsClientBeginDeleteOptions) (VirtualMachineScaleSetExtensionsClientDeletePollerResponse, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsClientBeginDeleteOptions) (*VirtualMachineScaleSetExtensionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, options)
 	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetExtensionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetExtensionsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetExtensionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetExtensionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - The operation to delete the extension.
@@ -315,20 +307,16 @@ func (client *VirtualMachineScaleSetExtensionsClient) listHandleResponse(resp *h
 // extensionParameters - Parameters supplied to the Update VM scale set Extension operation.
 // options - VirtualMachineScaleSetExtensionsClientBeginUpdateOptions contains the optional parameters for the VirtualMachineScaleSetExtensionsClient.BeginUpdate
 // method.
-func (client *VirtualMachineScaleSetExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate, options *VirtualMachineScaleSetExtensionsClientBeginUpdateOptions) (VirtualMachineScaleSetExtensionsClientUpdatePollerResponse, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate, options *VirtualMachineScaleSetExtensionsClientBeginUpdateOptions) (*VirtualMachineScaleSetExtensionsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetExtensionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetExtensionsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetExtensionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetExtensionsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetExtensionsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - The operation to update an extension.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
@@ -56,20 +56,16 @@ func NewVirtualMachineScaleSetRollingUpgradesClient(subscriptionID string, crede
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetRollingUpgradesClientBeginCancelOptions contains the optional parameters for the VirtualMachineScaleSetRollingUpgradesClient.BeginCancel
 // method.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginCancel(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesClientBeginCancelOptions) (VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginCancel(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesClientBeginCancelOptions) (*VirtualMachineScaleSetRollingUpgradesClientCancelPoller, error) {
 	resp, err := client.cancel(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetRollingUpgradesClient.Cancel", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientCancelPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetRollingUpgradesClientCancelPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetRollingUpgradesClientCancelPoller{pt: pt}, nil
 }
 
 // Cancel - Cancels the current virtual machine scale set rolling upgrade.
@@ -178,20 +174,16 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) getLatestHandleRespon
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetRollingUpgradesClientBeginStartExtensionUpgradeOptions contains the optional parameters
 // for the VirtualMachineScaleSetRollingUpgradesClient.BeginStartExtensionUpgrade method.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesClientBeginStartExtensionUpgradeOptions) (VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesClientBeginStartExtensionUpgradeOptions) (*VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller, error) {
 	resp, err := client.startExtensionUpgrade(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradePoller{pt: pt}, nil
 }
 
 // StartExtensionUpgrade - Starts a rolling upgrade to move all extensions for all virtual machine scale set instances to
@@ -246,20 +238,16 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) startExtensionUpgrade
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetRollingUpgradesClientBeginStartOSUpgradeOptions contains the optional parameters for the
 // VirtualMachineScaleSetRollingUpgradesClient.BeginStartOSUpgrade method.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesClientBeginStartOSUpgradeOptions) (VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesClientBeginStartOSUpgradeOptions) (*VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller, error) {
 	resp, err := client.startOSUpgrade(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradePoller{pt: pt}, nil
 }
 
 // StartOSUpgrade - Starts a rolling upgrade to move all virtual machine scale set instances to the latest available Platform

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
@@ -105,20 +105,16 @@ func (client *VirtualMachineScaleSetsClient) convertToSinglePlacementGroupCreate
 // parameters - The scale set object.
 // options - VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet, options *VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions) (VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet, options *VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions) (*VirtualMachineScaleSetsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a VM scale set.
@@ -172,20 +168,16 @@ func (client *VirtualMachineScaleSetsClient) createOrUpdateCreateRequest(ctx con
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginDeallocateOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginDeallocate
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginDeallocateOptions) (VirtualMachineScaleSetsClientDeallocatePollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginDeallocateOptions) (*VirtualMachineScaleSetsClientDeallocatePoller, error) {
 	resp, err := client.deallocate(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientDeallocatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientDeallocatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Deallocate", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientDeallocatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientDeallocatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientDeallocatePoller{pt: pt}, nil
 }
 
 // Deallocate - Deallocates specific virtual machines in a VM scale set. Shuts down the virtual machines and releases the
@@ -241,20 +233,16 @@ func (client *VirtualMachineScaleSetsClient) deallocateCreateRequest(ctx context
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginDeleteOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginDelete
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginDeleteOptions) (VirtualMachineScaleSetsClientDeletePollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginDeleteOptions) (*VirtualMachineScaleSetsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a VM scale set.
@@ -306,20 +294,16 @@ func (client *VirtualMachineScaleSetsClient) deleteCreateRequest(ctx context.Con
 // vmInstanceIDs - A list of virtual machine instance IDs from the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginDeleteInstancesOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginDeleteInstances
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginDeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (VirtualMachineScaleSetsClientDeleteInstancesPollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginDeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (*VirtualMachineScaleSetsClientDeleteInstancesPoller, error) {
 	resp, err := client.deleteInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientDeleteInstancesPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientDeleteInstancesPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.DeleteInstances", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientDeleteInstancesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientDeleteInstancesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientDeleteInstancesPoller{pt: pt}, nil
 }
 
 // DeleteInstances - Deletes virtual machines in a VM scale set.
@@ -743,20 +727,16 @@ func (client *VirtualMachineScaleSetsClient) listSKUsHandleResponse(resp *http.R
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginPerformMaintenanceOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginPerformMaintenance
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginPerformMaintenanceOptions) (VirtualMachineScaleSetsClientPerformMaintenancePollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginPerformMaintenanceOptions) (*VirtualMachineScaleSetsClientPerformMaintenancePoller, error) {
 	resp, err := client.performMaintenance(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientPerformMaintenancePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientPerformMaintenancePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.PerformMaintenance", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientPerformMaintenancePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientPerformMaintenancePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientPerformMaintenancePoller{pt: pt}, nil
 }
 
 // PerformMaintenance - Perform maintenance on one or more virtual machines in a VM scale set. Operation on instances which
@@ -814,20 +794,16 @@ func (client *VirtualMachineScaleSetsClient) performMaintenanceCreateRequest(ctx
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginPowerOffOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginPowerOff
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginPowerOffOptions) (VirtualMachineScaleSetsClientPowerOffPollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginPowerOffOptions) (*VirtualMachineScaleSetsClientPowerOffPoller, error) {
 	resp, err := client.powerOff(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientPowerOffPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientPowerOffPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.PowerOff", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientPowerOffPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientPowerOffPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientPowerOffPoller{pt: pt}, nil
 }
 
 // PowerOff - Power off (stop) one or more virtual machines in a VM scale set. Note that resources are still attached and
@@ -887,20 +863,16 @@ func (client *VirtualMachineScaleSetsClient) powerOffCreateRequest(ctx context.C
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginRedeployOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginRedeploy
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginRedeployOptions) (VirtualMachineScaleSetsClientRedeployPollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginRedeployOptions) (*VirtualMachineScaleSetsClientRedeployPoller, error) {
 	resp, err := client.redeploy(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientRedeployPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientRedeployPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Redeploy", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientRedeployPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientRedeployPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientRedeployPoller{pt: pt}, nil
 }
 
 // Redeploy - Shuts down all the virtual machines in the virtual machine scale set, moves them to a new node, and powers them
@@ -957,20 +929,16 @@ func (client *VirtualMachineScaleSetsClient) redeployCreateRequest(ctx context.C
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginReimageOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginReimage
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginReimageOptions) (VirtualMachineScaleSetsClientReimagePollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginReimageOptions) (*VirtualMachineScaleSetsClientReimagePoller, error) {
 	resp, err := client.reimage(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientReimagePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientReimagePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Reimage", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientReimagePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientReimagePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientReimagePoller{pt: pt}, nil
 }
 
 // Reimage - Reimages (upgrade the operating system) one or more virtual machines in a VM scale set which don't have a ephemeral
@@ -1027,20 +995,16 @@ func (client *VirtualMachineScaleSetsClient) reimageCreateRequest(ctx context.Co
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginReimageAllOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginReimageAll
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginReimageAllOptions) (VirtualMachineScaleSetsClientReimageAllPollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginReimageAllOptions) (*VirtualMachineScaleSetsClientReimageAllPoller, error) {
 	resp, err := client.reimageAll(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientReimageAllPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientReimageAllPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.ReimageAll", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientReimageAllPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientReimageAllPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientReimageAllPoller{pt: pt}, nil
 }
 
 // ReimageAll - Reimages all the disks ( including data disks ) in the virtual machines in a VM scale set. This operation
@@ -1095,20 +1059,16 @@ func (client *VirtualMachineScaleSetsClient) reimageAllCreateRequest(ctx context
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginRestartOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginRestart
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginRestartOptions) (VirtualMachineScaleSetsClientRestartPollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginRestartOptions) (*VirtualMachineScaleSetsClientRestartPoller, error) {
 	resp, err := client.restart(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientRestartPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientRestartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Restart", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientRestartPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientRestartPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientRestartPoller{pt: pt}, nil
 }
 
 // Restart - Restarts one or more virtual machines in a VM scale set.
@@ -1163,20 +1123,16 @@ func (client *VirtualMachineScaleSetsClient) restartCreateRequest(ctx context.Co
 // parameters - The input object for SetOrchestrationServiceState API.
 // options - VirtualMachineScaleSetsClientBeginSetOrchestrationServiceStateOptions contains the optional parameters for the
 // VirtualMachineScaleSetsClient.BeginSetOrchestrationServiceState method.
-func (client *VirtualMachineScaleSetsClient) BeginSetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput, options *VirtualMachineScaleSetsClientBeginSetOrchestrationServiceStateOptions) (VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginSetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput, options *VirtualMachineScaleSetsClientBeginSetOrchestrationServiceStateOptions) (*VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller, error) {
 	resp, err := client.setOrchestrationServiceState(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.SetOrchestrationServiceState", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientSetOrchestrationServiceStatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientSetOrchestrationServiceStatePoller{pt: pt}, nil
 }
 
 // SetOrchestrationServiceState - Changes ServiceState property for a given service
@@ -1227,20 +1183,16 @@ func (client *VirtualMachineScaleSetsClient) setOrchestrationServiceStateCreateR
 // vmScaleSetName - The name of the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginStartOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginStart
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginStartOptions) (VirtualMachineScaleSetsClientStartPollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsClientBeginStartOptions) (*VirtualMachineScaleSetsClientStartPoller, error) {
 	resp, err := client.start(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Start", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientStartPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientStartPoller{pt: pt}, nil
 }
 
 // Start - Starts one or more virtual machines in a VM scale set.
@@ -1295,20 +1247,16 @@ func (client *VirtualMachineScaleSetsClient) startCreateRequest(ctx context.Cont
 // parameters - The scale set object.
 // options - VirtualMachineScaleSetsClientBeginUpdateOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginUpdate
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate, options *VirtualMachineScaleSetsClientBeginUpdateOptions) (VirtualMachineScaleSetsClientUpdatePollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate, options *VirtualMachineScaleSetsClientBeginUpdateOptions) (*VirtualMachineScaleSetsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Update a VM scale set.
@@ -1361,20 +1309,16 @@ func (client *VirtualMachineScaleSetsClient) updateCreateRequest(ctx context.Con
 // vmInstanceIDs - A list of virtual machine instance IDs from the VM scale set.
 // options - VirtualMachineScaleSetsClientBeginUpdateInstancesOptions contains the optional parameters for the VirtualMachineScaleSetsClient.BeginUpdateInstances
 // method.
-func (client *VirtualMachineScaleSetsClient) BeginUpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsClientBeginUpdateInstancesOptions) (VirtualMachineScaleSetsClientUpdateInstancesPollerResponse, error) {
+func (client *VirtualMachineScaleSetsClient) BeginUpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsClientBeginUpdateInstancesOptions) (*VirtualMachineScaleSetsClientUpdateInstancesPoller, error) {
 	resp, err := client.updateInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs, options)
 	if err != nil {
-		return VirtualMachineScaleSetsClientUpdateInstancesPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetsClientUpdateInstancesPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetsClient.UpdateInstances", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetsClientUpdateInstancesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetsClientUpdateInstancesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetsClientUpdateInstancesPoller{pt: pt}, nil
 }
 
 // UpdateInstances - Upgrades one or more virtual machines to the latest SKU set in the VM scale set model.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
@@ -59,20 +59,16 @@ func NewVirtualMachineScaleSetVMExtensionsClient(subscriptionID string, credenti
 // extensionParameters - Parameters supplied to the Create Virtual Machine Extension operation.
 // options - VirtualMachineScaleSetVMExtensionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensionsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualMachineScaleSetVMExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineScaleSetVMExtensionsClientBeginCreateOrUpdateOptions) (VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineScaleSetVMExtensionsClientBeginCreateOrUpdateOptions) (*VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, vmScaleSetName, instanceID, vmExtensionName, extensionParameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMExtensionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - The operation to create or update the VMSS VM extension.
@@ -134,20 +130,16 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) createOrUpdateCreateRequ
 // vmExtensionName - The name of the virtual machine extension.
 // options - VirtualMachineScaleSetVMExtensionsClientBeginDeleteOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensionsClient.BeginDelete
 // method.
-func (client *VirtualMachineScaleSetVMExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsClientBeginDeleteOptions) (VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsClientBeginDeleteOptions) (*VirtualMachineScaleSetVMExtensionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, vmScaleSetName, instanceID, vmExtensionName, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMExtensionsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMExtensionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMExtensionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - The operation to delete the VMSS VM extension.
@@ -343,20 +335,16 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) listHandleResponse(resp 
 // extensionParameters - Parameters supplied to the Update Virtual Machine Extension operation.
 // options - VirtualMachineScaleSetVMExtensionsClientBeginUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensionsClient.BeginUpdate
 // method.
-func (client *VirtualMachineScaleSetVMExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineScaleSetVMExtensionsClientBeginUpdateOptions) (VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineScaleSetVMExtensionsClientBeginUpdateOptions) (*VirtualMachineScaleSetVMExtensionsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, vmScaleSetName, instanceID, vmExtensionName, extensionParameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMExtensionsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMExtensionsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMExtensionsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMExtensionsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - The operation to update the VMSS VM extension.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
@@ -60,20 +60,16 @@ func NewVirtualMachineScaleSetVMsClient(subscriptionID string, credential azcore
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginDeallocateOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginDeallocate
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginDeallocateOptions) (VirtualMachineScaleSetVMsClientDeallocatePollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginDeallocateOptions) (*VirtualMachineScaleSetVMsClientDeallocatePoller, error) {
 	resp, err := client.deallocate(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientDeallocatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientDeallocatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Deallocate", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientDeallocatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientDeallocatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientDeallocatePoller{pt: pt}, nil
 }
 
 // Deallocate - Deallocates a specific virtual machine in a VM scale set. Shuts down the virtual machine and releases the
@@ -131,20 +127,16 @@ func (client *VirtualMachineScaleSetVMsClient) deallocateCreateRequest(ctx conte
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginDeleteOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginDelete
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginDeleteOptions) (VirtualMachineScaleSetVMsClientDeletePollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginDeleteOptions) (*VirtualMachineScaleSetVMsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a virtual machine from a VM scale set.
@@ -388,20 +380,16 @@ func (client *VirtualMachineScaleSetVMsClient) listHandleResponse(resp *http.Res
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginPerformMaintenanceOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginPerformMaintenance
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginPerformMaintenanceOptions) (VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginPerformMaintenanceOptions) (*VirtualMachineScaleSetVMsClientPerformMaintenancePoller, error) {
 	resp, err := client.performMaintenance(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.PerformMaintenance", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientPerformMaintenancePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientPerformMaintenancePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientPerformMaintenancePoller{pt: pt}, nil
 }
 
 // PerformMaintenance - Shuts down the virtual machine in a VMScaleSet, moves it to an already updated node, and powers it
@@ -460,20 +448,16 @@ func (client *VirtualMachineScaleSetVMsClient) performMaintenanceCreateRequest(c
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginPowerOffOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginPowerOff
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginPowerOffOptions) (VirtualMachineScaleSetVMsClientPowerOffPollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginPowerOffOptions) (*VirtualMachineScaleSetVMsClientPowerOffPoller, error) {
 	resp, err := client.powerOff(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientPowerOffPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientPowerOffPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.PowerOff", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientPowerOffPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientPowerOffPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientPowerOffPoller{pt: pt}, nil
 }
 
 // PowerOff - Power off (stop) a virtual machine in a VM scale set. Note that resources are still attached and you are getting
@@ -535,20 +519,16 @@ func (client *VirtualMachineScaleSetVMsClient) powerOffCreateRequest(ctx context
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginRedeployOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginRedeploy
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginRedeployOptions) (VirtualMachineScaleSetVMsClientRedeployPollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginRedeployOptions) (*VirtualMachineScaleSetVMsClientRedeployPoller, error) {
 	resp, err := client.redeploy(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientRedeployPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientRedeployPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Redeploy", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientRedeployPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientRedeployPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientRedeployPoller{pt: pt}, nil
 }
 
 // Redeploy - Shuts down the virtual machine in the virtual machine scale set, moves it to a new node, and powers it back
@@ -605,20 +585,16 @@ func (client *VirtualMachineScaleSetVMsClient) redeployCreateRequest(ctx context
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginReimageOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginReimage
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginReimageOptions) (VirtualMachineScaleSetVMsClientReimagePollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginReimageOptions) (*VirtualMachineScaleSetVMsClientReimagePoller, error) {
 	resp, err := client.reimage(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientReimagePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientReimagePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Reimage", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientReimagePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientReimagePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientReimagePoller{pt: pt}, nil
 }
 
 // Reimage - Reimages (upgrade the operating system) a specific virtual machine in a VM scale set.
@@ -678,20 +654,16 @@ func (client *VirtualMachineScaleSetVMsClient) reimageCreateRequest(ctx context.
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginReimageAllOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginReimageAll
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginReimageAllOptions) (VirtualMachineScaleSetVMsClientReimageAllPollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginReimageAllOptions) (*VirtualMachineScaleSetVMsClientReimageAllPoller, error) {
 	resp, err := client.reimageAll(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientReimageAllPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientReimageAllPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.ReimageAll", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientReimageAllPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientReimageAllPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientReimageAllPoller{pt: pt}, nil
 }
 
 // ReimageAll - Allows you to re-image all the disks ( including data disks ) in the a VM scale set instance. This operation
@@ -748,20 +720,16 @@ func (client *VirtualMachineScaleSetVMsClient) reimageAllCreateRequest(ctx conte
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginRestartOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginRestart
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginRestartOptions) (VirtualMachineScaleSetVMsClientRestartPollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginRestartOptions) (*VirtualMachineScaleSetVMsClientRestartPoller, error) {
 	resp, err := client.restart(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientRestartPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientRestartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Restart", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientRestartPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientRestartPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientRestartPoller{pt: pt}, nil
 }
 
 // Restart - Restarts a virtual machine in a VM scale set.
@@ -818,20 +786,16 @@ func (client *VirtualMachineScaleSetVMsClient) restartCreateRequest(ctx context.
 // parameters - Parameters supplied to the Run command operation.
 // options - VirtualMachineScaleSetVMsClientBeginRunCommandOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginRunCommand
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, parameters RunCommandInput, options *VirtualMachineScaleSetVMsClientBeginRunCommandOptions) (VirtualMachineScaleSetVMsClientRunCommandPollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, parameters RunCommandInput, options *VirtualMachineScaleSetVMsClientBeginRunCommandOptions) (*VirtualMachineScaleSetVMsClientRunCommandPoller, error) {
 	resp, err := client.runCommand(ctx, resourceGroupName, vmScaleSetName, instanceID, parameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientRunCommandPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientRunCommandPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.RunCommand", "location", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientRunCommandPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientRunCommandPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientRunCommandPoller{pt: pt}, nil
 }
 
 // RunCommand - Run command on a virtual machine in a VM scale set.
@@ -940,20 +904,16 @@ func (client *VirtualMachineScaleSetVMsClient) simulateEvictionCreateRequest(ctx
 // instanceID - The instance ID of the virtual machine.
 // options - VirtualMachineScaleSetVMsClientBeginStartOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginStart
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginStartOptions) (VirtualMachineScaleSetVMsClientStartPollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *VirtualMachineScaleSetVMsClientBeginStartOptions) (*VirtualMachineScaleSetVMsClientStartPoller, error) {
 	resp, err := client.start(ctx, resourceGroupName, vmScaleSetName, instanceID, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Start", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientStartPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientStartPoller{pt: pt}, nil
 }
 
 // Start - Starts a virtual machine in a VM scale set.
@@ -1010,20 +970,16 @@ func (client *VirtualMachineScaleSetVMsClient) startCreateRequest(ctx context.Co
 // parameters - Parameters supplied to the Update Virtual Machine Scale Sets VM operation.
 // options - VirtualMachineScaleSetVMsClientBeginUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginUpdate
 // method.
-func (client *VirtualMachineScaleSetVMsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, parameters VirtualMachineScaleSetVM, options *VirtualMachineScaleSetVMsClientBeginUpdateOptions) (VirtualMachineScaleSetVMsClientUpdatePollerResponse, error) {
+func (client *VirtualMachineScaleSetVMsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, parameters VirtualMachineScaleSetVM, options *VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*VirtualMachineScaleSetVMsClientUpdatePoller, error) {
 	resp, err := client.update(ctx, resourceGroupName, vmScaleSetName, instanceID, parameters, options)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualMachineScaleSetVMsClientUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualMachineScaleSetVMsClient.Update", "", resp, client.pl)
 	if err != nil {
-		return VirtualMachineScaleSetVMsClientUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualMachineScaleSetVMsClientUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualMachineScaleSetVMsClientUpdatePoller{pt: pt}, nil
 }
 
 // Update - Updates a virtual machine of a VM scale set.

--- a/test/consumption/2019-10-01/armconsumption/go.mod
+++ b/test/consumption/2019-10-01/armconsumption/go.mod
@@ -2,4 +2,4 @@ module armconsumption
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/consumption/2019-10-01/armconsumption/go.sum
+++ b/test/consumption/2019-10-01/armconsumption/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/databoxedge/2021-02-01/armdataboxedge/go.mod
+++ b/test/databoxedge/2021-02-01/armdataboxedge/go.mod
@@ -2,4 +2,4 @@ module armdataboxedge
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/databoxedge/2021-02-01/armdataboxedge/go.sum
+++ b/test/databoxedge/2021-02-01/armdataboxedge/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_addons_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_addons_client.go
@@ -58,20 +58,16 @@ func NewAddonsClient(subscriptionID string, credential azcore.TokenCredential, o
 // addon - The addon properties.
 // options - AddonsClientBeginCreateOrUpdateOptions contains the optional parameters for the AddonsClient.BeginCreateOrUpdate
 // method.
-func (client *AddonsClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, roleName string, addonName string, resourceGroupName string, addon AddonClassification, options *AddonsClientBeginCreateOrUpdateOptions) (AddonsClientCreateOrUpdatePollerResponse, error) {
+func (client *AddonsClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, roleName string, addonName string, resourceGroupName string, addon AddonClassification, options *AddonsClientBeginCreateOrUpdateOptions) (*AddonsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, roleName, addonName, resourceGroupName, addon, options)
 	if err != nil {
-		return AddonsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := AddonsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("AddonsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return AddonsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &AddonsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &AddonsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a addon.
@@ -132,20 +128,16 @@ func (client *AddonsClient) createOrUpdateCreateRequest(ctx context.Context, dev
 // addonName - The addon name.
 // resourceGroupName - The resource group name.
 // options - AddonsClientBeginDeleteOptions contains the optional parameters for the AddonsClient.BeginDelete method.
-func (client *AddonsClient) BeginDelete(ctx context.Context, deviceName string, roleName string, addonName string, resourceGroupName string, options *AddonsClientBeginDeleteOptions) (AddonsClientDeletePollerResponse, error) {
+func (client *AddonsClient) BeginDelete(ctx context.Context, deviceName string, roleName string, addonName string, resourceGroupName string, options *AddonsClientBeginDeleteOptions) (*AddonsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, roleName, addonName, resourceGroupName, options)
 	if err != nil {
-		return AddonsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := AddonsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("AddonsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return AddonsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &AddonsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &AddonsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the addon on the device.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
@@ -57,20 +57,16 @@ func NewBandwidthSchedulesClient(subscriptionID string, credential azcore.TokenC
 // parameters - The bandwidth schedule to be added or updated.
 // options - BandwidthSchedulesClientBeginCreateOrUpdateOptions contains the optional parameters for the BandwidthSchedulesClient.BeginCreateOrUpdate
 // method.
-func (client *BandwidthSchedulesClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, parameters BandwidthSchedule, options *BandwidthSchedulesClientBeginCreateOrUpdateOptions) (BandwidthSchedulesClientCreateOrUpdatePollerResponse, error) {
+func (client *BandwidthSchedulesClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, parameters BandwidthSchedule, options *BandwidthSchedulesClientBeginCreateOrUpdateOptions) (*BandwidthSchedulesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, name, resourceGroupName, parameters, options)
 	if err != nil {
-		return BandwidthSchedulesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := BandwidthSchedulesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("BandwidthSchedulesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return BandwidthSchedulesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &BandwidthSchedulesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &BandwidthSchedulesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a bandwidth schedule.
@@ -127,20 +123,16 @@ func (client *BandwidthSchedulesClient) createOrUpdateCreateRequest(ctx context.
 // resourceGroupName - The resource group name.
 // options - BandwidthSchedulesClientBeginDeleteOptions contains the optional parameters for the BandwidthSchedulesClient.BeginDelete
 // method.
-func (client *BandwidthSchedulesClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *BandwidthSchedulesClientBeginDeleteOptions) (BandwidthSchedulesClientDeletePollerResponse, error) {
+func (client *BandwidthSchedulesClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *BandwidthSchedulesClientBeginDeleteOptions) (*BandwidthSchedulesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, name, resourceGroupName, options)
 	if err != nil {
-		return BandwidthSchedulesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := BandwidthSchedulesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("BandwidthSchedulesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return BandwidthSchedulesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &BandwidthSchedulesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &BandwidthSchedulesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified bandwidth schedule.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
@@ -58,20 +58,16 @@ func NewContainersClient(subscriptionID string, credential azcore.TokenCredentia
 // containerParam - The container properties.
 // options - ContainersClientBeginCreateOrUpdateOptions contains the optional parameters for the ContainersClient.BeginCreateOrUpdate
 // method.
-func (client *ContainersClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, storageAccountName string, containerName string, resourceGroupName string, containerParam Container, options *ContainersClientBeginCreateOrUpdateOptions) (ContainersClientCreateOrUpdatePollerResponse, error) {
+func (client *ContainersClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, storageAccountName string, containerName string, resourceGroupName string, containerParam Container, options *ContainersClientBeginCreateOrUpdateOptions) (*ContainersClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, storageAccountName, containerName, resourceGroupName, containerParam, options)
 	if err != nil {
-		return ContainersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ContainersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ContainersClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return ContainersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ContainersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ContainersClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a new container or updates an existing container on the device.
@@ -132,20 +128,16 @@ func (client *ContainersClient) createOrUpdateCreateRequest(ctx context.Context,
 // containerName - The container name.
 // resourceGroupName - The resource group name.
 // options - ContainersClientBeginDeleteOptions contains the optional parameters for the ContainersClient.BeginDelete method.
-func (client *ContainersClient) BeginDelete(ctx context.Context, deviceName string, storageAccountName string, containerName string, resourceGroupName string, options *ContainersClientBeginDeleteOptions) (ContainersClientDeletePollerResponse, error) {
+func (client *ContainersClient) BeginDelete(ctx context.Context, deviceName string, storageAccountName string, containerName string, resourceGroupName string, options *ContainersClientBeginDeleteOptions) (*ContainersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, storageAccountName, containerName, resourceGroupName, options)
 	if err != nil {
-		return ContainersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ContainersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ContainersClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return ContainersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ContainersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ContainersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the container on the Data Box Edge/Data Box Gateway device.
@@ -329,20 +321,16 @@ func (client *ContainersClient) listByStorageAccountHandleResponse(resp *http.Re
 // containerName - The container name.
 // resourceGroupName - The resource group name.
 // options - ContainersClientBeginRefreshOptions contains the optional parameters for the ContainersClient.BeginRefresh method.
-func (client *ContainersClient) BeginRefresh(ctx context.Context, deviceName string, storageAccountName string, containerName string, resourceGroupName string, options *ContainersClientBeginRefreshOptions) (ContainersClientRefreshPollerResponse, error) {
+func (client *ContainersClient) BeginRefresh(ctx context.Context, deviceName string, storageAccountName string, containerName string, resourceGroupName string, options *ContainersClientBeginRefreshOptions) (*ContainersClientRefreshPoller, error) {
 	resp, err := client.refresh(ctx, deviceName, storageAccountName, containerName, resourceGroupName, options)
 	if err != nil {
-		return ContainersClientRefreshPollerResponse{}, err
+		return nil, err
 	}
-	result := ContainersClientRefreshPollerResponse{}
 	pt, err := armruntime.NewPoller("ContainersClient.Refresh", "", resp, client.pl)
 	if err != nil {
-		return ContainersClientRefreshPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ContainersClientRefreshPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ContainersClientRefreshPoller{pt: pt}, nil
 }
 
 // Refresh - Refreshes the container metadata with the data from the cloud.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_devices_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_devices_client.go
@@ -112,20 +112,16 @@ func (client *DevicesClient) createOrUpdateHandleResponse(resp *http.Response) (
 // securitySettings - The security settings.
 // options - DevicesClientBeginCreateOrUpdateSecuritySettingsOptions contains the optional parameters for the DevicesClient.BeginCreateOrUpdateSecuritySettings
 // method.
-func (client *DevicesClient) BeginCreateOrUpdateSecuritySettings(ctx context.Context, deviceName string, resourceGroupName string, securitySettings SecuritySettings, options *DevicesClientBeginCreateOrUpdateSecuritySettingsOptions) (DevicesClientCreateOrUpdateSecuritySettingsPollerResponse, error) {
+func (client *DevicesClient) BeginCreateOrUpdateSecuritySettings(ctx context.Context, deviceName string, resourceGroupName string, securitySettings SecuritySettings, options *DevicesClientBeginCreateOrUpdateSecuritySettingsOptions) (*DevicesClientCreateOrUpdateSecuritySettingsPoller, error) {
 	resp, err := client.createOrUpdateSecuritySettings(ctx, deviceName, resourceGroupName, securitySettings, options)
 	if err != nil {
-		return DevicesClientCreateOrUpdateSecuritySettingsPollerResponse{}, err
+		return nil, err
 	}
-	result := DevicesClientCreateOrUpdateSecuritySettingsPollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.CreateOrUpdateSecuritySettings", "", resp, client.pl)
 	if err != nil {
-		return DevicesClientCreateOrUpdateSecuritySettingsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DevicesClientCreateOrUpdateSecuritySettingsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DevicesClientCreateOrUpdateSecuritySettingsPoller{pt: pt}, nil
 }
 
 // CreateOrUpdateSecuritySettings - Updates the security settings on a Data Box Edge/Data Box Gateway device.
@@ -176,20 +172,16 @@ func (client *DevicesClient) createOrUpdateSecuritySettingsCreateRequest(ctx con
 // deviceName - The device name.
 // resourceGroupName - The resource group name.
 // options - DevicesClientBeginDeleteOptions contains the optional parameters for the DevicesClient.BeginDelete method.
-func (client *DevicesClient) BeginDelete(ctx context.Context, deviceName string, resourceGroupName string, options *DevicesClientBeginDeleteOptions) (DevicesClientDeletePollerResponse, error) {
+func (client *DevicesClient) BeginDelete(ctx context.Context, deviceName string, resourceGroupName string, options *DevicesClientBeginDeleteOptions) (*DevicesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, resourceGroupName, options)
 	if err != nil {
-		return DevicesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := DevicesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return DevicesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DevicesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DevicesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the Data Box Edge/Data Box Gateway device.
@@ -241,20 +233,16 @@ func (client *DevicesClient) deleteCreateRequest(ctx context.Context, deviceName
 // resourceGroupName - The resource group name.
 // options - DevicesClientBeginDownloadUpdatesOptions contains the optional parameters for the DevicesClient.BeginDownloadUpdates
 // method.
-func (client *DevicesClient) BeginDownloadUpdates(ctx context.Context, deviceName string, resourceGroupName string, options *DevicesClientBeginDownloadUpdatesOptions) (DevicesClientDownloadUpdatesPollerResponse, error) {
+func (client *DevicesClient) BeginDownloadUpdates(ctx context.Context, deviceName string, resourceGroupName string, options *DevicesClientBeginDownloadUpdatesOptions) (*DevicesClientDownloadUpdatesPoller, error) {
 	resp, err := client.downloadUpdates(ctx, deviceName, resourceGroupName, options)
 	if err != nil {
-		return DevicesClientDownloadUpdatesPollerResponse{}, err
+		return nil, err
 	}
-	result := DevicesClientDownloadUpdatesPollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.DownloadUpdates", "", resp, client.pl)
 	if err != nil {
-		return DevicesClientDownloadUpdatesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DevicesClientDownloadUpdatesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DevicesClientDownloadUpdatesPoller{pt: pt}, nil
 }
 
 // DownloadUpdates - Downloads the updates on a Data Box Edge/Data Box Gateway device.
@@ -586,20 +574,16 @@ func (client *DevicesClient) getUpdateSummaryHandleResponse(resp *http.Response)
 // resourceGroupName - The resource group name.
 // options - DevicesClientBeginInstallUpdatesOptions contains the optional parameters for the DevicesClient.BeginInstallUpdates
 // method.
-func (client *DevicesClient) BeginInstallUpdates(ctx context.Context, deviceName string, resourceGroupName string, options *DevicesClientBeginInstallUpdatesOptions) (DevicesClientInstallUpdatesPollerResponse, error) {
+func (client *DevicesClient) BeginInstallUpdates(ctx context.Context, deviceName string, resourceGroupName string, options *DevicesClientBeginInstallUpdatesOptions) (*DevicesClientInstallUpdatesPoller, error) {
 	resp, err := client.installUpdates(ctx, deviceName, resourceGroupName, options)
 	if err != nil {
-		return DevicesClientInstallUpdatesPollerResponse{}, err
+		return nil, err
 	}
-	result := DevicesClientInstallUpdatesPollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.InstallUpdates", "", resp, client.pl)
 	if err != nil {
-		return DevicesClientInstallUpdatesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DevicesClientInstallUpdatesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DevicesClientInstallUpdatesPoller{pt: pt}, nil
 }
 
 // InstallUpdates - Installs the updates on the Data Box Edge/Data Box Gateway device.
@@ -748,20 +732,16 @@ func (client *DevicesClient) listBySubscriptionHandleResponse(resp *http.Respons
 // resourceGroupName - The resource group name.
 // options - DevicesClientBeginScanForUpdatesOptions contains the optional parameters for the DevicesClient.BeginScanForUpdates
 // method.
-func (client *DevicesClient) BeginScanForUpdates(ctx context.Context, deviceName string, resourceGroupName string, options *DevicesClientBeginScanForUpdatesOptions) (DevicesClientScanForUpdatesPollerResponse, error) {
+func (client *DevicesClient) BeginScanForUpdates(ctx context.Context, deviceName string, resourceGroupName string, options *DevicesClientBeginScanForUpdatesOptions) (*DevicesClientScanForUpdatesPoller, error) {
 	resp, err := client.scanForUpdates(ctx, deviceName, resourceGroupName, options)
 	if err != nil {
-		return DevicesClientScanForUpdatesPollerResponse{}, err
+		return nil, err
 	}
-	result := DevicesClientScanForUpdatesPollerResponse{}
 	pt, err := armruntime.NewPoller("DevicesClient.ScanForUpdates", "", resp, client.pl)
 	if err != nil {
-		return DevicesClientScanForUpdatesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DevicesClientScanForUpdatesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DevicesClientScanForUpdatesPoller{pt: pt}, nil
 }
 
 // ScanForUpdates - Scans for updates on a Data Box Edge/Data Box Gateway device.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_diagnosticsettings_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_diagnosticsettings_client.go
@@ -171,20 +171,16 @@ func (client *DiagnosticSettingsClient) getDiagnosticRemoteSupportSettingsHandle
 // proactiveLogCollectionSettings - The proactive log collection settings.
 // options - DiagnosticSettingsClientBeginUpdateDiagnosticProactiveLogCollectionSettingsOptions contains the optional parameters
 // for the DiagnosticSettingsClient.BeginUpdateDiagnosticProactiveLogCollectionSettings method.
-func (client *DiagnosticSettingsClient) BeginUpdateDiagnosticProactiveLogCollectionSettings(ctx context.Context, deviceName string, resourceGroupName string, proactiveLogCollectionSettings DiagnosticProactiveLogCollectionSettings, options *DiagnosticSettingsClientBeginUpdateDiagnosticProactiveLogCollectionSettingsOptions) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse, error) {
+func (client *DiagnosticSettingsClient) BeginUpdateDiagnosticProactiveLogCollectionSettings(ctx context.Context, deviceName string, resourceGroupName string, proactiveLogCollectionSettings DiagnosticProactiveLogCollectionSettings, options *DiagnosticSettingsClientBeginUpdateDiagnosticProactiveLogCollectionSettingsOptions) (*DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller, error) {
 	resp, err := client.updateDiagnosticProactiveLogCollectionSettings(ctx, deviceName, resourceGroupName, proactiveLogCollectionSettings, options)
 	if err != nil {
-		return DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse{}, err
+		return nil, err
 	}
-	result := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse{}
 	pt, err := armruntime.NewPoller("DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings", "", resp, client.pl)
 	if err != nil {
-		return DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller{pt: pt}, nil
 }
 
 // UpdateDiagnosticProactiveLogCollectionSettings - Updates the proactive log collection settings on a Data Box Edge/Data
@@ -239,20 +235,16 @@ func (client *DiagnosticSettingsClient) updateDiagnosticProactiveLogCollectionSe
 // diagnosticRemoteSupportSettings - The diagnostic remote support settings.
 // options - DiagnosticSettingsClientBeginUpdateDiagnosticRemoteSupportSettingsOptions contains the optional parameters for
 // the DiagnosticSettingsClient.BeginUpdateDiagnosticRemoteSupportSettings method.
-func (client *DiagnosticSettingsClient) BeginUpdateDiagnosticRemoteSupportSettings(ctx context.Context, deviceName string, resourceGroupName string, diagnosticRemoteSupportSettings DiagnosticRemoteSupportSettings, options *DiagnosticSettingsClientBeginUpdateDiagnosticRemoteSupportSettingsOptions) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse, error) {
+func (client *DiagnosticSettingsClient) BeginUpdateDiagnosticRemoteSupportSettings(ctx context.Context, deviceName string, resourceGroupName string, diagnosticRemoteSupportSettings DiagnosticRemoteSupportSettings, options *DiagnosticSettingsClientBeginUpdateDiagnosticRemoteSupportSettingsOptions) (*DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller, error) {
 	resp, err := client.updateDiagnosticRemoteSupportSettings(ctx, deviceName, resourceGroupName, diagnosticRemoteSupportSettings, options)
 	if err != nil {
-		return DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse{}, err
+		return nil, err
 	}
-	result := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse{}
 	pt, err := armruntime.NewPoller("DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings", "", resp, client.pl)
 	if err != nil {
-		return DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller{pt: pt}, nil
 }
 
 // UpdateDiagnosticRemoteSupportSettings - Updates the diagnostic remote support settings on a Data Box Edge/Data Box Gateway

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
@@ -57,20 +57,16 @@ func NewMonitoringConfigClient(subscriptionID string, credential azcore.TokenCre
 // monitoringMetricConfiguration - The metric configuration.
 // options - MonitoringConfigClientBeginCreateOrUpdateOptions contains the optional parameters for the MonitoringConfigClient.BeginCreateOrUpdate
 // method.
-func (client *MonitoringConfigClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, roleName string, resourceGroupName string, monitoringMetricConfiguration MonitoringMetricConfiguration, options *MonitoringConfigClientBeginCreateOrUpdateOptions) (MonitoringConfigClientCreateOrUpdatePollerResponse, error) {
+func (client *MonitoringConfigClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, roleName string, resourceGroupName string, monitoringMetricConfiguration MonitoringMetricConfiguration, options *MonitoringConfigClientBeginCreateOrUpdateOptions) (*MonitoringConfigClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, roleName, resourceGroupName, monitoringMetricConfiguration, options)
 	if err != nil {
-		return MonitoringConfigClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := MonitoringConfigClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("MonitoringConfigClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return MonitoringConfigClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &MonitoringConfigClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &MonitoringConfigClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a new metric configuration or updates an existing one for a role.
@@ -127,20 +123,16 @@ func (client *MonitoringConfigClient) createOrUpdateCreateRequest(ctx context.Co
 // resourceGroupName - The resource group name.
 // options - MonitoringConfigClientBeginDeleteOptions contains the optional parameters for the MonitoringConfigClient.BeginDelete
 // method.
-func (client *MonitoringConfigClient) BeginDelete(ctx context.Context, deviceName string, roleName string, resourceGroupName string, options *MonitoringConfigClientBeginDeleteOptions) (MonitoringConfigClientDeletePollerResponse, error) {
+func (client *MonitoringConfigClient) BeginDelete(ctx context.Context, deviceName string, roleName string, resourceGroupName string, options *MonitoringConfigClientBeginDeleteOptions) (*MonitoringConfigClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, roleName, resourceGroupName, options)
 	if err != nil {
-		return MonitoringConfigClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := MonitoringConfigClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("MonitoringConfigClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return MonitoringConfigClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &MonitoringConfigClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &MonitoringConfigClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - deletes a new metric configuration for a role.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
@@ -56,20 +56,16 @@ func NewOrdersClient(subscriptionID string, credential azcore.TokenCredential, o
 // order - The order to be created or updated.
 // options - OrdersClientBeginCreateOrUpdateOptions contains the optional parameters for the OrdersClient.BeginCreateOrUpdate
 // method.
-func (client *OrdersClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, resourceGroupName string, order Order, options *OrdersClientBeginCreateOrUpdateOptions) (OrdersClientCreateOrUpdatePollerResponse, error) {
+func (client *OrdersClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, resourceGroupName string, order Order, options *OrdersClientBeginCreateOrUpdateOptions) (*OrdersClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, resourceGroupName, order, options)
 	if err != nil {
-		return OrdersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := OrdersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("OrdersClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return OrdersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &OrdersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &OrdersClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates an order.
@@ -120,20 +116,16 @@ func (client *OrdersClient) createOrUpdateCreateRequest(ctx context.Context, dev
 // deviceName - The device name.
 // resourceGroupName - The resource group name.
 // options - OrdersClientBeginDeleteOptions contains the optional parameters for the OrdersClient.BeginDelete method.
-func (client *OrdersClient) BeginDelete(ctx context.Context, deviceName string, resourceGroupName string, options *OrdersClientBeginDeleteOptions) (OrdersClientDeletePollerResponse, error) {
+func (client *OrdersClient) BeginDelete(ctx context.Context, deviceName string, resourceGroupName string, options *OrdersClientBeginDeleteOptions) (*OrdersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, resourceGroupName, options)
 	if err != nil {
-		return OrdersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := OrdersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("OrdersClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return OrdersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &OrdersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &OrdersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the order related to the device.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pollers.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pollers.go
@@ -11,7 +11,8 @@ package armdataboxedge
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
+	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"time"
 )
 
 // AddonsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -24,36 +25,52 @@ func (p *AddonsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *AddonsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *AddonsClientCreateOrUpdatePoller) Poll(ctx context.Context) (AddonsClientCreateOrUpdateResponse, error) {
+	result := AddonsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final AddonsClientCreateOrUpdateResponse will be returned.
-func (p *AddonsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (AddonsClientCreateOrUpdateResponse, error) {
-	respType := AddonsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType)
-	if err != nil {
-		return AddonsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *AddonsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsClientCreateOrUpdateResponse, error) {
+	result := AddonsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *AddonsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a AddonsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *AddonsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *AddonsClient, token string) (AddonsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("AddonsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return AddonsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // AddonsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -66,36 +83,52 @@ func (p *AddonsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *AddonsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *AddonsClientDeletePoller) Poll(ctx context.Context) (AddonsClientDeleteResponse, error) {
+	result := AddonsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final AddonsClientDeleteResponse will be returned.
-func (p *AddonsClientDeletePoller) FinalResponse(ctx context.Context) (AddonsClientDeleteResponse, error) {
-	respType := AddonsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return AddonsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *AddonsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsClientDeleteResponse, error) {
+	result := AddonsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *AddonsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a AddonsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *AddonsClientDeletePoller) Resume(ctx context.Context, client *AddonsClient, token string) (AddonsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("AddonsClient.Delete", token, client.pl); err != nil {
+		return AddonsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // BandwidthSchedulesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -108,36 +141,52 @@ func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
+	result := BandwidthSchedulesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.BandwidthSchedule)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final BandwidthSchedulesClientCreateOrUpdateResponse will be returned.
-func (p *BandwidthSchedulesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
-	respType := BandwidthSchedulesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.BandwidthSchedule)
-	if err != nil {
-		return BandwidthSchedulesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *BandwidthSchedulesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
+	result := BandwidthSchedulesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.BandwidthSchedule)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *BandwidthSchedulesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a BandwidthSchedulesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *BandwidthSchedulesClient, token string) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("BandwidthSchedulesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return BandwidthSchedulesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // BandwidthSchedulesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -150,36 +199,52 @@ func (p *BandwidthSchedulesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *BandwidthSchedulesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *BandwidthSchedulesClientDeletePoller) Poll(ctx context.Context) (BandwidthSchedulesClientDeleteResponse, error) {
+	result := BandwidthSchedulesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final BandwidthSchedulesClientDeleteResponse will be returned.
-func (p *BandwidthSchedulesClientDeletePoller) FinalResponse(ctx context.Context) (BandwidthSchedulesClientDeleteResponse, error) {
-	respType := BandwidthSchedulesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return BandwidthSchedulesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *BandwidthSchedulesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (BandwidthSchedulesClientDeleteResponse, error) {
+	result := BandwidthSchedulesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *BandwidthSchedulesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a BandwidthSchedulesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *BandwidthSchedulesClientDeletePoller) Resume(ctx context.Context, client *BandwidthSchedulesClient, token string) (BandwidthSchedulesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("BandwidthSchedulesClient.Delete", token, client.pl); err != nil {
+		return BandwidthSchedulesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ContainersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -192,36 +257,52 @@ func (p *ContainersClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ContainersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ContainersClientCreateOrUpdatePoller) Poll(ctx context.Context) (ContainersClientCreateOrUpdateResponse, error) {
+	result := ContainersClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Container)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ContainersClientCreateOrUpdateResponse will be returned.
-func (p *ContainersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ContainersClientCreateOrUpdateResponse, error) {
-	respType := ContainersClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Container)
-	if err != nil {
-		return ContainersClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ContainersClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientCreateOrUpdateResponse, error) {
+	result := ContainersClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Container)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ContainersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ContainersClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ContainersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ContainersClient, token string) (ContainersClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ContainersClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ContainersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -234,36 +315,52 @@ func (p *ContainersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ContainersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ContainersClientDeletePoller) Poll(ctx context.Context) (ContainersClientDeleteResponse, error) {
+	result := ContainersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ContainersClientDeleteResponse will be returned.
-func (p *ContainersClientDeletePoller) FinalResponse(ctx context.Context) (ContainersClientDeleteResponse, error) {
-	respType := ContainersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ContainersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ContainersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientDeleteResponse, error) {
+	result := ContainersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ContainersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ContainersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ContainersClientDeletePoller) Resume(ctx context.Context, client *ContainersClient, token string) (ContainersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.Delete", token, client.pl); err != nil {
+		return ContainersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ContainersClientRefreshPoller provides polling facilities until the operation reaches a terminal state.
@@ -276,36 +373,52 @@ func (p *ContainersClientRefreshPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ContainersClientRefreshPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ContainersClientRefreshPoller) Poll(ctx context.Context) (ContainersClientRefreshResponse, error) {
+	result := ContainersClientRefreshResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ContainersClientRefreshResponse will be returned.
-func (p *ContainersClientRefreshPoller) FinalResponse(ctx context.Context) (ContainersClientRefreshResponse, error) {
-	respType := ContainersClientRefreshResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ContainersClientRefreshResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ContainersClientRefreshPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientRefreshResponse, error) {
+	result := ContainersClientRefreshResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ContainersClientRefreshPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ContainersClientRefreshPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ContainersClientRefreshPoller) Resume(ctx context.Context, client *ContainersClient, token string) (ContainersClientRefreshResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.Refresh", token, client.pl); err != nil {
+		return ContainersClientRefreshResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DevicesClientCreateOrUpdateSecuritySettingsPoller provides polling facilities until the operation reaches a terminal state.
@@ -318,36 +431,52 @@ func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Poll(ctx context.Context) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
+	result := DevicesClientCreateOrUpdateSecuritySettingsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DevicesClientCreateOrUpdateSecuritySettingsResponse will be returned.
-func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) FinalResponse(ctx context.Context) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
-	respType := DevicesClientCreateOrUpdateSecuritySettingsResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DevicesClientCreateOrUpdateSecuritySettingsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
+	result := DevicesClientCreateOrUpdateSecuritySettingsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DevicesClientCreateOrUpdateSecuritySettingsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.CreateOrUpdateSecuritySettings", token, client.pl); err != nil {
+		return DevicesClientCreateOrUpdateSecuritySettingsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DevicesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -360,36 +489,52 @@ func (p *DevicesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DevicesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DevicesClientDeletePoller) Poll(ctx context.Context) (DevicesClientDeleteResponse, error) {
+	result := DevicesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DevicesClientDeleteResponse will be returned.
-func (p *DevicesClientDeletePoller) FinalResponse(ctx context.Context) (DevicesClientDeleteResponse, error) {
-	respType := DevicesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DevicesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DevicesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientDeleteResponse, error) {
+	result := DevicesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DevicesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DevicesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DevicesClientDeletePoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.Delete", token, client.pl); err != nil {
+		return DevicesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DevicesClientDownloadUpdatesPoller provides polling facilities until the operation reaches a terminal state.
@@ -402,36 +547,52 @@ func (p *DevicesClientDownloadUpdatesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DevicesClientDownloadUpdatesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DevicesClientDownloadUpdatesPoller) Poll(ctx context.Context) (DevicesClientDownloadUpdatesResponse, error) {
+	result := DevicesClientDownloadUpdatesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DevicesClientDownloadUpdatesResponse will be returned.
-func (p *DevicesClientDownloadUpdatesPoller) FinalResponse(ctx context.Context) (DevicesClientDownloadUpdatesResponse, error) {
-	respType := DevicesClientDownloadUpdatesResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DevicesClientDownloadUpdatesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DevicesClientDownloadUpdatesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientDownloadUpdatesResponse, error) {
+	result := DevicesClientDownloadUpdatesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DevicesClientDownloadUpdatesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DevicesClientDownloadUpdatesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DevicesClientDownloadUpdatesPoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientDownloadUpdatesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.DownloadUpdates", token, client.pl); err != nil {
+		return DevicesClientDownloadUpdatesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DevicesClientInstallUpdatesPoller provides polling facilities until the operation reaches a terminal state.
@@ -444,36 +605,52 @@ func (p *DevicesClientInstallUpdatesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DevicesClientInstallUpdatesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DevicesClientInstallUpdatesPoller) Poll(ctx context.Context) (DevicesClientInstallUpdatesResponse, error) {
+	result := DevicesClientInstallUpdatesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DevicesClientInstallUpdatesResponse will be returned.
-func (p *DevicesClientInstallUpdatesPoller) FinalResponse(ctx context.Context) (DevicesClientInstallUpdatesResponse, error) {
-	respType := DevicesClientInstallUpdatesResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DevicesClientInstallUpdatesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DevicesClientInstallUpdatesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientInstallUpdatesResponse, error) {
+	result := DevicesClientInstallUpdatesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DevicesClientInstallUpdatesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DevicesClientInstallUpdatesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DevicesClientInstallUpdatesPoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientInstallUpdatesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.InstallUpdates", token, client.pl); err != nil {
+		return DevicesClientInstallUpdatesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DevicesClientScanForUpdatesPoller provides polling facilities until the operation reaches a terminal state.
@@ -486,36 +663,52 @@ func (p *DevicesClientScanForUpdatesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DevicesClientScanForUpdatesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DevicesClientScanForUpdatesPoller) Poll(ctx context.Context) (DevicesClientScanForUpdatesResponse, error) {
+	result := DevicesClientScanForUpdatesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DevicesClientScanForUpdatesResponse will be returned.
-func (p *DevicesClientScanForUpdatesPoller) FinalResponse(ctx context.Context) (DevicesClientScanForUpdatesResponse, error) {
-	respType := DevicesClientScanForUpdatesResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DevicesClientScanForUpdatesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DevicesClientScanForUpdatesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientScanForUpdatesResponse, error) {
+	result := DevicesClientScanForUpdatesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DevicesClientScanForUpdatesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DevicesClientScanForUpdatesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DevicesClientScanForUpdatesPoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientScanForUpdatesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.ScanForUpdates", token, client.pl); err != nil {
+		return DevicesClientScanForUpdatesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller provides polling facilities until the operation reaches a terminal state.
@@ -528,36 +721,52 @@ func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsP
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) Poll(ctx context.Context) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
+	result := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse will be returned.
-func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) FinalResponse(ctx context.Context) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
-	respType := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
+	result := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) Resume(ctx context.Context, client *DiagnosticSettingsClient, token string) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings", token, client.pl); err != nil {
+		return DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller provides polling facilities until the operation reaches a terminal state.
@@ -570,36 +779,52 @@ func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Do
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Poll(ctx context.Context) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
+	result := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse will be returned.
-func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) FinalResponse(ctx context.Context) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
-	respType := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
+	result := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Resume(ctx context.Context, client *DiagnosticSettingsClient, token string) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings", token, client.pl); err != nil {
+		return DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // MonitoringConfigClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -612,36 +837,52 @@ func (p *MonitoringConfigClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *MonitoringConfigClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *MonitoringConfigClientCreateOrUpdatePoller) Poll(ctx context.Context) (MonitoringConfigClientCreateOrUpdateResponse, error) {
+	result := MonitoringConfigClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.MonitoringMetricConfiguration)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final MonitoringConfigClientCreateOrUpdateResponse will be returned.
-func (p *MonitoringConfigClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (MonitoringConfigClientCreateOrUpdateResponse, error) {
-	respType := MonitoringConfigClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.MonitoringMetricConfiguration)
-	if err != nil {
-		return MonitoringConfigClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *MonitoringConfigClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (MonitoringConfigClientCreateOrUpdateResponse, error) {
+	result := MonitoringConfigClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.MonitoringMetricConfiguration)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *MonitoringConfigClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a MonitoringConfigClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *MonitoringConfigClientCreateOrUpdatePoller) Resume(ctx context.Context, client *MonitoringConfigClient, token string) (MonitoringConfigClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("MonitoringConfigClient.CreateOrUpdate", token, client.pl); err != nil {
+		return MonitoringConfigClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // MonitoringConfigClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -654,36 +895,52 @@ func (p *MonitoringConfigClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *MonitoringConfigClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *MonitoringConfigClientDeletePoller) Poll(ctx context.Context) (MonitoringConfigClientDeleteResponse, error) {
+	result := MonitoringConfigClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final MonitoringConfigClientDeleteResponse will be returned.
-func (p *MonitoringConfigClientDeletePoller) FinalResponse(ctx context.Context) (MonitoringConfigClientDeleteResponse, error) {
-	respType := MonitoringConfigClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return MonitoringConfigClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *MonitoringConfigClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (MonitoringConfigClientDeleteResponse, error) {
+	result := MonitoringConfigClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *MonitoringConfigClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a MonitoringConfigClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *MonitoringConfigClientDeletePoller) Resume(ctx context.Context, client *MonitoringConfigClient, token string) (MonitoringConfigClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("MonitoringConfigClient.Delete", token, client.pl); err != nil {
+		return MonitoringConfigClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // OrdersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -696,36 +953,52 @@ func (p *OrdersClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *OrdersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *OrdersClientCreateOrUpdatePoller) Poll(ctx context.Context) (OrdersClientCreateOrUpdateResponse, error) {
+	result := OrdersClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Order)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final OrdersClientCreateOrUpdateResponse will be returned.
-func (p *OrdersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (OrdersClientCreateOrUpdateResponse, error) {
-	respType := OrdersClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Order)
-	if err != nil {
-		return OrdersClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *OrdersClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (OrdersClientCreateOrUpdateResponse, error) {
+	result := OrdersClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Order)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *OrdersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a OrdersClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *OrdersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *OrdersClient, token string) (OrdersClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("OrdersClient.CreateOrUpdate", token, client.pl); err != nil {
+		return OrdersClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // OrdersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -738,36 +1011,52 @@ func (p *OrdersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *OrdersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *OrdersClientDeletePoller) Poll(ctx context.Context) (OrdersClientDeleteResponse, error) {
+	result := OrdersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final OrdersClientDeleteResponse will be returned.
-func (p *OrdersClientDeletePoller) FinalResponse(ctx context.Context) (OrdersClientDeleteResponse, error) {
-	respType := OrdersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return OrdersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *OrdersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (OrdersClientDeleteResponse, error) {
+	result := OrdersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *OrdersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a OrdersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *OrdersClientDeletePoller) Resume(ctx context.Context, client *OrdersClient, token string) (OrdersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("OrdersClient.Delete", token, client.pl); err != nil {
+		return OrdersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RolesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -780,36 +1069,52 @@ func (p *RolesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RolesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RolesClientCreateOrUpdatePoller) Poll(ctx context.Context) (RolesClientCreateOrUpdateResponse, error) {
+	result := RolesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RolesClientCreateOrUpdateResponse will be returned.
-func (p *RolesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RolesClientCreateOrUpdateResponse, error) {
-	respType := RolesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType)
-	if err != nil {
-		return RolesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RolesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RolesClientCreateOrUpdateResponse, error) {
+	result := RolesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RolesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RolesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RolesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RolesClient, token string) (RolesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RolesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return RolesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RolesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -822,36 +1127,52 @@ func (p *RolesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RolesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RolesClientDeletePoller) Poll(ctx context.Context) (RolesClientDeleteResponse, error) {
+	result := RolesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RolesClientDeleteResponse will be returned.
-func (p *RolesClientDeletePoller) FinalResponse(ctx context.Context) (RolesClientDeleteResponse, error) {
-	respType := RolesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return RolesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RolesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RolesClientDeleteResponse, error) {
+	result := RolesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RolesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RolesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RolesClientDeletePoller) Resume(ctx context.Context, client *RolesClient, token string) (RolesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RolesClient.Delete", token, client.pl); err != nil {
+		return RolesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SharesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -864,36 +1185,52 @@ func (p *SharesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SharesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SharesClientCreateOrUpdatePoller) Poll(ctx context.Context) (SharesClientCreateOrUpdateResponse, error) {
+	result := SharesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Share)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SharesClientCreateOrUpdateResponse will be returned.
-func (p *SharesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SharesClientCreateOrUpdateResponse, error) {
-	respType := SharesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Share)
-	if err != nil {
-		return SharesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SharesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientCreateOrUpdateResponse, error) {
+	result := SharesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Share)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SharesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SharesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SharesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SharesClient, token string) (SharesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return SharesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SharesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -906,36 +1243,52 @@ func (p *SharesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SharesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SharesClientDeletePoller) Poll(ctx context.Context) (SharesClientDeleteResponse, error) {
+	result := SharesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SharesClientDeleteResponse will be returned.
-func (p *SharesClientDeletePoller) FinalResponse(ctx context.Context) (SharesClientDeleteResponse, error) {
-	respType := SharesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SharesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SharesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientDeleteResponse, error) {
+	result := SharesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SharesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SharesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SharesClientDeletePoller) Resume(ctx context.Context, client *SharesClient, token string) (SharesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.Delete", token, client.pl); err != nil {
+		return SharesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SharesClientRefreshPoller provides polling facilities until the operation reaches a terminal state.
@@ -948,36 +1301,52 @@ func (p *SharesClientRefreshPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SharesClientRefreshPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SharesClientRefreshPoller) Poll(ctx context.Context) (SharesClientRefreshResponse, error) {
+	result := SharesClientRefreshResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SharesClientRefreshResponse will be returned.
-func (p *SharesClientRefreshPoller) FinalResponse(ctx context.Context) (SharesClientRefreshResponse, error) {
-	respType := SharesClientRefreshResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SharesClientRefreshResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SharesClientRefreshPoller) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientRefreshResponse, error) {
+	result := SharesClientRefreshResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SharesClientRefreshPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SharesClientRefreshPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SharesClientRefreshPoller) Resume(ctx context.Context, client *SharesClient, token string) (SharesClientRefreshResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.Refresh", token, client.pl); err != nil {
+		return SharesClientRefreshResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // StorageAccountCredentialsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -990,36 +1359,52 @@ func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Poll(ctx context.Context) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
+	result := StorageAccountCredentialsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.StorageAccountCredential)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final StorageAccountCredentialsClientCreateOrUpdateResponse will be returned.
-func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
-	respType := StorageAccountCredentialsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.StorageAccountCredential)
-	if err != nil {
-		return StorageAccountCredentialsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
+	result := StorageAccountCredentialsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.StorageAccountCredential)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a StorageAccountCredentialsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *StorageAccountCredentialsClient, token string) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountCredentialsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return StorageAccountCredentialsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // StorageAccountCredentialsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1032,36 +1417,52 @@ func (p *StorageAccountCredentialsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *StorageAccountCredentialsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *StorageAccountCredentialsClientDeletePoller) Poll(ctx context.Context) (StorageAccountCredentialsClientDeleteResponse, error) {
+	result := StorageAccountCredentialsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final StorageAccountCredentialsClientDeleteResponse will be returned.
-func (p *StorageAccountCredentialsClientDeletePoller) FinalResponse(ctx context.Context) (StorageAccountCredentialsClientDeleteResponse, error) {
-	respType := StorageAccountCredentialsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return StorageAccountCredentialsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *StorageAccountCredentialsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountCredentialsClientDeleteResponse, error) {
+	result := StorageAccountCredentialsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *StorageAccountCredentialsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a StorageAccountCredentialsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *StorageAccountCredentialsClientDeletePoller) Resume(ctx context.Context, client *StorageAccountCredentialsClient, token string) (StorageAccountCredentialsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountCredentialsClient.Delete", token, client.pl); err != nil {
+		return StorageAccountCredentialsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // StorageAccountsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1074,36 +1475,52 @@ func (p *StorageAccountsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *StorageAccountsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *StorageAccountsClientCreateOrUpdatePoller) Poll(ctx context.Context) (StorageAccountsClientCreateOrUpdateResponse, error) {
+	result := StorageAccountsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.StorageAccount)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final StorageAccountsClientCreateOrUpdateResponse will be returned.
-func (p *StorageAccountsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (StorageAccountsClientCreateOrUpdateResponse, error) {
-	respType := StorageAccountsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.StorageAccount)
-	if err != nil {
-		return StorageAccountsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *StorageAccountsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountsClientCreateOrUpdateResponse, error) {
+	result := StorageAccountsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.StorageAccount)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *StorageAccountsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a StorageAccountsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *StorageAccountsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *StorageAccountsClient, token string) (StorageAccountsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return StorageAccountsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // StorageAccountsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1116,36 +1533,52 @@ func (p *StorageAccountsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *StorageAccountsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *StorageAccountsClientDeletePoller) Poll(ctx context.Context) (StorageAccountsClientDeleteResponse, error) {
+	result := StorageAccountsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final StorageAccountsClientDeleteResponse will be returned.
-func (p *StorageAccountsClientDeletePoller) FinalResponse(ctx context.Context) (StorageAccountsClientDeleteResponse, error) {
-	respType := StorageAccountsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return StorageAccountsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *StorageAccountsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountsClientDeleteResponse, error) {
+	result := StorageAccountsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *StorageAccountsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a StorageAccountsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *StorageAccountsClientDeletePoller) Resume(ctx context.Context, client *StorageAccountsClient, token string) (StorageAccountsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountsClient.Delete", token, client.pl); err != nil {
+		return StorageAccountsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SupportPackagesClientTriggerSupportPackagePoller provides polling facilities until the operation reaches a terminal state.
@@ -1158,36 +1591,52 @@ func (p *SupportPackagesClientTriggerSupportPackagePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SupportPackagesClientTriggerSupportPackagePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SupportPackagesClientTriggerSupportPackagePoller) Poll(ctx context.Context) (SupportPackagesClientTriggerSupportPackageResponse, error) {
+	result := SupportPackagesClientTriggerSupportPackageResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SupportPackagesClientTriggerSupportPackageResponse will be returned.
-func (p *SupportPackagesClientTriggerSupportPackagePoller) FinalResponse(ctx context.Context) (SupportPackagesClientTriggerSupportPackageResponse, error) {
-	respType := SupportPackagesClientTriggerSupportPackageResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SupportPackagesClientTriggerSupportPackageResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SupportPackagesClientTriggerSupportPackagePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SupportPackagesClientTriggerSupportPackageResponse, error) {
+	result := SupportPackagesClientTriggerSupportPackageResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SupportPackagesClientTriggerSupportPackagePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SupportPackagesClientTriggerSupportPackagePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SupportPackagesClientTriggerSupportPackagePoller) Resume(ctx context.Context, client *SupportPackagesClient, token string) (SupportPackagesClientTriggerSupportPackageResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SupportPackagesClient.TriggerSupportPackage", token, client.pl); err != nil {
+		return SupportPackagesClientTriggerSupportPackageResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // TriggersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1200,36 +1649,52 @@ func (p *TriggersClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *TriggersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *TriggersClientCreateOrUpdatePoller) Poll(ctx context.Context) (TriggersClientCreateOrUpdateResponse, error) {
+	result := TriggersClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final TriggersClientCreateOrUpdateResponse will be returned.
-func (p *TriggersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (TriggersClientCreateOrUpdateResponse, error) {
-	respType := TriggersClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType)
-	if err != nil {
-		return TriggersClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *TriggersClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersClientCreateOrUpdateResponse, error) {
+	result := TriggersClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *TriggersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a TriggersClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *TriggersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *TriggersClient, token string) (TriggersClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("TriggersClient.CreateOrUpdate", token, client.pl); err != nil {
+		return TriggersClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // TriggersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1242,36 +1707,52 @@ func (p *TriggersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *TriggersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *TriggersClientDeletePoller) Poll(ctx context.Context) (TriggersClientDeleteResponse, error) {
+	result := TriggersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final TriggersClientDeleteResponse will be returned.
-func (p *TriggersClientDeletePoller) FinalResponse(ctx context.Context) (TriggersClientDeleteResponse, error) {
-	respType := TriggersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return TriggersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *TriggersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersClientDeleteResponse, error) {
+	result := TriggersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *TriggersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a TriggersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *TriggersClientDeletePoller) Resume(ctx context.Context, client *TriggersClient, token string) (TriggersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("TriggersClient.Delete", token, client.pl); err != nil {
+		return TriggersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // UsersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1284,36 +1765,52 @@ func (p *UsersClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *UsersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *UsersClientCreateOrUpdatePoller) Poll(ctx context.Context) (UsersClientCreateOrUpdateResponse, error) {
+	result := UsersClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.User)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final UsersClientCreateOrUpdateResponse will be returned.
-func (p *UsersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (UsersClientCreateOrUpdateResponse, error) {
-	respType := UsersClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.User)
-	if err != nil {
-		return UsersClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *UsersClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (UsersClientCreateOrUpdateResponse, error) {
+	result := UsersClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.User)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *UsersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a UsersClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *UsersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *UsersClient, token string) (UsersClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("UsersClient.CreateOrUpdate", token, client.pl); err != nil {
+		return UsersClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // UsersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1326,34 +1823,50 @@ func (p *UsersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *UsersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *UsersClientDeletePoller) Poll(ctx context.Context) (UsersClientDeleteResponse, error) {
+	result := UsersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final UsersClientDeleteResponse will be returned.
-func (p *UsersClientDeletePoller) FinalResponse(ctx context.Context) (UsersClientDeleteResponse, error) {
-	respType := UsersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return UsersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *UsersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (UsersClientDeleteResponse, error) {
+	result := UsersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *UsersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a UsersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *UsersClientDeletePoller) Resume(ctx context.Context, client *UsersClient, token string) (UsersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("UsersClient.Delete", token, client.pl); err != nil {
+		return UsersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pollers.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_pollers.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"net/http"
 	"time"
 )
 
@@ -31,20 +32,19 @@ func (p *AddonsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *AddonsClientCreateOrUpdatePoller) Poll(ctx context.Context) (AddonsClientCreateOrUpdateResponse, error) {
-	result := AddonsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result)
-	return result, err
+func (p *AddonsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *AddonsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp AddonsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -65,12 +65,9 @@ func (p *AddonsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a AddonsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *AddonsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *AddonsClient, token string) (AddonsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("AddonsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return AddonsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *AddonsClientCreateOrUpdatePoller) Resume(token string, client *AddonsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("AddonsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // AddonsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -89,20 +86,19 @@ func (p *AddonsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *AddonsClientDeletePoller) Poll(ctx context.Context) (AddonsClientDeleteResponse, error) {
-	result := AddonsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *AddonsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *AddonsClientDeletePoller) Result(ctx context.Context) (resp AddonsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -123,12 +119,9 @@ func (p *AddonsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a AddonsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *AddonsClientDeletePoller) Resume(ctx context.Context, client *AddonsClient, token string) (AddonsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("AddonsClient.Delete", token, client.pl); err != nil {
-		return AddonsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *AddonsClientDeletePoller) Resume(token string, client *AddonsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("AddonsClient.Delete", token, client.pl)
+	return
 }
 
 // BandwidthSchedulesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -147,20 +140,19 @@ func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
-	result := BandwidthSchedulesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.BandwidthSchedule)
-	return result, err
+func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp BandwidthSchedulesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -181,12 +173,9 @@ func (p *BandwidthSchedulesClientCreateOrUpdatePoller) ResumeToken() (string, er
 
 // Resume rehydrates a BandwidthSchedulesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *BandwidthSchedulesClient, token string) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("BandwidthSchedulesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return BandwidthSchedulesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *BandwidthSchedulesClientCreateOrUpdatePoller) Resume(token string, client *BandwidthSchedulesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("BandwidthSchedulesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // BandwidthSchedulesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -205,20 +194,19 @@ func (p *BandwidthSchedulesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *BandwidthSchedulesClientDeletePoller) Poll(ctx context.Context) (BandwidthSchedulesClientDeleteResponse, error) {
-	result := BandwidthSchedulesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *BandwidthSchedulesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *BandwidthSchedulesClientDeletePoller) Result(ctx context.Context) (resp BandwidthSchedulesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -239,12 +227,9 @@ func (p *BandwidthSchedulesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a BandwidthSchedulesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *BandwidthSchedulesClientDeletePoller) Resume(ctx context.Context, client *BandwidthSchedulesClient, token string) (BandwidthSchedulesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("BandwidthSchedulesClient.Delete", token, client.pl); err != nil {
-		return BandwidthSchedulesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *BandwidthSchedulesClientDeletePoller) Resume(token string, client *BandwidthSchedulesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("BandwidthSchedulesClient.Delete", token, client.pl)
+	return
 }
 
 // ContainersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -263,20 +248,19 @@ func (p *ContainersClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ContainersClientCreateOrUpdatePoller) Poll(ctx context.Context) (ContainersClientCreateOrUpdateResponse, error) {
-	result := ContainersClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Container)
-	return result, err
+func (p *ContainersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ContainersClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ContainersClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -297,12 +281,9 @@ func (p *ContainersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ContainersClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ContainersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ContainersClient, token string) (ContainersClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ContainersClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ContainersClientCreateOrUpdatePoller) Resume(token string, client *ContainersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ContainersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -321,20 +302,19 @@ func (p *ContainersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ContainersClientDeletePoller) Poll(ctx context.Context) (ContainersClientDeleteResponse, error) {
-	result := ContainersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ContainersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ContainersClientDeletePoller) Result(ctx context.Context) (resp ContainersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -355,12 +335,9 @@ func (p *ContainersClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ContainersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ContainersClientDeletePoller) Resume(ctx context.Context, client *ContainersClient, token string) (ContainersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.Delete", token, client.pl); err != nil {
-		return ContainersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ContainersClientDeletePoller) Resume(token string, client *ContainersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.Delete", token, client.pl)
+	return
 }
 
 // ContainersClientRefreshPoller provides polling facilities until the operation reaches a terminal state.
@@ -379,20 +356,19 @@ func (p *ContainersClientRefreshPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ContainersClientRefreshPoller) Poll(ctx context.Context) (ContainersClientRefreshResponse, error) {
-	result := ContainersClientRefreshResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ContainersClientRefreshPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ContainersClientRefreshPoller) Result(ctx context.Context) (resp ContainersClientRefreshResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -413,12 +389,9 @@ func (p *ContainersClientRefreshPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ContainersClientRefreshPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ContainersClientRefreshPoller) Resume(ctx context.Context, client *ContainersClient, token string) (ContainersClientRefreshResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.Refresh", token, client.pl); err != nil {
-		return ContainersClientRefreshResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ContainersClientRefreshPoller) Resume(token string, client *ContainersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ContainersClient.Refresh", token, client.pl)
+	return
 }
 
 // DevicesClientCreateOrUpdateSecuritySettingsPoller provides polling facilities until the operation reaches a terminal state.
@@ -437,20 +410,19 @@ func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Poll(ctx context.Context) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
-	result := DevicesClientCreateOrUpdateSecuritySettingsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Result(ctx context.Context) (resp DevicesClientCreateOrUpdateSecuritySettingsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -471,12 +443,9 @@ func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) ResumeToken() (strin
 
 // Resume rehydrates a DevicesClientCreateOrUpdateSecuritySettingsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.CreateOrUpdateSecuritySettings", token, client.pl); err != nil {
-		return DevicesClientCreateOrUpdateSecuritySettingsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DevicesClientCreateOrUpdateSecuritySettingsPoller) Resume(token string, client *DevicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.CreateOrUpdateSecuritySettings", token, client.pl)
+	return
 }
 
 // DevicesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -495,20 +464,19 @@ func (p *DevicesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DevicesClientDeletePoller) Poll(ctx context.Context) (DevicesClientDeleteResponse, error) {
-	result := DevicesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DevicesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DevicesClientDeletePoller) Result(ctx context.Context) (resp DevicesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -529,12 +497,9 @@ func (p *DevicesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DevicesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DevicesClientDeletePoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.Delete", token, client.pl); err != nil {
-		return DevicesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DevicesClientDeletePoller) Resume(token string, client *DevicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.Delete", token, client.pl)
+	return
 }
 
 // DevicesClientDownloadUpdatesPoller provides polling facilities until the operation reaches a terminal state.
@@ -553,20 +518,19 @@ func (p *DevicesClientDownloadUpdatesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DevicesClientDownloadUpdatesPoller) Poll(ctx context.Context) (DevicesClientDownloadUpdatesResponse, error) {
-	result := DevicesClientDownloadUpdatesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DevicesClientDownloadUpdatesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DevicesClientDownloadUpdatesPoller) Result(ctx context.Context) (resp DevicesClientDownloadUpdatesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -587,12 +551,9 @@ func (p *DevicesClientDownloadUpdatesPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DevicesClientDownloadUpdatesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DevicesClientDownloadUpdatesPoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientDownloadUpdatesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.DownloadUpdates", token, client.pl); err != nil {
-		return DevicesClientDownloadUpdatesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DevicesClientDownloadUpdatesPoller) Resume(token string, client *DevicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.DownloadUpdates", token, client.pl)
+	return
 }
 
 // DevicesClientInstallUpdatesPoller provides polling facilities until the operation reaches a terminal state.
@@ -611,20 +572,19 @@ func (p *DevicesClientInstallUpdatesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DevicesClientInstallUpdatesPoller) Poll(ctx context.Context) (DevicesClientInstallUpdatesResponse, error) {
-	result := DevicesClientInstallUpdatesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DevicesClientInstallUpdatesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DevicesClientInstallUpdatesPoller) Result(ctx context.Context) (resp DevicesClientInstallUpdatesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -645,12 +605,9 @@ func (p *DevicesClientInstallUpdatesPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DevicesClientInstallUpdatesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DevicesClientInstallUpdatesPoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientInstallUpdatesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.InstallUpdates", token, client.pl); err != nil {
-		return DevicesClientInstallUpdatesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DevicesClientInstallUpdatesPoller) Resume(token string, client *DevicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.InstallUpdates", token, client.pl)
+	return
 }
 
 // DevicesClientScanForUpdatesPoller provides polling facilities until the operation reaches a terminal state.
@@ -669,20 +626,19 @@ func (p *DevicesClientScanForUpdatesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DevicesClientScanForUpdatesPoller) Poll(ctx context.Context) (DevicesClientScanForUpdatesResponse, error) {
-	result := DevicesClientScanForUpdatesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DevicesClientScanForUpdatesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DevicesClientScanForUpdatesPoller) Result(ctx context.Context) (resp DevicesClientScanForUpdatesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -703,12 +659,9 @@ func (p *DevicesClientScanForUpdatesPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DevicesClientScanForUpdatesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DevicesClientScanForUpdatesPoller) Resume(ctx context.Context, client *DevicesClient, token string) (DevicesClientScanForUpdatesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.ScanForUpdates", token, client.pl); err != nil {
-		return DevicesClientScanForUpdatesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DevicesClientScanForUpdatesPoller) Resume(token string, client *DevicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DevicesClient.ScanForUpdates", token, client.pl)
+	return
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller provides polling facilities until the operation reaches a terminal state.
@@ -727,20 +680,19 @@ func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsP
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) Poll(ctx context.Context) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
-	result := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) Result(ctx context.Context) (resp DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -761,12 +713,9 @@ func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsP
 
 // Resume rehydrates a DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) Resume(ctx context.Context, client *DiagnosticSettingsClient, token string) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings", token, client.pl); err != nil {
-		return DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller) Resume(token string, client *DiagnosticSettingsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings", token, client.pl)
+	return
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller provides polling facilities until the operation reaches a terminal state.
@@ -785,20 +734,19 @@ func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Do
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Poll(ctx context.Context) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
-	result := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Result(ctx context.Context) (resp DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -819,12 +767,9 @@ func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Re
 
 // Resume rehydrates a DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Resume(ctx context.Context, client *DiagnosticSettingsClient, token string) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings", token, client.pl); err != nil {
-		return DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller) Resume(token string, client *DiagnosticSettingsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings", token, client.pl)
+	return
 }
 
 // MonitoringConfigClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -843,20 +788,19 @@ func (p *MonitoringConfigClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *MonitoringConfigClientCreateOrUpdatePoller) Poll(ctx context.Context) (MonitoringConfigClientCreateOrUpdateResponse, error) {
-	result := MonitoringConfigClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.MonitoringMetricConfiguration)
-	return result, err
+func (p *MonitoringConfigClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *MonitoringConfigClientCreateOrUpdatePoller) Result(ctx context.Context) (resp MonitoringConfigClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -877,12 +821,9 @@ func (p *MonitoringConfigClientCreateOrUpdatePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a MonitoringConfigClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *MonitoringConfigClientCreateOrUpdatePoller) Resume(ctx context.Context, client *MonitoringConfigClient, token string) (MonitoringConfigClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("MonitoringConfigClient.CreateOrUpdate", token, client.pl); err != nil {
-		return MonitoringConfigClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *MonitoringConfigClientCreateOrUpdatePoller) Resume(token string, client *MonitoringConfigClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("MonitoringConfigClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // MonitoringConfigClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -901,20 +842,19 @@ func (p *MonitoringConfigClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *MonitoringConfigClientDeletePoller) Poll(ctx context.Context) (MonitoringConfigClientDeleteResponse, error) {
-	result := MonitoringConfigClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *MonitoringConfigClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *MonitoringConfigClientDeletePoller) Result(ctx context.Context) (resp MonitoringConfigClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -935,12 +875,9 @@ func (p *MonitoringConfigClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a MonitoringConfigClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *MonitoringConfigClientDeletePoller) Resume(ctx context.Context, client *MonitoringConfigClient, token string) (MonitoringConfigClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("MonitoringConfigClient.Delete", token, client.pl); err != nil {
-		return MonitoringConfigClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *MonitoringConfigClientDeletePoller) Resume(token string, client *MonitoringConfigClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("MonitoringConfigClient.Delete", token, client.pl)
+	return
 }
 
 // OrdersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -959,20 +896,19 @@ func (p *OrdersClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *OrdersClientCreateOrUpdatePoller) Poll(ctx context.Context) (OrdersClientCreateOrUpdateResponse, error) {
-	result := OrdersClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Order)
-	return result, err
+func (p *OrdersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *OrdersClientCreateOrUpdatePoller) Result(ctx context.Context) (resp OrdersClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -993,12 +929,9 @@ func (p *OrdersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a OrdersClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *OrdersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *OrdersClient, token string) (OrdersClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("OrdersClient.CreateOrUpdate", token, client.pl); err != nil {
-		return OrdersClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *OrdersClientCreateOrUpdatePoller) Resume(token string, client *OrdersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("OrdersClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // OrdersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1017,20 +950,19 @@ func (p *OrdersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *OrdersClientDeletePoller) Poll(ctx context.Context) (OrdersClientDeleteResponse, error) {
-	result := OrdersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *OrdersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *OrdersClientDeletePoller) Result(ctx context.Context) (resp OrdersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1051,12 +983,9 @@ func (p *OrdersClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a OrdersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *OrdersClientDeletePoller) Resume(ctx context.Context, client *OrdersClient, token string) (OrdersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("OrdersClient.Delete", token, client.pl); err != nil {
-		return OrdersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *OrdersClientDeletePoller) Resume(token string, client *OrdersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("OrdersClient.Delete", token, client.pl)
+	return
 }
 
 // RolesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1075,20 +1004,19 @@ func (p *RolesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RolesClientCreateOrUpdatePoller) Poll(ctx context.Context) (RolesClientCreateOrUpdateResponse, error) {
-	result := RolesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result)
-	return result, err
+func (p *RolesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RolesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp RolesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1109,12 +1037,9 @@ func (p *RolesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RolesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RolesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RolesClient, token string) (RolesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RolesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return RolesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RolesClientCreateOrUpdatePoller) Resume(token string, client *RolesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RolesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // RolesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1133,20 +1058,19 @@ func (p *RolesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RolesClientDeletePoller) Poll(ctx context.Context) (RolesClientDeleteResponse, error) {
-	result := RolesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *RolesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RolesClientDeletePoller) Result(ctx context.Context) (resp RolesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1167,12 +1091,9 @@ func (p *RolesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RolesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RolesClientDeletePoller) Resume(ctx context.Context, client *RolesClient, token string) (RolesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RolesClient.Delete", token, client.pl); err != nil {
-		return RolesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RolesClientDeletePoller) Resume(token string, client *RolesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RolesClient.Delete", token, client.pl)
+	return
 }
 
 // SharesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1191,20 +1112,19 @@ func (p *SharesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SharesClientCreateOrUpdatePoller) Poll(ctx context.Context) (SharesClientCreateOrUpdateResponse, error) {
-	result := SharesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Share)
-	return result, err
+func (p *SharesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SharesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp SharesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1225,12 +1145,9 @@ func (p *SharesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SharesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SharesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SharesClient, token string) (SharesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return SharesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SharesClientCreateOrUpdatePoller) Resume(token string, client *SharesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // SharesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1249,20 +1166,19 @@ func (p *SharesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SharesClientDeletePoller) Poll(ctx context.Context) (SharesClientDeleteResponse, error) {
-	result := SharesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SharesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SharesClientDeletePoller) Result(ctx context.Context) (resp SharesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1283,12 +1199,9 @@ func (p *SharesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SharesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SharesClientDeletePoller) Resume(ctx context.Context, client *SharesClient, token string) (SharesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.Delete", token, client.pl); err != nil {
-		return SharesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SharesClientDeletePoller) Resume(token string, client *SharesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.Delete", token, client.pl)
+	return
 }
 
 // SharesClientRefreshPoller provides polling facilities until the operation reaches a terminal state.
@@ -1307,20 +1220,19 @@ func (p *SharesClientRefreshPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SharesClientRefreshPoller) Poll(ctx context.Context) (SharesClientRefreshResponse, error) {
-	result := SharesClientRefreshResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SharesClientRefreshPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SharesClientRefreshPoller) Result(ctx context.Context) (resp SharesClientRefreshResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1341,12 +1253,9 @@ func (p *SharesClientRefreshPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SharesClientRefreshPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SharesClientRefreshPoller) Resume(ctx context.Context, client *SharesClient, token string) (SharesClientRefreshResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.Refresh", token, client.pl); err != nil {
-		return SharesClientRefreshResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SharesClientRefreshPoller) Resume(token string, client *SharesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SharesClient.Refresh", token, client.pl)
+	return
 }
 
 // StorageAccountCredentialsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1365,20 +1274,19 @@ func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Poll(ctx context.Context) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
-	result := StorageAccountCredentialsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.StorageAccountCredential)
-	return result, err
+func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp StorageAccountCredentialsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1399,12 +1307,9 @@ func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) ResumeToken() (str
 
 // Resume rehydrates a StorageAccountCredentialsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *StorageAccountCredentialsClient, token string) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountCredentialsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return StorageAccountCredentialsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *StorageAccountCredentialsClientCreateOrUpdatePoller) Resume(token string, client *StorageAccountCredentialsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountCredentialsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // StorageAccountCredentialsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1423,20 +1328,19 @@ func (p *StorageAccountCredentialsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *StorageAccountCredentialsClientDeletePoller) Poll(ctx context.Context) (StorageAccountCredentialsClientDeleteResponse, error) {
-	result := StorageAccountCredentialsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *StorageAccountCredentialsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *StorageAccountCredentialsClientDeletePoller) Result(ctx context.Context) (resp StorageAccountCredentialsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1457,12 +1361,9 @@ func (p *StorageAccountCredentialsClientDeletePoller) ResumeToken() (string, err
 
 // Resume rehydrates a StorageAccountCredentialsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *StorageAccountCredentialsClientDeletePoller) Resume(ctx context.Context, client *StorageAccountCredentialsClient, token string) (StorageAccountCredentialsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountCredentialsClient.Delete", token, client.pl); err != nil {
-		return StorageAccountCredentialsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *StorageAccountCredentialsClientDeletePoller) Resume(token string, client *StorageAccountCredentialsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountCredentialsClient.Delete", token, client.pl)
+	return
 }
 
 // StorageAccountsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1481,20 +1382,19 @@ func (p *StorageAccountsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *StorageAccountsClientCreateOrUpdatePoller) Poll(ctx context.Context) (StorageAccountsClientCreateOrUpdateResponse, error) {
-	result := StorageAccountsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.StorageAccount)
-	return result, err
+func (p *StorageAccountsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *StorageAccountsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp StorageAccountsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1515,12 +1415,9 @@ func (p *StorageAccountsClientCreateOrUpdatePoller) ResumeToken() (string, error
 
 // Resume rehydrates a StorageAccountsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *StorageAccountsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *StorageAccountsClient, token string) (StorageAccountsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return StorageAccountsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *StorageAccountsClientCreateOrUpdatePoller) Resume(token string, client *StorageAccountsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // StorageAccountsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1539,20 +1436,19 @@ func (p *StorageAccountsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *StorageAccountsClientDeletePoller) Poll(ctx context.Context) (StorageAccountsClientDeleteResponse, error) {
-	result := StorageAccountsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *StorageAccountsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *StorageAccountsClientDeletePoller) Result(ctx context.Context) (resp StorageAccountsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1573,12 +1469,9 @@ func (p *StorageAccountsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a StorageAccountsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *StorageAccountsClientDeletePoller) Resume(ctx context.Context, client *StorageAccountsClient, token string) (StorageAccountsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountsClient.Delete", token, client.pl); err != nil {
-		return StorageAccountsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *StorageAccountsClientDeletePoller) Resume(token string, client *StorageAccountsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("StorageAccountsClient.Delete", token, client.pl)
+	return
 }
 
 // SupportPackagesClientTriggerSupportPackagePoller provides polling facilities until the operation reaches a terminal state.
@@ -1597,20 +1490,19 @@ func (p *SupportPackagesClientTriggerSupportPackagePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SupportPackagesClientTriggerSupportPackagePoller) Poll(ctx context.Context) (SupportPackagesClientTriggerSupportPackageResponse, error) {
-	result := SupportPackagesClientTriggerSupportPackageResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SupportPackagesClientTriggerSupportPackagePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SupportPackagesClientTriggerSupportPackagePoller) Result(ctx context.Context) (resp SupportPackagesClientTriggerSupportPackageResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1631,12 +1523,9 @@ func (p *SupportPackagesClientTriggerSupportPackagePoller) ResumeToken() (string
 
 // Resume rehydrates a SupportPackagesClientTriggerSupportPackagePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SupportPackagesClientTriggerSupportPackagePoller) Resume(ctx context.Context, client *SupportPackagesClient, token string) (SupportPackagesClientTriggerSupportPackageResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SupportPackagesClient.TriggerSupportPackage", token, client.pl); err != nil {
-		return SupportPackagesClientTriggerSupportPackageResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SupportPackagesClientTriggerSupportPackagePoller) Resume(token string, client *SupportPackagesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SupportPackagesClient.TriggerSupportPackage", token, client.pl)
+	return
 }
 
 // TriggersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1655,20 +1544,19 @@ func (p *TriggersClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *TriggersClientCreateOrUpdatePoller) Poll(ctx context.Context) (TriggersClientCreateOrUpdateResponse, error) {
-	result := TriggersClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result)
-	return result, err
+func (p *TriggersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *TriggersClientCreateOrUpdatePoller) Result(ctx context.Context) (resp TriggersClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1689,12 +1577,9 @@ func (p *TriggersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a TriggersClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *TriggersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *TriggersClient, token string) (TriggersClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("TriggersClient.CreateOrUpdate", token, client.pl); err != nil {
-		return TriggersClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *TriggersClientCreateOrUpdatePoller) Resume(token string, client *TriggersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("TriggersClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // TriggersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1713,20 +1598,19 @@ func (p *TriggersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *TriggersClientDeletePoller) Poll(ctx context.Context) (TriggersClientDeleteResponse, error) {
-	result := TriggersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *TriggersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *TriggersClientDeletePoller) Result(ctx context.Context) (resp TriggersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1747,12 +1631,9 @@ func (p *TriggersClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a TriggersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *TriggersClientDeletePoller) Resume(ctx context.Context, client *TriggersClient, token string) (TriggersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("TriggersClient.Delete", token, client.pl); err != nil {
-		return TriggersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *TriggersClientDeletePoller) Resume(token string, client *TriggersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("TriggersClient.Delete", token, client.pl)
+	return
 }
 
 // UsersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1771,20 +1652,19 @@ func (p *UsersClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *UsersClientCreateOrUpdatePoller) Poll(ctx context.Context) (UsersClientCreateOrUpdateResponse, error) {
-	result := UsersClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.User)
-	return result, err
+func (p *UsersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *UsersClientCreateOrUpdatePoller) Result(ctx context.Context) (resp UsersClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1805,12 +1685,9 @@ func (p *UsersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a UsersClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *UsersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *UsersClient, token string) (UsersClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("UsersClient.CreateOrUpdate", token, client.pl); err != nil {
-		return UsersClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *UsersClientCreateOrUpdatePoller) Resume(token string, client *UsersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("UsersClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // UsersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1829,20 +1706,19 @@ func (p *UsersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *UsersClientDeletePoller) Poll(ctx context.Context) (UsersClientDeleteResponse, error) {
-	result := UsersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *UsersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *UsersClientDeletePoller) Result(ctx context.Context) (resp UsersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1863,10 +1739,7 @@ func (p *UsersClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a UsersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *UsersClientDeletePoller) Resume(ctx context.Context, client *UsersClient, token string) (UsersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("UsersClient.Delete", token, client.pl); err != nil {
-		return UsersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *UsersClientDeletePoller) Resume(token string, client *UsersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("UsersClient.Delete", token, client.pl)
+	return
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_response_types.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_response_types.go
@@ -8,47 +8,6 @@
 
 package armdataboxedge
 
-import (
-	"context"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"time"
-)
-
-// AddonsClientCreateOrUpdatePollerResponse contains the response from method AddonsClient.CreateOrUpdate.
-type AddonsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *AddonsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l AddonsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsClientCreateOrUpdateResponse, error) {
-	respType := AddonsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a AddonsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *AddonsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *AddonsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("AddonsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &AddonsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // AddonsClientCreateOrUpdateResponse contains the response from method AddonsClient.CreateOrUpdate.
 type AddonsClientCreateOrUpdateResponse struct {
 	AddonClassification
@@ -61,41 +20,6 @@ func (a *AddonsClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	a.AddonClassification = res
-	return nil
-}
-
-// AddonsClientDeletePollerResponse contains the response from method AddonsClient.Delete.
-type AddonsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *AddonsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l AddonsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AddonsClientDeleteResponse, error) {
-	respType := AddonsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a AddonsClientDeletePollerResponse from the provided client and resume token.
-func (l *AddonsClientDeletePollerResponse) Resume(ctx context.Context, client *AddonsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("AddonsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &AddonsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
 	return nil
 }
 
@@ -139,79 +63,9 @@ type AvailableSKUsClientListResponse struct {
 	SKUList
 }
 
-// BandwidthSchedulesClientCreateOrUpdatePollerResponse contains the response from method BandwidthSchedulesClient.CreateOrUpdate.
-type BandwidthSchedulesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *BandwidthSchedulesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l BandwidthSchedulesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BandwidthSchedulesClientCreateOrUpdateResponse, error) {
-	respType := BandwidthSchedulesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BandwidthSchedule)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a BandwidthSchedulesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *BandwidthSchedulesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *BandwidthSchedulesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("BandwidthSchedulesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &BandwidthSchedulesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // BandwidthSchedulesClientCreateOrUpdateResponse contains the response from method BandwidthSchedulesClient.CreateOrUpdate.
 type BandwidthSchedulesClientCreateOrUpdateResponse struct {
 	BandwidthSchedule
-}
-
-// BandwidthSchedulesClientDeletePollerResponse contains the response from method BandwidthSchedulesClient.Delete.
-type BandwidthSchedulesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *BandwidthSchedulesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l BandwidthSchedulesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BandwidthSchedulesClientDeleteResponse, error) {
-	respType := BandwidthSchedulesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a BandwidthSchedulesClientDeletePollerResponse from the provided client and resume token.
-func (l *BandwidthSchedulesClientDeletePollerResponse) Resume(ctx context.Context, client *BandwidthSchedulesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("BandwidthSchedulesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &BandwidthSchedulesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // BandwidthSchedulesClientDeleteResponse contains the response from method BandwidthSchedulesClient.Delete.
@@ -229,79 +83,9 @@ type BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse struct {
 	BandwidthSchedulesList
 }
 
-// ContainersClientCreateOrUpdatePollerResponse contains the response from method ContainersClient.CreateOrUpdate.
-type ContainersClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ContainersClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ContainersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientCreateOrUpdateResponse, error) {
-	respType := ContainersClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Container)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ContainersClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ContainersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ContainersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ContainersClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ContainersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ContainersClientCreateOrUpdateResponse contains the response from method ContainersClient.CreateOrUpdate.
 type ContainersClientCreateOrUpdateResponse struct {
 	Container
-}
-
-// ContainersClientDeletePollerResponse contains the response from method ContainersClient.Delete.
-type ContainersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ContainersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ContainersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientDeleteResponse, error) {
-	respType := ContainersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ContainersClientDeletePollerResponse from the provided client and resume token.
-func (l *ContainersClientDeletePollerResponse) Resume(ctx context.Context, client *ContainersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ContainersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ContainersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ContainersClientDeleteResponse contains the response from method ContainersClient.Delete.
@@ -319,41 +103,6 @@ type ContainersClientListByStorageAccountResponse struct {
 	ContainerList
 }
 
-// ContainersClientRefreshPollerResponse contains the response from method ContainersClient.Refresh.
-type ContainersClientRefreshPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ContainersClientRefreshPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ContainersClientRefreshPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ContainersClientRefreshResponse, error) {
-	respType := ContainersClientRefreshResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ContainersClientRefreshPollerResponse from the provided client and resume token.
-func (l *ContainersClientRefreshPollerResponse) Resume(ctx context.Context, client *ContainersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ContainersClient.Refresh", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ContainersClientRefreshPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ContainersClientRefreshResponse contains the response from method ContainersClient.Refresh.
 type ContainersClientRefreshResponse struct {
 	// placeholder for future response values
@@ -364,119 +113,14 @@ type DevicesClientCreateOrUpdateResponse struct {
 	Device
 }
 
-// DevicesClientCreateOrUpdateSecuritySettingsPollerResponse contains the response from method DevicesClient.CreateOrUpdateSecuritySettings.
-type DevicesClientCreateOrUpdateSecuritySettingsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DevicesClientCreateOrUpdateSecuritySettingsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DevicesClientCreateOrUpdateSecuritySettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientCreateOrUpdateSecuritySettingsResponse, error) {
-	respType := DevicesClientCreateOrUpdateSecuritySettingsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DevicesClientCreateOrUpdateSecuritySettingsPollerResponse from the provided client and resume token.
-func (l *DevicesClientCreateOrUpdateSecuritySettingsPollerResponse) Resume(ctx context.Context, client *DevicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DevicesClient.CreateOrUpdateSecuritySettings", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DevicesClientCreateOrUpdateSecuritySettingsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DevicesClientCreateOrUpdateSecuritySettingsResponse contains the response from method DevicesClient.CreateOrUpdateSecuritySettings.
 type DevicesClientCreateOrUpdateSecuritySettingsResponse struct {
 	// placeholder for future response values
 }
 
-// DevicesClientDeletePollerResponse contains the response from method DevicesClient.Delete.
-type DevicesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DevicesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DevicesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientDeleteResponse, error) {
-	respType := DevicesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DevicesClientDeletePollerResponse from the provided client and resume token.
-func (l *DevicesClientDeletePollerResponse) Resume(ctx context.Context, client *DevicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DevicesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DevicesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DevicesClientDeleteResponse contains the response from method DevicesClient.Delete.
 type DevicesClientDeleteResponse struct {
 	// placeholder for future response values
-}
-
-// DevicesClientDownloadUpdatesPollerResponse contains the response from method DevicesClient.DownloadUpdates.
-type DevicesClientDownloadUpdatesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DevicesClientDownloadUpdatesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DevicesClientDownloadUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientDownloadUpdatesResponse, error) {
-	respType := DevicesClientDownloadUpdatesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DevicesClientDownloadUpdatesPollerResponse from the provided client and resume token.
-func (l *DevicesClientDownloadUpdatesPollerResponse) Resume(ctx context.Context, client *DevicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DevicesClient.DownloadUpdates", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DevicesClientDownloadUpdatesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DevicesClientDownloadUpdatesResponse contains the response from method DevicesClient.DownloadUpdates.
@@ -509,41 +153,6 @@ type DevicesClientGetUpdateSummaryResponse struct {
 	UpdateSummary
 }
 
-// DevicesClientInstallUpdatesPollerResponse contains the response from method DevicesClient.InstallUpdates.
-type DevicesClientInstallUpdatesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DevicesClientInstallUpdatesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DevicesClientInstallUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientInstallUpdatesResponse, error) {
-	respType := DevicesClientInstallUpdatesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DevicesClientInstallUpdatesPollerResponse from the provided client and resume token.
-func (l *DevicesClientInstallUpdatesPollerResponse) Resume(ctx context.Context, client *DevicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DevicesClient.InstallUpdates", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DevicesClientInstallUpdatesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DevicesClientInstallUpdatesResponse contains the response from method DevicesClient.InstallUpdates.
 type DevicesClientInstallUpdatesResponse struct {
 	// placeholder for future response values
@@ -557,41 +166,6 @@ type DevicesClientListByResourceGroupResponse struct {
 // DevicesClientListBySubscriptionResponse contains the response from method DevicesClient.ListBySubscription.
 type DevicesClientListBySubscriptionResponse struct {
 	DeviceList
-}
-
-// DevicesClientScanForUpdatesPollerResponse contains the response from method DevicesClient.ScanForUpdates.
-type DevicesClientScanForUpdatesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DevicesClientScanForUpdatesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DevicesClientScanForUpdatesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DevicesClientScanForUpdatesResponse, error) {
-	respType := DevicesClientScanForUpdatesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DevicesClientScanForUpdatesPollerResponse from the provided client and resume token.
-func (l *DevicesClientScanForUpdatesPollerResponse) Resume(ctx context.Context, client *DevicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DevicesClient.ScanForUpdates", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DevicesClientScanForUpdatesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DevicesClientScanForUpdatesResponse contains the response from method DevicesClient.ScanForUpdates.
@@ -624,82 +198,9 @@ type DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse struct {
 	DiagnosticRemoteSupportSettings
 }
 
-// DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse contains the response from method
-// DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings.
-type DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse, error) {
-	respType := DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse from the provided
-// client and resume token.
-func (l *DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPollerResponse) Resume(ctx context.Context, client *DiagnosticSettingsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse contains the response from method DiagnosticSettingsClient.UpdateDiagnosticProactiveLogCollectionSettings.
 type DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse struct {
 	// placeholder for future response values
-}
-
-// DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse contains the response from method DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings.
-type DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse, error) {
-	respType := DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse from the provided client
-// and resume token.
-func (l *DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPollerResponse) Resume(ctx context.Context, client *DiagnosticSettingsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse contains the response from method DiagnosticSettingsClient.UpdateDiagnosticRemoteSupportSettings.
@@ -712,79 +213,9 @@ type JobsClientGetResponse struct {
 	Job
 }
 
-// MonitoringConfigClientCreateOrUpdatePollerResponse contains the response from method MonitoringConfigClient.CreateOrUpdate.
-type MonitoringConfigClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *MonitoringConfigClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l MonitoringConfigClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (MonitoringConfigClientCreateOrUpdateResponse, error) {
-	respType := MonitoringConfigClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.MonitoringMetricConfiguration)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a MonitoringConfigClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *MonitoringConfigClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *MonitoringConfigClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("MonitoringConfigClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &MonitoringConfigClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // MonitoringConfigClientCreateOrUpdateResponse contains the response from method MonitoringConfigClient.CreateOrUpdate.
 type MonitoringConfigClientCreateOrUpdateResponse struct {
 	MonitoringMetricConfiguration
-}
-
-// MonitoringConfigClientDeletePollerResponse contains the response from method MonitoringConfigClient.Delete.
-type MonitoringConfigClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *MonitoringConfigClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l MonitoringConfigClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (MonitoringConfigClientDeleteResponse, error) {
-	respType := MonitoringConfigClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a MonitoringConfigClientDeletePollerResponse from the provided client and resume token.
-func (l *MonitoringConfigClientDeletePollerResponse) Resume(ctx context.Context, client *MonitoringConfigClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("MonitoringConfigClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &MonitoringConfigClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // MonitoringConfigClientDeleteResponse contains the response from method MonitoringConfigClient.Delete.
@@ -817,79 +248,9 @@ type OperationsStatusClientGetResponse struct {
 	Job
 }
 
-// OrdersClientCreateOrUpdatePollerResponse contains the response from method OrdersClient.CreateOrUpdate.
-type OrdersClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *OrdersClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l OrdersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (OrdersClientCreateOrUpdateResponse, error) {
-	respType := OrdersClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Order)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a OrdersClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *OrdersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *OrdersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("OrdersClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &OrdersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // OrdersClientCreateOrUpdateResponse contains the response from method OrdersClient.CreateOrUpdate.
 type OrdersClientCreateOrUpdateResponse struct {
 	Order
-}
-
-// OrdersClientDeletePollerResponse contains the response from method OrdersClient.Delete.
-type OrdersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *OrdersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l OrdersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (OrdersClientDeleteResponse, error) {
-	respType := OrdersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a OrdersClientDeletePollerResponse from the provided client and resume token.
-func (l *OrdersClientDeletePollerResponse) Resume(ctx context.Context, client *OrdersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("OrdersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &OrdersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // OrdersClientDeleteResponse contains the response from method OrdersClient.Delete.
@@ -912,41 +273,6 @@ type OrdersClientListDCAccessCodeResponse struct {
 	DCAccessCode
 }
 
-// RolesClientCreateOrUpdatePollerResponse contains the response from method RolesClient.CreateOrUpdate.
-type RolesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RolesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RolesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RolesClientCreateOrUpdateResponse, error) {
-	respType := RolesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RolesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *RolesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *RolesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RolesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RolesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // RolesClientCreateOrUpdateResponse contains the response from method RolesClient.CreateOrUpdate.
 type RolesClientCreateOrUpdateResponse struct {
 	RoleClassification
@@ -959,41 +285,6 @@ func (r *RolesClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	r.RoleClassification = res
-	return nil
-}
-
-// RolesClientDeletePollerResponse contains the response from method RolesClient.Delete.
-type RolesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RolesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RolesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RolesClientDeleteResponse, error) {
-	respType := RolesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RolesClientDeletePollerResponse from the provided client and resume token.
-func (l *RolesClientDeletePollerResponse) Resume(ctx context.Context, client *RolesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RolesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RolesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
 	return nil
 }
 
@@ -1022,79 +313,9 @@ type RolesClientListByDataBoxEdgeDeviceResponse struct {
 	RoleList
 }
 
-// SharesClientCreateOrUpdatePollerResponse contains the response from method SharesClient.CreateOrUpdate.
-type SharesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SharesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SharesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientCreateOrUpdateResponse, error) {
-	respType := SharesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Share)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SharesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *SharesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *SharesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SharesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SharesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SharesClientCreateOrUpdateResponse contains the response from method SharesClient.CreateOrUpdate.
 type SharesClientCreateOrUpdateResponse struct {
 	Share
-}
-
-// SharesClientDeletePollerResponse contains the response from method SharesClient.Delete.
-type SharesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SharesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SharesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientDeleteResponse, error) {
-	respType := SharesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SharesClientDeletePollerResponse from the provided client and resume token.
-func (l *SharesClientDeletePollerResponse) Resume(ctx context.Context, client *SharesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SharesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SharesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SharesClientDeleteResponse contains the response from method SharesClient.Delete.
@@ -1112,119 +333,14 @@ type SharesClientListByDataBoxEdgeDeviceResponse struct {
 	ShareList
 }
 
-// SharesClientRefreshPollerResponse contains the response from method SharesClient.Refresh.
-type SharesClientRefreshPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SharesClientRefreshPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SharesClientRefreshPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SharesClientRefreshResponse, error) {
-	respType := SharesClientRefreshResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SharesClientRefreshPollerResponse from the provided client and resume token.
-func (l *SharesClientRefreshPollerResponse) Resume(ctx context.Context, client *SharesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SharesClient.Refresh", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SharesClientRefreshPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SharesClientRefreshResponse contains the response from method SharesClient.Refresh.
 type SharesClientRefreshResponse struct {
 	// placeholder for future response values
 }
 
-// StorageAccountCredentialsClientCreateOrUpdatePollerResponse contains the response from method StorageAccountCredentialsClient.CreateOrUpdate.
-type StorageAccountCredentialsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *StorageAccountCredentialsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l StorageAccountCredentialsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountCredentialsClientCreateOrUpdateResponse, error) {
-	respType := StorageAccountCredentialsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.StorageAccountCredential)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a StorageAccountCredentialsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *StorageAccountCredentialsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *StorageAccountCredentialsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("StorageAccountCredentialsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &StorageAccountCredentialsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // StorageAccountCredentialsClientCreateOrUpdateResponse contains the response from method StorageAccountCredentialsClient.CreateOrUpdate.
 type StorageAccountCredentialsClientCreateOrUpdateResponse struct {
 	StorageAccountCredential
-}
-
-// StorageAccountCredentialsClientDeletePollerResponse contains the response from method StorageAccountCredentialsClient.Delete.
-type StorageAccountCredentialsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *StorageAccountCredentialsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l StorageAccountCredentialsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountCredentialsClientDeleteResponse, error) {
-	respType := StorageAccountCredentialsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a StorageAccountCredentialsClientDeletePollerResponse from the provided client and resume token.
-func (l *StorageAccountCredentialsClientDeletePollerResponse) Resume(ctx context.Context, client *StorageAccountCredentialsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("StorageAccountCredentialsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &StorageAccountCredentialsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // StorageAccountCredentialsClientDeleteResponse contains the response from method StorageAccountCredentialsClient.Delete.
@@ -1242,79 +358,9 @@ type StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse struct {
 	StorageAccountCredentialList
 }
 
-// StorageAccountsClientCreateOrUpdatePollerResponse contains the response from method StorageAccountsClient.CreateOrUpdate.
-type StorageAccountsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *StorageAccountsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l StorageAccountsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountsClientCreateOrUpdateResponse, error) {
-	respType := StorageAccountsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.StorageAccount)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a StorageAccountsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *StorageAccountsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *StorageAccountsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("StorageAccountsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &StorageAccountsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // StorageAccountsClientCreateOrUpdateResponse contains the response from method StorageAccountsClient.CreateOrUpdate.
 type StorageAccountsClientCreateOrUpdateResponse struct {
 	StorageAccount
-}
-
-// StorageAccountsClientDeletePollerResponse contains the response from method StorageAccountsClient.Delete.
-type StorageAccountsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *StorageAccountsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l StorageAccountsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (StorageAccountsClientDeleteResponse, error) {
-	respType := StorageAccountsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a StorageAccountsClientDeletePollerResponse from the provided client and resume token.
-func (l *StorageAccountsClientDeletePollerResponse) Resume(ctx context.Context, client *StorageAccountsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("StorageAccountsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &StorageAccountsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // StorageAccountsClientDeleteResponse contains the response from method StorageAccountsClient.Delete.
@@ -1332,79 +378,9 @@ type StorageAccountsClientListByDataBoxEdgeDeviceResponse struct {
 	StorageAccountList
 }
 
-// SupportPackagesClientTriggerSupportPackagePollerResponse contains the response from method SupportPackagesClient.TriggerSupportPackage.
-type SupportPackagesClientTriggerSupportPackagePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SupportPackagesClientTriggerSupportPackagePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SupportPackagesClientTriggerSupportPackagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SupportPackagesClientTriggerSupportPackageResponse, error) {
-	respType := SupportPackagesClientTriggerSupportPackageResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SupportPackagesClientTriggerSupportPackagePollerResponse from the provided client and resume token.
-func (l *SupportPackagesClientTriggerSupportPackagePollerResponse) Resume(ctx context.Context, client *SupportPackagesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SupportPackagesClient.TriggerSupportPackage", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SupportPackagesClientTriggerSupportPackagePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SupportPackagesClientTriggerSupportPackageResponse contains the response from method SupportPackagesClient.TriggerSupportPackage.
 type SupportPackagesClientTriggerSupportPackageResponse struct {
 	// placeholder for future response values
-}
-
-// TriggersClientCreateOrUpdatePollerResponse contains the response from method TriggersClient.CreateOrUpdate.
-type TriggersClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *TriggersClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l TriggersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersClientCreateOrUpdateResponse, error) {
-	respType := TriggersClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a TriggersClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *TriggersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *TriggersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("TriggersClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &TriggersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // TriggersClientCreateOrUpdateResponse contains the response from method TriggersClient.CreateOrUpdate.
@@ -1419,41 +395,6 @@ func (t *TriggersClientCreateOrUpdateResponse) UnmarshalJSON(data []byte) error 
 		return err
 	}
 	t.TriggerClassification = res
-	return nil
-}
-
-// TriggersClientDeletePollerResponse contains the response from method TriggersClient.Delete.
-type TriggersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *TriggersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l TriggersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (TriggersClientDeleteResponse, error) {
-	respType := TriggersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a TriggersClientDeletePollerResponse from the provided client and resume token.
-func (l *TriggersClientDeletePollerResponse) Resume(ctx context.Context, client *TriggersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("TriggersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &TriggersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
 	return nil
 }
 
@@ -1482,79 +423,9 @@ type TriggersClientListByDataBoxEdgeDeviceResponse struct {
 	TriggerList
 }
 
-// UsersClientCreateOrUpdatePollerResponse contains the response from method UsersClient.CreateOrUpdate.
-type UsersClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *UsersClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l UsersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (UsersClientCreateOrUpdateResponse, error) {
-	respType := UsersClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.User)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a UsersClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *UsersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *UsersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("UsersClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &UsersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // UsersClientCreateOrUpdateResponse contains the response from method UsersClient.CreateOrUpdate.
 type UsersClientCreateOrUpdateResponse struct {
 	User
-}
-
-// UsersClientDeletePollerResponse contains the response from method UsersClient.Delete.
-type UsersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *UsersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l UsersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (UsersClientDeleteResponse, error) {
-	respType := UsersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a UsersClientDeletePollerResponse from the provided client and resume token.
-func (l *UsersClientDeletePollerResponse) Resume(ctx context.Context, client *UsersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("UsersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &UsersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // UsersClientDeleteResponse contains the response from method UsersClient.Delete.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_roles_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_roles_client.go
@@ -57,20 +57,16 @@ func NewRolesClient(subscriptionID string, credential azcore.TokenCredential, op
 // role - The role properties.
 // options - RolesClientBeginCreateOrUpdateOptions contains the optional parameters for the RolesClient.BeginCreateOrUpdate
 // method.
-func (client *RolesClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, role RoleClassification, options *RolesClientBeginCreateOrUpdateOptions) (RolesClientCreateOrUpdatePollerResponse, error) {
+func (client *RolesClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, role RoleClassification, options *RolesClientBeginCreateOrUpdateOptions) (*RolesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, name, resourceGroupName, role, options)
 	if err != nil {
-		return RolesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := RolesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RolesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return RolesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RolesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RolesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a role.
@@ -126,20 +122,16 @@ func (client *RolesClient) createOrUpdateCreateRequest(ctx context.Context, devi
 // name - The role name.
 // resourceGroupName - The resource group name.
 // options - RolesClientBeginDeleteOptions contains the optional parameters for the RolesClient.BeginDelete method.
-func (client *RolesClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *RolesClientBeginDeleteOptions) (RolesClientDeletePollerResponse, error) {
+func (client *RolesClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *RolesClientBeginDeleteOptions) (*RolesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, name, resourceGroupName, options)
 	if err != nil {
-		return RolesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := RolesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RolesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return RolesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RolesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RolesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the role on the device.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
@@ -57,20 +57,16 @@ func NewSharesClient(subscriptionID string, credential azcore.TokenCredential, o
 // share - The share properties.
 // options - SharesClientBeginCreateOrUpdateOptions contains the optional parameters for the SharesClient.BeginCreateOrUpdate
 // method.
-func (client *SharesClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, share Share, options *SharesClientBeginCreateOrUpdateOptions) (SharesClientCreateOrUpdatePollerResponse, error) {
+func (client *SharesClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, share Share, options *SharesClientBeginCreateOrUpdateOptions) (*SharesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, name, resourceGroupName, share, options)
 	if err != nil {
-		return SharesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := SharesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SharesClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return SharesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SharesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SharesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a new share or updates an existing share on the device.
@@ -126,20 +122,16 @@ func (client *SharesClient) createOrUpdateCreateRequest(ctx context.Context, dev
 // name - The share name.
 // resourceGroupName - The resource group name.
 // options - SharesClientBeginDeleteOptions contains the optional parameters for the SharesClient.BeginDelete method.
-func (client *SharesClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *SharesClientBeginDeleteOptions) (SharesClientDeletePollerResponse, error) {
+func (client *SharesClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *SharesClientBeginDeleteOptions) (*SharesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, name, resourceGroupName, options)
 	if err != nil {
-		return SharesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := SharesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SharesClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return SharesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SharesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SharesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the share on the Data Box Edge/Data Box Gateway device.
@@ -308,20 +300,16 @@ func (client *SharesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Res
 // name - The share name.
 // resourceGroupName - The resource group name.
 // options - SharesClientBeginRefreshOptions contains the optional parameters for the SharesClient.BeginRefresh method.
-func (client *SharesClient) BeginRefresh(ctx context.Context, deviceName string, name string, resourceGroupName string, options *SharesClientBeginRefreshOptions) (SharesClientRefreshPollerResponse, error) {
+func (client *SharesClient) BeginRefresh(ctx context.Context, deviceName string, name string, resourceGroupName string, options *SharesClientBeginRefreshOptions) (*SharesClientRefreshPoller, error) {
 	resp, err := client.refresh(ctx, deviceName, name, resourceGroupName, options)
 	if err != nil {
-		return SharesClientRefreshPollerResponse{}, err
+		return nil, err
 	}
-	result := SharesClientRefreshPollerResponse{}
 	pt, err := armruntime.NewPoller("SharesClient.Refresh", "", resp, client.pl)
 	if err != nil {
-		return SharesClientRefreshPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SharesClientRefreshPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SharesClientRefreshPoller{pt: pt}, nil
 }
 
 // Refresh - Refreshes the share metadata with the data from the cloud.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
@@ -57,20 +57,16 @@ func NewStorageAccountCredentialsClient(subscriptionID string, credential azcore
 // storageAccountCredential - The storage account credential.
 // options - StorageAccountCredentialsClientBeginCreateOrUpdateOptions contains the optional parameters for the StorageAccountCredentialsClient.BeginCreateOrUpdate
 // method.
-func (client *StorageAccountCredentialsClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, storageAccountCredential StorageAccountCredential, options *StorageAccountCredentialsClientBeginCreateOrUpdateOptions) (StorageAccountCredentialsClientCreateOrUpdatePollerResponse, error) {
+func (client *StorageAccountCredentialsClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, storageAccountCredential StorageAccountCredential, options *StorageAccountCredentialsClientBeginCreateOrUpdateOptions) (*StorageAccountCredentialsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, name, resourceGroupName, storageAccountCredential, options)
 	if err != nil {
-		return StorageAccountCredentialsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := StorageAccountCredentialsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("StorageAccountCredentialsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return StorageAccountCredentialsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &StorageAccountCredentialsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &StorageAccountCredentialsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the storage account credential.
@@ -127,20 +123,16 @@ func (client *StorageAccountCredentialsClient) createOrUpdateCreateRequest(ctx c
 // resourceGroupName - The resource group name.
 // options - StorageAccountCredentialsClientBeginDeleteOptions contains the optional parameters for the StorageAccountCredentialsClient.BeginDelete
 // method.
-func (client *StorageAccountCredentialsClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *StorageAccountCredentialsClientBeginDeleteOptions) (StorageAccountCredentialsClientDeletePollerResponse, error) {
+func (client *StorageAccountCredentialsClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *StorageAccountCredentialsClientBeginDeleteOptions) (*StorageAccountCredentialsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, name, resourceGroupName, options)
 	if err != nil {
-		return StorageAccountCredentialsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := StorageAccountCredentialsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("StorageAccountCredentialsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return StorageAccountCredentialsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &StorageAccountCredentialsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &StorageAccountCredentialsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the storage account credential.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
@@ -57,20 +57,16 @@ func NewStorageAccountsClient(subscriptionID string, credential azcore.TokenCred
 // storageAccount - The StorageAccount properties.
 // options - StorageAccountsClientBeginCreateOrUpdateOptions contains the optional parameters for the StorageAccountsClient.BeginCreateOrUpdate
 // method.
-func (client *StorageAccountsClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, storageAccountName string, resourceGroupName string, storageAccount StorageAccount, options *StorageAccountsClientBeginCreateOrUpdateOptions) (StorageAccountsClientCreateOrUpdatePollerResponse, error) {
+func (client *StorageAccountsClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, storageAccountName string, resourceGroupName string, storageAccount StorageAccount, options *StorageAccountsClientBeginCreateOrUpdateOptions) (*StorageAccountsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, storageAccountName, resourceGroupName, storageAccount, options)
 	if err != nil {
-		return StorageAccountsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := StorageAccountsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("StorageAccountsClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return StorageAccountsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &StorageAccountsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &StorageAccountsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a new StorageAccount or updates an existing StorageAccount on the device.
@@ -127,20 +123,16 @@ func (client *StorageAccountsClient) createOrUpdateCreateRequest(ctx context.Con
 // resourceGroupName - The resource group name.
 // options - StorageAccountsClientBeginDeleteOptions contains the optional parameters for the StorageAccountsClient.BeginDelete
 // method.
-func (client *StorageAccountsClient) BeginDelete(ctx context.Context, deviceName string, storageAccountName string, resourceGroupName string, options *StorageAccountsClientBeginDeleteOptions) (StorageAccountsClientDeletePollerResponse, error) {
+func (client *StorageAccountsClient) BeginDelete(ctx context.Context, deviceName string, storageAccountName string, resourceGroupName string, options *StorageAccountsClientBeginDeleteOptions) (*StorageAccountsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, storageAccountName, resourceGroupName, options)
 	if err != nil {
-		return StorageAccountsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := StorageAccountsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("StorageAccountsClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return StorageAccountsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &StorageAccountsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &StorageAccountsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the StorageAccount on the Data Box Edge/Data Box Gateway device.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_supportpackages_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_supportpackages_client.go
@@ -56,20 +56,16 @@ func NewSupportPackagesClient(subscriptionID string, credential azcore.TokenCred
 // triggerSupportPackageRequest - The trigger support package request object
 // options - SupportPackagesClientBeginTriggerSupportPackageOptions contains the optional parameters for the SupportPackagesClient.BeginTriggerSupportPackage
 // method.
-func (client *SupportPackagesClient) BeginTriggerSupportPackage(ctx context.Context, deviceName string, resourceGroupName string, triggerSupportPackageRequest TriggerSupportPackageRequest, options *SupportPackagesClientBeginTriggerSupportPackageOptions) (SupportPackagesClientTriggerSupportPackagePollerResponse, error) {
+func (client *SupportPackagesClient) BeginTriggerSupportPackage(ctx context.Context, deviceName string, resourceGroupName string, triggerSupportPackageRequest TriggerSupportPackageRequest, options *SupportPackagesClientBeginTriggerSupportPackageOptions) (*SupportPackagesClientTriggerSupportPackagePoller, error) {
 	resp, err := client.triggerSupportPackage(ctx, deviceName, resourceGroupName, triggerSupportPackageRequest, options)
 	if err != nil {
-		return SupportPackagesClientTriggerSupportPackagePollerResponse{}, err
+		return nil, err
 	}
-	result := SupportPackagesClientTriggerSupportPackagePollerResponse{}
 	pt, err := armruntime.NewPoller("SupportPackagesClient.TriggerSupportPackage", "", resp, client.pl)
 	if err != nil {
-		return SupportPackagesClientTriggerSupportPackagePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SupportPackagesClientTriggerSupportPackagePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SupportPackagesClientTriggerSupportPackagePoller{pt: pt}, nil
 }
 
 // TriggerSupportPackage - Triggers support package on the device

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
@@ -57,20 +57,16 @@ func NewTriggersClient(subscriptionID string, credential azcore.TokenCredential,
 // trigger - The trigger.
 // options - TriggersClientBeginCreateOrUpdateOptions contains the optional parameters for the TriggersClient.BeginCreateOrUpdate
 // method.
-func (client *TriggersClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, trigger TriggerClassification, options *TriggersClientBeginCreateOrUpdateOptions) (TriggersClientCreateOrUpdatePollerResponse, error) {
+func (client *TriggersClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, trigger TriggerClassification, options *TriggersClientBeginCreateOrUpdateOptions) (*TriggersClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, name, resourceGroupName, trigger, options)
 	if err != nil {
-		return TriggersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := TriggersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("TriggersClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return TriggersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &TriggersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &TriggersClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a trigger.
@@ -126,20 +122,16 @@ func (client *TriggersClient) createOrUpdateCreateRequest(ctx context.Context, d
 // name - The trigger name.
 // resourceGroupName - The resource group name.
 // options - TriggersClientBeginDeleteOptions contains the optional parameters for the TriggersClient.BeginDelete method.
-func (client *TriggersClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *TriggersClientBeginDeleteOptions) (TriggersClientDeletePollerResponse, error) {
+func (client *TriggersClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *TriggersClientBeginDeleteOptions) (*TriggersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, name, resourceGroupName, options)
 	if err != nil {
-		return TriggersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := TriggersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("TriggersClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return TriggersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &TriggersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &TriggersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the trigger on the gateway device.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
@@ -58,20 +58,16 @@ func NewUsersClient(subscriptionID string, credential azcore.TokenCredential, op
 // userParam - The user details.
 // options - UsersClientBeginCreateOrUpdateOptions contains the optional parameters for the UsersClient.BeginCreateOrUpdate
 // method.
-func (client *UsersClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, userParam User, options *UsersClientBeginCreateOrUpdateOptions) (UsersClientCreateOrUpdatePollerResponse, error) {
+func (client *UsersClient) BeginCreateOrUpdate(ctx context.Context, deviceName string, name string, resourceGroupName string, userParam User, options *UsersClientBeginCreateOrUpdateOptions) (*UsersClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, deviceName, name, resourceGroupName, userParam, options)
 	if err != nil {
-		return UsersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := UsersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("UsersClient.CreateOrUpdate", "", resp, client.pl)
 	if err != nil {
-		return UsersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &UsersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &UsersClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a new user or updates an existing user's information on a Data Box Edge/Data Box Gateway device.
@@ -127,20 +123,16 @@ func (client *UsersClient) createOrUpdateCreateRequest(ctx context.Context, devi
 // name - The user name.
 // resourceGroupName - The resource group name.
 // options - UsersClientBeginDeleteOptions contains the optional parameters for the UsersClient.BeginDelete method.
-func (client *UsersClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *UsersClientBeginDeleteOptions) (UsersClientDeletePollerResponse, error) {
+func (client *UsersClient) BeginDelete(ctx context.Context, deviceName string, name string, resourceGroupName string, options *UsersClientBeginDeleteOptions) (*UsersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, deviceName, name, resourceGroupName, options)
 	if err != nil {
-		return UsersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := UsersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("UsersClient.Delete", "", resp, client.pl)
 	if err != nil {
-		return UsersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &UsersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &UsersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the user on a databox edge/gateway device.

--- a/test/keyvault/7.2/azkeyvault/go.mod
+++ b/test/keyvault/7.2/azkeyvault/go.mod
@@ -2,4 +2,4 @@ module azkeyvault
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/keyvault/7.2/azkeyvault/go.sum
+++ b/test/keyvault/7.2/azkeyvault/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/keyvault/7.2/azkeyvault/zz_generated_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_client.go
@@ -873,20 +873,16 @@ func (client *Client) encryptHandleResponse(resp *http.Response) (ClientEncryptR
 // If the operation fails it returns an *azcore.ResponseError type.
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientBeginFullBackupOptions contains the optional parameters for the Client.BeginFullBackup method.
-func (client *Client) BeginFullBackup(ctx context.Context, vaultBaseURL string, options *ClientBeginFullBackupOptions) (ClientFullBackupPollerResponse, error) {
+func (client *Client) BeginFullBackup(ctx context.Context, vaultBaseURL string, options *ClientBeginFullBackupOptions) (*ClientFullBackupPoller, error) {
 	resp, err := client.fullBackup(ctx, vaultBaseURL, options)
 	if err != nil {
-		return ClientFullBackupPollerResponse{}, err
+		return nil, err
 	}
-	result := ClientFullBackupPollerResponse{}
 	pt, err := runtime.NewPoller("Client.FullBackup", resp, client.pl)
 	if err != nil {
-		return ClientFullBackupPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ClientFullBackupPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ClientFullBackupPoller{pt: pt}, nil
 }
 
 // FullBackup - Creates a full backup using a user-provided SAS token to an Azure blob storage container.
@@ -980,20 +976,16 @@ func (client *Client) fullBackupStatusHandleResponse(resp *http.Response) (Clien
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientBeginFullRestoreOperationOptions contains the optional parameters for the Client.BeginFullRestoreOperation
 // method.
-func (client *Client) BeginFullRestoreOperation(ctx context.Context, vaultBaseURL string, options *ClientBeginFullRestoreOperationOptions) (ClientFullRestoreOperationPollerResponse, error) {
+func (client *Client) BeginFullRestoreOperation(ctx context.Context, vaultBaseURL string, options *ClientBeginFullRestoreOperationOptions) (*ClientFullRestoreOperationPoller, error) {
 	resp, err := client.fullRestoreOperation(ctx, vaultBaseURL, options)
 	if err != nil {
-		return ClientFullRestoreOperationPollerResponse{}, err
+		return nil, err
 	}
-	result := ClientFullRestoreOperationPollerResponse{}
 	pt, err := runtime.NewPoller("Client.FullRestoreOperation", resp, client.pl)
 	if err != nil {
-		return ClientFullRestoreOperationPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ClientFullRestoreOperationPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ClientFullRestoreOperationPoller{pt: pt}, nil
 }
 
 // FullRestoreOperation - Restores all key materials using the SAS token pointing to a previously stored Azure Blob storage
@@ -3315,20 +3307,16 @@ func (client *Client) restoreStorageAccountHandleResponse(resp *http.Response) (
 // keyName - The name of the key to be restored from the user supplied backup
 // options - ClientBeginSelectiveKeyRestoreOperationOptions contains the optional parameters for the Client.BeginSelectiveKeyRestoreOperation
 // method.
-func (client *Client) BeginSelectiveKeyRestoreOperation(ctx context.Context, vaultBaseURL string, keyName string, options *ClientBeginSelectiveKeyRestoreOperationOptions) (ClientSelectiveKeyRestoreOperationPollerResponse, error) {
+func (client *Client) BeginSelectiveKeyRestoreOperation(ctx context.Context, vaultBaseURL string, keyName string, options *ClientBeginSelectiveKeyRestoreOperationOptions) (*ClientSelectiveKeyRestoreOperationPoller, error) {
 	resp, err := client.selectiveKeyRestoreOperation(ctx, vaultBaseURL, keyName, options)
 	if err != nil {
-		return ClientSelectiveKeyRestoreOperationPollerResponse{}, err
+		return nil, err
 	}
-	result := ClientSelectiveKeyRestoreOperationPollerResponse{}
 	pt, err := runtime.NewPoller("Client.SelectiveKeyRestoreOperation", resp, client.pl)
 	if err != nil {
-		return ClientSelectiveKeyRestoreOperationPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ClientSelectiveKeyRestoreOperationPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ClientSelectiveKeyRestoreOperationPoller{pt: pt}, nil
 }
 
 // SelectiveKeyRestoreOperation - Restores all key versions of a given key using user supplied SAS token pointing to a previously

--- a/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
@@ -39,20 +39,16 @@ func NewHSMSecurityDomainClient(pl runtime.Pipeline) *HSMSecurityDomainClient {
 // maximum 10) containing a public key in JWK format.
 // options - HSMSecurityDomainClientBeginDownloadOptions contains the optional parameters for the HSMSecurityDomainClient.BeginDownload
 // method.
-func (client *HSMSecurityDomainClient) BeginDownload(ctx context.Context, vaultBaseURL string, certificateInfoObject CertificateInfoObject, options *HSMSecurityDomainClientBeginDownloadOptions) (HSMSecurityDomainClientDownloadPollerResponse, error) {
+func (client *HSMSecurityDomainClient) BeginDownload(ctx context.Context, vaultBaseURL string, certificateInfoObject CertificateInfoObject, options *HSMSecurityDomainClientBeginDownloadOptions) (*HSMSecurityDomainClientDownloadPoller, error) {
 	resp, err := client.download(ctx, vaultBaseURL, certificateInfoObject, options)
 	if err != nil {
-		return HSMSecurityDomainClientDownloadPollerResponse{}, err
+		return nil, err
 	}
-	result := HSMSecurityDomainClientDownloadPollerResponse{}
 	pt, err := runtime.NewPoller("HSMSecurityDomainClient.Download", resp, client.pl)
 	if err != nil {
-		return HSMSecurityDomainClientDownloadPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &HSMSecurityDomainClientDownloadPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &HSMSecurityDomainClientDownloadPoller{pt: pt}, nil
 }
 
 // Download - Retrieves the Security Domain from the managed HSM. Calling this endpoint can be used to activate a provisioned
@@ -182,20 +178,16 @@ func (client *HSMSecurityDomainClient) transferKeyHandleResponse(resp *http.Resp
 // securityDomain - The Security Domain to be restored.
 // options - HSMSecurityDomainClientBeginUploadOptions contains the optional parameters for the HSMSecurityDomainClient.BeginUpload
 // method.
-func (client *HSMSecurityDomainClient) BeginUpload(ctx context.Context, vaultBaseURL string, securityDomain SecurityDomainObject, options *HSMSecurityDomainClientBeginUploadOptions) (HSMSecurityDomainClientUploadPollerResponse, error) {
+func (client *HSMSecurityDomainClient) BeginUpload(ctx context.Context, vaultBaseURL string, securityDomain SecurityDomainObject, options *HSMSecurityDomainClientBeginUploadOptions) (*HSMSecurityDomainClientUploadPoller, error) {
 	resp, err := client.upload(ctx, vaultBaseURL, securityDomain, options)
 	if err != nil {
-		return HSMSecurityDomainClientUploadPollerResponse{}, err
+		return nil, err
 	}
-	result := HSMSecurityDomainClientUploadPollerResponse{}
 	pt, err := runtime.NewPoller("HSMSecurityDomainClient.Upload", resp, client.pl)
 	if err != nil {
-		return HSMSecurityDomainClientUploadPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &HSMSecurityDomainClientUploadPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &HSMSecurityDomainClientUploadPoller{pt: pt}, nil
 }
 
 // Upload - Restore the provided Security Domain.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_pollers.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_pollers.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"net/http"
 	"time"
 )
 
@@ -31,20 +32,19 @@ func (p *ClientFullBackupPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ClientFullBackupPoller) Poll(ctx context.Context) (ClientFullBackupResponse, error) {
-	result := ClientFullBackupResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.FullBackupOperation)
-	return result, err
+func (p *ClientFullBackupPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ClientFullBackupPoller) Result(ctx context.Context) (resp ClientFullBackupResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -64,12 +64,9 @@ func (p *ClientFullBackupPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ClientFullBackupPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ClientFullBackupPoller) Resume(ctx context.Context, client *Client, token string) (ClientFullBackupResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("Client.FullBackup", token, client.pl); err != nil {
-		return ClientFullBackupResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ClientFullBackupPoller) Resume(token string, client *Client) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("Client.FullBackup", token, client.pl)
+	return
 }
 
 // ClientFullRestoreOperationPoller provides polling facilities until the operation reaches a terminal state.
@@ -88,20 +85,19 @@ func (p *ClientFullRestoreOperationPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ClientFullRestoreOperationPoller) Poll(ctx context.Context) (ClientFullRestoreOperationResponse, error) {
-	result := ClientFullRestoreOperationResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.RestoreOperation)
-	return result, err
+func (p *ClientFullRestoreOperationPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ClientFullRestoreOperationPoller) Result(ctx context.Context) (resp ClientFullRestoreOperationResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -121,12 +117,9 @@ func (p *ClientFullRestoreOperationPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ClientFullRestoreOperationPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ClientFullRestoreOperationPoller) Resume(ctx context.Context, client *Client, token string) (ClientFullRestoreOperationResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("Client.FullRestoreOperation", token, client.pl); err != nil {
-		return ClientFullRestoreOperationResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ClientFullRestoreOperationPoller) Resume(token string, client *Client) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("Client.FullRestoreOperation", token, client.pl)
+	return
 }
 
 // ClientSelectiveKeyRestoreOperationPoller provides polling facilities until the operation reaches a terminal state.
@@ -145,20 +138,19 @@ func (p *ClientSelectiveKeyRestoreOperationPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ClientSelectiveKeyRestoreOperationPoller) Poll(ctx context.Context) (ClientSelectiveKeyRestoreOperationResponse, error) {
-	result := ClientSelectiveKeyRestoreOperationResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SelectiveKeyRestoreOperation)
-	return result, err
+func (p *ClientSelectiveKeyRestoreOperationPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ClientSelectiveKeyRestoreOperationPoller) Result(ctx context.Context) (resp ClientSelectiveKeyRestoreOperationResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -178,12 +170,9 @@ func (p *ClientSelectiveKeyRestoreOperationPoller) ResumeToken() (string, error)
 
 // Resume rehydrates a ClientSelectiveKeyRestoreOperationPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ClientSelectiveKeyRestoreOperationPoller) Resume(ctx context.Context, client *Client, token string) (ClientSelectiveKeyRestoreOperationResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("Client.SelectiveKeyRestoreOperation", token, client.pl); err != nil {
-		return ClientSelectiveKeyRestoreOperationResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ClientSelectiveKeyRestoreOperationPoller) Resume(token string, client *Client) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("Client.SelectiveKeyRestoreOperation", token, client.pl)
+	return
 }
 
 // HSMSecurityDomainClientDownloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -202,20 +191,19 @@ func (p *HSMSecurityDomainClientDownloadPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *HSMSecurityDomainClientDownloadPoller) Poll(ctx context.Context) (HSMSecurityDomainClientDownloadResponse, error) {
-	result := HSMSecurityDomainClientDownloadResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SecurityDomainObject)
-	return result, err
+func (p *HSMSecurityDomainClientDownloadPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *HSMSecurityDomainClientDownloadPoller) Result(ctx context.Context) (resp HSMSecurityDomainClientDownloadResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -235,12 +223,9 @@ func (p *HSMSecurityDomainClientDownloadPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a HSMSecurityDomainClientDownloadPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *HSMSecurityDomainClientDownloadPoller) Resume(ctx context.Context, client *HSMSecurityDomainClient, token string) (HSMSecurityDomainClientDownloadResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("HSMSecurityDomainClient.Download", token, client.pl); err != nil {
-		return HSMSecurityDomainClientDownloadResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *HSMSecurityDomainClientDownloadPoller) Resume(token string, client *HSMSecurityDomainClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("HSMSecurityDomainClient.Download", token, client.pl)
+	return
 }
 
 // HSMSecurityDomainClientUploadPoller provides polling facilities until the operation reaches a terminal state.
@@ -259,20 +244,19 @@ func (p *HSMSecurityDomainClientUploadPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *HSMSecurityDomainClientUploadPoller) Poll(ctx context.Context) (HSMSecurityDomainClientUploadResponse, error) {
-	result := HSMSecurityDomainClientUploadResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SecurityDomainOperationStatus)
-	return result, err
+func (p *HSMSecurityDomainClientUploadPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *HSMSecurityDomainClientUploadPoller) Result(ctx context.Context) (resp HSMSecurityDomainClientUploadResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -292,10 +276,7 @@ func (p *HSMSecurityDomainClientUploadPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a HSMSecurityDomainClientUploadPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *HSMSecurityDomainClientUploadPoller) Resume(ctx context.Context, client *HSMSecurityDomainClient, token string) (HSMSecurityDomainClientUploadResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("HSMSecurityDomainClient.Upload", token, client.pl); err != nil {
-		return HSMSecurityDomainClientUploadResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *HSMSecurityDomainClientUploadPoller) Resume(token string, client *HSMSecurityDomainClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("HSMSecurityDomainClient.Upload", token, client.pl)
+	return
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_pollers.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_pollers.go
@@ -11,7 +11,8 @@ package azkeyvault
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"time"
 )
 
 // ClientFullBackupPoller provides polling facilities until the operation reaches a terminal state.
@@ -24,36 +25,51 @@ func (p *ClientFullBackupPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ClientFullBackupPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ClientFullBackupPoller) Poll(ctx context.Context) (ClientFullBackupResponse, error) {
+	result := ClientFullBackupResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.FullBackupOperation)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ClientFullBackupResponse will be returned.
-func (p *ClientFullBackupPoller) FinalResponse(ctx context.Context) (ClientFullBackupResponse, error) {
-	respType := ClientFullBackupResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.FullBackupOperation)
-	if err != nil {
-		return ClientFullBackupResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *ClientFullBackupPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ClientFullBackupResponse, error) {
+	result := ClientFullBackupResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.FullBackupOperation)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ClientFullBackupPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ClientFullBackupPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ClientFullBackupPoller) Resume(ctx context.Context, client *Client, token string) (ClientFullBackupResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("Client.FullBackup", token, client.pl); err != nil {
+		return ClientFullBackupResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ClientFullRestoreOperationPoller provides polling facilities until the operation reaches a terminal state.
@@ -66,36 +82,51 @@ func (p *ClientFullRestoreOperationPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ClientFullRestoreOperationPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ClientFullRestoreOperationPoller) Poll(ctx context.Context) (ClientFullRestoreOperationResponse, error) {
+	result := ClientFullRestoreOperationResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.RestoreOperation)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ClientFullRestoreOperationResponse will be returned.
-func (p *ClientFullRestoreOperationPoller) FinalResponse(ctx context.Context) (ClientFullRestoreOperationResponse, error) {
-	respType := ClientFullRestoreOperationResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.RestoreOperation)
-	if err != nil {
-		return ClientFullRestoreOperationResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *ClientFullRestoreOperationPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ClientFullRestoreOperationResponse, error) {
+	result := ClientFullRestoreOperationResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.RestoreOperation)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ClientFullRestoreOperationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ClientFullRestoreOperationPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ClientFullRestoreOperationPoller) Resume(ctx context.Context, client *Client, token string) (ClientFullRestoreOperationResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("Client.FullRestoreOperation", token, client.pl); err != nil {
+		return ClientFullRestoreOperationResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ClientSelectiveKeyRestoreOperationPoller provides polling facilities until the operation reaches a terminal state.
@@ -108,36 +139,51 @@ func (p *ClientSelectiveKeyRestoreOperationPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ClientSelectiveKeyRestoreOperationPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ClientSelectiveKeyRestoreOperationPoller) Poll(ctx context.Context) (ClientSelectiveKeyRestoreOperationResponse, error) {
+	result := ClientSelectiveKeyRestoreOperationResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SelectiveKeyRestoreOperation)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ClientSelectiveKeyRestoreOperationResponse will be returned.
-func (p *ClientSelectiveKeyRestoreOperationPoller) FinalResponse(ctx context.Context) (ClientSelectiveKeyRestoreOperationResponse, error) {
-	respType := ClientSelectiveKeyRestoreOperationResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SelectiveKeyRestoreOperation)
-	if err != nil {
-		return ClientSelectiveKeyRestoreOperationResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *ClientSelectiveKeyRestoreOperationPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ClientSelectiveKeyRestoreOperationResponse, error) {
+	result := ClientSelectiveKeyRestoreOperationResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SelectiveKeyRestoreOperation)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ClientSelectiveKeyRestoreOperationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ClientSelectiveKeyRestoreOperationPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ClientSelectiveKeyRestoreOperationPoller) Resume(ctx context.Context, client *Client, token string) (ClientSelectiveKeyRestoreOperationResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("Client.SelectiveKeyRestoreOperation", token, client.pl); err != nil {
+		return ClientSelectiveKeyRestoreOperationResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // HSMSecurityDomainClientDownloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -150,36 +196,51 @@ func (p *HSMSecurityDomainClientDownloadPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *HSMSecurityDomainClientDownloadPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *HSMSecurityDomainClientDownloadPoller) Poll(ctx context.Context) (HSMSecurityDomainClientDownloadResponse, error) {
+	result := HSMSecurityDomainClientDownloadResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SecurityDomainObject)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final HSMSecurityDomainClientDownloadResponse will be returned.
-func (p *HSMSecurityDomainClientDownloadPoller) FinalResponse(ctx context.Context) (HSMSecurityDomainClientDownloadResponse, error) {
-	respType := HSMSecurityDomainClientDownloadResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SecurityDomainObject)
-	if err != nil {
-		return HSMSecurityDomainClientDownloadResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *HSMSecurityDomainClientDownloadPoller) PollUntilDone(ctx context.Context, freq time.Duration) (HSMSecurityDomainClientDownloadResponse, error) {
+	result := HSMSecurityDomainClientDownloadResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SecurityDomainObject)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *HSMSecurityDomainClientDownloadPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a HSMSecurityDomainClientDownloadPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *HSMSecurityDomainClientDownloadPoller) Resume(ctx context.Context, client *HSMSecurityDomainClient, token string) (HSMSecurityDomainClientDownloadResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("HSMSecurityDomainClient.Download", token, client.pl); err != nil {
+		return HSMSecurityDomainClientDownloadResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // HSMSecurityDomainClientUploadPoller provides polling facilities until the operation reaches a terminal state.
@@ -192,34 +253,49 @@ func (p *HSMSecurityDomainClientUploadPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *HSMSecurityDomainClientUploadPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *HSMSecurityDomainClientUploadPoller) Poll(ctx context.Context) (HSMSecurityDomainClientUploadResponse, error) {
+	result := HSMSecurityDomainClientUploadResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SecurityDomainOperationStatus)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final HSMSecurityDomainClientUploadResponse will be returned.
-func (p *HSMSecurityDomainClientUploadPoller) FinalResponse(ctx context.Context) (HSMSecurityDomainClientUploadResponse, error) {
-	respType := HSMSecurityDomainClientUploadResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SecurityDomainOperationStatus)
-	if err != nil {
-		return HSMSecurityDomainClientUploadResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *HSMSecurityDomainClientUploadPoller) PollUntilDone(ctx context.Context, freq time.Duration) (HSMSecurityDomainClientUploadResponse, error) {
+	result := HSMSecurityDomainClientUploadResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SecurityDomainOperationStatus)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *HSMSecurityDomainClientUploadPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a HSMSecurityDomainClientUploadPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *HSMSecurityDomainClientUploadPoller) Resume(ctx context.Context, client *HSMSecurityDomainClient, token string) (HSMSecurityDomainClientUploadResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("HSMSecurityDomainClient.Upload", token, client.pl); err != nil {
+		return HSMSecurityDomainClientUploadResponse{}, err
+	}
+	return p.Poll(ctx)
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
@@ -8,12 +8,6 @@
 
 package azkeyvault
 
-import (
-	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"time"
-)
-
 // ClientBackupCertificateResponse contains the response from method Client.BackupCertificate.
 type ClientBackupCertificateResponse struct {
 	BackupCertificateResult
@@ -94,40 +88,6 @@ type ClientEncryptResponse struct {
 	KeyOperationResult
 }
 
-// ClientFullBackupPollerResponse contains the response from method Client.FullBackup.
-type ClientFullBackupPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ClientFullBackupPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l ClientFullBackupPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ClientFullBackupResponse, error) {
-	respType := ClientFullBackupResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FullBackupOperation)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ClientFullBackupPollerResponse from the provided client and resume token.
-func (l *ClientFullBackupPollerResponse) Resume(ctx context.Context, client *Client, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("Client.FullBackup", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ClientFullBackupPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ClientFullBackupResponse contains the response from method Client.FullBackup.
 type ClientFullBackupResponse struct {
 	FullBackupOperation
@@ -136,40 +96,6 @@ type ClientFullBackupResponse struct {
 // ClientFullBackupStatusResponse contains the response from method Client.FullBackupStatus.
 type ClientFullBackupStatusResponse struct {
 	FullBackupOperation
-}
-
-// ClientFullRestoreOperationPollerResponse contains the response from method Client.FullRestoreOperation.
-type ClientFullRestoreOperationPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ClientFullRestoreOperationPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l ClientFullRestoreOperationPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ClientFullRestoreOperationResponse, error) {
-	respType := ClientFullRestoreOperationResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RestoreOperation)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ClientFullRestoreOperationPollerResponse from the provided client and resume token.
-func (l *ClientFullRestoreOperationPollerResponse) Resume(ctx context.Context, client *Client, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("Client.FullRestoreOperation", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ClientFullRestoreOperationPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ClientFullRestoreOperationResponse contains the response from method Client.FullRestoreOperation.
@@ -407,40 +333,6 @@ type ClientRestoreStorageAccountResponse struct {
 	StorageBundle
 }
 
-// ClientSelectiveKeyRestoreOperationPollerResponse contains the response from method Client.SelectiveKeyRestoreOperation.
-type ClientSelectiveKeyRestoreOperationPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ClientSelectiveKeyRestoreOperationPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l ClientSelectiveKeyRestoreOperationPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ClientSelectiveKeyRestoreOperationResponse, error) {
-	respType := ClientSelectiveKeyRestoreOperationResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SelectiveKeyRestoreOperation)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ClientSelectiveKeyRestoreOperationPollerResponse from the provided client and resume token.
-func (l *ClientSelectiveKeyRestoreOperationPollerResponse) Resume(ctx context.Context, client *Client, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("Client.SelectiveKeyRestoreOperation", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ClientSelectiveKeyRestoreOperationPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ClientSelectiveKeyRestoreOperationResponse contains the response from method Client.SelectiveKeyRestoreOperation.
 type ClientSelectiveKeyRestoreOperationResponse struct {
 	SelectiveKeyRestoreOperation
@@ -536,40 +428,6 @@ type HSMSecurityDomainClientDownloadPendingResponse struct {
 	SecurityDomainOperationStatus
 }
 
-// HSMSecurityDomainClientDownloadPollerResponse contains the response from method HSMSecurityDomainClient.Download.
-type HSMSecurityDomainClientDownloadPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *HSMSecurityDomainClientDownloadPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l HSMSecurityDomainClientDownloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (HSMSecurityDomainClientDownloadResponse, error) {
-	respType := HSMSecurityDomainClientDownloadResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityDomainObject)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a HSMSecurityDomainClientDownloadPollerResponse from the provided client and resume token.
-func (l *HSMSecurityDomainClientDownloadPollerResponse) Resume(ctx context.Context, client *HSMSecurityDomainClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("HSMSecurityDomainClient.Download", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &HSMSecurityDomainClientDownloadPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // HSMSecurityDomainClientDownloadResponse contains the response from method HSMSecurityDomainClient.Download.
 type HSMSecurityDomainClientDownloadResponse struct {
 	SecurityDomainObject
@@ -583,40 +441,6 @@ type HSMSecurityDomainClientTransferKeyResponse struct {
 // HSMSecurityDomainClientUploadPendingResponse contains the response from method HSMSecurityDomainClient.UploadPending.
 type HSMSecurityDomainClientUploadPendingResponse struct {
 	SecurityDomainOperationStatus
-}
-
-// HSMSecurityDomainClientUploadPollerResponse contains the response from method HSMSecurityDomainClient.Upload.
-type HSMSecurityDomainClientUploadPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *HSMSecurityDomainClientUploadPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l HSMSecurityDomainClientUploadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (HSMSecurityDomainClientUploadResponse, error) {
-	respType := HSMSecurityDomainClientUploadResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityDomainOperationStatus)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a HSMSecurityDomainClientUploadPollerResponse from the provided client and resume token.
-func (l *HSMSecurityDomainClientUploadPollerResponse) Resume(ctx context.Context, client *HSMSecurityDomainClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("HSMSecurityDomainClient.Upload", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &HSMSecurityDomainClientUploadPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // HSMSecurityDomainClientUploadResponse contains the response from method HSMSecurityDomainClient.Upload.

--- a/test/maps/azalias/go.mod
+++ b/test/maps/azalias/go.mod
@@ -2,4 +2,4 @@ module azalias
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/maps/azalias/go.sum
+++ b/test/maps/azalias/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/network/2020-03-01/armnetwork/go.mod
+++ b/test/network/2020-03-01/armnetwork/go.mod
@@ -2,4 +2,4 @@ module armnetwork
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/network/2020-03-01/armnetwork/go.sum
+++ b/test/network/2020-03-01/armnetwork/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
@@ -56,20 +56,16 @@ func NewApplicationGatewaysClient(subscriptionID string, credential azcore.Token
 // applicationGatewayName - The name of the application gateway.
 // options - ApplicationGatewaysClientBeginBackendHealthOptions contains the optional parameters for the ApplicationGatewaysClient.BeginBackendHealth
 // method.
-func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysClientBeginBackendHealthOptions) (ApplicationGatewaysClientBackendHealthPollerResponse, error) {
+func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysClientBeginBackendHealthOptions) (*ApplicationGatewaysClientBackendHealthPoller, error) {
 	resp, err := client.backendHealth(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
-		return ApplicationGatewaysClientBackendHealthPollerResponse{}, err
+		return nil, err
 	}
-	result := ApplicationGatewaysClientBackendHealthPollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.BackendHealth", "location", resp, client.pl)
 	if err != nil {
-		return ApplicationGatewaysClientBackendHealthPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ApplicationGatewaysClientBackendHealthPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ApplicationGatewaysClientBackendHealthPoller{pt: pt}, nil
 }
 
 // BackendHealth - Gets the backend health of the specified application gateway in a resource group.
@@ -126,20 +122,16 @@ func (client *ApplicationGatewaysClient) backendHealthCreateRequest(ctx context.
 // probeRequest - Request body for on-demand test probe operation.
 // options - ApplicationGatewaysClientBeginBackendHealthOnDemandOptions contains the optional parameters for the ApplicationGatewaysClient.BeginBackendHealthOnDemand
 // method.
-func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, options *ApplicationGatewaysClientBeginBackendHealthOnDemandOptions) (ApplicationGatewaysClientBackendHealthOnDemandPollerResponse, error) {
+func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, options *ApplicationGatewaysClientBeginBackendHealthOnDemandOptions) (*ApplicationGatewaysClientBackendHealthOnDemandPoller, error) {
 	resp, err := client.backendHealthOnDemand(ctx, resourceGroupName, applicationGatewayName, probeRequest, options)
 	if err != nil {
-		return ApplicationGatewaysClientBackendHealthOnDemandPollerResponse{}, err
+		return nil, err
 	}
-	result := ApplicationGatewaysClientBackendHealthOnDemandPollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.BackendHealthOnDemand", "location", resp, client.pl)
 	if err != nil {
-		return ApplicationGatewaysClientBackendHealthOnDemandPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ApplicationGatewaysClientBackendHealthOnDemandPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ApplicationGatewaysClientBackendHealthOnDemandPoller{pt: pt}, nil
 }
 
 // BackendHealthOnDemand - Gets the backend health for given combination of backend pool and http setting of the specified
@@ -196,20 +188,16 @@ func (client *ApplicationGatewaysClient) backendHealthOnDemandCreateRequest(ctx 
 // parameters - Parameters supplied to the create or update application gateway operation.
 // options - ApplicationGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the ApplicationGatewaysClient.BeginCreateOrUpdate
 // method.
-func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, options *ApplicationGatewaysClientBeginCreateOrUpdateOptions) (ApplicationGatewaysClientCreateOrUpdatePollerResponse, error) {
+func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, options *ApplicationGatewaysClientBeginCreateOrUpdateOptions) (*ApplicationGatewaysClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, applicationGatewayName, parameters, options)
 	if err != nil {
-		return ApplicationGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ApplicationGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ApplicationGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ApplicationGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ApplicationGatewaysClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified application gateway.
@@ -261,20 +249,16 @@ func (client *ApplicationGatewaysClient) createOrUpdateCreateRequest(ctx context
 // applicationGatewayName - The name of the application gateway.
 // options - ApplicationGatewaysClientBeginDeleteOptions contains the optional parameters for the ApplicationGatewaysClient.BeginDelete
 // method.
-func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysClientBeginDeleteOptions) (ApplicationGatewaysClientDeletePollerResponse, error) {
+func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysClientBeginDeleteOptions) (*ApplicationGatewaysClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
-		return ApplicationGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ApplicationGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ApplicationGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ApplicationGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ApplicationGatewaysClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified application gateway.
@@ -796,20 +780,16 @@ func (client *ApplicationGatewaysClient) listAvailableWafRuleSetsHandleResponse(
 // applicationGatewayName - The name of the application gateway.
 // options - ApplicationGatewaysClientBeginStartOptions contains the optional parameters for the ApplicationGatewaysClient.BeginStart
 // method.
-func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysClientBeginStartOptions) (ApplicationGatewaysClientStartPollerResponse, error) {
+func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysClientBeginStartOptions) (*ApplicationGatewaysClientStartPoller, error) {
 	resp, err := client.start(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
-		return ApplicationGatewaysClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result := ApplicationGatewaysClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.Start", "location", resp, client.pl)
 	if err != nil {
-		return ApplicationGatewaysClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ApplicationGatewaysClientStartPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ApplicationGatewaysClientStartPoller{pt: pt}, nil
 }
 
 // Start - Starts the specified application gateway.
@@ -861,20 +841,16 @@ func (client *ApplicationGatewaysClient) startCreateRequest(ctx context.Context,
 // applicationGatewayName - The name of the application gateway.
 // options - ApplicationGatewaysClientBeginStopOptions contains the optional parameters for the ApplicationGatewaysClient.BeginStop
 // method.
-func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysClientBeginStopOptions) (ApplicationGatewaysClientStopPollerResponse, error) {
+func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysClientBeginStopOptions) (*ApplicationGatewaysClientStopPoller, error) {
 	resp, err := client.stop(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
-		return ApplicationGatewaysClientStopPollerResponse{}, err
+		return nil, err
 	}
-	result := ApplicationGatewaysClientStopPollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationGatewaysClient.Stop", "location", resp, client.pl)
 	if err != nil {
-		return ApplicationGatewaysClientStopPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ApplicationGatewaysClientStopPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ApplicationGatewaysClientStopPoller{pt: pt}, nil
 }
 
 // Stop - Stops the specified application gateway in a resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
@@ -57,20 +57,16 @@ func NewApplicationSecurityGroupsClient(subscriptionID string, credential azcore
 // parameters - Parameters supplied to the create or update ApplicationSecurityGroup operation.
 // options - ApplicationSecurityGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the ApplicationSecurityGroupsClient.BeginCreateOrUpdate
 // method.
-func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup, options *ApplicationSecurityGroupsClientBeginCreateOrUpdateOptions) (ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse, error) {
+func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup, options *ApplicationSecurityGroupsClientBeginCreateOrUpdateOptions) (*ApplicationSecurityGroupsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, applicationSecurityGroupName, parameters, options)
 	if err != nil {
-		return ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationSecurityGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ApplicationSecurityGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ApplicationSecurityGroupsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates an application security group.
@@ -122,20 +118,16 @@ func (client *ApplicationSecurityGroupsClient) createOrUpdateCreateRequest(ctx c
 // applicationSecurityGroupName - The name of the application security group.
 // options - ApplicationSecurityGroupsClientBeginDeleteOptions contains the optional parameters for the ApplicationSecurityGroupsClient.BeginDelete
 // method.
-func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsClientBeginDeleteOptions) (ApplicationSecurityGroupsClientDeletePollerResponse, error) {
+func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsClientBeginDeleteOptions) (*ApplicationSecurityGroupsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, applicationSecurityGroupName, options)
 	if err != nil {
-		return ApplicationSecurityGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ApplicationSecurityGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ApplicationSecurityGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ApplicationSecurityGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ApplicationSecurityGroupsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ApplicationSecurityGroupsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified application security group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
@@ -57,20 +57,16 @@ func NewAzureFirewallsClient(subscriptionID string, credential azcore.TokenCrede
 // parameters - Parameters supplied to the create or update Azure Firewall operation.
 // options - AzureFirewallsClientBeginCreateOrUpdateOptions contains the optional parameters for the AzureFirewallsClient.BeginCreateOrUpdate
 // method.
-func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall, options *AzureFirewallsClientBeginCreateOrUpdateOptions) (AzureFirewallsClientCreateOrUpdatePollerResponse, error) {
+func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall, options *AzureFirewallsClientBeginCreateOrUpdateOptions) (*AzureFirewallsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, azureFirewallName, parameters, options)
 	if err != nil {
-		return AzureFirewallsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := AzureFirewallsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("AzureFirewallsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return AzureFirewallsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &AzureFirewallsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &AzureFirewallsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Azure Firewall.
@@ -122,20 +118,16 @@ func (client *AzureFirewallsClient) createOrUpdateCreateRequest(ctx context.Cont
 // azureFirewallName - The name of the Azure Firewall.
 // options - AzureFirewallsClientBeginDeleteOptions contains the optional parameters for the AzureFirewallsClient.BeginDelete
 // method.
-func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsClientBeginDeleteOptions) (AzureFirewallsClientDeletePollerResponse, error) {
+func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsClientBeginDeleteOptions) (*AzureFirewallsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, azureFirewallName, options)
 	if err != nil {
-		return AzureFirewallsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := AzureFirewallsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("AzureFirewallsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return AzureFirewallsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &AzureFirewallsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &AzureFirewallsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified Azure Firewall.
@@ -332,20 +324,16 @@ func (client *AzureFirewallsClient) listAllHandleResponse(resp *http.Response) (
 // parameters - Parameters supplied to update azure firewall tags.
 // options - AzureFirewallsClientBeginUpdateTagsOptions contains the optional parameters for the AzureFirewallsClient.BeginUpdateTags
 // method.
-func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject, options *AzureFirewallsClientBeginUpdateTagsOptions) (AzureFirewallsClientUpdateTagsPollerResponse, error) {
+func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject, options *AzureFirewallsClientBeginUpdateTagsOptions) (*AzureFirewallsClientUpdateTagsPoller, error) {
 	resp, err := client.updateTags(ctx, resourceGroupName, azureFirewallName, parameters, options)
 	if err != nil {
-		return AzureFirewallsClientUpdateTagsPollerResponse{}, err
+		return nil, err
 	}
-	result := AzureFirewallsClientUpdateTagsPollerResponse{}
 	pt, err := armruntime.NewPoller("AzureFirewallsClient.UpdateTags", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return AzureFirewallsClientUpdateTagsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &AzureFirewallsClientUpdateTagsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &AzureFirewallsClientUpdateTagsPoller{pt: pt}, nil
 }
 
 // UpdateTags - Updates tags of an Azure Firewall resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
@@ -57,20 +57,16 @@ func NewBastionHostsClient(subscriptionID string, credential azcore.TokenCredent
 // parameters - Parameters supplied to the create or update Bastion Host operation.
 // options - BastionHostsClientBeginCreateOrUpdateOptions contains the optional parameters for the BastionHostsClient.BeginCreateOrUpdate
 // method.
-func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost, options *BastionHostsClientBeginCreateOrUpdateOptions) (BastionHostsClientCreateOrUpdatePollerResponse, error) {
+func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost, options *BastionHostsClientBeginCreateOrUpdateOptions) (*BastionHostsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, bastionHostName, parameters, options)
 	if err != nil {
-		return BastionHostsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := BastionHostsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("BastionHostsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return BastionHostsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &BastionHostsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &BastionHostsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Bastion Host.
@@ -122,20 +118,16 @@ func (client *BastionHostsClient) createOrUpdateCreateRequest(ctx context.Contex
 // bastionHostName - The name of the Bastion Host.
 // options - BastionHostsClientBeginDeleteOptions contains the optional parameters for the BastionHostsClient.BeginDelete
 // method.
-func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsClientBeginDeleteOptions) (BastionHostsClientDeletePollerResponse, error) {
+func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsClientBeginDeleteOptions) (*BastionHostsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
-		return BastionHostsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := BastionHostsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("BastionHostsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return BastionHostsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &BastionHostsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &BastionHostsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified Bastion Host.

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
@@ -58,20 +58,16 @@ func NewConnectionMonitorsClient(subscriptionID string, credential azcore.TokenC
 // parameters - Parameters that define the operation to create a connection monitor.
 // options - ConnectionMonitorsClientBeginCreateOrUpdateOptions contains the optional parameters for the ConnectionMonitorsClient.BeginCreateOrUpdate
 // method.
-func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor, options *ConnectionMonitorsClientBeginCreateOrUpdateOptions) (ConnectionMonitorsClientCreateOrUpdatePollerResponse, error) {
+func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor, options *ConnectionMonitorsClientBeginCreateOrUpdateOptions) (*ConnectionMonitorsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, parameters, options)
 	if err != nil {
-		return ConnectionMonitorsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ConnectionMonitorsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ConnectionMonitorsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ConnectionMonitorsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ConnectionMonitorsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a connection monitor.
@@ -128,20 +124,16 @@ func (client *ConnectionMonitorsClient) createOrUpdateCreateRequest(ctx context.
 // connectionMonitorName - The name of the connection monitor.
 // options - ConnectionMonitorsClientBeginDeleteOptions contains the optional parameters for the ConnectionMonitorsClient.BeginDelete
 // method.
-func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsClientBeginDeleteOptions) (ConnectionMonitorsClientDeletePollerResponse, error) {
+func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsClientBeginDeleteOptions) (*ConnectionMonitorsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
-		return ConnectionMonitorsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ConnectionMonitorsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ConnectionMonitorsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ConnectionMonitorsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ConnectionMonitorsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified connection monitor.
@@ -307,20 +299,16 @@ func (client *ConnectionMonitorsClient) listHandleResponse(resp *http.Response) 
 // connectionMonitorName - The name given to the connection monitor.
 // options - ConnectionMonitorsClientBeginQueryOptions contains the optional parameters for the ConnectionMonitorsClient.BeginQuery
 // method.
-func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsClientBeginQueryOptions) (ConnectionMonitorsClientQueryPollerResponse, error) {
+func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsClientBeginQueryOptions) (*ConnectionMonitorsClientQueryPoller, error) {
 	resp, err := client.query(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
-		return ConnectionMonitorsClientQueryPollerResponse{}, err
+		return nil, err
 	}
-	result := ConnectionMonitorsClientQueryPollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.Query", "location", resp, client.pl)
 	if err != nil {
-		return ConnectionMonitorsClientQueryPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ConnectionMonitorsClientQueryPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ConnectionMonitorsClientQueryPoller{pt: pt}, nil
 }
 
 // Query - Query a snapshot of the most recent connection states.
@@ -377,20 +365,16 @@ func (client *ConnectionMonitorsClient) queryCreateRequest(ctx context.Context, 
 // connectionMonitorName - The name of the connection monitor.
 // options - ConnectionMonitorsClientBeginStartOptions contains the optional parameters for the ConnectionMonitorsClient.BeginStart
 // method.
-func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsClientBeginStartOptions) (ConnectionMonitorsClientStartPollerResponse, error) {
+func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsClientBeginStartOptions) (*ConnectionMonitorsClientStartPoller, error) {
 	resp, err := client.start(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
-		return ConnectionMonitorsClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result := ConnectionMonitorsClientStartPollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.Start", "location", resp, client.pl)
 	if err != nil {
-		return ConnectionMonitorsClientStartPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ConnectionMonitorsClientStartPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ConnectionMonitorsClientStartPoller{pt: pt}, nil
 }
 
 // Start - Starts the specified connection monitor.
@@ -447,20 +431,16 @@ func (client *ConnectionMonitorsClient) startCreateRequest(ctx context.Context, 
 // connectionMonitorName - The name of the connection monitor.
 // options - ConnectionMonitorsClientBeginStopOptions contains the optional parameters for the ConnectionMonitorsClient.BeginStop
 // method.
-func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsClientBeginStopOptions) (ConnectionMonitorsClientStopPollerResponse, error) {
+func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsClientBeginStopOptions) (*ConnectionMonitorsClientStopPoller, error) {
 	resp, err := client.stop(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
-		return ConnectionMonitorsClientStopPollerResponse{}, err
+		return nil, err
 	}
-	result := ConnectionMonitorsClientStopPollerResponse{}
 	pt, err := armruntime.NewPoller("ConnectionMonitorsClient.Stop", "location", resp, client.pl)
 	if err != nil {
-		return ConnectionMonitorsClientStopPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ConnectionMonitorsClientStopPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ConnectionMonitorsClientStopPoller{pt: pt}, nil
 }
 
 // Stop - Stops the specified connection monitor.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
@@ -57,20 +57,16 @@ func NewDdosCustomPoliciesClient(subscriptionID string, credential azcore.TokenC
 // parameters - Parameters supplied to the create or update operation.
 // options - DdosCustomPoliciesClientBeginCreateOrUpdateOptions contains the optional parameters for the DdosCustomPoliciesClient.BeginCreateOrUpdate
 // method.
-func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy, options *DdosCustomPoliciesClientBeginCreateOrUpdateOptions) (DdosCustomPoliciesClientCreateOrUpdatePollerResponse, error) {
+func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy, options *DdosCustomPoliciesClientBeginCreateOrUpdateOptions) (*DdosCustomPoliciesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, ddosCustomPolicyName, parameters, options)
 	if err != nil {
-		return DdosCustomPoliciesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := DdosCustomPoliciesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DdosCustomPoliciesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return DdosCustomPoliciesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DdosCustomPoliciesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DdosCustomPoliciesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a DDoS custom policy.
@@ -122,20 +118,16 @@ func (client *DdosCustomPoliciesClient) createOrUpdateCreateRequest(ctx context.
 // ddosCustomPolicyName - The name of the DDoS custom policy.
 // options - DdosCustomPoliciesClientBeginDeleteOptions contains the optional parameters for the DdosCustomPoliciesClient.BeginDelete
 // method.
-func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesClientBeginDeleteOptions) (DdosCustomPoliciesClientDeletePollerResponse, error) {
+func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesClientBeginDeleteOptions) (*DdosCustomPoliciesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, ddosCustomPolicyName, options)
 	if err != nil {
-		return DdosCustomPoliciesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := DdosCustomPoliciesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DdosCustomPoliciesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return DdosCustomPoliciesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DdosCustomPoliciesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DdosCustomPoliciesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified DDoS custom policy.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
@@ -57,20 +57,16 @@ func NewDdosProtectionPlansClient(subscriptionID string, credential azcore.Token
 // parameters - Parameters supplied to the create or update operation.
 // options - DdosProtectionPlansClientBeginCreateOrUpdateOptions contains the optional parameters for the DdosProtectionPlansClient.BeginCreateOrUpdate
 // method.
-func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan, options *DdosProtectionPlansClientBeginCreateOrUpdateOptions) (DdosProtectionPlansClientCreateOrUpdatePollerResponse, error) {
+func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan, options *DdosProtectionPlansClientBeginCreateOrUpdateOptions) (*DdosProtectionPlansClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, ddosProtectionPlanName, parameters, options)
 	if err != nil {
-		return DdosProtectionPlansClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := DdosProtectionPlansClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("DdosProtectionPlansClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return DdosProtectionPlansClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DdosProtectionPlansClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DdosProtectionPlansClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a DDoS protection plan.
@@ -122,20 +118,16 @@ func (client *DdosProtectionPlansClient) createOrUpdateCreateRequest(ctx context
 // ddosProtectionPlanName - The name of the DDoS protection plan.
 // options - DdosProtectionPlansClientBeginDeleteOptions contains the optional parameters for the DdosProtectionPlansClient.BeginDelete
 // method.
-func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansClientBeginDeleteOptions) (DdosProtectionPlansClientDeletePollerResponse, error) {
+func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansClientBeginDeleteOptions) (*DdosProtectionPlansClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, ddosProtectionPlanName, options)
 	if err != nil {
-		return DdosProtectionPlansClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := DdosProtectionPlansClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("DdosProtectionPlansClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return DdosProtectionPlansClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &DdosProtectionPlansClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &DdosProtectionPlansClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified DDoS protection plan.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
@@ -58,20 +58,16 @@ func NewExpressRouteCircuitAuthorizationsClient(subscriptionID string, credentia
 // authorizationParameters - Parameters supplied to the create or update express route circuit authorization operation.
 // options - ExpressRouteCircuitAuthorizationsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitAuthorizationsClient.BeginCreateOrUpdate
 // method.
-func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, options *ExpressRouteCircuitAuthorizationsClientBeginCreateOrUpdateOptions) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, options *ExpressRouteCircuitAuthorizationsClientBeginCreateOrUpdateOptions) (*ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, circuitName, authorizationName, authorizationParameters, options)
 	if err != nil {
-		return ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates an authorization in the specified express route circuit.
@@ -128,20 +124,16 @@ func (client *ExpressRouteCircuitAuthorizationsClient) createOrUpdateCreateReque
 // authorizationName - The name of the authorization.
 // options - ExpressRouteCircuitAuthorizationsClientBeginDeleteOptions contains the optional parameters for the ExpressRouteCircuitAuthorizationsClient.BeginDelete
 // method.
-func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsClientBeginDeleteOptions) (ExpressRouteCircuitAuthorizationsClientDeletePollerResponse, error) {
+func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsClientBeginDeleteOptions) (*ExpressRouteCircuitAuthorizationsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, circuitName, authorizationName, options)
 	if err != nil {
-		return ExpressRouteCircuitAuthorizationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitAuthorizationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitAuthorizationsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitAuthorizationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitAuthorizationsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitAuthorizationsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified authorization from the specified express route circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
@@ -60,20 +60,16 @@ func NewExpressRouteCircuitConnectionsClient(subscriptionID string, credential a
 // operation.
 // options - ExpressRouteCircuitConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitConnectionsClient.BeginCreateOrUpdate
 // method.
-func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection, options *ExpressRouteCircuitConnectionsClientBeginCreateOrUpdateOptions) (ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection, options *ExpressRouteCircuitConnectionsClientBeginCreateOrUpdateOptions) (*ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, circuitName, peeringName, connectionName, expressRouteCircuitConnectionParameters, options)
 	if err != nil {
-		return ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a Express Route Circuit Connection in the specified express route circuits.
@@ -135,20 +131,16 @@ func (client *ExpressRouteCircuitConnectionsClient) createOrUpdateCreateRequest(
 // connectionName - The name of the express route circuit connection.
 // options - ExpressRouteCircuitConnectionsClientBeginDeleteOptions contains the optional parameters for the ExpressRouteCircuitConnectionsClient.BeginDelete
 // method.
-func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsClientBeginDeleteOptions) (ExpressRouteCircuitConnectionsClientDeletePollerResponse, error) {
+func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsClientBeginDeleteOptions) (*ExpressRouteCircuitConnectionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, circuitName, peeringName, connectionName, options)
 	if err != nil {
-		return ExpressRouteCircuitConnectionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitConnectionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitConnectionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitConnectionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitConnectionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitConnectionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified Express Route Circuit Connection from the specified express route circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
@@ -58,20 +58,16 @@ func NewExpressRouteCircuitPeeringsClient(subscriptionID string, credential azco
 // peeringParameters - Parameters supplied to the create or update express route circuit peering operation.
 // options - ExpressRouteCircuitPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitPeeringsClient.BeginCreateOrUpdate
 // method.
-func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, options *ExpressRouteCircuitPeeringsClientBeginCreateOrUpdateOptions) (ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, options *ExpressRouteCircuitPeeringsClientBeginCreateOrUpdateOptions) (*ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, circuitName, peeringName, peeringParameters, options)
 	if err != nil {
-		return ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitPeeringsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified express route circuits.
@@ -128,20 +124,16 @@ func (client *ExpressRouteCircuitPeeringsClient) createOrUpdateCreateRequest(ctx
 // peeringName - The name of the peering.
 // options - ExpressRouteCircuitPeeringsClientBeginDeleteOptions contains the optional parameters for the ExpressRouteCircuitPeeringsClient.BeginDelete
 // method.
-func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsClientBeginDeleteOptions) (ExpressRouteCircuitPeeringsClientDeletePollerResponse, error) {
+func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsClientBeginDeleteOptions) (*ExpressRouteCircuitPeeringsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, circuitName, peeringName, options)
 	if err != nil {
-		return ExpressRouteCircuitPeeringsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitPeeringsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitPeeringsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitPeeringsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitPeeringsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitPeeringsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified peering from the specified express route circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
@@ -57,20 +57,16 @@ func NewExpressRouteCircuitsClient(subscriptionID string, credential azcore.Toke
 // parameters - Parameters supplied to the create or update express route circuit operation.
 // options - ExpressRouteCircuitsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitsClient.BeginCreateOrUpdate
 // method.
-func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, options *ExpressRouteCircuitsClientBeginCreateOrUpdateOptions) (ExpressRouteCircuitsClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, options *ExpressRouteCircuitsClientBeginCreateOrUpdateOptions) (*ExpressRouteCircuitsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, circuitName, parameters, options)
 	if err != nil {
-		return ExpressRouteCircuitsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates an express route circuit.
@@ -122,20 +118,16 @@ func (client *ExpressRouteCircuitsClient) createOrUpdateCreateRequest(ctx contex
 // circuitName - The name of the express route circuit.
 // options - ExpressRouteCircuitsClientBeginDeleteOptions contains the optional parameters for the ExpressRouteCircuitsClient.BeginDelete
 // method.
-func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsClientBeginDeleteOptions) (ExpressRouteCircuitsClientDeletePollerResponse, error) {
+func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsClientBeginDeleteOptions) (*ExpressRouteCircuitsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, circuitName, options)
 	if err != nil {
-		return ExpressRouteCircuitsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified express route circuit.
@@ -453,20 +445,16 @@ func (client *ExpressRouteCircuitsClient) listAllHandleResponse(resp *http.Respo
 // devicePath - The path of the device.
 // options - ExpressRouteCircuitsClientBeginListArpTableOptions contains the optional parameters for the ExpressRouteCircuitsClient.BeginListArpTable
 // method.
-func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsClientBeginListArpTableOptions) (ExpressRouteCircuitsClientListArpTablePollerResponse, error) {
+func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsClientBeginListArpTableOptions) (*ExpressRouteCircuitsClientListArpTablePoller, error) {
 	resp, err := client.listArpTable(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
-		return ExpressRouteCircuitsClientListArpTablePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitsClientListArpTablePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.ListArpTable", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitsClientListArpTablePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitsClientListArpTablePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitsClientListArpTablePoller{pt: pt}, nil
 }
 
 // ListArpTable - Gets the currently advertised ARP table associated with the express route circuit in a resource group.
@@ -529,20 +517,16 @@ func (client *ExpressRouteCircuitsClient) listArpTableCreateRequest(ctx context.
 // devicePath - The path of the device.
 // options - ExpressRouteCircuitsClientBeginListRoutesTableOptions contains the optional parameters for the ExpressRouteCircuitsClient.BeginListRoutesTable
 // method.
-func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsClientBeginListRoutesTableOptions) (ExpressRouteCircuitsClientListRoutesTablePollerResponse, error) {
+func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsClientBeginListRoutesTableOptions) (*ExpressRouteCircuitsClientListRoutesTablePoller, error) {
 	resp, err := client.listRoutesTable(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
-		return ExpressRouteCircuitsClientListRoutesTablePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitsClientListRoutesTablePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.ListRoutesTable", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitsClientListRoutesTablePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitsClientListRoutesTablePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitsClientListRoutesTablePoller{pt: pt}, nil
 }
 
 // ListRoutesTable - Gets the currently advertised routes table associated with the express route circuit in a resource group.
@@ -605,20 +589,16 @@ func (client *ExpressRouteCircuitsClient) listRoutesTableCreateRequest(ctx conte
 // devicePath - The path of the device.
 // options - ExpressRouteCircuitsClientBeginListRoutesTableSummaryOptions contains the optional parameters for the ExpressRouteCircuitsClient.BeginListRoutesTableSummary
 // method.
-func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsClientBeginListRoutesTableSummaryOptions) (ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse, error) {
+func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsClientBeginListRoutesTableSummaryOptions) (*ExpressRouteCircuitsClientListRoutesTableSummaryPoller, error) {
 	resp, err := client.listRoutesTableSummary(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
-		return ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCircuitsClient.ListRoutesTableSummary", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCircuitsClientListRoutesTableSummaryPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCircuitsClientListRoutesTableSummaryPoller{pt: pt}, nil
 }
 
 // ListRoutesTableSummary - Gets the currently advertised routes table summary associated with the express route circuit in

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
@@ -58,20 +58,16 @@ func NewExpressRouteConnectionsClient(subscriptionID string, credential azcore.T
 // putExpressRouteConnectionParameters - Parameters required in an ExpressRouteConnection PUT operation.
 // options - ExpressRouteConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteConnectionsClient.BeginCreateOrUpdate
 // method.
-func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection, options *ExpressRouteConnectionsClientBeginCreateOrUpdateOptions) (ExpressRouteConnectionsClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection, options *ExpressRouteConnectionsClientBeginCreateOrUpdateOptions) (*ExpressRouteConnectionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, expressRouteGatewayName, connectionName, putExpressRouteConnectionParameters, options)
 	if err != nil {
-		return ExpressRouteConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRouteConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteConnectionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a connection between an ExpressRoute gateway and an ExpressRoute circuit.
@@ -128,20 +124,16 @@ func (client *ExpressRouteConnectionsClient) createOrUpdateCreateRequest(ctx con
 // connectionName - The name of the connection subresource.
 // options - ExpressRouteConnectionsClientBeginDeleteOptions contains the optional parameters for the ExpressRouteConnectionsClient.BeginDelete
 // method.
-func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsClientBeginDeleteOptions) (ExpressRouteConnectionsClientDeletePollerResponse, error) {
+func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsClientBeginDeleteOptions) (*ExpressRouteConnectionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, expressRouteGatewayName, connectionName, options)
 	if err != nil {
-		return ExpressRouteConnectionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteConnectionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteConnectionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteConnectionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteConnectionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteConnectionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a connection to a ExpressRoute circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
@@ -58,20 +58,16 @@ func NewExpressRouteCrossConnectionPeeringsClient(subscriptionID string, credent
 // peeringParameters - Parameters supplied to the create or update ExpressRouteCrossConnection peering operation.
 // options - ExpressRouteCrossConnectionPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the
 // ExpressRouteCrossConnectionPeeringsClient.BeginCreateOrUpdate method.
-func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering, options *ExpressRouteCrossConnectionPeeringsClientBeginCreateOrUpdateOptions) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering, options *ExpressRouteCrossConnectionPeeringsClientBeginCreateOrUpdateOptions) (*ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, crossConnectionName, peeringName, peeringParameters, options)
 	if err != nil {
-		return ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified ExpressRouteCrossConnection.
@@ -128,20 +124,16 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) createOrUpdateCreateReq
 // peeringName - The name of the peering.
 // options - ExpressRouteCrossConnectionPeeringsClientBeginDeleteOptions contains the optional parameters for the ExpressRouteCrossConnectionPeeringsClient.BeginDelete
 // method.
-func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsClientBeginDeleteOptions) (ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse, error) {
+func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsClientBeginDeleteOptions) (*ExpressRouteCrossConnectionPeeringsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, crossConnectionName, peeringName, options)
 	if err != nil {
-		return ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionPeeringsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCrossConnectionPeeringsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCrossConnectionPeeringsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified peering from the ExpressRouteCrossConnection.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
@@ -57,20 +57,16 @@ func NewExpressRouteCrossConnectionsClient(subscriptionID string, credential azc
 // parameters - Parameters supplied to the update express route crossConnection operation.
 // options - ExpressRouteCrossConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.BeginCreateOrUpdate
 // method.
-func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection, options *ExpressRouteCrossConnectionsClientBeginCreateOrUpdateOptions) (ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection, options *ExpressRouteCrossConnectionsClientBeginCreateOrUpdateOptions) (*ExpressRouteCrossConnectionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, crossConnectionName, parameters, options)
 	if err != nil {
-		return ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCrossConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCrossConnectionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Update the specified ExpressRouteCrossConnection.
@@ -224,20 +220,16 @@ func (client *ExpressRouteCrossConnectionsClient) listHandleResponse(resp *http.
 // devicePath - The path of the device.
 // options - ExpressRouteCrossConnectionsClientBeginListArpTableOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.BeginListArpTable
 // method.
-func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsClientBeginListArpTableOptions) (ExpressRouteCrossConnectionsClientListArpTablePollerResponse, error) {
+func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsClientBeginListArpTableOptions) (*ExpressRouteCrossConnectionsClientListArpTablePoller, error) {
 	resp, err := client.listArpTable(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
-		return ExpressRouteCrossConnectionsClientListArpTablePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCrossConnectionsClientListArpTablePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionsClient.ListArpTable", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCrossConnectionsClientListArpTablePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCrossConnectionsClientListArpTablePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCrossConnectionsClientListArpTablePoller{pt: pt}, nil
 }
 
 // ListArpTable - Gets the currently advertised ARP table associated with the express route cross connection in a resource
@@ -349,20 +341,16 @@ func (client *ExpressRouteCrossConnectionsClient) listByResourceGroupHandleRespo
 // devicePath - The path of the device.
 // options - ExpressRouteCrossConnectionsClientBeginListRoutesTableOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.BeginListRoutesTable
 // method.
-func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsClientBeginListRoutesTableOptions) (ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse, error) {
+func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsClientBeginListRoutesTableOptions) (*ExpressRouteCrossConnectionsClientListRoutesTablePoller, error) {
 	resp, err := client.listRoutesTable(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
-		return ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionsClient.ListRoutesTable", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCrossConnectionsClientListRoutesTablePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCrossConnectionsClientListRoutesTablePoller{pt: pt}, nil
 }
 
 // ListRoutesTable - Gets the currently advertised routes table associated with the express route cross connection in a resource
@@ -426,20 +414,16 @@ func (client *ExpressRouteCrossConnectionsClient) listRoutesTableCreateRequest(c
 // devicePath - The path of the device.
 // options - ExpressRouteCrossConnectionsClientBeginListRoutesTableSummaryOptions contains the optional parameters for the
 // ExpressRouteCrossConnectionsClient.BeginListRoutesTableSummary method.
-func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsClientBeginListRoutesTableSummaryOptions) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse, error) {
+func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsClientBeginListRoutesTableSummaryOptions) (*ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller, error) {
 	resp, err := client.listRoutesTableSummary(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
-		return ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteCrossConnectionsClient.ListRoutesTableSummary", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller{pt: pt}, nil
 }
 
 // ListRoutesTableSummary - Gets the route table summary associated with the express route cross connection in a resource

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
@@ -57,20 +57,16 @@ func NewExpressRouteGatewaysClient(subscriptionID string, credential azcore.Toke
 // putExpressRouteGatewayParameters - Parameters required in an ExpressRoute gateway PUT operation.
 // options - ExpressRouteGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteGatewaysClient.BeginCreateOrUpdate
 // method.
-func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway, options *ExpressRouteGatewaysClientBeginCreateOrUpdateOptions) (ExpressRouteGatewaysClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway, options *ExpressRouteGatewaysClientBeginCreateOrUpdateOptions) (*ExpressRouteGatewaysClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, expressRouteGatewayName, putExpressRouteGatewayParameters, options)
 	if err != nil {
-		return ExpressRouteGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRouteGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteGatewaysClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a ExpressRoute gateway in a specified resource group.
@@ -123,20 +119,16 @@ func (client *ExpressRouteGatewaysClient) createOrUpdateCreateRequest(ctx contex
 // expressRouteGatewayName - The name of the ExpressRoute gateway.
 // options - ExpressRouteGatewaysClientBeginDeleteOptions contains the optional parameters for the ExpressRouteGatewaysClient.BeginDelete
 // method.
-func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysClientBeginDeleteOptions) (ExpressRouteGatewaysClientDeletePollerResponse, error) {
+func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysClientBeginDeleteOptions) (*ExpressRouteGatewaysClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, expressRouteGatewayName, options)
 	if err != nil {
-		return ExpressRouteGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRouteGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRouteGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRouteGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRouteGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRouteGatewaysClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified ExpressRoute gateway in a resource group. An ExpressRoute gateway resource can only be deleted

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
@@ -57,20 +57,16 @@ func NewExpressRoutePortsClient(subscriptionID string, credential azcore.TokenCr
 // parameters - Parameters supplied to the create ExpressRoutePort operation.
 // options - ExpressRoutePortsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRoutePortsClient.BeginCreateOrUpdate
 // method.
-func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort, options *ExpressRoutePortsClientBeginCreateOrUpdateOptions) (ExpressRoutePortsClientCreateOrUpdatePollerResponse, error) {
+func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort, options *ExpressRoutePortsClientBeginCreateOrUpdateOptions) (*ExpressRoutePortsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, expressRoutePortName, parameters, options)
 	if err != nil {
-		return ExpressRoutePortsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRoutePortsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRoutePortsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ExpressRoutePortsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRoutePortsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRoutePortsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified ExpressRoutePort resource.
@@ -122,20 +118,16 @@ func (client *ExpressRoutePortsClient) createOrUpdateCreateRequest(ctx context.C
 // expressRoutePortName - The name of the ExpressRoutePort resource.
 // options - ExpressRoutePortsClientBeginDeleteOptions contains the optional parameters for the ExpressRoutePortsClient.BeginDelete
 // method.
-func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsClientBeginDeleteOptions) (ExpressRoutePortsClientDeletePollerResponse, error) {
+func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsClientBeginDeleteOptions) (*ExpressRoutePortsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, expressRoutePortName, options)
 	if err != nil {
-		return ExpressRoutePortsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ExpressRoutePortsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ExpressRoutePortsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ExpressRoutePortsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ExpressRoutePortsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ExpressRoutePortsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified ExpressRoutePort resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
@@ -57,20 +57,16 @@ func NewFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCre
 // parameters - Parameters supplied to the create or update Firewall Policy operation.
 // options - FirewallPoliciesClientBeginCreateOrUpdateOptions contains the optional parameters for the FirewallPoliciesClient.BeginCreateOrUpdate
 // method.
-func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy, options *FirewallPoliciesClientBeginCreateOrUpdateOptions) (FirewallPoliciesClientCreateOrUpdatePollerResponse, error) {
+func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy, options *FirewallPoliciesClientBeginCreateOrUpdateOptions) (*FirewallPoliciesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, firewallPolicyName, parameters, options)
 	if err != nil {
-		return FirewallPoliciesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := FirewallPoliciesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("FirewallPoliciesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return FirewallPoliciesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &FirewallPoliciesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &FirewallPoliciesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Firewall Policy.
@@ -122,20 +118,16 @@ func (client *FirewallPoliciesClient) createOrUpdateCreateRequest(ctx context.Co
 // firewallPolicyName - The name of the Firewall Policy.
 // options - FirewallPoliciesClientBeginDeleteOptions contains the optional parameters for the FirewallPoliciesClient.BeginDelete
 // method.
-func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesClientBeginDeleteOptions) (FirewallPoliciesClientDeletePollerResponse, error) {
+func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesClientBeginDeleteOptions) (*FirewallPoliciesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, firewallPolicyName, options)
 	if err != nil {
-		return FirewallPoliciesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := FirewallPoliciesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("FirewallPoliciesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return FirewallPoliciesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &FirewallPoliciesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &FirewallPoliciesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified Firewall Policy.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
@@ -58,20 +58,16 @@ func NewFirewallPolicyRuleGroupsClient(subscriptionID string, credential azcore.
 // parameters - Parameters supplied to the create or update FirewallPolicyRuleGroup operation.
 // options - FirewallPolicyRuleGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the FirewallPolicyRuleGroupsClient.BeginCreateOrUpdate
 // method.
-func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup, options *FirewallPolicyRuleGroupsClientBeginCreateOrUpdateOptions) (FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse, error) {
+func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup, options *FirewallPolicyRuleGroupsClientBeginCreateOrUpdateOptions) (*FirewallPolicyRuleGroupsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, parameters, options)
 	if err != nil {
-		return FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("FirewallPolicyRuleGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &FirewallPolicyRuleGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &FirewallPolicyRuleGroupsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified FirewallPolicyRuleGroup.
@@ -128,20 +124,16 @@ func (client *FirewallPolicyRuleGroupsClient) createOrUpdateCreateRequest(ctx co
 // ruleGroupName - The name of the FirewallPolicyRuleGroup.
 // options - FirewallPolicyRuleGroupsClientBeginDeleteOptions contains the optional parameters for the FirewallPolicyRuleGroupsClient.BeginDelete
 // method.
-func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsClientBeginDeleteOptions) (FirewallPolicyRuleGroupsClientDeletePollerResponse, error) {
+func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsClientBeginDeleteOptions) (*FirewallPolicyRuleGroupsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, options)
 	if err != nil {
-		return FirewallPolicyRuleGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := FirewallPolicyRuleGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("FirewallPolicyRuleGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return FirewallPolicyRuleGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &FirewallPolicyRuleGroupsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &FirewallPolicyRuleGroupsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified FirewallPolicyRuleGroup.

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
@@ -58,20 +58,16 @@ func NewFlowLogsClient(subscriptionID string, credential azcore.TokenCredential,
 // parameters - Parameters that define the create or update flow log resource.
 // options - FlowLogsClientBeginCreateOrUpdateOptions contains the optional parameters for the FlowLogsClient.BeginCreateOrUpdate
 // method.
-func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog, options *FlowLogsClientBeginCreateOrUpdateOptions) (FlowLogsClientCreateOrUpdatePollerResponse, error) {
+func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog, options *FlowLogsClientBeginCreateOrUpdateOptions) (*FlowLogsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkWatcherName, flowLogName, parameters, options)
 	if err != nil {
-		return FlowLogsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := FlowLogsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("FlowLogsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return FlowLogsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &FlowLogsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &FlowLogsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or update a flow log for the specified network security group.
@@ -127,20 +123,16 @@ func (client *FlowLogsClient) createOrUpdateCreateRequest(ctx context.Context, r
 // networkWatcherName - The name of the network watcher.
 // flowLogName - The name of the flow log resource.
 // options - FlowLogsClientBeginDeleteOptions contains the optional parameters for the FlowLogsClient.BeginDelete method.
-func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsClientBeginDeleteOptions) (FlowLogsClientDeletePollerResponse, error) {
+func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsClientBeginDeleteOptions) (*FlowLogsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkWatcherName, flowLogName, options)
 	if err != nil {
-		return FlowLogsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := FlowLogsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("FlowLogsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return FlowLogsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &FlowLogsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &FlowLogsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified flow log resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
@@ -58,20 +58,16 @@ func NewInboundNatRulesClient(subscriptionID string, credential azcore.TokenCred
 // inboundNatRuleParameters - Parameters supplied to the create or update inbound nat rule operation.
 // options - InboundNatRulesClientBeginCreateOrUpdateOptions contains the optional parameters for the InboundNatRulesClient.BeginCreateOrUpdate
 // method.
-func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule, options *InboundNatRulesClientBeginCreateOrUpdateOptions) (InboundNatRulesClientCreateOrUpdatePollerResponse, error) {
+func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule, options *InboundNatRulesClientBeginCreateOrUpdateOptions) (*InboundNatRulesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, inboundNatRuleParameters, options)
 	if err != nil {
-		return InboundNatRulesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := InboundNatRulesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("InboundNatRulesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return InboundNatRulesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &InboundNatRulesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &InboundNatRulesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a load balancer inbound nat rule.
@@ -128,20 +124,16 @@ func (client *InboundNatRulesClient) createOrUpdateCreateRequest(ctx context.Con
 // inboundNatRuleName - The name of the inbound nat rule.
 // options - InboundNatRulesClientBeginDeleteOptions contains the optional parameters for the InboundNatRulesClient.BeginDelete
 // method.
-func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesClientBeginDeleteOptions) (InboundNatRulesClientDeletePollerResponse, error) {
+func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesClientBeginDeleteOptions) (*InboundNatRulesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, options)
 	if err != nil {
-		return InboundNatRulesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := InboundNatRulesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("InboundNatRulesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return InboundNatRulesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &InboundNatRulesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &InboundNatRulesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified load balancer inbound nat rule.

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaces_client.go
@@ -57,20 +57,16 @@ func NewInterfacesClient(subscriptionID string, credential azcore.TokenCredentia
 // parameters - Parameters supplied to the create or update network interface operation.
 // options - InterfacesClientBeginCreateOrUpdateOptions contains the optional parameters for the InterfacesClient.BeginCreateOrUpdate
 // method.
-func (client *InterfacesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters Interface, options *InterfacesClientBeginCreateOrUpdateOptions) (InterfacesClientCreateOrUpdatePollerResponse, error) {
+func (client *InterfacesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters Interface, options *InterfacesClientBeginCreateOrUpdateOptions) (*InterfacesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkInterfaceName, parameters, options)
 	if err != nil {
-		return InterfacesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := InterfacesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfacesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return InterfacesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &InterfacesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &InterfacesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a network interface.
@@ -121,20 +117,16 @@ func (client *InterfacesClient) createOrUpdateCreateRequest(ctx context.Context,
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.
 // options - InterfacesClientBeginDeleteOptions contains the optional parameters for the InterfacesClient.BeginDelete method.
-func (client *InterfacesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *InterfacesClientBeginDeleteOptions) (InterfacesClientDeletePollerResponse, error) {
+func (client *InterfacesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *InterfacesClientBeginDeleteOptions) (*InterfacesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
-		return InterfacesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := InterfacesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfacesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return InterfacesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &InterfacesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &InterfacesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified network interface.
@@ -244,20 +236,16 @@ func (client *InterfacesClient) getHandleResponse(resp *http.Response) (Interfac
 // networkInterfaceName - The name of the network interface.
 // options - InterfacesClientBeginGetEffectiveRouteTableOptions contains the optional parameters for the InterfacesClient.BeginGetEffectiveRouteTable
 // method.
-func (client *InterfacesClient) BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *InterfacesClientBeginGetEffectiveRouteTableOptions) (InterfacesClientGetEffectiveRouteTablePollerResponse, error) {
+func (client *InterfacesClient) BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *InterfacesClientBeginGetEffectiveRouteTableOptions) (*InterfacesClientGetEffectiveRouteTablePoller, error) {
 	resp, err := client.getEffectiveRouteTable(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
-		return InterfacesClientGetEffectiveRouteTablePollerResponse{}, err
+		return nil, err
 	}
-	result := InterfacesClientGetEffectiveRouteTablePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfacesClient.GetEffectiveRouteTable", "location", resp, client.pl)
 	if err != nil {
-		return InterfacesClientGetEffectiveRouteTablePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &InterfacesClientGetEffectiveRouteTablePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &InterfacesClientGetEffectiveRouteTablePoller{pt: pt}, nil
 }
 
 // GetEffectiveRouteTable - Gets all route tables applied to a network interface.
@@ -542,20 +530,16 @@ func (client *InterfacesClient) listAllHandleResponse(resp *http.Response) (Inte
 // networkInterfaceName - The name of the network interface.
 // options - InterfacesClientBeginListEffectiveNetworkSecurityGroupsOptions contains the optional parameters for the InterfacesClient.BeginListEffectiveNetworkSecurityGroups
 // method.
-func (client *InterfacesClient) BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *InterfacesClientBeginListEffectiveNetworkSecurityGroupsOptions) (InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse, error) {
+func (client *InterfacesClient) BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *InterfacesClientBeginListEffectiveNetworkSecurityGroupsOptions) (*InterfacesClientListEffectiveNetworkSecurityGroupsPoller, error) {
 	resp, err := client.listEffectiveNetworkSecurityGroups(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
-		return InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse{}, err
+		return nil, err
 	}
-	result := InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse{}
 	pt, err := armruntime.NewPoller("InterfacesClient.ListEffectiveNetworkSecurityGroups", "location", resp, client.pl)
 	if err != nil {
-		return InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &InterfacesClientListEffectiveNetworkSecurityGroupsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &InterfacesClientListEffectiveNetworkSecurityGroupsPoller{pt: pt}, nil
 }
 
 // ListEffectiveNetworkSecurityGroups - Gets all network security groups applied to a network interface.

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfacetapconfigurations_client.go
@@ -58,20 +58,16 @@ func NewInterfaceTapConfigurationsClient(subscriptionID string, credential azcor
 // tapConfigurationParameters - Parameters supplied to the create or update tap configuration operation.
 // options - InterfaceTapConfigurationsClientBeginCreateOrUpdateOptions contains the optional parameters for the InterfaceTapConfigurationsClient.BeginCreateOrUpdate
 // method.
-func (client *InterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters InterfaceTapConfiguration, options *InterfaceTapConfigurationsClientBeginCreateOrUpdateOptions) (InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse, error) {
+func (client *InterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters InterfaceTapConfiguration, options *InterfaceTapConfigurationsClientBeginCreateOrUpdateOptions) (*InterfaceTapConfigurationsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, tapConfigurationParameters, options)
 	if err != nil {
-		return InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfaceTapConfigurationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &InterfaceTapConfigurationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &InterfaceTapConfigurationsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a Tap configuration in the specified NetworkInterface.
@@ -128,20 +124,16 @@ func (client *InterfaceTapConfigurationsClient) createOrUpdateCreateRequest(ctx 
 // tapConfigurationName - The name of the tap configuration.
 // options - InterfaceTapConfigurationsClientBeginDeleteOptions contains the optional parameters for the InterfaceTapConfigurationsClient.BeginDelete
 // method.
-func (client *InterfaceTapConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *InterfaceTapConfigurationsClientBeginDeleteOptions) (InterfaceTapConfigurationsClientDeletePollerResponse, error) {
+func (client *InterfaceTapConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *InterfaceTapConfigurationsClientBeginDeleteOptions) (*InterfaceTapConfigurationsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, options)
 	if err != nil {
-		return InterfaceTapConfigurationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := InterfaceTapConfigurationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("InterfaceTapConfigurationsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return InterfaceTapConfigurationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &InterfaceTapConfigurationsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &InterfaceTapConfigurationsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified tap configuration from the NetworkInterface.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
@@ -57,20 +57,16 @@ func NewIPAllocationsClient(subscriptionID string, credential azcore.TokenCreden
 // parameters - Parameters supplied to the create or update virtual network operation.
 // options - IPAllocationsClientBeginCreateOrUpdateOptions contains the optional parameters for the IPAllocationsClient.BeginCreateOrUpdate
 // method.
-func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation, options *IPAllocationsClientBeginCreateOrUpdateOptions) (IPAllocationsClientCreateOrUpdatePollerResponse, error) {
+func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation, options *IPAllocationsClientBeginCreateOrUpdateOptions) (*IPAllocationsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, ipAllocationName, parameters, options)
 	if err != nil {
-		return IPAllocationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := IPAllocationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("IPAllocationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return IPAllocationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &IPAllocationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &IPAllocationsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates an IpAllocation in the specified resource group.
@@ -122,20 +118,16 @@ func (client *IPAllocationsClient) createOrUpdateCreateRequest(ctx context.Conte
 // ipAllocationName - The name of the IpAllocation.
 // options - IPAllocationsClientBeginDeleteOptions contains the optional parameters for the IPAllocationsClient.BeginDelete
 // method.
-func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsClientBeginDeleteOptions) (IPAllocationsClientDeletePollerResponse, error) {
+func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsClientBeginDeleteOptions) (*IPAllocationsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, ipAllocationName, options)
 	if err != nil {
-		return IPAllocationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := IPAllocationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("IPAllocationsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return IPAllocationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &IPAllocationsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &IPAllocationsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified IpAllocation.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
@@ -57,20 +57,16 @@ func NewIPGroupsClient(subscriptionID string, credential azcore.TokenCredential,
 // parameters - Parameters supplied to the create or update IpGroups operation.
 // options - IPGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the IPGroupsClient.BeginCreateOrUpdate
 // method.
-func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup, options *IPGroupsClientBeginCreateOrUpdateOptions) (IPGroupsClientCreateOrUpdatePollerResponse, error) {
+func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup, options *IPGroupsClientBeginCreateOrUpdateOptions) (*IPGroupsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, ipGroupsName, parameters, options)
 	if err != nil {
-		return IPGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := IPGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("IPGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return IPGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &IPGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &IPGroupsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates an ipGroups in a specified resource group.
@@ -121,20 +117,16 @@ func (client *IPGroupsClient) createOrUpdateCreateRequest(ctx context.Context, r
 // resourceGroupName - The name of the resource group.
 // ipGroupsName - The name of the ipGroups.
 // options - IPGroupsClientBeginDeleteOptions contains the optional parameters for the IPGroupsClient.BeginDelete method.
-func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsClientBeginDeleteOptions) (IPGroupsClientDeletePollerResponse, error) {
+func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsClientBeginDeleteOptions) (*IPGroupsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, ipGroupsName, options)
 	if err != nil {
-		return IPGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := IPGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("IPGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return IPGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &IPGroupsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &IPGroupsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified ipGroups.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
@@ -57,20 +57,16 @@ func NewLoadBalancersClient(subscriptionID string, credential azcore.TokenCreden
 // parameters - Parameters supplied to the create or update load balancer operation.
 // options - LoadBalancersClientBeginCreateOrUpdateOptions contains the optional parameters for the LoadBalancersClient.BeginCreateOrUpdate
 // method.
-func (client *LoadBalancersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer, options *LoadBalancersClientBeginCreateOrUpdateOptions) (LoadBalancersClientCreateOrUpdatePollerResponse, error) {
+func (client *LoadBalancersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer, options *LoadBalancersClientBeginCreateOrUpdateOptions) (*LoadBalancersClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, loadBalancerName, parameters, options)
 	if err != nil {
-		return LoadBalancersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := LoadBalancersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("LoadBalancersClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return LoadBalancersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LoadBalancersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LoadBalancersClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a load balancer.
@@ -122,20 +118,16 @@ func (client *LoadBalancersClient) createOrUpdateCreateRequest(ctx context.Conte
 // loadBalancerName - The name of the load balancer.
 // options - LoadBalancersClientBeginDeleteOptions contains the optional parameters for the LoadBalancersClient.BeginDelete
 // method.
-func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersClientBeginDeleteOptions) (LoadBalancersClientDeletePollerResponse, error) {
+func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersClientBeginDeleteOptions) (*LoadBalancersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, loadBalancerName, options)
 	if err != nil {
-		return LoadBalancersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := LoadBalancersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("LoadBalancersClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return LoadBalancersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LoadBalancersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LoadBalancersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified load balancer.

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
@@ -57,20 +57,16 @@ func NewLocalNetworkGatewaysClient(subscriptionID string, credential azcore.Toke
 // parameters - Parameters supplied to the create or update local network gateway operation.
 // options - LocalNetworkGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the LocalNetworkGatewaysClient.BeginCreateOrUpdate
 // method.
-func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, options *LocalNetworkGatewaysClientBeginCreateOrUpdateOptions) (LocalNetworkGatewaysClientCreateOrUpdatePollerResponse, error) {
+func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, options *LocalNetworkGatewaysClientBeginCreateOrUpdateOptions) (*LocalNetworkGatewaysClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, localNetworkGatewayName, parameters, options)
 	if err != nil {
-		return LocalNetworkGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := LocalNetworkGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("LocalNetworkGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return LocalNetworkGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LocalNetworkGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LocalNetworkGatewaysClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a local network gateway in the specified resource group.
@@ -122,20 +118,16 @@ func (client *LocalNetworkGatewaysClient) createOrUpdateCreateRequest(ctx contex
 // localNetworkGatewayName - The name of the local network gateway.
 // options - LocalNetworkGatewaysClientBeginDeleteOptions contains the optional parameters for the LocalNetworkGatewaysClient.BeginDelete
 // method.
-func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysClientBeginDeleteOptions) (LocalNetworkGatewaysClientDeletePollerResponse, error) {
+func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysClientBeginDeleteOptions) (*LocalNetworkGatewaysClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, localNetworkGatewayName, options)
 	if err != nil {
-		return LocalNetworkGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := LocalNetworkGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("LocalNetworkGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return LocalNetworkGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &LocalNetworkGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &LocalNetworkGatewaysClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified local network gateway.

--- a/test/network/2020-03-01/armnetwork/zz_generated_management_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_management_client.go
@@ -110,20 +110,16 @@ func (client *ManagementClient) checkDNSNameAvailabilityHandleResponse(resp *htt
 // bslRequest - Post request for all the Bastion Shareable Link endpoints.
 // options - ManagementClientBeginDeleteBastionShareableLinkOptions contains the optional parameters for the ManagementClient.BeginDeleteBastionShareableLink
 // method.
-func (client *ManagementClient) BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *ManagementClientBeginDeleteBastionShareableLinkOptions) (ManagementClientDeleteBastionShareableLinkPollerResponse, error) {
+func (client *ManagementClient) BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *ManagementClientBeginDeleteBastionShareableLinkOptions) (*ManagementClientDeleteBastionShareableLinkPoller, error) {
 	resp, err := client.deleteBastionShareableLink(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
-		return ManagementClientDeleteBastionShareableLinkPollerResponse{}, err
+		return nil, err
 	}
-	result := ManagementClientDeleteBastionShareableLinkPollerResponse{}
 	pt, err := armruntime.NewPoller("ManagementClient.DeleteBastionShareableLink", "location", resp, client.pl)
 	if err != nil {
-		return ManagementClientDeleteBastionShareableLinkPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ManagementClientDeleteBastionShareableLinkPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ManagementClientDeleteBastionShareableLinkPoller{pt: pt}, nil
 }
 
 // DeleteBastionShareableLink - Deletes the Bastion Shareable Links for all the VMs specified in the request.
@@ -231,20 +227,16 @@ func (client *ManagementClient) disconnectActiveSessionsHandleResponse(resp *htt
 // vpnClientParams - Parameters supplied to the generate VirtualWan VPN profile generation operation.
 // options - ManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions contains the optional parameters
 // for the ManagementClient.BeginGeneratevirtualwanvpnserverconfigurationvpnprofile method.
-func (client *ManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWANName string, vpnClientParams VirtualWanVPNProfileParameters, options *ManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse, error) {
+func (client *ManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWANName string, vpnClientParams VirtualWanVPNProfileParameters, options *ManagementClientBeginGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller, error) {
 	resp, err := client.generatevirtualwanvpnserverconfigurationvpnprofile(ctx, resourceGroupName, virtualWANName, vpnClientParams, options)
 	if err != nil {
-		return ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{}, err
+		return nil, err
 	}
-	result := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{}
 	pt, err := armruntime.NewPoller("ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", "location", resp, client.pl)
 	if err != nil {
-		return ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller{pt: pt}, nil
 }
 
 // Generatevirtualwanvpnserverconfigurationvpnprofile - Generates a unique VPN profile for P2S clients for VirtualWan and
@@ -297,21 +289,16 @@ func (client *ManagementClient) generatevirtualwanvpnserverconfigurationvpnprofi
 // bastionHostName - The name of the Bastion Host.
 // options - ManagementClientBeginGetActiveSessionsOptions contains the optional parameters for the ManagementClient.BeginGetActiveSessions
 // method.
-func (client *ManagementClient) BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *ManagementClientBeginGetActiveSessionsOptions) (ManagementClientGetActiveSessionsPollerResponse, error) {
+func (client *ManagementClient) BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *ManagementClientBeginGetActiveSessionsOptions) (*ManagementClientGetActiveSessionsPoller, error) {
 	resp, err := client.getActiveSessions(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
-		return ManagementClientGetActiveSessionsPollerResponse{}, err
+		return nil, err
 	}
-	result := ManagementClientGetActiveSessionsPollerResponse{}
 	pt, err := armruntime.NewPoller("ManagementClient.GetActiveSessions", "location", resp, client.pl)
 	if err != nil {
-		return ManagementClientGetActiveSessionsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ManagementClientGetActiveSessionsPoller{
-		pt:     pt,
-		client: client,
-	}
-	return result, nil
+	return &ManagementClientGetActiveSessionsPoller{pt: pt}, nil
 }
 
 // GetActiveSessions - Returns the list of currently active sessions on the Bastion.
@@ -427,21 +414,16 @@ func (client *ManagementClient) getBastionShareableLinkHandleResponse(resp *http
 // bslRequest - Post request for all the Bastion Shareable Link endpoints.
 // options - ManagementClientBeginPutBastionShareableLinkOptions contains the optional parameters for the ManagementClient.BeginPutBastionShareableLink
 // method.
-func (client *ManagementClient) BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *ManagementClientBeginPutBastionShareableLinkOptions) (ManagementClientPutBastionShareableLinkPollerResponse, error) {
+func (client *ManagementClient) BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *ManagementClientBeginPutBastionShareableLinkOptions) (*ManagementClientPutBastionShareableLinkPoller, error) {
 	resp, err := client.putBastionShareableLink(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
-		return ManagementClientPutBastionShareableLinkPollerResponse{}, err
+		return nil, err
 	}
-	result := ManagementClientPutBastionShareableLinkPollerResponse{}
 	pt, err := armruntime.NewPoller("ManagementClient.PutBastionShareableLink", "location", resp, client.pl)
 	if err != nil {
-		return ManagementClientPutBastionShareableLinkPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ManagementClientPutBastionShareableLinkPoller{
-		pt:     pt,
-		client: client,
-	}
-	return result, nil
+	return &ManagementClientPutBastionShareableLinkPoller{pt: pt}, nil
 }
 
 // PutBastionShareableLink - Creates a Bastion Shareable Links for all the VMs specified in the request.

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
@@ -57,20 +57,16 @@ func NewNatGatewaysClient(subscriptionID string, credential azcore.TokenCredenti
 // parameters - Parameters supplied to the create or update nat gateway operation.
 // options - NatGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the NatGatewaysClient.BeginCreateOrUpdate
 // method.
-func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway, options *NatGatewaysClientBeginCreateOrUpdateOptions) (NatGatewaysClientCreateOrUpdatePollerResponse, error) {
+func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway, options *NatGatewaysClientBeginCreateOrUpdateOptions) (*NatGatewaysClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, natGatewayName, parameters, options)
 	if err != nil {
-		return NatGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := NatGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("NatGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return NatGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &NatGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &NatGatewaysClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a nat gateway.
@@ -121,20 +117,16 @@ func (client *NatGatewaysClient) createOrUpdateCreateRequest(ctx context.Context
 // resourceGroupName - The name of the resource group.
 // natGatewayName - The name of the nat gateway.
 // options - NatGatewaysClientBeginDeleteOptions contains the optional parameters for the NatGatewaysClient.BeginDelete method.
-func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysClientBeginDeleteOptions) (NatGatewaysClientDeletePollerResponse, error) {
+func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysClientBeginDeleteOptions) (*NatGatewaysClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, natGatewayName, options)
 	if err != nil {
-		return NatGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := NatGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("NatGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return NatGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &NatGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &NatGatewaysClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified nat gateway.

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
@@ -57,20 +57,16 @@ func NewP2SVPNGatewaysClient(subscriptionID string, credential azcore.TokenCrede
 // p2SVPNGatewayParameters - Parameters supplied to create or Update a virtual wan p2s vpn gateway.
 // options - P2SVPNGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the P2SVPNGatewaysClient.BeginCreateOrUpdate
 // method.
-func (client *P2SVPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, p2SVPNGatewayParameters P2SVPNGateway, options *P2SVPNGatewaysClientBeginCreateOrUpdateOptions) (P2SVPNGatewaysClientCreateOrUpdatePollerResponse, error) {
+func (client *P2SVPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, p2SVPNGatewayParameters P2SVPNGateway, options *P2SVPNGatewaysClientBeginCreateOrUpdateOptions) (*P2SVPNGatewaysClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, gatewayName, p2SVPNGatewayParameters, options)
 	if err != nil {
-		return P2SVPNGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := P2SVPNGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return P2SVPNGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &P2SVPNGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &P2SVPNGatewaysClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a virtual wan p2s vpn gateway if it doesn't exist else updates the existing gateway.
@@ -122,20 +118,16 @@ func (client *P2SVPNGatewaysClient) createOrUpdateCreateRequest(ctx context.Cont
 // gatewayName - The name of the gateway.
 // options - P2SVPNGatewaysClientBeginDeleteOptions contains the optional parameters for the P2SVPNGatewaysClient.BeginDelete
 // method.
-func (client *P2SVPNGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVPNGatewaysClientBeginDeleteOptions) (P2SVPNGatewaysClientDeletePollerResponse, error) {
+func (client *P2SVPNGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVPNGatewaysClientBeginDeleteOptions) (*P2SVPNGatewaysClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
-		return P2SVPNGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := P2SVPNGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return P2SVPNGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &P2SVPNGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &P2SVPNGatewaysClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a virtual wan p2s vpn gateway.
@@ -189,20 +181,16 @@ func (client *P2SVPNGatewaysClient) deleteCreateRequest(ctx context.Context, res
 // request - The parameters are supplied to disconnect p2s vpn connections.
 // options - P2SVPNGatewaysClientBeginDisconnectP2SVPNConnectionsOptions contains the optional parameters for the P2SVPNGatewaysClient.BeginDisconnectP2SVPNConnections
 // method.
-func (client *P2SVPNGatewaysClient) BeginDisconnectP2SVPNConnections(ctx context.Context, resourceGroupName string, p2SVPNGatewayName string, request P2SVPNConnectionRequest, options *P2SVPNGatewaysClientBeginDisconnectP2SVPNConnectionsOptions) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse, error) {
+func (client *P2SVPNGatewaysClient) BeginDisconnectP2SVPNConnections(ctx context.Context, resourceGroupName string, p2SVPNGatewayName string, request P2SVPNConnectionRequest, options *P2SVPNGatewaysClientBeginDisconnectP2SVPNConnectionsOptions) (*P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller, error) {
 	resp, err := client.disconnectP2SVPNConnections(ctx, resourceGroupName, p2SVPNGatewayName, request, options)
 	if err != nil {
-		return P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse{}, err
+		return nil, err
 	}
-	result := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.DisconnectP2SVPNConnections", "location", resp, client.pl)
 	if err != nil {
-		return P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller{pt: pt}, nil
 }
 
 // DisconnectP2SVPNConnections - Disconnect P2S vpn connections of the virtual wan P2SVpnGateway in the specified resource
@@ -256,20 +244,16 @@ func (client *P2SVPNGatewaysClient) disconnectP2SVPNConnectionsCreateRequest(ctx
 // parameters - Parameters supplied to the generate P2SVpnGateway VPN client package operation.
 // options - P2SVPNGatewaysClientBeginGenerateVPNProfileOptions contains the optional parameters for the P2SVPNGatewaysClient.BeginGenerateVPNProfile
 // method.
-func (client *P2SVPNGatewaysClient) BeginGenerateVPNProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVPNProfileParameters, options *P2SVPNGatewaysClientBeginGenerateVPNProfileOptions) (P2SVPNGatewaysClientGenerateVPNProfilePollerResponse, error) {
+func (client *P2SVPNGatewaysClient) BeginGenerateVPNProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVPNProfileParameters, options *P2SVPNGatewaysClientBeginGenerateVPNProfileOptions) (*P2SVPNGatewaysClientGenerateVPNProfilePoller, error) {
 	resp, err := client.generateVPNProfile(ctx, resourceGroupName, gatewayName, parameters, options)
 	if err != nil {
-		return P2SVPNGatewaysClientGenerateVPNProfilePollerResponse{}, err
+		return nil, err
 	}
-	result := P2SVPNGatewaysClientGenerateVPNProfilePollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.GenerateVPNProfile", "location", resp, client.pl)
 	if err != nil {
-		return P2SVPNGatewaysClientGenerateVPNProfilePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &P2SVPNGatewaysClientGenerateVPNProfilePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &P2SVPNGatewaysClientGenerateVPNProfilePoller{pt: pt}, nil
 }
 
 // GenerateVPNProfile - Generates VPN profile for P2S client of the P2SVpnGateway in the specified resource group.
@@ -377,20 +361,16 @@ func (client *P2SVPNGatewaysClient) getHandleResponse(resp *http.Response) (P2SV
 // gatewayName - The name of the P2SVpnGateway.
 // options - P2SVPNGatewaysClientBeginGetP2SVPNConnectionHealthOptions contains the optional parameters for the P2SVPNGatewaysClient.BeginGetP2SVPNConnectionHealth
 // method.
-func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVPNGatewaysClientBeginGetP2SVPNConnectionHealthOptions) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse, error) {
+func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVPNGatewaysClientBeginGetP2SVPNConnectionHealthOptions) (*P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller, error) {
 	resp, err := client.getP2SVPNConnectionHealth(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
-		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse{}, err
+		return nil, err
 	}
-	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.GetP2SVPNConnectionHealth", "location", resp, client.pl)
 	if err != nil {
-		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller{pt: pt}, nil
 }
 
 // GetP2SVPNConnectionHealth - Gets the connection health of P2S clients of the virtual wan P2SVpnGateway in the specified
@@ -445,20 +425,16 @@ func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthCreateRequest(ctx c
 // request - Request parameters supplied to get p2s vpn connections detailed health.
 // options - P2SVPNGatewaysClientBeginGetP2SVPNConnectionHealthDetailedOptions contains the optional parameters for the P2SVPNGatewaysClient.BeginGetP2SVPNConnectionHealthDetailed
 // method.
-func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVPNConnectionHealthRequest, options *P2SVPNGatewaysClientBeginGetP2SVPNConnectionHealthDetailedOptions) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse, error) {
+func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVPNConnectionHealthRequest, options *P2SVPNGatewaysClientBeginGetP2SVPNConnectionHealthDetailedOptions) (*P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller, error) {
 	resp, err := client.getP2SVPNConnectionHealthDetailed(ctx, resourceGroupName, gatewayName, request, options)
 	if err != nil {
-		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse{}, err
+		return nil, err
 	}
-	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse{}
 	pt, err := armruntime.NewPoller("P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed", "location", resp, client.pl)
 	if err != nil {
-		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller{pt: pt}, nil
 }
 
 // GetP2SVPNConnectionHealthDetailed - Gets the sas url to get the connection health detail of P2S clients of the virtual

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
@@ -58,20 +58,16 @@ func NewPacketCapturesClient(subscriptionID string, credential azcore.TokenCrede
 // parameters - Parameters that define the create packet capture operation.
 // options - PacketCapturesClientBeginCreateOptions contains the optional parameters for the PacketCapturesClient.BeginCreate
 // method.
-func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture, options *PacketCapturesClientBeginCreateOptions) (PacketCapturesClientCreatePollerResponse, error) {
+func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture, options *PacketCapturesClientBeginCreateOptions) (*PacketCapturesClientCreatePoller, error) {
 	resp, err := client.create(ctx, resourceGroupName, networkWatcherName, packetCaptureName, parameters, options)
 	if err != nil {
-		return PacketCapturesClientCreatePollerResponse{}, err
+		return nil, err
 	}
-	result := PacketCapturesClientCreatePollerResponse{}
 	pt, err := armruntime.NewPoller("PacketCapturesClient.Create", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return PacketCapturesClientCreatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PacketCapturesClientCreatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PacketCapturesClientCreatePoller{pt: pt}, nil
 }
 
 // Create - Create and start a packet capture on the specified VM.
@@ -128,20 +124,16 @@ func (client *PacketCapturesClient) createCreateRequest(ctx context.Context, res
 // packetCaptureName - The name of the packet capture session.
 // options - PacketCapturesClientBeginDeleteOptions contains the optional parameters for the PacketCapturesClient.BeginDelete
 // method.
-func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesClientBeginDeleteOptions) (PacketCapturesClientDeletePollerResponse, error) {
+func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesClientBeginDeleteOptions) (*PacketCapturesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
-		return PacketCapturesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := PacketCapturesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PacketCapturesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return PacketCapturesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PacketCapturesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PacketCapturesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified packet capture session.
@@ -258,20 +250,16 @@ func (client *PacketCapturesClient) getHandleResponse(resp *http.Response) (Pack
 // packetCaptureName - The name given to the packet capture session.
 // options - PacketCapturesClientBeginGetStatusOptions contains the optional parameters for the PacketCapturesClient.BeginGetStatus
 // method.
-func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesClientBeginGetStatusOptions) (PacketCapturesClientGetStatusPollerResponse, error) {
+func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesClientBeginGetStatusOptions) (*PacketCapturesClientGetStatusPoller, error) {
 	resp, err := client.getStatus(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
-		return PacketCapturesClientGetStatusPollerResponse{}, err
+		return nil, err
 	}
-	result := PacketCapturesClientGetStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("PacketCapturesClient.GetStatus", "location", resp, client.pl)
 	if err != nil {
-		return PacketCapturesClientGetStatusPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PacketCapturesClientGetStatusPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PacketCapturesClientGetStatusPoller{pt: pt}, nil
 }
 
 // GetStatus - Query the status of a running packet capture session.
@@ -377,20 +365,16 @@ func (client *PacketCapturesClient) listHandleResponse(resp *http.Response) (Pac
 // packetCaptureName - The name of the packet capture session.
 // options - PacketCapturesClientBeginStopOptions contains the optional parameters for the PacketCapturesClient.BeginStop
 // method.
-func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesClientBeginStopOptions) (PacketCapturesClientStopPollerResponse, error) {
+func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesClientBeginStopOptions) (*PacketCapturesClientStopPoller, error) {
 	resp, err := client.stop(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
-		return PacketCapturesClientStopPollerResponse{}, err
+		return nil, err
 	}
-	result := PacketCapturesClientStopPollerResponse{}
 	pt, err := armruntime.NewPoller("PacketCapturesClient.Stop", "location", resp, client.pl)
 	if err != nil {
-		return PacketCapturesClientStopPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PacketCapturesClientStopPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PacketCapturesClientStopPoller{pt: pt}, nil
 }
 
 // Stop - Stops a specified packet capture session.

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -11,7 +11,8 @@ package armnetwork
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
+	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"time"
 )
 
 // ApplicationGatewaysClientBackendHealthOnDemandPoller provides polling facilities until the operation reaches a terminal state.
@@ -24,36 +25,52 @@ func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Poll(ctx context.Context) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
+	result := ApplicationGatewaysClientBackendHealthOnDemandResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ApplicationGatewayBackendHealthOnDemand)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ApplicationGatewaysClientBackendHealthOnDemandResponse will be returned.
-func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
-	respType := ApplicationGatewaysClientBackendHealthOnDemandResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ApplicationGatewayBackendHealthOnDemand)
-	if err != nil {
-		return ApplicationGatewaysClientBackendHealthOnDemandResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
+	result := ApplicationGatewaysClientBackendHealthOnDemandResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ApplicationGatewayBackendHealthOnDemand)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ApplicationGatewaysClientBackendHealthOnDemandPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealthOnDemand", token, client.pl); err != nil {
+		return ApplicationGatewaysClientBackendHealthOnDemandResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ApplicationGatewaysClientBackendHealthPoller provides polling facilities until the operation reaches a terminal state.
@@ -66,36 +83,52 @@ func (p *ApplicationGatewaysClientBackendHealthPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ApplicationGatewaysClientBackendHealthPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ApplicationGatewaysClientBackendHealthPoller) Poll(ctx context.Context) (ApplicationGatewaysClientBackendHealthResponse, error) {
+	result := ApplicationGatewaysClientBackendHealthResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ApplicationGatewayBackendHealth)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ApplicationGatewaysClientBackendHealthResponse will be returned.
-func (p *ApplicationGatewaysClientBackendHealthPoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientBackendHealthResponse, error) {
-	respType := ApplicationGatewaysClientBackendHealthResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ApplicationGatewayBackendHealth)
-	if err != nil {
-		return ApplicationGatewaysClientBackendHealthResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ApplicationGatewaysClientBackendHealthPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientBackendHealthResponse, error) {
+	result := ApplicationGatewaysClientBackendHealthResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ApplicationGatewayBackendHealth)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ApplicationGatewaysClientBackendHealthPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ApplicationGatewaysClientBackendHealthPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ApplicationGatewaysClientBackendHealthPoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientBackendHealthResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealth", token, client.pl); err != nil {
+		return ApplicationGatewaysClientBackendHealthResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ApplicationGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -108,36 +141,52 @@ func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
+	result := ApplicationGatewaysClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ApplicationGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ApplicationGatewaysClientCreateOrUpdateResponse will be returned.
-func (p *ApplicationGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
-	respType := ApplicationGatewaysClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ApplicationGateway)
-	if err != nil {
-		return ApplicationGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ApplicationGatewaysClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
+	result := ApplicationGatewaysClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ApplicationGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ApplicationGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ApplicationGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ApplicationGatewaysClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ApplicationGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -150,36 +199,52 @@ func (p *ApplicationGatewaysClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ApplicationGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ApplicationGatewaysClientDeletePoller) Poll(ctx context.Context) (ApplicationGatewaysClientDeleteResponse, error) {
+	result := ApplicationGatewaysClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ApplicationGatewaysClientDeleteResponse will be returned.
-func (p *ApplicationGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientDeleteResponse, error) {
-	respType := ApplicationGatewaysClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ApplicationGatewaysClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ApplicationGatewaysClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientDeleteResponse, error) {
+	result := ApplicationGatewaysClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ApplicationGatewaysClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ApplicationGatewaysClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ApplicationGatewaysClientDeletePoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Delete", token, client.pl); err != nil {
+		return ApplicationGatewaysClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ApplicationGatewaysClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -192,36 +257,52 @@ func (p *ApplicationGatewaysClientStartPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ApplicationGatewaysClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ApplicationGatewaysClientStartPoller) Poll(ctx context.Context) (ApplicationGatewaysClientStartResponse, error) {
+	result := ApplicationGatewaysClientStartResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ApplicationGatewaysClientStartResponse will be returned.
-func (p *ApplicationGatewaysClientStartPoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientStartResponse, error) {
-	respType := ApplicationGatewaysClientStartResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ApplicationGatewaysClientStartResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ApplicationGatewaysClientStartPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientStartResponse, error) {
+	result := ApplicationGatewaysClientStartResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ApplicationGatewaysClientStartPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ApplicationGatewaysClientStartPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ApplicationGatewaysClientStartPoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientStartResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Start", token, client.pl); err != nil {
+		return ApplicationGatewaysClientStartResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ApplicationGatewaysClientStopPoller provides polling facilities until the operation reaches a terminal state.
@@ -234,36 +315,52 @@ func (p *ApplicationGatewaysClientStopPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ApplicationGatewaysClientStopPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ApplicationGatewaysClientStopPoller) Poll(ctx context.Context) (ApplicationGatewaysClientStopResponse, error) {
+	result := ApplicationGatewaysClientStopResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ApplicationGatewaysClientStopResponse will be returned.
-func (p *ApplicationGatewaysClientStopPoller) FinalResponse(ctx context.Context) (ApplicationGatewaysClientStopResponse, error) {
-	respType := ApplicationGatewaysClientStopResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ApplicationGatewaysClientStopResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ApplicationGatewaysClientStopPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientStopResponse, error) {
+	result := ApplicationGatewaysClientStopResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ApplicationGatewaysClientStopPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ApplicationGatewaysClientStopPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ApplicationGatewaysClientStopPoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientStopResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Stop", token, client.pl); err != nil {
+		return ApplicationGatewaysClientStopResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ApplicationSecurityGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -276,36 +373,52 @@ func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
+	result := ApplicationSecurityGroupsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ApplicationSecurityGroup)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ApplicationSecurityGroupsClientCreateOrUpdateResponse will be returned.
-func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
-	respType := ApplicationSecurityGroupsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ApplicationSecurityGroup)
-	if err != nil {
-		return ApplicationSecurityGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
+	result := ApplicationSecurityGroupsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ApplicationSecurityGroup)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ApplicationSecurityGroupsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ApplicationSecurityGroupsClient, token string) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ApplicationSecurityGroupsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ApplicationSecurityGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -318,36 +431,52 @@ func (p *ApplicationSecurityGroupsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ApplicationSecurityGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ApplicationSecurityGroupsClientDeletePoller) Poll(ctx context.Context) (ApplicationSecurityGroupsClientDeleteResponse, error) {
+	result := ApplicationSecurityGroupsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ApplicationSecurityGroupsClientDeleteResponse will be returned.
-func (p *ApplicationSecurityGroupsClientDeletePoller) FinalResponse(ctx context.Context) (ApplicationSecurityGroupsClientDeleteResponse, error) {
-	respType := ApplicationSecurityGroupsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ApplicationSecurityGroupsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ApplicationSecurityGroupsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationSecurityGroupsClientDeleteResponse, error) {
+	result := ApplicationSecurityGroupsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ApplicationSecurityGroupsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ApplicationSecurityGroupsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ApplicationSecurityGroupsClientDeletePoller) Resume(ctx context.Context, client *ApplicationSecurityGroupsClient, token string) (ApplicationSecurityGroupsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.Delete", token, client.pl); err != nil {
+		return ApplicationSecurityGroupsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // AzureFirewallsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -360,36 +489,52 @@ func (p *AzureFirewallsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *AzureFirewallsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *AzureFirewallsClientCreateOrUpdatePoller) Poll(ctx context.Context) (AzureFirewallsClientCreateOrUpdateResponse, error) {
+	result := AzureFirewallsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.AzureFirewall)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final AzureFirewallsClientCreateOrUpdateResponse will be returned.
-func (p *AzureFirewallsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (AzureFirewallsClientCreateOrUpdateResponse, error) {
-	respType := AzureFirewallsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.AzureFirewall)
-	if err != nil {
-		return AzureFirewallsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *AzureFirewallsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientCreateOrUpdateResponse, error) {
+	result := AzureFirewallsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.AzureFirewall)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *AzureFirewallsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a AzureFirewallsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *AzureFirewallsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *AzureFirewallsClient, token string) (AzureFirewallsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return AzureFirewallsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // AzureFirewallsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -402,36 +547,52 @@ func (p *AzureFirewallsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *AzureFirewallsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *AzureFirewallsClientDeletePoller) Poll(ctx context.Context) (AzureFirewallsClientDeleteResponse, error) {
+	result := AzureFirewallsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final AzureFirewallsClientDeleteResponse will be returned.
-func (p *AzureFirewallsClientDeletePoller) FinalResponse(ctx context.Context) (AzureFirewallsClientDeleteResponse, error) {
-	respType := AzureFirewallsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return AzureFirewallsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *AzureFirewallsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientDeleteResponse, error) {
+	result := AzureFirewallsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *AzureFirewallsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a AzureFirewallsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *AzureFirewallsClientDeletePoller) Resume(ctx context.Context, client *AzureFirewallsClient, token string) (AzureFirewallsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.Delete", token, client.pl); err != nil {
+		return AzureFirewallsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // AzureFirewallsClientUpdateTagsPoller provides polling facilities until the operation reaches a terminal state.
@@ -444,36 +605,52 @@ func (p *AzureFirewallsClientUpdateTagsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *AzureFirewallsClientUpdateTagsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *AzureFirewallsClientUpdateTagsPoller) Poll(ctx context.Context) (AzureFirewallsClientUpdateTagsResponse, error) {
+	result := AzureFirewallsClientUpdateTagsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.AzureFirewall)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final AzureFirewallsClientUpdateTagsResponse will be returned.
-func (p *AzureFirewallsClientUpdateTagsPoller) FinalResponse(ctx context.Context) (AzureFirewallsClientUpdateTagsResponse, error) {
-	respType := AzureFirewallsClientUpdateTagsResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.AzureFirewall)
-	if err != nil {
-		return AzureFirewallsClientUpdateTagsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *AzureFirewallsClientUpdateTagsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientUpdateTagsResponse, error) {
+	result := AzureFirewallsClientUpdateTagsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.AzureFirewall)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *AzureFirewallsClientUpdateTagsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a AzureFirewallsClientUpdateTagsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *AzureFirewallsClientUpdateTagsPoller) Resume(ctx context.Context, client *AzureFirewallsClient, token string) (AzureFirewallsClientUpdateTagsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.UpdateTags", token, client.pl); err != nil {
+		return AzureFirewallsClientUpdateTagsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // BastionHostsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -486,36 +663,52 @@ func (p *BastionHostsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *BastionHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *BastionHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (BastionHostsClientCreateOrUpdateResponse, error) {
+	result := BastionHostsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.BastionHost)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final BastionHostsClientCreateOrUpdateResponse will be returned.
-func (p *BastionHostsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (BastionHostsClientCreateOrUpdateResponse, error) {
-	respType := BastionHostsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.BastionHost)
-	if err != nil {
-		return BastionHostsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *BastionHostsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (BastionHostsClientCreateOrUpdateResponse, error) {
+	result := BastionHostsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.BastionHost)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *BastionHostsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a BastionHostsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *BastionHostsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *BastionHostsClient, token string) (BastionHostsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("BastionHostsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return BastionHostsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // BastionHostsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -528,36 +721,52 @@ func (p *BastionHostsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *BastionHostsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *BastionHostsClientDeletePoller) Poll(ctx context.Context) (BastionHostsClientDeleteResponse, error) {
+	result := BastionHostsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final BastionHostsClientDeleteResponse will be returned.
-func (p *BastionHostsClientDeletePoller) FinalResponse(ctx context.Context) (BastionHostsClientDeleteResponse, error) {
-	respType := BastionHostsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return BastionHostsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *BastionHostsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (BastionHostsClientDeleteResponse, error) {
+	result := BastionHostsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *BastionHostsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a BastionHostsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *BastionHostsClientDeletePoller) Resume(ctx context.Context, client *BastionHostsClient, token string) (BastionHostsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("BastionHostsClient.Delete", token, client.pl); err != nil {
+		return BastionHostsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ConnectionMonitorsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -570,36 +779,52 @@ func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
+	result := ConnectionMonitorsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ConnectionMonitorResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ConnectionMonitorsClientCreateOrUpdateResponse will be returned.
-func (p *ConnectionMonitorsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
-	respType := ConnectionMonitorsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ConnectionMonitorResult)
-	if err != nil {
-		return ConnectionMonitorsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ConnectionMonitorsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
+	result := ConnectionMonitorsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ConnectionMonitorResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ConnectionMonitorsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ConnectionMonitorsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ConnectionMonitorsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ConnectionMonitorsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -612,36 +837,52 @@ func (p *ConnectionMonitorsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ConnectionMonitorsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ConnectionMonitorsClientDeletePoller) Poll(ctx context.Context) (ConnectionMonitorsClientDeleteResponse, error) {
+	result := ConnectionMonitorsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ConnectionMonitorsClientDeleteResponse will be returned.
-func (p *ConnectionMonitorsClientDeletePoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientDeleteResponse, error) {
-	respType := ConnectionMonitorsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ConnectionMonitorsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ConnectionMonitorsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientDeleteResponse, error) {
+	result := ConnectionMonitorsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ConnectionMonitorsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ConnectionMonitorsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ConnectionMonitorsClientDeletePoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Delete", token, client.pl); err != nil {
+		return ConnectionMonitorsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ConnectionMonitorsClientQueryPoller provides polling facilities until the operation reaches a terminal state.
@@ -654,36 +895,52 @@ func (p *ConnectionMonitorsClientQueryPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ConnectionMonitorsClientQueryPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ConnectionMonitorsClientQueryPoller) Poll(ctx context.Context) (ConnectionMonitorsClientQueryResponse, error) {
+	result := ConnectionMonitorsClientQueryResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ConnectionMonitorQueryResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ConnectionMonitorsClientQueryResponse will be returned.
-func (p *ConnectionMonitorsClientQueryPoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientQueryResponse, error) {
-	respType := ConnectionMonitorsClientQueryResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ConnectionMonitorQueryResult)
-	if err != nil {
-		return ConnectionMonitorsClientQueryResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ConnectionMonitorsClientQueryPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientQueryResponse, error) {
+	result := ConnectionMonitorsClientQueryResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ConnectionMonitorQueryResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ConnectionMonitorsClientQueryPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ConnectionMonitorsClientQueryPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ConnectionMonitorsClientQueryPoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientQueryResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Query", token, client.pl); err != nil {
+		return ConnectionMonitorsClientQueryResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ConnectionMonitorsClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -696,36 +953,52 @@ func (p *ConnectionMonitorsClientStartPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ConnectionMonitorsClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ConnectionMonitorsClientStartPoller) Poll(ctx context.Context) (ConnectionMonitorsClientStartResponse, error) {
+	result := ConnectionMonitorsClientStartResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ConnectionMonitorsClientStartResponse will be returned.
-func (p *ConnectionMonitorsClientStartPoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientStartResponse, error) {
-	respType := ConnectionMonitorsClientStartResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ConnectionMonitorsClientStartResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ConnectionMonitorsClientStartPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientStartResponse, error) {
+	result := ConnectionMonitorsClientStartResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ConnectionMonitorsClientStartPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ConnectionMonitorsClientStartPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ConnectionMonitorsClientStartPoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientStartResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Start", token, client.pl); err != nil {
+		return ConnectionMonitorsClientStartResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ConnectionMonitorsClientStopPoller provides polling facilities until the operation reaches a terminal state.
@@ -738,36 +1011,52 @@ func (p *ConnectionMonitorsClientStopPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ConnectionMonitorsClientStopPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ConnectionMonitorsClientStopPoller) Poll(ctx context.Context) (ConnectionMonitorsClientStopResponse, error) {
+	result := ConnectionMonitorsClientStopResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ConnectionMonitorsClientStopResponse will be returned.
-func (p *ConnectionMonitorsClientStopPoller) FinalResponse(ctx context.Context) (ConnectionMonitorsClientStopResponse, error) {
-	respType := ConnectionMonitorsClientStopResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ConnectionMonitorsClientStopResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ConnectionMonitorsClientStopPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientStopResponse, error) {
+	result := ConnectionMonitorsClientStopResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ConnectionMonitorsClientStopPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ConnectionMonitorsClientStopPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ConnectionMonitorsClientStopPoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientStopResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Stop", token, client.pl); err != nil {
+		return ConnectionMonitorsClientStopResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DdosCustomPoliciesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -780,36 +1069,52 @@ func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
+	result := DdosCustomPoliciesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DdosCustomPolicy)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DdosCustomPoliciesClientCreateOrUpdateResponse will be returned.
-func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
-	respType := DdosCustomPoliciesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DdosCustomPolicy)
-	if err != nil {
-		return DdosCustomPoliciesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
+	result := DdosCustomPoliciesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DdosCustomPolicy)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DdosCustomPoliciesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DdosCustomPoliciesClient, token string) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DdosCustomPoliciesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return DdosCustomPoliciesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DdosCustomPoliciesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -822,36 +1127,52 @@ func (p *DdosCustomPoliciesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DdosCustomPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DdosCustomPoliciesClientDeletePoller) Poll(ctx context.Context) (DdosCustomPoliciesClientDeleteResponse, error) {
+	result := DdosCustomPoliciesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DdosCustomPoliciesClientDeleteResponse will be returned.
-func (p *DdosCustomPoliciesClientDeletePoller) FinalResponse(ctx context.Context) (DdosCustomPoliciesClientDeleteResponse, error) {
-	respType := DdosCustomPoliciesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DdosCustomPoliciesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DdosCustomPoliciesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DdosCustomPoliciesClientDeleteResponse, error) {
+	result := DdosCustomPoliciesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DdosCustomPoliciesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DdosCustomPoliciesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DdosCustomPoliciesClientDeletePoller) Resume(ctx context.Context, client *DdosCustomPoliciesClient, token string) (DdosCustomPoliciesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DdosCustomPoliciesClient.Delete", token, client.pl); err != nil {
+		return DdosCustomPoliciesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DdosProtectionPlansClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -864,36 +1185,52 @@ func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Poll(ctx context.Context) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
+	result := DdosProtectionPlansClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DdosProtectionPlan)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DdosProtectionPlansClientCreateOrUpdateResponse will be returned.
-func (p *DdosProtectionPlansClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
-	respType := DdosProtectionPlansClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DdosProtectionPlan)
-	if err != nil {
-		return DdosProtectionPlansClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DdosProtectionPlansClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
+	result := DdosProtectionPlansClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DdosProtectionPlan)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DdosProtectionPlansClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DdosProtectionPlansClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DdosProtectionPlansClient, token string) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DdosProtectionPlansClient.CreateOrUpdate", token, client.pl); err != nil {
+		return DdosProtectionPlansClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // DdosProtectionPlansClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -906,36 +1243,52 @@ func (p *DdosProtectionPlansClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *DdosProtectionPlansClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *DdosProtectionPlansClientDeletePoller) Poll(ctx context.Context) (DdosProtectionPlansClientDeleteResponse, error) {
+	result := DdosProtectionPlansClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final DdosProtectionPlansClientDeleteResponse will be returned.
-func (p *DdosProtectionPlansClientDeletePoller) FinalResponse(ctx context.Context) (DdosProtectionPlansClientDeleteResponse, error) {
-	respType := DdosProtectionPlansClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return DdosProtectionPlansClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *DdosProtectionPlansClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (DdosProtectionPlansClientDeleteResponse, error) {
+	result := DdosProtectionPlansClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *DdosProtectionPlansClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a DdosProtectionPlansClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *DdosProtectionPlansClientDeletePoller) Resume(ctx context.Context, client *DdosProtectionPlansClient, token string) (DdosProtectionPlansClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("DdosProtectionPlansClient.Delete", token, client.pl); err != nil {
+		return DdosProtectionPlansClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -948,36 +1301,52 @@ func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Done() boo
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitAuthorization)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitAuthorization)
-	if err != nil {
-		return ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuitAuthorization)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCircuitAuthorizationsClient, token string) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitAuthorizationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -990,36 +1359,52 @@ func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
+	result := ExpressRouteCircuitAuthorizationsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitAuthorizationsClientDeleteResponse will be returned.
-func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
-	respType := ExpressRouteCircuitAuthorizationsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ExpressRouteCircuitAuthorizationsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
+	result := ExpressRouteCircuitAuthorizationsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitAuthorizationsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCircuitAuthorizationsClient, token string) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.Delete", token, client.pl); err != nil {
+		return ExpressRouteCircuitAuthorizationsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1032,36 +1417,52 @@ func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitConnection)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitConnection)
-	if err != nil {
-		return ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuitConnection)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCircuitConnectionsClient, token string) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitConnectionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1074,36 +1475,52 @@ func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
+	result := ExpressRouteCircuitConnectionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitConnectionsClientDeleteResponse will be returned.
-func (p *ExpressRouteCircuitConnectionsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
-	respType := ExpressRouteCircuitConnectionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ExpressRouteCircuitConnectionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitConnectionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
+	result := ExpressRouteCircuitConnectionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitConnectionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitConnectionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCircuitConnectionsClient, token string) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.Delete", token, client.pl); err != nil {
+		return ExpressRouteCircuitConnectionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1116,36 +1533,52 @@ func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitPeering)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitPeering)
-	if err != nil {
-		return ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuitPeering)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCircuitPeeringsClient, token string) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitPeeringsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1158,36 +1591,52 @@ func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
+	result := ExpressRouteCircuitPeeringsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitPeeringsClientDeleteResponse will be returned.
-func (p *ExpressRouteCircuitPeeringsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
-	respType := ExpressRouteCircuitPeeringsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ExpressRouteCircuitPeeringsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitPeeringsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
+	result := ExpressRouteCircuitPeeringsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitPeeringsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitPeeringsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCircuitPeeringsClient, token string) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.Delete", token, client.pl); err != nil {
+		return ExpressRouteCircuitPeeringsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1200,36 +1649,52 @@ func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCircuitsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuit)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitsClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCircuitsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuit)
-	if err != nil {
-		return ExpressRouteCircuitsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCircuitsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuit)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRouteCircuitsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1242,36 +1707,52 @@ func (p *ExpressRouteCircuitsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientDeleteResponse, error) {
+	result := ExpressRouteCircuitsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitsClientDeleteResponse will be returned.
-func (p *ExpressRouteCircuitsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientDeleteResponse, error) {
-	respType := ExpressRouteCircuitsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ExpressRouteCircuitsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientDeleteResponse, error) {
+	result := ExpressRouteCircuitsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.Delete", token, client.pl); err != nil {
+		return ExpressRouteCircuitsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitsClientListArpTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -1284,36 +1765,52 @@ func (p *ExpressRouteCircuitsClientListArpTablePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitsClientListArpTablePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitsClientListArpTablePoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientListArpTableResponse, error) {
+	result := ExpressRouteCircuitsClientListArpTableResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsArpTableListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitsClientListArpTableResponse will be returned.
-func (p *ExpressRouteCircuitsClientListArpTablePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientListArpTableResponse, error) {
-	respType := ExpressRouteCircuitsClientListArpTableResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsArpTableListResult)
-	if err != nil {
-		return ExpressRouteCircuitsClientListArpTableResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitsClientListArpTablePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListArpTableResponse, error) {
+	result := ExpressRouteCircuitsClientListArpTableResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuitsArpTableListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitsClientListArpTablePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitsClientListArpTablePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitsClientListArpTablePoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientListArpTableResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListArpTable", token, client.pl); err != nil {
+		return ExpressRouteCircuitsClientListArpTableResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitsClientListRoutesTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -1326,36 +1823,52 @@ func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
+	result := ExpressRouteCircuitsClientListRoutesTableResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsRoutesTableListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitsClientListRoutesTableResponse will be returned.
-func (p *ExpressRouteCircuitsClientListRoutesTablePoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
-	respType := ExpressRouteCircuitsClientListRoutesTableResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableListResult)
-	if err != nil {
-		return ExpressRouteCircuitsClientListRoutesTableResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitsClientListRoutesTablePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
+	result := ExpressRouteCircuitsClientListRoutesTableResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuitsRoutesTableListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitsClientListRoutesTablePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitsClientListRoutesTablePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTable", token, client.pl); err != nil {
+		return ExpressRouteCircuitsClientListRoutesTableResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCircuitsClientListRoutesTableSummaryPoller provides polling facilities until the operation reaches a terminal state.
@@ -1368,36 +1881,52 @@ func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
+	result := ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsRoutesTableSummaryListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCircuitsClientListRoutesTableSummaryResponse will be returned.
-func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) FinalResponse(ctx context.Context) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
-	respType := ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableSummaryListResult)
-	if err != nil {
-		return ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
+	result := ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuitsRoutesTableSummaryListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCircuitsClientListRoutesTableSummaryPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTableSummary", token, client.pl); err != nil {
+		return ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1410,36 +1939,52 @@ func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteConnectionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteConnection)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteConnectionsClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteConnectionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteConnection)
-	if err != nil {
-		return ExpressRouteConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteConnectionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteConnection)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteConnectionsClient, token string) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRouteConnectionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteConnectionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1452,36 +1997,52 @@ func (p *ExpressRouteConnectionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteConnectionsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteConnectionsClientDeleteResponse, error) {
+	result := ExpressRouteConnectionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteConnectionsClientDeleteResponse will be returned.
-func (p *ExpressRouteConnectionsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteConnectionsClientDeleteResponse, error) {
-	respType := ExpressRouteConnectionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ExpressRouteConnectionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteConnectionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteConnectionsClientDeleteResponse, error) {
+	result := ExpressRouteConnectionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteConnectionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteConnectionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteConnectionsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteConnectionsClient, token string) (ExpressRouteConnectionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteConnectionsClient.Delete", token, client.pl); err != nil {
+		return ExpressRouteConnectionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1494,36 +2055,52 @@ func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Done() b
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCrossConnectionPeering)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnectionPeering)
-	if err != nil {
-		return ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCrossConnectionPeering)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionPeeringsClient, token string) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCrossConnectionPeeringsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1536,36 +2113,52 @@ func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
+	result := ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCrossConnectionPeeringsClientDeleteResponse will be returned.
-func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
-	respType := ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
+	result := ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCrossConnectionPeeringsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionPeeringsClient, token string) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.Delete", token, client.pl); err != nil {
+		return ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCrossConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1578,36 +2171,52 @@ func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCrossConnection)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCrossConnectionsClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnection)
-	if err != nil {
-		return ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCrossConnection)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCrossConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCrossConnectionsClientListArpTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -1620,36 +2229,52 @@ func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
+	result := ExpressRouteCrossConnectionsClientListArpTableResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsArpTableListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCrossConnectionsClientListArpTableResponse will be returned.
-func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
-	respType := ExpressRouteCrossConnectionsClientListArpTableResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsArpTableListResult)
-	if err != nil {
-		return ExpressRouteCrossConnectionsClientListArpTableResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
+	result := ExpressRouteCrossConnectionsClientListArpTableResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuitsArpTableListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCrossConnectionsClientListArpTablePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListArpTable", token, client.pl); err != nil {
+		return ExpressRouteCrossConnectionsClientListArpTableResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -1662,36 +2287,52 @@ func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
+	result := ExpressRouteCrossConnectionsClientListRoutesTableResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsRoutesTableListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCrossConnectionsClientListRoutesTableResponse will be returned.
-func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
-	respType := ExpressRouteCrossConnectionsClientListRoutesTableResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCircuitsRoutesTableListResult)
-	if err != nil {
-		return ExpressRouteCrossConnectionsClientListRoutesTableResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
+	result := ExpressRouteCrossConnectionsClientListRoutesTableResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCircuitsRoutesTableListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCrossConnectionsClientListRoutesTablePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTable", token, client.pl); err != nil {
+		return ExpressRouteCrossConnectionsClientListRoutesTableResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller provides polling facilities until the operation reaches a terminal state.
@@ -1704,36 +2345,52 @@ func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Done() 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
+	result := ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse will be returned.
-func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) FinalResponse(ctx context.Context) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
-	respType := ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
-	if err != nil {
-		return ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
+	result := ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTableSummary", token, client.pl); err != nil {
+		return ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1746,36 +2403,52 @@ func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteGatewaysClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteGatewaysClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteGatewaysClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRouteGateway)
-	if err != nil {
-		return ExpressRouteGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
+	result := ExpressRouteGatewaysClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRouteGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteGatewaysClient, token string) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRouteGatewaysClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRouteGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1788,36 +2461,52 @@ func (p *ExpressRouteGatewaysClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRouteGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRouteGatewaysClientDeletePoller) Poll(ctx context.Context) (ExpressRouteGatewaysClientDeleteResponse, error) {
+	result := ExpressRouteGatewaysClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRouteGatewaysClientDeleteResponse will be returned.
-func (p *ExpressRouteGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRouteGatewaysClientDeleteResponse, error) {
-	respType := ExpressRouteGatewaysClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ExpressRouteGatewaysClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRouteGatewaysClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteGatewaysClientDeleteResponse, error) {
+	result := ExpressRouteGatewaysClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRouteGatewaysClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRouteGatewaysClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRouteGatewaysClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteGatewaysClient, token string) (ExpressRouteGatewaysClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteGatewaysClient.Delete", token, client.pl); err != nil {
+		return ExpressRouteGatewaysClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRoutePortsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1830,36 +2519,52 @@ func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
+	result := ExpressRoutePortsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ExpressRoutePort)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRoutePortsClientCreateOrUpdateResponse will be returned.
-func (p *ExpressRoutePortsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRoutePortsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ExpressRoutePort)
-	if err != nil {
-		return ExpressRoutePortsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRoutePortsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
+	result := ExpressRoutePortsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ExpressRoutePort)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRoutePortsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRoutePortsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRoutePortsClient, token string) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRoutePortsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ExpressRoutePortsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ExpressRoutePortsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1872,36 +2577,52 @@ func (p *ExpressRoutePortsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ExpressRoutePortsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ExpressRoutePortsClientDeletePoller) Poll(ctx context.Context) (ExpressRoutePortsClientDeleteResponse, error) {
+	result := ExpressRoutePortsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ExpressRoutePortsClientDeleteResponse will be returned.
-func (p *ExpressRoutePortsClientDeletePoller) FinalResponse(ctx context.Context) (ExpressRoutePortsClientDeleteResponse, error) {
-	respType := ExpressRoutePortsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ExpressRoutePortsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ExpressRoutePortsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRoutePortsClientDeleteResponse, error) {
+	result := ExpressRoutePortsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ExpressRoutePortsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ExpressRoutePortsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ExpressRoutePortsClientDeletePoller) Resume(ctx context.Context, client *ExpressRoutePortsClient, token string) (ExpressRoutePortsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRoutePortsClient.Delete", token, client.pl); err != nil {
+		return ExpressRoutePortsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // FirewallPoliciesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1914,36 +2635,52 @@ func (p *FirewallPoliciesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *FirewallPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *FirewallPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
+	result := FirewallPoliciesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.FirewallPolicy)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final FirewallPoliciesClientCreateOrUpdateResponse will be returned.
-func (p *FirewallPoliciesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
-	respType := FirewallPoliciesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.FirewallPolicy)
-	if err != nil {
-		return FirewallPoliciesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *FirewallPoliciesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
+	result := FirewallPoliciesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.FirewallPolicy)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *FirewallPoliciesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a FirewallPoliciesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *FirewallPoliciesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *FirewallPoliciesClient, token string) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPoliciesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return FirewallPoliciesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // FirewallPoliciesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1956,36 +2693,52 @@ func (p *FirewallPoliciesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *FirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *FirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (FirewallPoliciesClientDeleteResponse, error) {
+	result := FirewallPoliciesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final FirewallPoliciesClientDeleteResponse will be returned.
-func (p *FirewallPoliciesClientDeletePoller) FinalResponse(ctx context.Context) (FirewallPoliciesClientDeleteResponse, error) {
-	respType := FirewallPoliciesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return FirewallPoliciesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *FirewallPoliciesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPoliciesClientDeleteResponse, error) {
+	result := FirewallPoliciesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *FirewallPoliciesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a FirewallPoliciesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *FirewallPoliciesClientDeletePoller) Resume(ctx context.Context, client *FirewallPoliciesClient, token string) (FirewallPoliciesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPoliciesClient.Delete", token, client.pl); err != nil {
+		return FirewallPoliciesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // FirewallPolicyRuleGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1998,36 +2751,52 @@ func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
+	result := FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.FirewallPolicyRuleGroup)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final FirewallPolicyRuleGroupsClientCreateOrUpdateResponse will be returned.
-func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
-	respType := FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.FirewallPolicyRuleGroup)
-	if err != nil {
-		return FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
+	result := FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.FirewallPolicyRuleGroup)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a FirewallPolicyRuleGroupsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *FirewallPolicyRuleGroupsClient, token string) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // FirewallPolicyRuleGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2040,36 +2809,52 @@ func (p *FirewallPolicyRuleGroupsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *FirewallPolicyRuleGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *FirewallPolicyRuleGroupsClientDeletePoller) Poll(ctx context.Context) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
+	result := FirewallPolicyRuleGroupsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final FirewallPolicyRuleGroupsClientDeleteResponse will be returned.
-func (p *FirewallPolicyRuleGroupsClientDeletePoller) FinalResponse(ctx context.Context) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
-	respType := FirewallPolicyRuleGroupsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return FirewallPolicyRuleGroupsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *FirewallPolicyRuleGroupsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
+	result := FirewallPolicyRuleGroupsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *FirewallPolicyRuleGroupsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a FirewallPolicyRuleGroupsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *FirewallPolicyRuleGroupsClientDeletePoller) Resume(ctx context.Context, client *FirewallPolicyRuleGroupsClient, token string) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.Delete", token, client.pl); err != nil {
+		return FirewallPolicyRuleGroupsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // FlowLogsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2082,36 +2867,52 @@ func (p *FlowLogsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *FlowLogsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *FlowLogsClientCreateOrUpdatePoller) Poll(ctx context.Context) (FlowLogsClientCreateOrUpdateResponse, error) {
+	result := FlowLogsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.FlowLog)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final FlowLogsClientCreateOrUpdateResponse will be returned.
-func (p *FlowLogsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (FlowLogsClientCreateOrUpdateResponse, error) {
-	respType := FlowLogsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.FlowLog)
-	if err != nil {
-		return FlowLogsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *FlowLogsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (FlowLogsClientCreateOrUpdateResponse, error) {
+	result := FlowLogsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.FlowLog)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *FlowLogsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a FlowLogsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *FlowLogsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *FlowLogsClient, token string) (FlowLogsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("FlowLogsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return FlowLogsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // FlowLogsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2124,36 +2925,52 @@ func (p *FlowLogsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *FlowLogsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *FlowLogsClientDeletePoller) Poll(ctx context.Context) (FlowLogsClientDeleteResponse, error) {
+	result := FlowLogsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final FlowLogsClientDeleteResponse will be returned.
-func (p *FlowLogsClientDeletePoller) FinalResponse(ctx context.Context) (FlowLogsClientDeleteResponse, error) {
-	respType := FlowLogsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return FlowLogsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *FlowLogsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (FlowLogsClientDeleteResponse, error) {
+	result := FlowLogsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *FlowLogsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a FlowLogsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *FlowLogsClientDeletePoller) Resume(ctx context.Context, client *FlowLogsClient, token string) (FlowLogsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("FlowLogsClient.Delete", token, client.pl); err != nil {
+		return FlowLogsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // IPAllocationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2166,36 +2983,52 @@ func (p *IPAllocationsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *IPAllocationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *IPAllocationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (IPAllocationsClientCreateOrUpdateResponse, error) {
+	result := IPAllocationsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.IPAllocation)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final IPAllocationsClientCreateOrUpdateResponse will be returned.
-func (p *IPAllocationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (IPAllocationsClientCreateOrUpdateResponse, error) {
-	respType := IPAllocationsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.IPAllocation)
-	if err != nil {
-		return IPAllocationsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *IPAllocationsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (IPAllocationsClientCreateOrUpdateResponse, error) {
+	result := IPAllocationsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.IPAllocation)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *IPAllocationsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a IPAllocationsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *IPAllocationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *IPAllocationsClient, token string) (IPAllocationsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("IPAllocationsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return IPAllocationsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // IPAllocationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2208,36 +3041,52 @@ func (p *IPAllocationsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *IPAllocationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *IPAllocationsClientDeletePoller) Poll(ctx context.Context) (IPAllocationsClientDeleteResponse, error) {
+	result := IPAllocationsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final IPAllocationsClientDeleteResponse will be returned.
-func (p *IPAllocationsClientDeletePoller) FinalResponse(ctx context.Context) (IPAllocationsClientDeleteResponse, error) {
-	respType := IPAllocationsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return IPAllocationsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *IPAllocationsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (IPAllocationsClientDeleteResponse, error) {
+	result := IPAllocationsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *IPAllocationsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a IPAllocationsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *IPAllocationsClientDeletePoller) Resume(ctx context.Context, client *IPAllocationsClient, token string) (IPAllocationsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("IPAllocationsClient.Delete", token, client.pl); err != nil {
+		return IPAllocationsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // IPGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2250,36 +3099,52 @@ func (p *IPGroupsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *IPGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *IPGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (IPGroupsClientCreateOrUpdateResponse, error) {
+	result := IPGroupsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.IPGroup)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final IPGroupsClientCreateOrUpdateResponse will be returned.
-func (p *IPGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (IPGroupsClientCreateOrUpdateResponse, error) {
-	respType := IPGroupsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.IPGroup)
-	if err != nil {
-		return IPGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *IPGroupsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (IPGroupsClientCreateOrUpdateResponse, error) {
+	result := IPGroupsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.IPGroup)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *IPGroupsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a IPGroupsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *IPGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *IPGroupsClient, token string) (IPGroupsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("IPGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return IPGroupsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // IPGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2292,36 +3157,52 @@ func (p *IPGroupsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *IPGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *IPGroupsClientDeletePoller) Poll(ctx context.Context) (IPGroupsClientDeleteResponse, error) {
+	result := IPGroupsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final IPGroupsClientDeleteResponse will be returned.
-func (p *IPGroupsClientDeletePoller) FinalResponse(ctx context.Context) (IPGroupsClientDeleteResponse, error) {
-	respType := IPGroupsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return IPGroupsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *IPGroupsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (IPGroupsClientDeleteResponse, error) {
+	result := IPGroupsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *IPGroupsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a IPGroupsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *IPGroupsClientDeletePoller) Resume(ctx context.Context, client *IPGroupsClient, token string) (IPGroupsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("IPGroupsClient.Delete", token, client.pl); err != nil {
+		return IPGroupsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // InboundNatRulesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2334,36 +3215,52 @@ func (p *InboundNatRulesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *InboundNatRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *InboundNatRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (InboundNatRulesClientCreateOrUpdateResponse, error) {
+	result := InboundNatRulesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.InboundNatRule)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final InboundNatRulesClientCreateOrUpdateResponse will be returned.
-func (p *InboundNatRulesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (InboundNatRulesClientCreateOrUpdateResponse, error) {
-	respType := InboundNatRulesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.InboundNatRule)
-	if err != nil {
-		return InboundNatRulesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *InboundNatRulesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (InboundNatRulesClientCreateOrUpdateResponse, error) {
+	result := InboundNatRulesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.InboundNatRule)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *InboundNatRulesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a InboundNatRulesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *InboundNatRulesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *InboundNatRulesClient, token string) (InboundNatRulesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("InboundNatRulesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return InboundNatRulesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // InboundNatRulesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2376,36 +3273,52 @@ func (p *InboundNatRulesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *InboundNatRulesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *InboundNatRulesClientDeletePoller) Poll(ctx context.Context) (InboundNatRulesClientDeleteResponse, error) {
+	result := InboundNatRulesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final InboundNatRulesClientDeleteResponse will be returned.
-func (p *InboundNatRulesClientDeletePoller) FinalResponse(ctx context.Context) (InboundNatRulesClientDeleteResponse, error) {
-	respType := InboundNatRulesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return InboundNatRulesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *InboundNatRulesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (InboundNatRulesClientDeleteResponse, error) {
+	result := InboundNatRulesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *InboundNatRulesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a InboundNatRulesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *InboundNatRulesClientDeletePoller) Resume(ctx context.Context, client *InboundNatRulesClient, token string) (InboundNatRulesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("InboundNatRulesClient.Delete", token, client.pl); err != nil {
+		return InboundNatRulesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // InterfaceTapConfigurationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2418,36 +3331,52 @@ func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
+	result := InterfaceTapConfigurationsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.InterfaceTapConfiguration)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final InterfaceTapConfigurationsClientCreateOrUpdateResponse will be returned.
-func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
-	respType := InterfaceTapConfigurationsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.InterfaceTapConfiguration)
-	if err != nil {
-		return InterfaceTapConfigurationsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
+	result := InterfaceTapConfigurationsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.InterfaceTapConfiguration)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a InterfaceTapConfigurationsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *InterfaceTapConfigurationsClient, token string) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return InterfaceTapConfigurationsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // InterfaceTapConfigurationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2460,36 +3389,52 @@ func (p *InterfaceTapConfigurationsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *InterfaceTapConfigurationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *InterfaceTapConfigurationsClientDeletePoller) Poll(ctx context.Context) (InterfaceTapConfigurationsClientDeleteResponse, error) {
+	result := InterfaceTapConfigurationsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final InterfaceTapConfigurationsClientDeleteResponse will be returned.
-func (p *InterfaceTapConfigurationsClientDeletePoller) FinalResponse(ctx context.Context) (InterfaceTapConfigurationsClientDeleteResponse, error) {
-	respType := InterfaceTapConfigurationsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return InterfaceTapConfigurationsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *InterfaceTapConfigurationsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (InterfaceTapConfigurationsClientDeleteResponse, error) {
+	result := InterfaceTapConfigurationsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *InterfaceTapConfigurationsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a InterfaceTapConfigurationsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *InterfaceTapConfigurationsClientDeletePoller) Resume(ctx context.Context, client *InterfaceTapConfigurationsClient, token string) (InterfaceTapConfigurationsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.Delete", token, client.pl); err != nil {
+		return InterfaceTapConfigurationsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // InterfacesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2502,36 +3447,52 @@ func (p *InterfacesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *InterfacesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *InterfacesClientCreateOrUpdatePoller) Poll(ctx context.Context) (InterfacesClientCreateOrUpdateResponse, error) {
+	result := InterfacesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Interface)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final InterfacesClientCreateOrUpdateResponse will be returned.
-func (p *InterfacesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (InterfacesClientCreateOrUpdateResponse, error) {
-	respType := InterfacesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Interface)
-	if err != nil {
-		return InterfacesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *InterfacesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientCreateOrUpdateResponse, error) {
+	result := InterfacesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Interface)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *InterfacesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a InterfacesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *InterfacesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *InterfacesClient, token string) (InterfacesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return InterfacesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // InterfacesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2544,36 +3505,52 @@ func (p *InterfacesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *InterfacesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *InterfacesClientDeletePoller) Poll(ctx context.Context) (InterfacesClientDeleteResponse, error) {
+	result := InterfacesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final InterfacesClientDeleteResponse will be returned.
-func (p *InterfacesClientDeletePoller) FinalResponse(ctx context.Context) (InterfacesClientDeleteResponse, error) {
-	respType := InterfacesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return InterfacesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *InterfacesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientDeleteResponse, error) {
+	result := InterfacesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *InterfacesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a InterfacesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *InterfacesClientDeletePoller) Resume(ctx context.Context, client *InterfacesClient, token string) (InterfacesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.Delete", token, client.pl); err != nil {
+		return InterfacesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // InterfacesClientGetEffectiveRouteTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -2586,36 +3563,52 @@ func (p *InterfacesClientGetEffectiveRouteTablePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *InterfacesClientGetEffectiveRouteTablePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *InterfacesClientGetEffectiveRouteTablePoller) Poll(ctx context.Context) (InterfacesClientGetEffectiveRouteTableResponse, error) {
+	result := InterfacesClientGetEffectiveRouteTableResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.EffectiveRouteListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final InterfacesClientGetEffectiveRouteTableResponse will be returned.
-func (p *InterfacesClientGetEffectiveRouteTablePoller) FinalResponse(ctx context.Context) (InterfacesClientGetEffectiveRouteTableResponse, error) {
-	respType := InterfacesClientGetEffectiveRouteTableResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.EffectiveRouteListResult)
-	if err != nil {
-		return InterfacesClientGetEffectiveRouteTableResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *InterfacesClientGetEffectiveRouteTablePoller) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientGetEffectiveRouteTableResponse, error) {
+	result := InterfacesClientGetEffectiveRouteTableResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.EffectiveRouteListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *InterfacesClientGetEffectiveRouteTablePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a InterfacesClientGetEffectiveRouteTablePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *InterfacesClientGetEffectiveRouteTablePoller) Resume(ctx context.Context, client *InterfacesClient, token string) (InterfacesClientGetEffectiveRouteTableResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.GetEffectiveRouteTable", token, client.pl); err != nil {
+		return InterfacesClientGetEffectiveRouteTableResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // InterfacesClientListEffectiveNetworkSecurityGroupsPoller provides polling facilities until the operation reaches a terminal state.
@@ -2628,36 +3621,52 @@ func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Poll(ctx context.Context) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
+	result := InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.EffectiveNetworkSecurityGroupListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final InterfacesClientListEffectiveNetworkSecurityGroupsResponse will be returned.
-func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) FinalResponse(ctx context.Context) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
-	respType := InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.EffectiveNetworkSecurityGroupListResult)
-	if err != nil {
-		return InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
+	result := InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.EffectiveNetworkSecurityGroupListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a InterfacesClientListEffectiveNetworkSecurityGroupsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Resume(ctx context.Context, client *InterfacesClient, token string) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.ListEffectiveNetworkSecurityGroups", token, client.pl); err != nil {
+		return InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LoadBalancersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2670,36 +3679,52 @@ func (p *LoadBalancersClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LoadBalancersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LoadBalancersClientCreateOrUpdatePoller) Poll(ctx context.Context) (LoadBalancersClientCreateOrUpdateResponse, error) {
+	result := LoadBalancersClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.LoadBalancer)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LoadBalancersClientCreateOrUpdateResponse will be returned.
-func (p *LoadBalancersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (LoadBalancersClientCreateOrUpdateResponse, error) {
-	respType := LoadBalancersClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.LoadBalancer)
-	if err != nil {
-		return LoadBalancersClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *LoadBalancersClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LoadBalancersClientCreateOrUpdateResponse, error) {
+	result := LoadBalancersClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.LoadBalancer)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LoadBalancersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LoadBalancersClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LoadBalancersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *LoadBalancersClient, token string) (LoadBalancersClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LoadBalancersClient.CreateOrUpdate", token, client.pl); err != nil {
+		return LoadBalancersClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LoadBalancersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2712,36 +3737,52 @@ func (p *LoadBalancersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LoadBalancersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LoadBalancersClientDeletePoller) Poll(ctx context.Context) (LoadBalancersClientDeleteResponse, error) {
+	result := LoadBalancersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LoadBalancersClientDeleteResponse will be returned.
-func (p *LoadBalancersClientDeletePoller) FinalResponse(ctx context.Context) (LoadBalancersClientDeleteResponse, error) {
-	respType := LoadBalancersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LoadBalancersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *LoadBalancersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LoadBalancersClientDeleteResponse, error) {
+	result := LoadBalancersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LoadBalancersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LoadBalancersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LoadBalancersClientDeletePoller) Resume(ctx context.Context, client *LoadBalancersClient, token string) (LoadBalancersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LoadBalancersClient.Delete", token, client.pl); err != nil {
+		return LoadBalancersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LocalNetworkGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2754,36 +3795,52 @@ func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
+	result := LocalNetworkGatewaysClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.LocalNetworkGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LocalNetworkGatewaysClientCreateOrUpdateResponse will be returned.
-func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
-	respType := LocalNetworkGatewaysClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.LocalNetworkGateway)
-	if err != nil {
-		return LocalNetworkGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
+	result := LocalNetworkGatewaysClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.LocalNetworkGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LocalNetworkGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *LocalNetworkGatewaysClient, token string) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LocalNetworkGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
+		return LocalNetworkGatewaysClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // LocalNetworkGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2796,36 +3853,52 @@ func (p *LocalNetworkGatewaysClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *LocalNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *LocalNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (LocalNetworkGatewaysClientDeleteResponse, error) {
+	result := LocalNetworkGatewaysClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final LocalNetworkGatewaysClientDeleteResponse will be returned.
-func (p *LocalNetworkGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (LocalNetworkGatewaysClientDeleteResponse, error) {
-	respType := LocalNetworkGatewaysClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return LocalNetworkGatewaysClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *LocalNetworkGatewaysClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (LocalNetworkGatewaysClientDeleteResponse, error) {
+	result := LocalNetworkGatewaysClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *LocalNetworkGatewaysClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a LocalNetworkGatewaysClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *LocalNetworkGatewaysClientDeletePoller) Resume(ctx context.Context, client *LocalNetworkGatewaysClient, token string) (LocalNetworkGatewaysClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("LocalNetworkGatewaysClient.Delete", token, client.pl); err != nil {
+		return LocalNetworkGatewaysClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ManagementClientDeleteBastionShareableLinkPoller provides polling facilities until the operation reaches a terminal state.
@@ -2838,36 +3911,52 @@ func (p *ManagementClientDeleteBastionShareableLinkPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ManagementClientDeleteBastionShareableLinkPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ManagementClientDeleteBastionShareableLinkPoller) Poll(ctx context.Context) (ManagementClientDeleteBastionShareableLinkResponse, error) {
+	result := ManagementClientDeleteBastionShareableLinkResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ManagementClientDeleteBastionShareableLinkResponse will be returned.
-func (p *ManagementClientDeleteBastionShareableLinkPoller) FinalResponse(ctx context.Context) (ManagementClientDeleteBastionShareableLinkResponse, error) {
-	respType := ManagementClientDeleteBastionShareableLinkResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ManagementClientDeleteBastionShareableLinkResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ManagementClientDeleteBastionShareableLinkPoller) PollUntilDone(ctx context.Context, freq time.Duration) (ManagementClientDeleteBastionShareableLinkResponse, error) {
+	result := ManagementClientDeleteBastionShareableLinkResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ManagementClientDeleteBastionShareableLinkPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ManagementClientDeleteBastionShareableLinkPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ManagementClientDeleteBastionShareableLinkPoller) Resume(ctx context.Context, client *ManagementClient, token string) (ManagementClientDeleteBastionShareableLinkResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.DeleteBastionShareableLink", token, client.pl); err != nil {
+		return ManagementClientDeleteBastionShareableLinkResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller provides polling facilities until the operation reaches a terminal state.
@@ -2880,36 +3969,52 @@ func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePolle
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) Poll(ctx context.Context) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
+	result := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNProfileResponse)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse will be returned.
-func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) FinalResponse(ctx context.Context) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
-	respType := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNProfileResponse)
-	if err != nil {
-		return ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
+	result := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNProfileResponse)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) Resume(ctx context.Context, client *ManagementClient, token string) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", token, client.pl); err != nil {
+		return ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ManagementClientGetActiveSessionsPoller provides polling facilities until the operation reaches a terminal state.
@@ -2923,35 +4028,60 @@ func (p *ManagementClientGetActiveSessionsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ManagementClientGetActiveSessionsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
-}
-
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final *ManagementClientGetActiveSessionsPager will be returned.
-func (p *ManagementClientGetActiveSessionsPoller) FinalResponse(ctx context.Context) (*ManagementClientGetActiveSessionsPager, error) {
-	respType := &ManagementClientGetActiveSessionsPager{client: p.client}
-	if _, err := p.pt.FinalResponse(ctx, &respType.current.BastionActiveSessionListResult); err != nil {
+// response or error.
+func (p *ManagementClientGetActiveSessionsPoller) Poll(ctx context.Context) (*ManagementClientGetActiveSessionsPager, error) {
+	result := &ManagementClientGetActiveSessionsPager{}
+	if _, err := p.pt.Poll(ctx); err != nil {
 		return nil, err
 	}
-	return respType, nil
+	if !p.Done() {
+		return nil, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.current.BastionActiveSessionListResult)
+	if err != nil {
+		return nil, err
+	}
+	result.client = p.client
+	return result, err
+}
+
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ManagementClientGetActiveSessionsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (*ManagementClientGetActiveSessionsPager, error) {
+	result := &ManagementClientGetActiveSessionsPager{client: p.client}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.current.BastionActiveSessionListResult)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ManagementClientGetActiveSessionsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ManagementClientGetActiveSessionsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ManagementClientGetActiveSessionsPoller) Resume(ctx context.Context, client *ManagementClient, token string) (*ManagementClientGetActiveSessionsPager, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.GetActiveSessions", token, client.pl); err != nil {
+		return nil, err
+	}
+	p.client = client
+	return p.Poll(ctx)
 }
 
 // ManagementClientPutBastionShareableLinkPoller provides polling facilities until the operation reaches a terminal state.
@@ -2965,35 +4095,60 @@ func (p *ManagementClientPutBastionShareableLinkPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ManagementClientPutBastionShareableLinkPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
-}
-
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final *ManagementClientPutBastionShareableLinkPager will be returned.
-func (p *ManagementClientPutBastionShareableLinkPoller) FinalResponse(ctx context.Context) (*ManagementClientPutBastionShareableLinkPager, error) {
-	respType := &ManagementClientPutBastionShareableLinkPager{client: p.client}
-	if _, err := p.pt.FinalResponse(ctx, &respType.current.BastionShareableLinkListResult); err != nil {
+// response or error.
+func (p *ManagementClientPutBastionShareableLinkPoller) Poll(ctx context.Context) (*ManagementClientPutBastionShareableLinkPager, error) {
+	result := &ManagementClientPutBastionShareableLinkPager{}
+	if _, err := p.pt.Poll(ctx); err != nil {
 		return nil, err
 	}
-	return respType, nil
+	if !p.Done() {
+		return nil, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.current.BastionShareableLinkListResult)
+	if err != nil {
+		return nil, err
+	}
+	result.client = p.client
+	return result, err
+}
+
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ManagementClientPutBastionShareableLinkPoller) PollUntilDone(ctx context.Context, freq time.Duration) (*ManagementClientPutBastionShareableLinkPager, error) {
+	result := &ManagementClientPutBastionShareableLinkPager{client: p.client}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.current.BastionShareableLinkListResult)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ManagementClientPutBastionShareableLinkPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ManagementClientPutBastionShareableLinkPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ManagementClientPutBastionShareableLinkPoller) Resume(ctx context.Context, client *ManagementClient, token string) (*ManagementClientPutBastionShareableLinkPager, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.PutBastionShareableLink", token, client.pl); err != nil {
+		return nil, err
+	}
+	p.client = client
+	return p.Poll(ctx)
 }
 
 // NatGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3006,36 +4161,52 @@ func (p *NatGatewaysClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *NatGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *NatGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (NatGatewaysClientCreateOrUpdateResponse, error) {
+	result := NatGatewaysClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.NatGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final NatGatewaysClientCreateOrUpdateResponse will be returned.
-func (p *NatGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (NatGatewaysClientCreateOrUpdateResponse, error) {
-	respType := NatGatewaysClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.NatGateway)
-	if err != nil {
-		return NatGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *NatGatewaysClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (NatGatewaysClientCreateOrUpdateResponse, error) {
+	result := NatGatewaysClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.NatGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *NatGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a NatGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *NatGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *NatGatewaysClient, token string) (NatGatewaysClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("NatGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
+		return NatGatewaysClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // NatGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3048,36 +4219,52 @@ func (p *NatGatewaysClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *NatGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *NatGatewaysClientDeletePoller) Poll(ctx context.Context) (NatGatewaysClientDeleteResponse, error) {
+	result := NatGatewaysClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final NatGatewaysClientDeleteResponse will be returned.
-func (p *NatGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (NatGatewaysClientDeleteResponse, error) {
-	respType := NatGatewaysClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return NatGatewaysClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *NatGatewaysClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (NatGatewaysClientDeleteResponse, error) {
+	result := NatGatewaysClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *NatGatewaysClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a NatGatewaysClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *NatGatewaysClientDeletePoller) Resume(ctx context.Context, client *NatGatewaysClient, token string) (NatGatewaysClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("NatGatewaysClient.Delete", token, client.pl); err != nil {
+		return NatGatewaysClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // P2SVPNGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3090,36 +4277,52 @@ func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
+	result := P2SVPNGatewaysClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.P2SVPNGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final P2SVPNGatewaysClientCreateOrUpdateResponse will be returned.
-func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
-	respType := P2SVPNGatewaysClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.P2SVPNGateway)
-	if err != nil {
-		return P2SVPNGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
+	result := P2SVPNGatewaysClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.P2SVPNGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a P2SVPNGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
+		return P2SVPNGatewaysClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // P2SVPNGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3132,36 +4335,52 @@ func (p *P2SVPNGatewaysClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *P2SVPNGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *P2SVPNGatewaysClientDeletePoller) Poll(ctx context.Context) (P2SVPNGatewaysClientDeleteResponse, error) {
+	result := P2SVPNGatewaysClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final P2SVPNGatewaysClientDeleteResponse will be returned.
-func (p *P2SVPNGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientDeleteResponse, error) {
-	respType := P2SVPNGatewaysClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return P2SVPNGatewaysClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *P2SVPNGatewaysClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientDeleteResponse, error) {
+	result := P2SVPNGatewaysClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *P2SVPNGatewaysClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a P2SVPNGatewaysClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *P2SVPNGatewaysClientDeletePoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.Delete", token, client.pl); err != nil {
+		return P2SVPNGatewaysClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller provides polling facilities until the operation reaches a terminal state.
@@ -3174,36 +4393,52 @@ func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Poll(ctx context.Context) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
+	result := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse will be returned.
-func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
-	respType := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
+	result := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.DisconnectP2SVPNConnections", token, client.pl); err != nil {
+		return P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // P2SVPNGatewaysClientGenerateVPNProfilePoller provides polling facilities until the operation reaches a terminal state.
@@ -3216,36 +4451,52 @@ func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
+	result := P2SVPNGatewaysClientGenerateVPNProfileResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNProfileResponse)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final P2SVPNGatewaysClientGenerateVPNProfileResponse will be returned.
-func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
-	respType := P2SVPNGatewaysClientGenerateVPNProfileResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNProfileResponse)
-	if err != nil {
-		return P2SVPNGatewaysClientGenerateVPNProfileResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
+	result := P2SVPNGatewaysClientGenerateVPNProfileResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNProfileResponse)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a P2SVPNGatewaysClientGenerateVPNProfilePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GenerateVPNProfile", token, client.pl); err != nil {
+		return P2SVPNGatewaysClientGenerateVPNProfileResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller provides polling facilities until the operation reaches a terminal state.
@@ -3258,36 +4509,52 @@ func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Done() boo
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Poll(ctx context.Context) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
+	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.P2SVPNConnectionHealth)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse will be returned.
-func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
-	respType := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.P2SVPNConnectionHealth)
-	if err != nil {
-		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
+	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.P2SVPNConnectionHealth)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed", token, client.pl); err != nil {
+		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller provides polling facilities until the operation reaches a terminal state.
@@ -3300,36 +4567,52 @@ func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Poll(ctx context.Context) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
+	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.P2SVPNGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse will be returned.
-func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) FinalResponse(ctx context.Context) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
-	respType := P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.P2SVPNGateway)
-	if err != nil {
-		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
+	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.P2SVPNGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealth", token, client.pl); err != nil {
+		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PacketCapturesClientCreatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3342,36 +4625,52 @@ func (p *PacketCapturesClientCreatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PacketCapturesClientCreatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PacketCapturesClientCreatePoller) Poll(ctx context.Context) (PacketCapturesClientCreateResponse, error) {
+	result := PacketCapturesClientCreateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PacketCaptureResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PacketCapturesClientCreateResponse will be returned.
-func (p *PacketCapturesClientCreatePoller) FinalResponse(ctx context.Context) (PacketCapturesClientCreateResponse, error) {
-	respType := PacketCapturesClientCreateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PacketCaptureResult)
-	if err != nil {
-		return PacketCapturesClientCreateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PacketCapturesClientCreatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientCreateResponse, error) {
+	result := PacketCapturesClientCreateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PacketCaptureResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PacketCapturesClientCreatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PacketCapturesClientCreatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PacketCapturesClientCreatePoller) Resume(ctx context.Context, client *PacketCapturesClient, token string) (PacketCapturesClientCreateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Create", token, client.pl); err != nil {
+		return PacketCapturesClientCreateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PacketCapturesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3384,36 +4683,52 @@ func (p *PacketCapturesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PacketCapturesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PacketCapturesClientDeletePoller) Poll(ctx context.Context) (PacketCapturesClientDeleteResponse, error) {
+	result := PacketCapturesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PacketCapturesClientDeleteResponse will be returned.
-func (p *PacketCapturesClientDeletePoller) FinalResponse(ctx context.Context) (PacketCapturesClientDeleteResponse, error) {
-	respType := PacketCapturesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return PacketCapturesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PacketCapturesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientDeleteResponse, error) {
+	result := PacketCapturesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PacketCapturesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PacketCapturesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PacketCapturesClientDeletePoller) Resume(ctx context.Context, client *PacketCapturesClient, token string) (PacketCapturesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Delete", token, client.pl); err != nil {
+		return PacketCapturesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PacketCapturesClientGetStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -3426,36 +4741,52 @@ func (p *PacketCapturesClientGetStatusPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PacketCapturesClientGetStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PacketCapturesClientGetStatusPoller) Poll(ctx context.Context) (PacketCapturesClientGetStatusResponse, error) {
+	result := PacketCapturesClientGetStatusResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PacketCaptureQueryStatusResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PacketCapturesClientGetStatusResponse will be returned.
-func (p *PacketCapturesClientGetStatusPoller) FinalResponse(ctx context.Context) (PacketCapturesClientGetStatusResponse, error) {
-	respType := PacketCapturesClientGetStatusResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PacketCaptureQueryStatusResult)
-	if err != nil {
-		return PacketCapturesClientGetStatusResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PacketCapturesClientGetStatusPoller) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientGetStatusResponse, error) {
+	result := PacketCapturesClientGetStatusResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PacketCaptureQueryStatusResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PacketCapturesClientGetStatusPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PacketCapturesClientGetStatusPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PacketCapturesClientGetStatusPoller) Resume(ctx context.Context, client *PacketCapturesClient, token string) (PacketCapturesClientGetStatusResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.GetStatus", token, client.pl); err != nil {
+		return PacketCapturesClientGetStatusResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PacketCapturesClientStopPoller provides polling facilities until the operation reaches a terminal state.
@@ -3468,36 +4799,52 @@ func (p *PacketCapturesClientStopPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PacketCapturesClientStopPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PacketCapturesClientStopPoller) Poll(ctx context.Context) (PacketCapturesClientStopResponse, error) {
+	result := PacketCapturesClientStopResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PacketCapturesClientStopResponse will be returned.
-func (p *PacketCapturesClientStopPoller) FinalResponse(ctx context.Context) (PacketCapturesClientStopResponse, error) {
-	respType := PacketCapturesClientStopResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return PacketCapturesClientStopResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PacketCapturesClientStopPoller) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientStopResponse, error) {
+	result := PacketCapturesClientStopResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PacketCapturesClientStopPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PacketCapturesClientStopPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PacketCapturesClientStopPoller) Resume(ctx context.Context, client *PacketCapturesClient, token string) (PacketCapturesClientStopResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Stop", token, client.pl); err != nil {
+		return PacketCapturesClientStopResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateDNSZoneGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3510,36 +4857,52 @@ func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
+	result := PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PrivateDNSZoneGroup)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateDNSZoneGroupsClientCreateOrUpdateResponse will be returned.
-func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
-	respType := PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PrivateDNSZoneGroup)
-	if err != nil {
-		return PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
+	result := PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PrivateDNSZoneGroup)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateDNSZoneGroupsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PrivateDNSZoneGroupsClient, token string) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateDNSZoneGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3552,36 +4915,52 @@ func (p *PrivateDNSZoneGroupsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateDNSZoneGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateDNSZoneGroupsClientDeletePoller) Poll(ctx context.Context) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
+	result := PrivateDNSZoneGroupsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateDNSZoneGroupsClientDeleteResponse will be returned.
-func (p *PrivateDNSZoneGroupsClientDeletePoller) FinalResponse(ctx context.Context) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
-	respType := PrivateDNSZoneGroupsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return PrivateDNSZoneGroupsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateDNSZoneGroupsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
+	result := PrivateDNSZoneGroupsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateDNSZoneGroupsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateDNSZoneGroupsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateDNSZoneGroupsClientDeletePoller) Resume(ctx context.Context, client *PrivateDNSZoneGroupsClient, token string) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.Delete", token, client.pl); err != nil {
+		return PrivateDNSZoneGroupsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateEndpointsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3594,36 +4973,52 @@ func (p *PrivateEndpointsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateEndpointsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateEndpointsClientCreateOrUpdatePoller) Poll(ctx context.Context) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
+	result := PrivateEndpointsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PrivateEndpoint)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateEndpointsClientCreateOrUpdateResponse will be returned.
-func (p *PrivateEndpointsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
-	respType := PrivateEndpointsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PrivateEndpoint)
-	if err != nil {
-		return PrivateEndpointsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateEndpointsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
+	result := PrivateEndpointsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PrivateEndpoint)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateEndpointsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateEndpointsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateEndpointsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PrivateEndpointsClient, token string) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateEndpointsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return PrivateEndpointsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateEndpointsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3636,36 +5031,52 @@ func (p *PrivateEndpointsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateEndpointsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateEndpointsClientDeletePoller) Poll(ctx context.Context) (PrivateEndpointsClientDeleteResponse, error) {
+	result := PrivateEndpointsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateEndpointsClientDeleteResponse will be returned.
-func (p *PrivateEndpointsClientDeletePoller) FinalResponse(ctx context.Context) (PrivateEndpointsClientDeleteResponse, error) {
-	respType := PrivateEndpointsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return PrivateEndpointsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateEndpointsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateEndpointsClientDeleteResponse, error) {
+	result := PrivateEndpointsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateEndpointsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateEndpointsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateEndpointsClientDeletePoller) Resume(ctx context.Context, client *PrivateEndpointsClient, token string) (PrivateEndpointsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateEndpointsClient.Delete", token, client.pl); err != nil {
+		return PrivateEndpointsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller provides polling facilities until the operation reaches a terminal state.
@@ -3678,36 +5089,52 @@ func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGro
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) Poll(ctx context.Context) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
+	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PrivateLinkServiceVisibility)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse will be returned.
-func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
-	respType := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkServiceVisibility)
-	if err != nil {
-		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
+	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PrivateLinkServiceVisibility)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup", token, client.pl); err != nil {
+		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller provides polling facilities until the operation reaches a terminal state.
@@ -3720,36 +5147,52 @@ func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Done(
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Poll(ctx context.Context) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
+	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PrivateLinkServiceVisibility)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse will be returned.
-func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
-	respType := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkServiceVisibility)
-	if err != nil {
-		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
+	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PrivateLinkServiceVisibility)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility", token, client.pl); err != nil {
+		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateLinkServicesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3762,36 +5205,52 @@ func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
+	result := PrivateLinkServicesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PrivateLinkService)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateLinkServicesClientCreateOrUpdateResponse will be returned.
-func (p *PrivateLinkServicesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
-	respType := PrivateLinkServicesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PrivateLinkService)
-	if err != nil {
-		return PrivateLinkServicesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateLinkServicesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
+	result := PrivateLinkServicesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PrivateLinkService)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateLinkServicesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateLinkServicesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return PrivateLinkServicesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateLinkServicesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3804,36 +5263,52 @@ func (p *PrivateLinkServicesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateLinkServicesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateLinkServicesClientDeletePoller) Poll(ctx context.Context) (PrivateLinkServicesClientDeleteResponse, error) {
+	result := PrivateLinkServicesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateLinkServicesClientDeleteResponse will be returned.
-func (p *PrivateLinkServicesClientDeletePoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientDeleteResponse, error) {
-	respType := PrivateLinkServicesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return PrivateLinkServicesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateLinkServicesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientDeleteResponse, error) {
+	result := PrivateLinkServicesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateLinkServicesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateLinkServicesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateLinkServicesClientDeletePoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.Delete", token, client.pl); err != nil {
+		return PrivateLinkServicesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller provides polling facilities until the operation reaches a terminal state.
@@ -3846,36 +5321,52 @@ func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Done() 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Poll(ctx context.Context) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
+	result := PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse will be returned.
-func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) FinalResponse(ctx context.Context) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
-	respType := PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
+	result := PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.DeletePrivateEndpointConnection", token, client.pl); err != nil {
+		return PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ProfilesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3888,36 +5379,52 @@ func (p *ProfilesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ProfilesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ProfilesClientDeletePoller) Poll(ctx context.Context) (ProfilesClientDeleteResponse, error) {
+	result := ProfilesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ProfilesClientDeleteResponse will be returned.
-func (p *ProfilesClientDeletePoller) FinalResponse(ctx context.Context) (ProfilesClientDeleteResponse, error) {
-	respType := ProfilesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ProfilesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ProfilesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ProfilesClientDeleteResponse, error) {
+	result := ProfilesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ProfilesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ProfilesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ProfilesClientDeletePoller) Resume(ctx context.Context, client *ProfilesClient, token string) (ProfilesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ProfilesClient.Delete", token, client.pl); err != nil {
+		return ProfilesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PublicIPAddressesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3930,36 +5437,52 @@ func (p *PublicIPAddressesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PublicIPAddressesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PublicIPAddressesClientCreateOrUpdatePoller) Poll(ctx context.Context) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
+	result := PublicIPAddressesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PublicIPAddress)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PublicIPAddressesClientCreateOrUpdateResponse will be returned.
-func (p *PublicIPAddressesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
-	respType := PublicIPAddressesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PublicIPAddress)
-	if err != nil {
-		return PublicIPAddressesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PublicIPAddressesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
+	result := PublicIPAddressesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PublicIPAddress)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PublicIPAddressesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PublicIPAddressesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PublicIPAddressesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PublicIPAddressesClient, token string) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPAddressesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return PublicIPAddressesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PublicIPAddressesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3972,36 +5495,52 @@ func (p *PublicIPAddressesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PublicIPAddressesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PublicIPAddressesClientDeletePoller) Poll(ctx context.Context) (PublicIPAddressesClientDeleteResponse, error) {
+	result := PublicIPAddressesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PublicIPAddressesClientDeleteResponse will be returned.
-func (p *PublicIPAddressesClientDeletePoller) FinalResponse(ctx context.Context) (PublicIPAddressesClientDeleteResponse, error) {
-	respType := PublicIPAddressesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return PublicIPAddressesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PublicIPAddressesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPAddressesClientDeleteResponse, error) {
+	result := PublicIPAddressesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PublicIPAddressesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PublicIPAddressesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PublicIPAddressesClientDeletePoller) Resume(ctx context.Context, client *PublicIPAddressesClient, token string) (PublicIPAddressesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPAddressesClient.Delete", token, client.pl); err != nil {
+		return PublicIPAddressesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PublicIPPrefixesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4014,36 +5553,52 @@ func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Poll(ctx context.Context) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
+	result := PublicIPPrefixesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PublicIPPrefix)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PublicIPPrefixesClientCreateOrUpdateResponse will be returned.
-func (p *PublicIPPrefixesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
-	respType := PublicIPPrefixesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PublicIPPrefix)
-	if err != nil {
-		return PublicIPPrefixesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PublicIPPrefixesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
+	result := PublicIPPrefixesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PublicIPPrefix)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PublicIPPrefixesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PublicIPPrefixesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PublicIPPrefixesClient, token string) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPPrefixesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return PublicIPPrefixesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // PublicIPPrefixesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4056,36 +5611,52 @@ func (p *PublicIPPrefixesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *PublicIPPrefixesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *PublicIPPrefixesClientDeletePoller) Poll(ctx context.Context) (PublicIPPrefixesClientDeleteResponse, error) {
+	result := PublicIPPrefixesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final PublicIPPrefixesClientDeleteResponse will be returned.
-func (p *PublicIPPrefixesClientDeletePoller) FinalResponse(ctx context.Context) (PublicIPPrefixesClientDeleteResponse, error) {
-	respType := PublicIPPrefixesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return PublicIPPrefixesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *PublicIPPrefixesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPPrefixesClientDeleteResponse, error) {
+	result := PublicIPPrefixesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *PublicIPPrefixesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a PublicIPPrefixesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *PublicIPPrefixesClientDeletePoller) Resume(ctx context.Context, client *PublicIPPrefixesClient, token string) (PublicIPPrefixesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPPrefixesClient.Delete", token, client.pl); err != nil {
+		return PublicIPPrefixesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RouteFilterRulesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4098,36 +5669,52 @@ func (p *RouteFilterRulesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RouteFilterRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RouteFilterRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
+	result := RouteFilterRulesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.RouteFilterRule)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RouteFilterRulesClientCreateOrUpdateResponse will be returned.
-func (p *RouteFilterRulesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
-	respType := RouteFilterRulesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.RouteFilterRule)
-	if err != nil {
-		return RouteFilterRulesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RouteFilterRulesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
+	result := RouteFilterRulesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.RouteFilterRule)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RouteFilterRulesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RouteFilterRulesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RouteFilterRulesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RouteFilterRulesClient, token string) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteFilterRulesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return RouteFilterRulesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RouteFilterRulesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4140,36 +5727,52 @@ func (p *RouteFilterRulesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RouteFilterRulesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RouteFilterRulesClientDeletePoller) Poll(ctx context.Context) (RouteFilterRulesClientDeleteResponse, error) {
+	result := RouteFilterRulesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RouteFilterRulesClientDeleteResponse will be returned.
-func (p *RouteFilterRulesClientDeletePoller) FinalResponse(ctx context.Context) (RouteFilterRulesClientDeleteResponse, error) {
-	respType := RouteFilterRulesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return RouteFilterRulesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RouteFilterRulesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFilterRulesClientDeleteResponse, error) {
+	result := RouteFilterRulesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RouteFilterRulesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RouteFilterRulesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RouteFilterRulesClientDeletePoller) Resume(ctx context.Context, client *RouteFilterRulesClient, token string) (RouteFilterRulesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteFilterRulesClient.Delete", token, client.pl); err != nil {
+		return RouteFilterRulesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RouteFiltersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4182,36 +5785,52 @@ func (p *RouteFiltersClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RouteFiltersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RouteFiltersClientCreateOrUpdatePoller) Poll(ctx context.Context) (RouteFiltersClientCreateOrUpdateResponse, error) {
+	result := RouteFiltersClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.RouteFilter)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RouteFiltersClientCreateOrUpdateResponse will be returned.
-func (p *RouteFiltersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RouteFiltersClientCreateOrUpdateResponse, error) {
-	respType := RouteFiltersClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.RouteFilter)
-	if err != nil {
-		return RouteFiltersClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RouteFiltersClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFiltersClientCreateOrUpdateResponse, error) {
+	result := RouteFiltersClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.RouteFilter)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RouteFiltersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RouteFiltersClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RouteFiltersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RouteFiltersClient, token string) (RouteFiltersClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteFiltersClient.CreateOrUpdate", token, client.pl); err != nil {
+		return RouteFiltersClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RouteFiltersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4224,36 +5843,52 @@ func (p *RouteFiltersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RouteFiltersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RouteFiltersClientDeletePoller) Poll(ctx context.Context) (RouteFiltersClientDeleteResponse, error) {
+	result := RouteFiltersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RouteFiltersClientDeleteResponse will be returned.
-func (p *RouteFiltersClientDeletePoller) FinalResponse(ctx context.Context) (RouteFiltersClientDeleteResponse, error) {
-	respType := RouteFiltersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return RouteFiltersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RouteFiltersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFiltersClientDeleteResponse, error) {
+	result := RouteFiltersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RouteFiltersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RouteFiltersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RouteFiltersClientDeletePoller) Resume(ctx context.Context, client *RouteFiltersClient, token string) (RouteFiltersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteFiltersClient.Delete", token, client.pl); err != nil {
+		return RouteFiltersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RouteTablesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4266,36 +5901,52 @@ func (p *RouteTablesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RouteTablesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RouteTablesClientCreateOrUpdatePoller) Poll(ctx context.Context) (RouteTablesClientCreateOrUpdateResponse, error) {
+	result := RouteTablesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.RouteTable)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RouteTablesClientCreateOrUpdateResponse will be returned.
-func (p *RouteTablesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RouteTablesClientCreateOrUpdateResponse, error) {
-	respType := RouteTablesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.RouteTable)
-	if err != nil {
-		return RouteTablesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RouteTablesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RouteTablesClientCreateOrUpdateResponse, error) {
+	result := RouteTablesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.RouteTable)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RouteTablesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RouteTablesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RouteTablesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RouteTablesClient, token string) (RouteTablesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteTablesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return RouteTablesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RouteTablesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4308,36 +5959,52 @@ func (p *RouteTablesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RouteTablesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RouteTablesClientDeletePoller) Poll(ctx context.Context) (RouteTablesClientDeleteResponse, error) {
+	result := RouteTablesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RouteTablesClientDeleteResponse will be returned.
-func (p *RouteTablesClientDeletePoller) FinalResponse(ctx context.Context) (RouteTablesClientDeleteResponse, error) {
-	respType := RouteTablesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return RouteTablesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RouteTablesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RouteTablesClientDeleteResponse, error) {
+	result := RouteTablesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RouteTablesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RouteTablesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RouteTablesClientDeletePoller) Resume(ctx context.Context, client *RouteTablesClient, token string) (RouteTablesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteTablesClient.Delete", token, client.pl); err != nil {
+		return RouteTablesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RoutesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4350,36 +6017,52 @@ func (p *RoutesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RoutesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RoutesClientCreateOrUpdatePoller) Poll(ctx context.Context) (RoutesClientCreateOrUpdateResponse, error) {
+	result := RoutesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Route)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RoutesClientCreateOrUpdateResponse will be returned.
-func (p *RoutesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (RoutesClientCreateOrUpdateResponse, error) {
-	respType := RoutesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Route)
-	if err != nil {
-		return RoutesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RoutesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RoutesClientCreateOrUpdateResponse, error) {
+	result := RoutesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Route)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RoutesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RoutesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RoutesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RoutesClient, token string) (RoutesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RoutesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return RoutesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // RoutesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4392,36 +6075,52 @@ func (p *RoutesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *RoutesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *RoutesClientDeletePoller) Poll(ctx context.Context) (RoutesClientDeleteResponse, error) {
+	result := RoutesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final RoutesClientDeleteResponse will be returned.
-func (p *RoutesClientDeletePoller) FinalResponse(ctx context.Context) (RoutesClientDeleteResponse, error) {
-	respType := RoutesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return RoutesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *RoutesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (RoutesClientDeleteResponse, error) {
+	result := RoutesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *RoutesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a RoutesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *RoutesClientDeletePoller) Resume(ctx context.Context, client *RoutesClient, token string) (RoutesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("RoutesClient.Delete", token, client.pl); err != nil {
+		return RoutesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SecurityGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4434,36 +6133,52 @@ func (p *SecurityGroupsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (SecurityGroupsClientCreateOrUpdateResponse, error) {
+	result := SecurityGroupsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SecurityGroup)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SecurityGroupsClientCreateOrUpdateResponse will be returned.
-func (p *SecurityGroupsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SecurityGroupsClientCreateOrUpdateResponse, error) {
-	respType := SecurityGroupsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SecurityGroup)
-	if err != nil {
-		return SecurityGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SecurityGroupsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityGroupsClientCreateOrUpdateResponse, error) {
+	result := SecurityGroupsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SecurityGroup)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SecurityGroupsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SecurityGroupsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SecurityGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SecurityGroupsClient, token string) (SecurityGroupsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return SecurityGroupsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SecurityGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4476,36 +6191,52 @@ func (p *SecurityGroupsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SecurityGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SecurityGroupsClientDeletePoller) Poll(ctx context.Context) (SecurityGroupsClientDeleteResponse, error) {
+	result := SecurityGroupsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SecurityGroupsClientDeleteResponse will be returned.
-func (p *SecurityGroupsClientDeletePoller) FinalResponse(ctx context.Context) (SecurityGroupsClientDeleteResponse, error) {
-	respType := SecurityGroupsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SecurityGroupsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SecurityGroupsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityGroupsClientDeleteResponse, error) {
+	result := SecurityGroupsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SecurityGroupsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SecurityGroupsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SecurityGroupsClientDeletePoller) Resume(ctx context.Context, client *SecurityGroupsClient, token string) (SecurityGroupsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityGroupsClient.Delete", token, client.pl); err != nil {
+		return SecurityGroupsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SecurityPartnerProvidersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4518,36 +6249,52 @@ func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Poll(ctx context.Context) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
+	result := SecurityPartnerProvidersClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SecurityPartnerProvider)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SecurityPartnerProvidersClientCreateOrUpdateResponse will be returned.
-func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
-	respType := SecurityPartnerProvidersClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SecurityPartnerProvider)
-	if err != nil {
-		return SecurityPartnerProvidersClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
+	result := SecurityPartnerProvidersClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SecurityPartnerProvider)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SecurityPartnerProvidersClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SecurityPartnerProvidersClient, token string) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityPartnerProvidersClient.CreateOrUpdate", token, client.pl); err != nil {
+		return SecurityPartnerProvidersClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SecurityPartnerProvidersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4560,36 +6307,52 @@ func (p *SecurityPartnerProvidersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SecurityPartnerProvidersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SecurityPartnerProvidersClientDeletePoller) Poll(ctx context.Context) (SecurityPartnerProvidersClientDeleteResponse, error) {
+	result := SecurityPartnerProvidersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SecurityPartnerProvidersClientDeleteResponse will be returned.
-func (p *SecurityPartnerProvidersClientDeletePoller) FinalResponse(ctx context.Context) (SecurityPartnerProvidersClientDeleteResponse, error) {
-	respType := SecurityPartnerProvidersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SecurityPartnerProvidersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SecurityPartnerProvidersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityPartnerProvidersClientDeleteResponse, error) {
+	result := SecurityPartnerProvidersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SecurityPartnerProvidersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SecurityPartnerProvidersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SecurityPartnerProvidersClientDeletePoller) Resume(ctx context.Context, client *SecurityPartnerProvidersClient, token string) (SecurityPartnerProvidersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityPartnerProvidersClient.Delete", token, client.pl); err != nil {
+		return SecurityPartnerProvidersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SecurityRulesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4602,36 +6365,52 @@ func (p *SecurityRulesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SecurityRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SecurityRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (SecurityRulesClientCreateOrUpdateResponse, error) {
+	result := SecurityRulesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SecurityRule)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SecurityRulesClientCreateOrUpdateResponse will be returned.
-func (p *SecurityRulesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SecurityRulesClientCreateOrUpdateResponse, error) {
-	respType := SecurityRulesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SecurityRule)
-	if err != nil {
-		return SecurityRulesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SecurityRulesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityRulesClientCreateOrUpdateResponse, error) {
+	result := SecurityRulesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SecurityRule)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SecurityRulesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SecurityRulesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SecurityRulesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SecurityRulesClient, token string) (SecurityRulesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityRulesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return SecurityRulesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SecurityRulesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4644,36 +6423,52 @@ func (p *SecurityRulesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SecurityRulesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SecurityRulesClientDeletePoller) Poll(ctx context.Context) (SecurityRulesClientDeleteResponse, error) {
+	result := SecurityRulesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SecurityRulesClientDeleteResponse will be returned.
-func (p *SecurityRulesClientDeletePoller) FinalResponse(ctx context.Context) (SecurityRulesClientDeleteResponse, error) {
-	respType := SecurityRulesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SecurityRulesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SecurityRulesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityRulesClientDeleteResponse, error) {
+	result := SecurityRulesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SecurityRulesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SecurityRulesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SecurityRulesClientDeletePoller) Resume(ctx context.Context, client *SecurityRulesClient, token string) (SecurityRulesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityRulesClient.Delete", token, client.pl); err != nil {
+		return SecurityRulesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ServiceEndpointPoliciesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4686,36 +6481,52 @@ func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
+	result := ServiceEndpointPoliciesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ServiceEndpointPolicy)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ServiceEndpointPoliciesClientCreateOrUpdateResponse will be returned.
-func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
-	respType := ServiceEndpointPoliciesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ServiceEndpointPolicy)
-	if err != nil {
-		return ServiceEndpointPoliciesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
+	result := ServiceEndpointPoliciesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ServiceEndpointPolicy)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ServiceEndpointPoliciesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ServiceEndpointPoliciesClient, token string) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ServiceEndpointPoliciesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ServiceEndpointPoliciesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4728,36 +6539,52 @@ func (p *ServiceEndpointPoliciesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ServiceEndpointPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ServiceEndpointPoliciesClientDeletePoller) Poll(ctx context.Context) (ServiceEndpointPoliciesClientDeleteResponse, error) {
+	result := ServiceEndpointPoliciesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ServiceEndpointPoliciesClientDeleteResponse will be returned.
-func (p *ServiceEndpointPoliciesClientDeletePoller) FinalResponse(ctx context.Context) (ServiceEndpointPoliciesClientDeleteResponse, error) {
-	respType := ServiceEndpointPoliciesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ServiceEndpointPoliciesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ServiceEndpointPoliciesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPoliciesClientDeleteResponse, error) {
+	result := ServiceEndpointPoliciesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ServiceEndpointPoliciesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ServiceEndpointPoliciesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ServiceEndpointPoliciesClientDeletePoller) Resume(ctx context.Context, client *ServiceEndpointPoliciesClient, token string) (ServiceEndpointPoliciesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.Delete", token, client.pl); err != nil {
+		return ServiceEndpointPoliciesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4770,36 +6597,52 @@ func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Done() bool
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
+	result := ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ServiceEndpointPolicyDefinition)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse will be returned.
-func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
-	respType := ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ServiceEndpointPolicyDefinition)
-	if err != nil {
-		return ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
+	result := ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ServiceEndpointPolicyDefinition)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ServiceEndpointPolicyDefinitionsClient, token string) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // ServiceEndpointPolicyDefinitionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4812,36 +6655,52 @@ func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Poll(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
+	result := ServiceEndpointPolicyDefinitionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final ServiceEndpointPolicyDefinitionsClientDeleteResponse will be returned.
-func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) FinalResponse(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
-	respType := ServiceEndpointPolicyDefinitionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return ServiceEndpointPolicyDefinitionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
+	result := ServiceEndpointPolicyDefinitionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a ServiceEndpointPolicyDefinitionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Resume(ctx context.Context, client *ServiceEndpointPolicyDefinitionsClient, token string) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.Delete", token, client.pl); err != nil {
+		return ServiceEndpointPolicyDefinitionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SubnetsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4854,36 +6713,52 @@ func (p *SubnetsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SubnetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SubnetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (SubnetsClientCreateOrUpdateResponse, error) {
+	result := SubnetsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Subnet)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SubnetsClientCreateOrUpdateResponse will be returned.
-func (p *SubnetsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (SubnetsClientCreateOrUpdateResponse, error) {
-	respType := SubnetsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Subnet)
-	if err != nil {
-		return SubnetsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SubnetsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientCreateOrUpdateResponse, error) {
+	result := SubnetsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Subnet)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SubnetsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SubnetsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SubnetsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SubnetsClient, token string) (SubnetsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return SubnetsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SubnetsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4896,36 +6771,52 @@ func (p *SubnetsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SubnetsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SubnetsClientDeletePoller) Poll(ctx context.Context) (SubnetsClientDeleteResponse, error) {
+	result := SubnetsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SubnetsClientDeleteResponse will be returned.
-func (p *SubnetsClientDeletePoller) FinalResponse(ctx context.Context) (SubnetsClientDeleteResponse, error) {
-	respType := SubnetsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SubnetsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SubnetsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientDeleteResponse, error) {
+	result := SubnetsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SubnetsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SubnetsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SubnetsClientDeletePoller) Resume(ctx context.Context, client *SubnetsClient, token string) (SubnetsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.Delete", token, client.pl); err != nil {
+		return SubnetsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SubnetsClientPrepareNetworkPoliciesPoller provides polling facilities until the operation reaches a terminal state.
@@ -4938,36 +6829,52 @@ func (p *SubnetsClientPrepareNetworkPoliciesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SubnetsClientPrepareNetworkPoliciesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SubnetsClientPrepareNetworkPoliciesPoller) Poll(ctx context.Context) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
+	result := SubnetsClientPrepareNetworkPoliciesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SubnetsClientPrepareNetworkPoliciesResponse will be returned.
-func (p *SubnetsClientPrepareNetworkPoliciesPoller) FinalResponse(ctx context.Context) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
-	respType := SubnetsClientPrepareNetworkPoliciesResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SubnetsClientPrepareNetworkPoliciesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SubnetsClientPrepareNetworkPoliciesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
+	result := SubnetsClientPrepareNetworkPoliciesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SubnetsClientPrepareNetworkPoliciesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SubnetsClientPrepareNetworkPoliciesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SubnetsClientPrepareNetworkPoliciesPoller) Resume(ctx context.Context, client *SubnetsClient, token string) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.PrepareNetworkPolicies", token, client.pl); err != nil {
+		return SubnetsClientPrepareNetworkPoliciesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // SubnetsClientUnprepareNetworkPoliciesPoller provides polling facilities until the operation reaches a terminal state.
@@ -4980,36 +6887,52 @@ func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Poll(ctx context.Context) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
+	result := SubnetsClientUnprepareNetworkPoliciesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final SubnetsClientUnprepareNetworkPoliciesResponse will be returned.
-func (p *SubnetsClientUnprepareNetworkPoliciesPoller) FinalResponse(ctx context.Context) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
-	respType := SubnetsClientUnprepareNetworkPoliciesResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return SubnetsClientUnprepareNetworkPoliciesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *SubnetsClientUnprepareNetworkPoliciesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
+	result := SubnetsClientUnprepareNetworkPoliciesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *SubnetsClientUnprepareNetworkPoliciesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a SubnetsClientUnprepareNetworkPoliciesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Resume(ctx context.Context, client *SubnetsClient, token string) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.UnprepareNetworkPolicies", token, client.pl); err != nil {
+		return SubnetsClientUnprepareNetworkPoliciesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5022,36 +6945,52 @@ func (p *VPNConnectionsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VPNConnectionsClientCreateOrUpdateResponse, error) {
+	result := VPNConnectionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNConnection)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNConnectionsClientCreateOrUpdateResponse will be returned.
-func (p *VPNConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VPNConnectionsClientCreateOrUpdateResponse, error) {
-	respType := VPNConnectionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNConnection)
-	if err != nil {
-		return VPNConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNConnectionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNConnectionsClientCreateOrUpdateResponse, error) {
+	result := VPNConnectionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNConnection)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNConnectionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VPNConnectionsClient, token string) (VPNConnectionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VPNConnectionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNConnectionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5064,36 +7003,52 @@ func (p *VPNConnectionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNConnectionsClientDeletePoller) Poll(ctx context.Context) (VPNConnectionsClientDeleteResponse, error) {
+	result := VPNConnectionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNConnectionsClientDeleteResponse will be returned.
-func (p *VPNConnectionsClientDeletePoller) FinalResponse(ctx context.Context) (VPNConnectionsClientDeleteResponse, error) {
-	respType := VPNConnectionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VPNConnectionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNConnectionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNConnectionsClientDeleteResponse, error) {
+	result := VPNConnectionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNConnectionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNConnectionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNConnectionsClientDeletePoller) Resume(ctx context.Context, client *VPNConnectionsClient, token string) (VPNConnectionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNConnectionsClient.Delete", token, client.pl); err != nil {
+		return VPNConnectionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5106,36 +7061,52 @@ func (p *VPNGatewaysClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (VPNGatewaysClientCreateOrUpdateResponse, error) {
+	result := VPNGatewaysClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNGatewaysClientCreateOrUpdateResponse will be returned.
-func (p *VPNGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VPNGatewaysClientCreateOrUpdateResponse, error) {
-	respType := VPNGatewaysClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNGateway)
-	if err != nil {
-		return VPNGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNGatewaysClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientCreateOrUpdateResponse, error) {
+	result := VPNGatewaysClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VPNGatewaysClient, token string) (VPNGatewaysClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VPNGatewaysClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5148,36 +7119,52 @@ func (p *VPNGatewaysClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNGatewaysClientDeletePoller) Poll(ctx context.Context) (VPNGatewaysClientDeleteResponse, error) {
+	result := VPNGatewaysClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNGatewaysClientDeleteResponse will be returned.
-func (p *VPNGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (VPNGatewaysClientDeleteResponse, error) {
-	respType := VPNGatewaysClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VPNGatewaysClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNGatewaysClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientDeleteResponse, error) {
+	result := VPNGatewaysClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNGatewaysClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNGatewaysClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNGatewaysClientDeletePoller) Resume(ctx context.Context, client *VPNGatewaysClient, token string) (VPNGatewaysClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.Delete", token, client.pl); err != nil {
+		return VPNGatewaysClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNGatewaysClientResetPoller provides polling facilities until the operation reaches a terminal state.
@@ -5190,36 +7177,52 @@ func (p *VPNGatewaysClientResetPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNGatewaysClientResetPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNGatewaysClientResetPoller) Poll(ctx context.Context) (VPNGatewaysClientResetResponse, error) {
+	result := VPNGatewaysClientResetResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNGatewaysClientResetResponse will be returned.
-func (p *VPNGatewaysClientResetPoller) FinalResponse(ctx context.Context) (VPNGatewaysClientResetResponse, error) {
-	respType := VPNGatewaysClientResetResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNGateway)
-	if err != nil {
-		return VPNGatewaysClientResetResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNGatewaysClientResetPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientResetResponse, error) {
+	result := VPNGatewaysClientResetResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNGatewaysClientResetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNGatewaysClientResetPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNGatewaysClientResetPoller) Resume(ctx context.Context, client *VPNGatewaysClient, token string) (VPNGatewaysClientResetResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.Reset", token, client.pl); err != nil {
+		return VPNGatewaysClientResetResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller provides polling facilities until the operation reaches a terminal state.
@@ -5232,36 +7235,52 @@ func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Done()
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Poll(ctx context.Context) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
+	result := VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNServerConfigurationsResponse)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse will be returned.
-func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) FinalResponse(ctx context.Context) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
-	respType := VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNServerConfigurationsResponse)
-	if err != nil {
-		return VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
+	result := VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNServerConfigurationsResponse)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Resume(ctx context.Context, client *VPNServerConfigurationsAssociatedWithVirtualWanClient, token string) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsAssociatedWithVirtualWanClient.List", token, client.pl); err != nil {
+		return VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNServerConfigurationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5274,36 +7293,52 @@ func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
+	result := VPNServerConfigurationsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNServerConfiguration)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNServerConfigurationsClientCreateOrUpdateResponse will be returned.
-func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
-	respType := VPNServerConfigurationsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNServerConfiguration)
-	if err != nil {
-		return VPNServerConfigurationsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
+	result := VPNServerConfigurationsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNServerConfiguration)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNServerConfigurationsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VPNServerConfigurationsClient, token string) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VPNServerConfigurationsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNServerConfigurationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5316,36 +7351,52 @@ func (p *VPNServerConfigurationsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNServerConfigurationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNServerConfigurationsClientDeletePoller) Poll(ctx context.Context) (VPNServerConfigurationsClientDeleteResponse, error) {
+	result := VPNServerConfigurationsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNServerConfigurationsClientDeleteResponse will be returned.
-func (p *VPNServerConfigurationsClientDeletePoller) FinalResponse(ctx context.Context) (VPNServerConfigurationsClientDeleteResponse, error) {
-	respType := VPNServerConfigurationsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VPNServerConfigurationsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNServerConfigurationsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsClientDeleteResponse, error) {
+	result := VPNServerConfigurationsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNServerConfigurationsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNServerConfigurationsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNServerConfigurationsClientDeletePoller) Resume(ctx context.Context, client *VPNServerConfigurationsClient, token string) (VPNServerConfigurationsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsClient.Delete", token, client.pl); err != nil {
+		return VPNServerConfigurationsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNSitesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5358,36 +7409,52 @@ func (p *VPNSitesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNSitesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNSitesClientCreateOrUpdatePoller) Poll(ctx context.Context) (VPNSitesClientCreateOrUpdateResponse, error) {
+	result := VPNSitesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNSite)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNSitesClientCreateOrUpdateResponse will be returned.
-func (p *VPNSitesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VPNSitesClientCreateOrUpdateResponse, error) {
-	respType := VPNSitesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNSite)
-	if err != nil {
-		return VPNSitesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNSitesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesClientCreateOrUpdateResponse, error) {
+	result := VPNSitesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNSite)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNSitesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNSitesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNSitesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VPNSitesClient, token string) (VPNSitesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VPNSitesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNSitesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5400,36 +7467,52 @@ func (p *VPNSitesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNSitesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNSitesClientDeletePoller) Poll(ctx context.Context) (VPNSitesClientDeleteResponse, error) {
+	result := VPNSitesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNSitesClientDeleteResponse will be returned.
-func (p *VPNSitesClientDeletePoller) FinalResponse(ctx context.Context) (VPNSitesClientDeleteResponse, error) {
-	respType := VPNSitesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VPNSitesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNSitesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesClientDeleteResponse, error) {
+	result := VPNSitesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNSitesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNSitesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNSitesClientDeletePoller) Resume(ctx context.Context, client *VPNSitesClient, token string) (VPNSitesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesClient.Delete", token, client.pl); err != nil {
+		return VPNSitesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VPNSitesConfigurationClientDownloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -5442,36 +7525,52 @@ func (p *VPNSitesConfigurationClientDownloadPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VPNSitesConfigurationClientDownloadPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VPNSitesConfigurationClientDownloadPoller) Poll(ctx context.Context) (VPNSitesConfigurationClientDownloadResponse, error) {
+	result := VPNSitesConfigurationClientDownloadResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VPNSitesConfigurationClientDownloadResponse will be returned.
-func (p *VPNSitesConfigurationClientDownloadPoller) FinalResponse(ctx context.Context) (VPNSitesConfigurationClientDownloadResponse, error) {
-	respType := VPNSitesConfigurationClientDownloadResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VPNSitesConfigurationClientDownloadResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VPNSitesConfigurationClientDownloadPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesConfigurationClientDownloadResponse, error) {
+	result := VPNSitesConfigurationClientDownloadResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VPNSitesConfigurationClientDownloadPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VPNSitesConfigurationClientDownloadPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VPNSitesConfigurationClientDownloadPoller) Resume(ctx context.Context, client *VPNSitesConfigurationClient, token string) (VPNSitesConfigurationClientDownloadResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesConfigurationClient.Download", token, client.pl); err != nil {
+		return VPNSitesConfigurationClientDownloadResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualAppliancesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5484,36 +7583,52 @@ func (p *VirtualAppliancesClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualAppliancesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualAppliancesClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
+	result := VirtualAppliancesClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualAppliance)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualAppliancesClientCreateOrUpdateResponse will be returned.
-func (p *VirtualAppliancesClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
-	respType := VirtualAppliancesClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualAppliance)
-	if err != nil {
-		return VirtualAppliancesClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualAppliancesClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
+	result := VirtualAppliancesClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualAppliance)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualAppliancesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualAppliancesClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualAppliancesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualAppliancesClient, token string) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualAppliancesClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualAppliancesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5526,36 +7641,52 @@ func (p *VirtualAppliancesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualAppliancesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualAppliancesClientDeletePoller) Poll(ctx context.Context) (VirtualAppliancesClientDeleteResponse, error) {
+	result := VirtualAppliancesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualAppliancesClientDeleteResponse will be returned.
-func (p *VirtualAppliancesClientDeletePoller) FinalResponse(ctx context.Context) (VirtualAppliancesClientDeleteResponse, error) {
-	respType := VirtualAppliancesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualAppliancesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualAppliancesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualAppliancesClientDeleteResponse, error) {
+	result := VirtualAppliancesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualAppliancesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualAppliancesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualAppliancesClientDeletePoller) Resume(ctx context.Context, client *VirtualAppliancesClient, token string) (VirtualAppliancesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.Delete", token, client.pl); err != nil {
+		return VirtualAppliancesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualHubRouteTableV2SClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5568,36 +7699,52 @@ func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
+	result := VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualHubRouteTableV2)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualHubRouteTableV2SClientCreateOrUpdateResponse will be returned.
-func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
-	respType := VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualHubRouteTableV2)
-	if err != nil {
-		return VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
+	result := VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualHubRouteTableV2)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualHubRouteTableV2SClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualHubRouteTableV2SClient, token string) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualHubRouteTableV2SClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5610,36 +7757,52 @@ func (p *VirtualHubRouteTableV2SClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualHubRouteTableV2SClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualHubRouteTableV2SClientDeletePoller) Poll(ctx context.Context) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
+	result := VirtualHubRouteTableV2SClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualHubRouteTableV2SClientDeleteResponse will be returned.
-func (p *VirtualHubRouteTableV2SClientDeletePoller) FinalResponse(ctx context.Context) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
-	respType := VirtualHubRouteTableV2SClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualHubRouteTableV2SClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualHubRouteTableV2SClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
+	result := VirtualHubRouteTableV2SClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualHubRouteTableV2SClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualHubRouteTableV2SClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualHubRouteTableV2SClientDeletePoller) Resume(ctx context.Context, client *VirtualHubRouteTableV2SClient, token string) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.Delete", token, client.pl); err != nil {
+		return VirtualHubRouteTableV2SClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualHubsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5652,36 +7815,52 @@ func (p *VirtualHubsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualHubsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualHubsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualHubsClientCreateOrUpdateResponse, error) {
+	result := VirtualHubsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualHub)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualHubsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualHubsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualHubsClientCreateOrUpdateResponse, error) {
-	respType := VirtualHubsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualHub)
-	if err != nil {
-		return VirtualHubsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualHubsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubsClientCreateOrUpdateResponse, error) {
+	result := VirtualHubsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualHub)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualHubsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualHubsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualHubsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualHubsClient, token string) (VirtualHubsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualHubsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualHubsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5694,36 +7873,52 @@ func (p *VirtualHubsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualHubsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualHubsClientDeletePoller) Poll(ctx context.Context) (VirtualHubsClientDeleteResponse, error) {
+	result := VirtualHubsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualHubsClientDeleteResponse will be returned.
-func (p *VirtualHubsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualHubsClientDeleteResponse, error) {
-	respType := VirtualHubsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualHubsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualHubsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubsClientDeleteResponse, error) {
+	result := VirtualHubsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualHubsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualHubsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualHubsClientDeletePoller) Resume(ctx context.Context, client *VirtualHubsClient, token string) (VirtualHubsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubsClient.Delete", token, client.pl); err != nil {
+		return VirtualHubsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5736,36 +7931,52 @@ func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Done() bool
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGatewayConnection)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGatewayConnection)
-	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualNetworkGatewayConnection)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewayConnectionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5778,36 +7989,52 @@ func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientDeleteResponse will be returned.
-func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewayConnectionsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.Delete", token, client.pl); err != nil {
+		return VirtualNetworkGatewayConnectionsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller provides polling facilities until the operation reaches a terminal state.
@@ -5820,36 +8047,52 @@ func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Done() bool
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ConnectionResetSharedKey)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse will be returned.
-func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ConnectionResetSharedKey)
-	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ConnectionResetSharedKey)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.ResetSharedKey", token, client.pl); err != nil {
+		return VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller provides polling facilities until the operation reaches a terminal state.
@@ -5862,36 +8105,52 @@ func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ConnectionSharedKey)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse will be returned.
-func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ConnectionSharedKey)
-	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ConnectionSharedKey)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.SetSharedKey", token, client.pl); err != nil {
+		return VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -5904,36 +8163,52 @@ func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Done() 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Value)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse will be returned.
-func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Value)
-	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Value)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StartPacketCapture", token, client.pl); err != nil {
+		return VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -5946,36 +8221,52 @@ func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Done() b
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Value)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse will be returned.
-func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Value)
-	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Value)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StopPacketCapture", token, client.pl); err != nil {
+		return VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewayConnectionsClientUpdateTagsPoller provides polling facilities until the operation reaches a terminal state.
@@ -5988,36 +8279,52 @@ func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGatewayConnection)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewayConnectionsClientUpdateTagsResponse will be returned.
-func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGatewayConnection)
-	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
+	result := VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualNetworkGatewayConnection)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewayConnectionsClientUpdateTagsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.UpdateTags", token, client.pl); err != nil {
+		return VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6030,36 +8337,52 @@ func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworkGatewaysClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientCreateOrUpdateResponse will be returned.
-func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworkGatewaysClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
-	if err != nil {
-		return VirtualNetworkGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworkGatewaysClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualNetworkGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6072,36 +8395,52 @@ func (p *VirtualNetworkGatewaysClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientDeleteResponse, error) {
+	result := VirtualNetworkGatewaysClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientDeleteResponse will be returned.
-func (p *VirtualNetworkGatewaysClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientDeleteResponse, error) {
-	respType := VirtualNetworkGatewaysClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualNetworkGatewaysClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientDeleteResponse, error) {
+	result := VirtualNetworkGatewaysClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Delete", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller provides polling facilities until the operation reaches a terminal state.
@@ -6114,36 +8453,52 @@ func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectio
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
+	result := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse will be returned.
-func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
-	respType := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
+	result := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientGenerateVPNProfilePoller provides polling facilities until the operation reaches a terminal state.
@@ -6156,36 +8511,52 @@ func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
+	result := VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Value)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientGenerateVPNProfileResponse will be returned.
-func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
-	respType := VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Value)
-	if err != nil {
-		return VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
+	result := VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Value)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientGenerateVPNProfilePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GenerateVPNProfile", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller provides polling facilities until the operation reaches a terminal state.
@@ -6198,36 +8569,52 @@ func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Done() bool
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
+	result := VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Value)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse will be returned.
-func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
-	respType := VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Value)
-	if err != nil {
-		return VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
+	result := VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Value)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Generatevpnclientpackage", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller provides polling facilities until the operation reaches a terminal state.
@@ -6240,36 +8627,52 @@ func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
+	result := VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GatewayRouteListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse will be returned.
-func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GatewayRouteListResult)
-	if err != nil {
-		return VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
+	result := VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GatewayRouteListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetAdvertisedRoutes", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientGetBgpPeerStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -6282,36 +8685,52 @@ func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
+	result := VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.BgpPeerStatusListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientGetBgpPeerStatusResponse will be returned.
-func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.BgpPeerStatusListResult)
-	if err != nil {
-		return VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
+	result := VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.BgpPeerStatusListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientGetBgpPeerStatusPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetBgpPeerStatus", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientGetLearnedRoutesPoller provides polling facilities until the operation reaches a terminal state.
@@ -6324,36 +8743,52 @@ func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
+	result := VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.GatewayRouteListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientGetLearnedRoutesResponse will be returned.
-func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.GatewayRouteListResult)
-	if err != nil {
-		return VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
+	result := VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.GatewayRouteListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientGetLearnedRoutesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetLearnedRoutes", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller provides polling facilities until the operation reaches a terminal state.
@@ -6366,36 +8801,52 @@ func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Done() bool 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
+	result := VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Value)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse will be returned.
-func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Value)
-	if err != nil {
-		return VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
+	result := VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Value)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVPNProfilePackageURL", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller provides polling facilities until the operation reaches a terminal state.
@@ -6408,36 +8859,52 @@ func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Done() 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
+	result := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNClientConnectionHealthDetailListResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse will be returned.
-func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNClientConnectionHealthDetailListResult)
-	if err != nil {
-		return VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
+	result := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNClientConnectionHealthDetailListResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller provides polling facilities until the operation reaches a terminal state.
@@ -6450,36 +8917,52 @@ func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Done() b
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
+	result := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNClientIPsecParameters)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse will be returned.
-func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNClientIPsecParameters)
-	if err != nil {
-		return VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
+	result := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNClientIPsecParameters)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientResetPoller provides polling facilities until the operation reaches a terminal state.
@@ -6492,36 +8975,52 @@ func (p *VirtualNetworkGatewaysClientResetPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientResetPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientResetPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientResetResponse, error) {
+	result := VirtualNetworkGatewaysClientResetResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientResetResponse will be returned.
-func (p *VirtualNetworkGatewaysClientResetPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientResetResponse, error) {
-	respType := VirtualNetworkGatewaysClientResetResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
-	if err != nil {
-		return VirtualNetworkGatewaysClientResetResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientResetPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientResetResponse, error) {
+	result := VirtualNetworkGatewaysClientResetResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualNetworkGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientResetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientResetPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientResetPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientResetResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Reset", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientResetResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller provides polling facilities until the operation reaches a terminal state.
@@ -6534,36 +9033,52 @@ func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Done() bool 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
+	result := VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse will be returned.
-func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
-	respType := VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
+	result := VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.ResetVPNClientSharedKey", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller provides polling facilities until the operation reaches a terminal state.
@@ -6576,36 +9091,52 @@ func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Done() b
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
+	result := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VPNClientIPsecParameters)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse will be returned.
-func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
-	respType := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VPNClientIPsecParameters)
-	if err != nil {
-		return VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
+	result := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VPNClientIPsecParameters)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientStartPacketCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -6618,36 +9149,52 @@ func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
+	result := VirtualNetworkGatewaysClientStartPacketCaptureResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Value)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientStartPacketCaptureResponse will be returned.
-func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
-	respType := VirtualNetworkGatewaysClientStartPacketCaptureResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Value)
-	if err != nil {
-		return VirtualNetworkGatewaysClientStartPacketCaptureResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
+	result := VirtualNetworkGatewaysClientStartPacketCaptureResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Value)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientStartPacketCapturePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StartPacketCapture", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientStartPacketCaptureResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientStopPacketCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -6660,36 +9207,52 @@ func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
+	result := VirtualNetworkGatewaysClientStopPacketCaptureResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.Value)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientStopPacketCaptureResponse will be returned.
-func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
-	respType := VirtualNetworkGatewaysClientStopPacketCaptureResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.Value)
-	if err != nil {
-		return VirtualNetworkGatewaysClientStopPacketCaptureResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
+	result := VirtualNetworkGatewaysClientStopPacketCaptureResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.Value)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientStopPacketCapturePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StopPacketCapture", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientStopPacketCaptureResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkGatewaysClientUpdateTagsPoller provides polling facilities until the operation reaches a terminal state.
@@ -6702,36 +9265,52 @@ func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
+	result := VirtualNetworkGatewaysClientUpdateTagsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGateway)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkGatewaysClientUpdateTagsResponse will be returned.
-func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) FinalResponse(ctx context.Context) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
-	respType := VirtualNetworkGatewaysClientUpdateTagsResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkGateway)
-	if err != nil {
-		return VirtualNetworkGatewaysClientUpdateTagsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
+	result := VirtualNetworkGatewaysClientUpdateTagsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualNetworkGateway)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkGatewaysClientUpdateTagsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.UpdateTags", token, client.pl); err != nil {
+		return VirtualNetworkGatewaysClientUpdateTagsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkPeeringsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6744,36 +9323,52 @@ func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworkPeeringsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkPeering)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkPeeringsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworkPeeringsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkPeering)
-	if err != nil {
-		return VirtualNetworkPeeringsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworkPeeringsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualNetworkPeering)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkPeeringsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworkPeeringsClient, token string) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualNetworkPeeringsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkPeeringsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6786,36 +9381,52 @@ func (p *VirtualNetworkPeeringsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkPeeringsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkPeeringsClientDeletePoller) Poll(ctx context.Context) (VirtualNetworkPeeringsClientDeleteResponse, error) {
+	result := VirtualNetworkPeeringsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkPeeringsClientDeleteResponse will be returned.
-func (p *VirtualNetworkPeeringsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworkPeeringsClientDeleteResponse, error) {
-	respType := VirtualNetworkPeeringsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualNetworkPeeringsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkPeeringsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkPeeringsClientDeleteResponse, error) {
+	result := VirtualNetworkPeeringsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkPeeringsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkPeeringsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkPeeringsClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworkPeeringsClient, token string) (VirtualNetworkPeeringsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.Delete", token, client.pl); err != nil {
+		return VirtualNetworkPeeringsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkTapsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6828,36 +9439,52 @@ func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworkTapsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkTap)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkTapsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworkTapsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetworkTap)
-	if err != nil {
-		return VirtualNetworkTapsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworkTapsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualNetworkTap)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkTapsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworkTapsClient, token string) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkTapsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualNetworkTapsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworkTapsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6870,36 +9497,52 @@ func (p *VirtualNetworkTapsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworkTapsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworkTapsClientDeletePoller) Poll(ctx context.Context) (VirtualNetworkTapsClientDeleteResponse, error) {
+	result := VirtualNetworkTapsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworkTapsClientDeleteResponse will be returned.
-func (p *VirtualNetworkTapsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworkTapsClientDeleteResponse, error) {
-	respType := VirtualNetworkTapsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualNetworkTapsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworkTapsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkTapsClientDeleteResponse, error) {
+	result := VirtualNetworkTapsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworkTapsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworkTapsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworkTapsClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworkTapsClient, token string) (VirtualNetworkTapsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkTapsClient.Delete", token, client.pl); err != nil {
+		return VirtualNetworkTapsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworksClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6912,36 +9555,52 @@ func (p *VirtualNetworksClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworksClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworksClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworksClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworksClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetwork)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworksClientCreateOrUpdateResponse will be returned.
-func (p *VirtualNetworksClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualNetworksClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworksClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualNetwork)
-	if err != nil {
-		return VirtualNetworksClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworksClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworksClientCreateOrUpdateResponse, error) {
+	result := VirtualNetworksClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualNetwork)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworksClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworksClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworksClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworksClient, token string) (VirtualNetworksClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworksClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualNetworksClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualNetworksClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6954,36 +9613,52 @@ func (p *VirtualNetworksClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualNetworksClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualNetworksClientDeletePoller) Poll(ctx context.Context) (VirtualNetworksClientDeleteResponse, error) {
+	result := VirtualNetworksClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualNetworksClientDeleteResponse will be returned.
-func (p *VirtualNetworksClientDeletePoller) FinalResponse(ctx context.Context) (VirtualNetworksClientDeleteResponse, error) {
-	respType := VirtualNetworksClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualNetworksClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualNetworksClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworksClientDeleteResponse, error) {
+	result := VirtualNetworksClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualNetworksClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualNetworksClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualNetworksClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworksClient, token string) (VirtualNetworksClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworksClient.Delete", token, client.pl); err != nil {
+		return VirtualNetworksClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualRouterPeeringsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6996,36 +9671,52 @@ func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
+	result := VirtualRouterPeeringsClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualRouterPeering)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualRouterPeeringsClientCreateOrUpdateResponse will be returned.
-func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
-	respType := VirtualRouterPeeringsClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualRouterPeering)
-	if err != nil {
-		return VirtualRouterPeeringsClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
+	result := VirtualRouterPeeringsClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualRouterPeering)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualRouterPeeringsClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualRouterPeeringsClient, token string) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRouterPeeringsClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualRouterPeeringsClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualRouterPeeringsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7038,36 +9729,52 @@ func (p *VirtualRouterPeeringsClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualRouterPeeringsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualRouterPeeringsClientDeletePoller) Poll(ctx context.Context) (VirtualRouterPeeringsClientDeleteResponse, error) {
+	result := VirtualRouterPeeringsClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualRouterPeeringsClientDeleteResponse will be returned.
-func (p *VirtualRouterPeeringsClientDeletePoller) FinalResponse(ctx context.Context) (VirtualRouterPeeringsClientDeleteResponse, error) {
-	respType := VirtualRouterPeeringsClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualRouterPeeringsClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualRouterPeeringsClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRouterPeeringsClientDeleteResponse, error) {
+	result := VirtualRouterPeeringsClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualRouterPeeringsClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualRouterPeeringsClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualRouterPeeringsClientDeletePoller) Resume(ctx context.Context, client *VirtualRouterPeeringsClient, token string) (VirtualRouterPeeringsClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRouterPeeringsClient.Delete", token, client.pl); err != nil {
+		return VirtualRouterPeeringsClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualRoutersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7080,36 +9787,52 @@ func (p *VirtualRoutersClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualRoutersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualRoutersClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualRoutersClientCreateOrUpdateResponse, error) {
+	result := VirtualRoutersClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualRouter)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualRoutersClientCreateOrUpdateResponse will be returned.
-func (p *VirtualRoutersClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualRoutersClientCreateOrUpdateResponse, error) {
-	respType := VirtualRoutersClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualRouter)
-	if err != nil {
-		return VirtualRoutersClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualRoutersClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRoutersClientCreateOrUpdateResponse, error) {
+	result := VirtualRoutersClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualRouter)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualRoutersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualRoutersClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualRoutersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualRoutersClient, token string) (VirtualRoutersClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRoutersClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualRoutersClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualRoutersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7122,36 +9845,52 @@ func (p *VirtualRoutersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualRoutersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualRoutersClientDeletePoller) Poll(ctx context.Context) (VirtualRoutersClientDeleteResponse, error) {
+	result := VirtualRoutersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualRoutersClientDeleteResponse will be returned.
-func (p *VirtualRoutersClientDeletePoller) FinalResponse(ctx context.Context) (VirtualRoutersClientDeleteResponse, error) {
-	respType := VirtualRoutersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualRoutersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualRoutersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRoutersClientDeleteResponse, error) {
+	result := VirtualRoutersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualRoutersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualRoutersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualRoutersClientDeletePoller) Resume(ctx context.Context, client *VirtualRoutersClient, token string) (VirtualRoutersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRoutersClient.Delete", token, client.pl); err != nil {
+		return VirtualRoutersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualWansClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7164,36 +9903,52 @@ func (p *VirtualWansClientCreateOrUpdatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualWansClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualWansClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualWansClientCreateOrUpdateResponse, error) {
+	result := VirtualWansClientCreateOrUpdateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VirtualWAN)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualWansClientCreateOrUpdateResponse will be returned.
-func (p *VirtualWansClientCreateOrUpdatePoller) FinalResponse(ctx context.Context) (VirtualWansClientCreateOrUpdateResponse, error) {
-	respType := VirtualWansClientCreateOrUpdateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VirtualWAN)
-	if err != nil {
-		return VirtualWansClientCreateOrUpdateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualWansClientCreateOrUpdatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualWansClientCreateOrUpdateResponse, error) {
+	result := VirtualWansClientCreateOrUpdateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VirtualWAN)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualWansClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualWansClientCreateOrUpdatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualWansClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualWansClient, token string) (VirtualWansClientCreateOrUpdateResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualWansClient.CreateOrUpdate", token, client.pl); err != nil {
+		return VirtualWansClientCreateOrUpdateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // VirtualWansClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7206,36 +9961,52 @@ func (p *VirtualWansClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *VirtualWansClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *VirtualWansClientDeletePoller) Poll(ctx context.Context) (VirtualWansClientDeleteResponse, error) {
+	result := VirtualWansClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final VirtualWansClientDeleteResponse will be returned.
-func (p *VirtualWansClientDeletePoller) FinalResponse(ctx context.Context) (VirtualWansClientDeleteResponse, error) {
-	respType := VirtualWansClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return VirtualWansClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *VirtualWansClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualWansClientDeleteResponse, error) {
+	result := VirtualWansClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *VirtualWansClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a VirtualWansClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *VirtualWansClientDeletePoller) Resume(ctx context.Context, client *VirtualWansClient, token string) (VirtualWansClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualWansClient.Delete", token, client.pl); err != nil {
+		return VirtualWansClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientCheckConnectivityPoller provides polling facilities until the operation reaches a terminal state.
@@ -7248,36 +10019,52 @@ func (p *WatchersClientCheckConnectivityPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientCheckConnectivityPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientCheckConnectivityPoller) Poll(ctx context.Context) (WatchersClientCheckConnectivityResponse, error) {
+	result := WatchersClientCheckConnectivityResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ConnectivityInformation)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientCheckConnectivityResponse will be returned.
-func (p *WatchersClientCheckConnectivityPoller) FinalResponse(ctx context.Context) (WatchersClientCheckConnectivityResponse, error) {
-	respType := WatchersClientCheckConnectivityResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ConnectivityInformation)
-	if err != nil {
-		return WatchersClientCheckConnectivityResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientCheckConnectivityPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientCheckConnectivityResponse, error) {
+	result := WatchersClientCheckConnectivityResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ConnectivityInformation)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientCheckConnectivityPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientCheckConnectivityPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientCheckConnectivityPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientCheckConnectivityResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.CheckConnectivity", token, client.pl); err != nil {
+		return WatchersClientCheckConnectivityResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7290,36 +10077,52 @@ func (p *WatchersClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientDeletePoller) Poll(ctx context.Context) (WatchersClientDeleteResponse, error) {
+	result := WatchersClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientDeleteResponse will be returned.
-func (p *WatchersClientDeletePoller) FinalResponse(ctx context.Context) (WatchersClientDeleteResponse, error) {
-	respType := WatchersClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return WatchersClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientDeleteResponse, error) {
+	result := WatchersClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientDeletePoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.Delete", token, client.pl); err != nil {
+		return WatchersClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientGetAzureReachabilityReportPoller provides polling facilities until the operation reaches a terminal state.
@@ -7332,36 +10135,52 @@ func (p *WatchersClientGetAzureReachabilityReportPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientGetAzureReachabilityReportPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientGetAzureReachabilityReportPoller) Poll(ctx context.Context) (WatchersClientGetAzureReachabilityReportResponse, error) {
+	result := WatchersClientGetAzureReachabilityReportResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.AzureReachabilityReport)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientGetAzureReachabilityReportResponse will be returned.
-func (p *WatchersClientGetAzureReachabilityReportPoller) FinalResponse(ctx context.Context) (WatchersClientGetAzureReachabilityReportResponse, error) {
-	respType := WatchersClientGetAzureReachabilityReportResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.AzureReachabilityReport)
-	if err != nil {
-		return WatchersClientGetAzureReachabilityReportResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientGetAzureReachabilityReportPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetAzureReachabilityReportResponse, error) {
+	result := WatchersClientGetAzureReachabilityReportResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.AzureReachabilityReport)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientGetAzureReachabilityReportPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientGetAzureReachabilityReportPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientGetAzureReachabilityReportPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetAzureReachabilityReportResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetAzureReachabilityReport", token, client.pl); err != nil {
+		return WatchersClientGetAzureReachabilityReportResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientGetFlowLogStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -7374,36 +10193,52 @@ func (p *WatchersClientGetFlowLogStatusPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientGetFlowLogStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientGetFlowLogStatusPoller) Poll(ctx context.Context) (WatchersClientGetFlowLogStatusResponse, error) {
+	result := WatchersClientGetFlowLogStatusResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.FlowLogInformation)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientGetFlowLogStatusResponse will be returned.
-func (p *WatchersClientGetFlowLogStatusPoller) FinalResponse(ctx context.Context) (WatchersClientGetFlowLogStatusResponse, error) {
-	respType := WatchersClientGetFlowLogStatusResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.FlowLogInformation)
-	if err != nil {
-		return WatchersClientGetFlowLogStatusResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientGetFlowLogStatusPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetFlowLogStatusResponse, error) {
+	result := WatchersClientGetFlowLogStatusResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.FlowLogInformation)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientGetFlowLogStatusPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientGetFlowLogStatusPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientGetFlowLogStatusPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetFlowLogStatusResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetFlowLogStatus", token, client.pl); err != nil {
+		return WatchersClientGetFlowLogStatusResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientGetNetworkConfigurationDiagnosticPoller provides polling facilities until the operation reaches a terminal state.
@@ -7416,36 +10251,52 @@ func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Poll(ctx context.Context) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
+	result := WatchersClientGetNetworkConfigurationDiagnosticResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.ConfigurationDiagnosticResponse)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientGetNetworkConfigurationDiagnosticResponse will be returned.
-func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) FinalResponse(ctx context.Context) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
-	respType := WatchersClientGetNetworkConfigurationDiagnosticResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.ConfigurationDiagnosticResponse)
-	if err != nil {
-		return WatchersClientGetNetworkConfigurationDiagnosticResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
+	result := WatchersClientGetNetworkConfigurationDiagnosticResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.ConfigurationDiagnosticResponse)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientGetNetworkConfigurationDiagnosticPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetNetworkConfigurationDiagnostic", token, client.pl); err != nil {
+		return WatchersClientGetNetworkConfigurationDiagnosticResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientGetNextHopPoller provides polling facilities until the operation reaches a terminal state.
@@ -7458,36 +10309,52 @@ func (p *WatchersClientGetNextHopPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientGetNextHopPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientGetNextHopPoller) Poll(ctx context.Context) (WatchersClientGetNextHopResponse, error) {
+	result := WatchersClientGetNextHopResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.NextHopResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientGetNextHopResponse will be returned.
-func (p *WatchersClientGetNextHopPoller) FinalResponse(ctx context.Context) (WatchersClientGetNextHopResponse, error) {
-	respType := WatchersClientGetNextHopResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.NextHopResult)
-	if err != nil {
-		return WatchersClientGetNextHopResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientGetNextHopPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetNextHopResponse, error) {
+	result := WatchersClientGetNextHopResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.NextHopResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientGetNextHopPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientGetNextHopPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientGetNextHopPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetNextHopResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetNextHop", token, client.pl); err != nil {
+		return WatchersClientGetNextHopResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientGetTroubleshootingPoller provides polling facilities until the operation reaches a terminal state.
@@ -7500,36 +10367,52 @@ func (p *WatchersClientGetTroubleshootingPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientGetTroubleshootingPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientGetTroubleshootingPoller) Poll(ctx context.Context) (WatchersClientGetTroubleshootingResponse, error) {
+	result := WatchersClientGetTroubleshootingResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.TroubleshootingResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientGetTroubleshootingResponse will be returned.
-func (p *WatchersClientGetTroubleshootingPoller) FinalResponse(ctx context.Context) (WatchersClientGetTroubleshootingResponse, error) {
-	respType := WatchersClientGetTroubleshootingResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.TroubleshootingResult)
-	if err != nil {
-		return WatchersClientGetTroubleshootingResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientGetTroubleshootingPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetTroubleshootingResponse, error) {
+	result := WatchersClientGetTroubleshootingResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.TroubleshootingResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientGetTroubleshootingPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientGetTroubleshootingPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientGetTroubleshootingPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetTroubleshootingResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshooting", token, client.pl); err != nil {
+		return WatchersClientGetTroubleshootingResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientGetTroubleshootingResultPoller provides polling facilities until the operation reaches a terminal state.
@@ -7542,36 +10425,52 @@ func (p *WatchersClientGetTroubleshootingResultPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientGetTroubleshootingResultPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientGetTroubleshootingResultPoller) Poll(ctx context.Context) (WatchersClientGetTroubleshootingResultResponse, error) {
+	result := WatchersClientGetTroubleshootingResultResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.TroubleshootingResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientGetTroubleshootingResultResponse will be returned.
-func (p *WatchersClientGetTroubleshootingResultPoller) FinalResponse(ctx context.Context) (WatchersClientGetTroubleshootingResultResponse, error) {
-	respType := WatchersClientGetTroubleshootingResultResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.TroubleshootingResult)
-	if err != nil {
-		return WatchersClientGetTroubleshootingResultResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientGetTroubleshootingResultPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetTroubleshootingResultResponse, error) {
+	result := WatchersClientGetTroubleshootingResultResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.TroubleshootingResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientGetTroubleshootingResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientGetTroubleshootingResultPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientGetTroubleshootingResultPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetTroubleshootingResultResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshootingResult", token, client.pl); err != nil {
+		return WatchersClientGetTroubleshootingResultResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientGetVMSecurityRulesPoller provides polling facilities until the operation reaches a terminal state.
@@ -7584,36 +10483,52 @@ func (p *WatchersClientGetVMSecurityRulesPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientGetVMSecurityRulesPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientGetVMSecurityRulesPoller) Poll(ctx context.Context) (WatchersClientGetVMSecurityRulesResponse, error) {
+	result := WatchersClientGetVMSecurityRulesResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SecurityGroupViewResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientGetVMSecurityRulesResponse will be returned.
-func (p *WatchersClientGetVMSecurityRulesPoller) FinalResponse(ctx context.Context) (WatchersClientGetVMSecurityRulesResponse, error) {
-	respType := WatchersClientGetVMSecurityRulesResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SecurityGroupViewResult)
-	if err != nil {
-		return WatchersClientGetVMSecurityRulesResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientGetVMSecurityRulesPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetVMSecurityRulesResponse, error) {
+	result := WatchersClientGetVMSecurityRulesResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SecurityGroupViewResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientGetVMSecurityRulesPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientGetVMSecurityRulesPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientGetVMSecurityRulesPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetVMSecurityRulesResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetVMSecurityRules", token, client.pl); err != nil {
+		return WatchersClientGetVMSecurityRulesResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientListAvailableProvidersPoller provides polling facilities until the operation reaches a terminal state.
@@ -7626,36 +10541,52 @@ func (p *WatchersClientListAvailableProvidersPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientListAvailableProvidersPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientListAvailableProvidersPoller) Poll(ctx context.Context) (WatchersClientListAvailableProvidersResponse, error) {
+	result := WatchersClientListAvailableProvidersResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.AvailableProvidersList)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientListAvailableProvidersResponse will be returned.
-func (p *WatchersClientListAvailableProvidersPoller) FinalResponse(ctx context.Context) (WatchersClientListAvailableProvidersResponse, error) {
-	respType := WatchersClientListAvailableProvidersResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.AvailableProvidersList)
-	if err != nil {
-		return WatchersClientListAvailableProvidersResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientListAvailableProvidersPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientListAvailableProvidersResponse, error) {
+	result := WatchersClientListAvailableProvidersResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.AvailableProvidersList)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientListAvailableProvidersPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientListAvailableProvidersPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientListAvailableProvidersPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientListAvailableProvidersResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.ListAvailableProviders", token, client.pl); err != nil {
+		return WatchersClientListAvailableProvidersResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientSetFlowLogConfigurationPoller provides polling facilities until the operation reaches a terminal state.
@@ -7668,36 +10599,52 @@ func (p *WatchersClientSetFlowLogConfigurationPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientSetFlowLogConfigurationPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientSetFlowLogConfigurationPoller) Poll(ctx context.Context) (WatchersClientSetFlowLogConfigurationResponse, error) {
+	result := WatchersClientSetFlowLogConfigurationResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.FlowLogInformation)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientSetFlowLogConfigurationResponse will be returned.
-func (p *WatchersClientSetFlowLogConfigurationPoller) FinalResponse(ctx context.Context) (WatchersClientSetFlowLogConfigurationResponse, error) {
-	respType := WatchersClientSetFlowLogConfigurationResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.FlowLogInformation)
-	if err != nil {
-		return WatchersClientSetFlowLogConfigurationResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientSetFlowLogConfigurationPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientSetFlowLogConfigurationResponse, error) {
+	result := WatchersClientSetFlowLogConfigurationResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.FlowLogInformation)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientSetFlowLogConfigurationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientSetFlowLogConfigurationPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientSetFlowLogConfigurationPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientSetFlowLogConfigurationResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.SetFlowLogConfiguration", token, client.pl); err != nil {
+		return WatchersClientSetFlowLogConfigurationResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WatchersClientVerifyIPFlowPoller provides polling facilities until the operation reaches a terminal state.
@@ -7710,36 +10657,52 @@ func (p *WatchersClientVerifyIPFlowPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WatchersClientVerifyIPFlowPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WatchersClientVerifyIPFlowPoller) Poll(ctx context.Context) (WatchersClientVerifyIPFlowResponse, error) {
+	result := WatchersClientVerifyIPFlowResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.VerificationIPFlowResult)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WatchersClientVerifyIPFlowResponse will be returned.
-func (p *WatchersClientVerifyIPFlowPoller) FinalResponse(ctx context.Context) (WatchersClientVerifyIPFlowResponse, error) {
-	respType := WatchersClientVerifyIPFlowResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.VerificationIPFlowResult)
-	if err != nil {
-		return WatchersClientVerifyIPFlowResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WatchersClientVerifyIPFlowPoller) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientVerifyIPFlowResponse, error) {
+	result := WatchersClientVerifyIPFlowResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.VerificationIPFlowResult)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WatchersClientVerifyIPFlowPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WatchersClientVerifyIPFlowPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WatchersClientVerifyIPFlowPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientVerifyIPFlowResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.VerifyIPFlow", token, client.pl); err != nil {
+		return WatchersClientVerifyIPFlowResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // WebApplicationFirewallPoliciesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7752,34 +10715,50 @@ func (p *WebApplicationFirewallPoliciesClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *WebApplicationFirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *WebApplicationFirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
+	result := WebApplicationFirewallPoliciesClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final WebApplicationFirewallPoliciesClientDeleteResponse will be returned.
-func (p *WebApplicationFirewallPoliciesClientDeletePoller) FinalResponse(ctx context.Context) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
-	respType := WebApplicationFirewallPoliciesClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return WebApplicationFirewallPoliciesClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
+func (p *WebApplicationFirewallPoliciesClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
+	result := WebApplicationFirewallPoliciesClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *WebApplicationFirewallPoliciesClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a WebApplicationFirewallPoliciesClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *WebApplicationFirewallPoliciesClientDeletePoller) Resume(ctx context.Context, client *WebApplicationFirewallPoliciesClient, token string) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = armruntime.NewPollerFromResumeToken("WebApplicationFirewallPoliciesClient.Delete", token, client.pl); err != nil {
+		return WebApplicationFirewallPoliciesClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"net/http"
 	"time"
 )
 
@@ -31,20 +32,19 @@ func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Poll(ctx context.Context) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
-	result := ApplicationGatewaysClientBackendHealthOnDemandResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ApplicationGatewayBackendHealthOnDemand)
-	return result, err
+func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Result(ctx context.Context) (resp ApplicationGatewaysClientBackendHealthOnDemandResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -65,12 +65,9 @@ func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) ResumeToken() (st
 
 // Resume rehydrates a ApplicationGatewaysClientBackendHealthOnDemandPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealthOnDemand", token, client.pl); err != nil {
-		return ApplicationGatewaysClientBackendHealthOnDemandResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ApplicationGatewaysClientBackendHealthOnDemandPoller) Resume(token string, client *ApplicationGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealthOnDemand", token, client.pl)
+	return
 }
 
 // ApplicationGatewaysClientBackendHealthPoller provides polling facilities until the operation reaches a terminal state.
@@ -89,20 +86,19 @@ func (p *ApplicationGatewaysClientBackendHealthPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ApplicationGatewaysClientBackendHealthPoller) Poll(ctx context.Context) (ApplicationGatewaysClientBackendHealthResponse, error) {
-	result := ApplicationGatewaysClientBackendHealthResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ApplicationGatewayBackendHealth)
-	return result, err
+func (p *ApplicationGatewaysClientBackendHealthPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ApplicationGatewaysClientBackendHealthPoller) Result(ctx context.Context) (resp ApplicationGatewaysClientBackendHealthResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -123,12 +119,9 @@ func (p *ApplicationGatewaysClientBackendHealthPoller) ResumeToken() (string, er
 
 // Resume rehydrates a ApplicationGatewaysClientBackendHealthPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ApplicationGatewaysClientBackendHealthPoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientBackendHealthResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealth", token, client.pl); err != nil {
-		return ApplicationGatewaysClientBackendHealthResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ApplicationGatewaysClientBackendHealthPoller) Resume(token string, client *ApplicationGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealth", token, client.pl)
+	return
 }
 
 // ApplicationGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -147,20 +140,19 @@ func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
-	result := ApplicationGatewaysClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ApplicationGateway)
-	return result, err
+func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ApplicationGatewaysClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -181,12 +173,9 @@ func (p *ApplicationGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, e
 
 // Resume rehydrates a ApplicationGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ApplicationGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ApplicationGatewaysClientCreateOrUpdatePoller) Resume(token string, client *ApplicationGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ApplicationGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -205,20 +194,19 @@ func (p *ApplicationGatewaysClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ApplicationGatewaysClientDeletePoller) Poll(ctx context.Context) (ApplicationGatewaysClientDeleteResponse, error) {
-	result := ApplicationGatewaysClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ApplicationGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ApplicationGatewaysClientDeletePoller) Result(ctx context.Context) (resp ApplicationGatewaysClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -239,12 +227,9 @@ func (p *ApplicationGatewaysClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ApplicationGatewaysClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ApplicationGatewaysClientDeletePoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Delete", token, client.pl); err != nil {
-		return ApplicationGatewaysClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ApplicationGatewaysClientDeletePoller) Resume(token string, client *ApplicationGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Delete", token, client.pl)
+	return
 }
 
 // ApplicationGatewaysClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -263,20 +248,19 @@ func (p *ApplicationGatewaysClientStartPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ApplicationGatewaysClientStartPoller) Poll(ctx context.Context) (ApplicationGatewaysClientStartResponse, error) {
-	result := ApplicationGatewaysClientStartResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ApplicationGatewaysClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ApplicationGatewaysClientStartPoller) Result(ctx context.Context) (resp ApplicationGatewaysClientStartResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -297,12 +281,9 @@ func (p *ApplicationGatewaysClientStartPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ApplicationGatewaysClientStartPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ApplicationGatewaysClientStartPoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientStartResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Start", token, client.pl); err != nil {
-		return ApplicationGatewaysClientStartResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ApplicationGatewaysClientStartPoller) Resume(token string, client *ApplicationGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Start", token, client.pl)
+	return
 }
 
 // ApplicationGatewaysClientStopPoller provides polling facilities until the operation reaches a terminal state.
@@ -321,20 +302,19 @@ func (p *ApplicationGatewaysClientStopPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ApplicationGatewaysClientStopPoller) Poll(ctx context.Context) (ApplicationGatewaysClientStopResponse, error) {
-	result := ApplicationGatewaysClientStopResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ApplicationGatewaysClientStopPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ApplicationGatewaysClientStopPoller) Result(ctx context.Context) (resp ApplicationGatewaysClientStopResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -355,12 +335,9 @@ func (p *ApplicationGatewaysClientStopPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ApplicationGatewaysClientStopPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ApplicationGatewaysClientStopPoller) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) (ApplicationGatewaysClientStopResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Stop", token, client.pl); err != nil {
-		return ApplicationGatewaysClientStopResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ApplicationGatewaysClientStopPoller) Resume(token string, client *ApplicationGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Stop", token, client.pl)
+	return
 }
 
 // ApplicationSecurityGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -379,20 +356,19 @@ func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
-	result := ApplicationSecurityGroupsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ApplicationSecurityGroup)
-	return result, err
+func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ApplicationSecurityGroupsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -413,12 +389,9 @@ func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) ResumeToken() (str
 
 // Resume rehydrates a ApplicationSecurityGroupsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ApplicationSecurityGroupsClient, token string) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ApplicationSecurityGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ApplicationSecurityGroupsClientCreateOrUpdatePoller) Resume(token string, client *ApplicationSecurityGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ApplicationSecurityGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -437,20 +410,19 @@ func (p *ApplicationSecurityGroupsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ApplicationSecurityGroupsClientDeletePoller) Poll(ctx context.Context) (ApplicationSecurityGroupsClientDeleteResponse, error) {
-	result := ApplicationSecurityGroupsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ApplicationSecurityGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ApplicationSecurityGroupsClientDeletePoller) Result(ctx context.Context) (resp ApplicationSecurityGroupsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -471,12 +443,9 @@ func (p *ApplicationSecurityGroupsClientDeletePoller) ResumeToken() (string, err
 
 // Resume rehydrates a ApplicationSecurityGroupsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ApplicationSecurityGroupsClientDeletePoller) Resume(ctx context.Context, client *ApplicationSecurityGroupsClient, token string) (ApplicationSecurityGroupsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.Delete", token, client.pl); err != nil {
-		return ApplicationSecurityGroupsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ApplicationSecurityGroupsClientDeletePoller) Resume(token string, client *ApplicationSecurityGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.Delete", token, client.pl)
+	return
 }
 
 // AzureFirewallsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -495,20 +464,19 @@ func (p *AzureFirewallsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *AzureFirewallsClientCreateOrUpdatePoller) Poll(ctx context.Context) (AzureFirewallsClientCreateOrUpdateResponse, error) {
-	result := AzureFirewallsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.AzureFirewall)
-	return result, err
+func (p *AzureFirewallsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *AzureFirewallsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp AzureFirewallsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -529,12 +497,9 @@ func (p *AzureFirewallsClientCreateOrUpdatePoller) ResumeToken() (string, error)
 
 // Resume rehydrates a AzureFirewallsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *AzureFirewallsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *AzureFirewallsClient, token string) (AzureFirewallsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return AzureFirewallsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *AzureFirewallsClientCreateOrUpdatePoller) Resume(token string, client *AzureFirewallsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // AzureFirewallsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -553,20 +518,19 @@ func (p *AzureFirewallsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *AzureFirewallsClientDeletePoller) Poll(ctx context.Context) (AzureFirewallsClientDeleteResponse, error) {
-	result := AzureFirewallsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *AzureFirewallsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *AzureFirewallsClientDeletePoller) Result(ctx context.Context) (resp AzureFirewallsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -587,12 +551,9 @@ func (p *AzureFirewallsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a AzureFirewallsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *AzureFirewallsClientDeletePoller) Resume(ctx context.Context, client *AzureFirewallsClient, token string) (AzureFirewallsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.Delete", token, client.pl); err != nil {
-		return AzureFirewallsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *AzureFirewallsClientDeletePoller) Resume(token string, client *AzureFirewallsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.Delete", token, client.pl)
+	return
 }
 
 // AzureFirewallsClientUpdateTagsPoller provides polling facilities until the operation reaches a terminal state.
@@ -611,20 +572,19 @@ func (p *AzureFirewallsClientUpdateTagsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *AzureFirewallsClientUpdateTagsPoller) Poll(ctx context.Context) (AzureFirewallsClientUpdateTagsResponse, error) {
-	result := AzureFirewallsClientUpdateTagsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.AzureFirewall)
-	return result, err
+func (p *AzureFirewallsClientUpdateTagsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *AzureFirewallsClientUpdateTagsPoller) Result(ctx context.Context) (resp AzureFirewallsClientUpdateTagsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -645,12 +605,9 @@ func (p *AzureFirewallsClientUpdateTagsPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a AzureFirewallsClientUpdateTagsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *AzureFirewallsClientUpdateTagsPoller) Resume(ctx context.Context, client *AzureFirewallsClient, token string) (AzureFirewallsClientUpdateTagsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.UpdateTags", token, client.pl); err != nil {
-		return AzureFirewallsClientUpdateTagsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *AzureFirewallsClientUpdateTagsPoller) Resume(token string, client *AzureFirewallsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("AzureFirewallsClient.UpdateTags", token, client.pl)
+	return
 }
 
 // BastionHostsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -669,20 +626,19 @@ func (p *BastionHostsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *BastionHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (BastionHostsClientCreateOrUpdateResponse, error) {
-	result := BastionHostsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.BastionHost)
-	return result, err
+func (p *BastionHostsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *BastionHostsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp BastionHostsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -703,12 +659,9 @@ func (p *BastionHostsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a BastionHostsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *BastionHostsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *BastionHostsClient, token string) (BastionHostsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("BastionHostsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return BastionHostsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *BastionHostsClientCreateOrUpdatePoller) Resume(token string, client *BastionHostsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("BastionHostsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // BastionHostsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -727,20 +680,19 @@ func (p *BastionHostsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *BastionHostsClientDeletePoller) Poll(ctx context.Context) (BastionHostsClientDeleteResponse, error) {
-	result := BastionHostsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *BastionHostsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *BastionHostsClientDeletePoller) Result(ctx context.Context) (resp BastionHostsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -761,12 +713,9 @@ func (p *BastionHostsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a BastionHostsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *BastionHostsClientDeletePoller) Resume(ctx context.Context, client *BastionHostsClient, token string) (BastionHostsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("BastionHostsClient.Delete", token, client.pl); err != nil {
-		return BastionHostsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *BastionHostsClientDeletePoller) Resume(token string, client *BastionHostsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("BastionHostsClient.Delete", token, client.pl)
+	return
 }
 
 // ConnectionMonitorsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -785,20 +734,19 @@ func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
-	result := ConnectionMonitorsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ConnectionMonitorResult)
-	return result, err
+func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ConnectionMonitorsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -819,12 +767,9 @@ func (p *ConnectionMonitorsClientCreateOrUpdatePoller) ResumeToken() (string, er
 
 // Resume rehydrates a ConnectionMonitorsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ConnectionMonitorsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ConnectionMonitorsClientCreateOrUpdatePoller) Resume(token string, client *ConnectionMonitorsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ConnectionMonitorsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -843,20 +788,19 @@ func (p *ConnectionMonitorsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ConnectionMonitorsClientDeletePoller) Poll(ctx context.Context) (ConnectionMonitorsClientDeleteResponse, error) {
-	result := ConnectionMonitorsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ConnectionMonitorsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ConnectionMonitorsClientDeletePoller) Result(ctx context.Context) (resp ConnectionMonitorsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -877,12 +821,9 @@ func (p *ConnectionMonitorsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ConnectionMonitorsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ConnectionMonitorsClientDeletePoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Delete", token, client.pl); err != nil {
-		return ConnectionMonitorsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ConnectionMonitorsClientDeletePoller) Resume(token string, client *ConnectionMonitorsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Delete", token, client.pl)
+	return
 }
 
 // ConnectionMonitorsClientQueryPoller provides polling facilities until the operation reaches a terminal state.
@@ -901,20 +842,19 @@ func (p *ConnectionMonitorsClientQueryPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ConnectionMonitorsClientQueryPoller) Poll(ctx context.Context) (ConnectionMonitorsClientQueryResponse, error) {
-	result := ConnectionMonitorsClientQueryResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ConnectionMonitorQueryResult)
-	return result, err
+func (p *ConnectionMonitorsClientQueryPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ConnectionMonitorsClientQueryPoller) Result(ctx context.Context) (resp ConnectionMonitorsClientQueryResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -935,12 +875,9 @@ func (p *ConnectionMonitorsClientQueryPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ConnectionMonitorsClientQueryPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ConnectionMonitorsClientQueryPoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientQueryResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Query", token, client.pl); err != nil {
-		return ConnectionMonitorsClientQueryResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ConnectionMonitorsClientQueryPoller) Resume(token string, client *ConnectionMonitorsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Query", token, client.pl)
+	return
 }
 
 // ConnectionMonitorsClientStartPoller provides polling facilities until the operation reaches a terminal state.
@@ -959,20 +896,19 @@ func (p *ConnectionMonitorsClientStartPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ConnectionMonitorsClientStartPoller) Poll(ctx context.Context) (ConnectionMonitorsClientStartResponse, error) {
-	result := ConnectionMonitorsClientStartResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ConnectionMonitorsClientStartPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ConnectionMonitorsClientStartPoller) Result(ctx context.Context) (resp ConnectionMonitorsClientStartResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -993,12 +929,9 @@ func (p *ConnectionMonitorsClientStartPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ConnectionMonitorsClientStartPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ConnectionMonitorsClientStartPoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientStartResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Start", token, client.pl); err != nil {
-		return ConnectionMonitorsClientStartResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ConnectionMonitorsClientStartPoller) Resume(token string, client *ConnectionMonitorsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Start", token, client.pl)
+	return
 }
 
 // ConnectionMonitorsClientStopPoller provides polling facilities until the operation reaches a terminal state.
@@ -1017,20 +950,19 @@ func (p *ConnectionMonitorsClientStopPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ConnectionMonitorsClientStopPoller) Poll(ctx context.Context) (ConnectionMonitorsClientStopResponse, error) {
-	result := ConnectionMonitorsClientStopResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ConnectionMonitorsClientStopPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ConnectionMonitorsClientStopPoller) Result(ctx context.Context) (resp ConnectionMonitorsClientStopResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1051,12 +983,9 @@ func (p *ConnectionMonitorsClientStopPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ConnectionMonitorsClientStopPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ConnectionMonitorsClientStopPoller) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) (ConnectionMonitorsClientStopResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Stop", token, client.pl); err != nil {
-		return ConnectionMonitorsClientStopResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ConnectionMonitorsClientStopPoller) Resume(token string, client *ConnectionMonitorsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Stop", token, client.pl)
+	return
 }
 
 // DdosCustomPoliciesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1075,20 +1004,19 @@ func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
-	result := DdosCustomPoliciesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DdosCustomPolicy)
-	return result, err
+func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp DdosCustomPoliciesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1109,12 +1037,9 @@ func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) ResumeToken() (string, er
 
 // Resume rehydrates a DdosCustomPoliciesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DdosCustomPoliciesClient, token string) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DdosCustomPoliciesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return DdosCustomPoliciesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DdosCustomPoliciesClientCreateOrUpdatePoller) Resume(token string, client *DdosCustomPoliciesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DdosCustomPoliciesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // DdosCustomPoliciesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1133,20 +1058,19 @@ func (p *DdosCustomPoliciesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DdosCustomPoliciesClientDeletePoller) Poll(ctx context.Context) (DdosCustomPoliciesClientDeleteResponse, error) {
-	result := DdosCustomPoliciesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DdosCustomPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DdosCustomPoliciesClientDeletePoller) Result(ctx context.Context) (resp DdosCustomPoliciesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1167,12 +1091,9 @@ func (p *DdosCustomPoliciesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DdosCustomPoliciesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DdosCustomPoliciesClientDeletePoller) Resume(ctx context.Context, client *DdosCustomPoliciesClient, token string) (DdosCustomPoliciesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DdosCustomPoliciesClient.Delete", token, client.pl); err != nil {
-		return DdosCustomPoliciesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DdosCustomPoliciesClientDeletePoller) Resume(token string, client *DdosCustomPoliciesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DdosCustomPoliciesClient.Delete", token, client.pl)
+	return
 }
 
 // DdosProtectionPlansClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1191,20 +1112,19 @@ func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Poll(ctx context.Context) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
-	result := DdosProtectionPlansClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DdosProtectionPlan)
-	return result, err
+func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Result(ctx context.Context) (resp DdosProtectionPlansClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1225,12 +1145,9 @@ func (p *DdosProtectionPlansClientCreateOrUpdatePoller) ResumeToken() (string, e
 
 // Resume rehydrates a DdosProtectionPlansClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Resume(ctx context.Context, client *DdosProtectionPlansClient, token string) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DdosProtectionPlansClient.CreateOrUpdate", token, client.pl); err != nil {
-		return DdosProtectionPlansClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DdosProtectionPlansClientCreateOrUpdatePoller) Resume(token string, client *DdosProtectionPlansClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DdosProtectionPlansClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // DdosProtectionPlansClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1249,20 +1166,19 @@ func (p *DdosProtectionPlansClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *DdosProtectionPlansClientDeletePoller) Poll(ctx context.Context) (DdosProtectionPlansClientDeleteResponse, error) {
-	result := DdosProtectionPlansClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *DdosProtectionPlansClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *DdosProtectionPlansClientDeletePoller) Result(ctx context.Context) (resp DdosProtectionPlansClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1283,12 +1199,9 @@ func (p *DdosProtectionPlansClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a DdosProtectionPlansClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *DdosProtectionPlansClientDeletePoller) Resume(ctx context.Context, client *DdosProtectionPlansClient, token string) (DdosProtectionPlansClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("DdosProtectionPlansClient.Delete", token, client.pl); err != nil {
-		return DdosProtectionPlansClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *DdosProtectionPlansClientDeletePoller) Resume(token string, client *DdosProtectionPlansClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("DdosProtectionPlansClient.Delete", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1307,20 +1220,19 @@ func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Done() boo
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
-	result := ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitAuthorization)
-	return result, err
+func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1341,12 +1253,9 @@ func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) ResumeToke
 
 // Resume rehydrates a ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCircuitAuthorizationsClient, token string) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller) Resume(token string, client *ExpressRouteCircuitAuthorizationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitAuthorizationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1365,20 +1274,19 @@ func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
-	result := ExpressRouteCircuitAuthorizationsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Result(ctx context.Context) (resp ExpressRouteCircuitAuthorizationsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1399,12 +1307,9 @@ func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) ResumeToken() (str
 
 // Resume rehydrates a ExpressRouteCircuitAuthorizationsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCircuitAuthorizationsClient, token string) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.Delete", token, client.pl); err != nil {
-		return ExpressRouteCircuitAuthorizationsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitAuthorizationsClientDeletePoller) Resume(token string, client *ExpressRouteCircuitAuthorizationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.Delete", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1423,20 +1328,19 @@ func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
-	result := ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitConnection)
-	return result, err
+func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1457,12 +1361,9 @@ func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) ResumeToken()
 
 // Resume rehydrates a ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCircuitConnectionsClient, token string) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller) Resume(token string, client *ExpressRouteCircuitConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitConnectionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1481,20 +1382,19 @@ func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
-	result := ExpressRouteCircuitConnectionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Result(ctx context.Context) (resp ExpressRouteCircuitConnectionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1515,12 +1415,9 @@ func (p *ExpressRouteCircuitConnectionsClientDeletePoller) ResumeToken() (string
 
 // Resume rehydrates a ExpressRouteCircuitConnectionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCircuitConnectionsClient, token string) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.Delete", token, client.pl); err != nil {
-		return ExpressRouteCircuitConnectionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitConnectionsClientDeletePoller) Resume(token string, client *ExpressRouteCircuitConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.Delete", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1539,20 +1436,19 @@ func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
-	result := ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitPeering)
-	return result, err
+func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1573,12 +1469,9 @@ func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) ResumeToken() (s
 
 // Resume rehydrates a ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCircuitPeeringsClient, token string) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller) Resume(token string, client *ExpressRouteCircuitPeeringsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitPeeringsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1597,20 +1490,19 @@ func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
-	result := ExpressRouteCircuitPeeringsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Result(ctx context.Context) (resp ExpressRouteCircuitPeeringsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1631,12 +1523,9 @@ func (p *ExpressRouteCircuitPeeringsClientDeletePoller) ResumeToken() (string, e
 
 // Resume rehydrates a ExpressRouteCircuitPeeringsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCircuitPeeringsClient, token string) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.Delete", token, client.pl); err != nil {
-		return ExpressRouteCircuitPeeringsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitPeeringsClientDeletePoller) Resume(token string, client *ExpressRouteCircuitPeeringsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.Delete", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1655,20 +1544,19 @@ func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
-	result := ExpressRouteCircuitsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuit)
-	return result, err
+func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRouteCircuitsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1689,12 +1577,9 @@ func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) ResumeToken() (string, 
 
 // Resume rehydrates a ExpressRouteCircuitsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRouteCircuitsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitsClientCreateOrUpdatePoller) Resume(token string, client *ExpressRouteCircuitsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -1713,20 +1598,19 @@ func (p *ExpressRouteCircuitsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientDeleteResponse, error) {
-	result := ExpressRouteCircuitsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ExpressRouteCircuitsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitsClientDeletePoller) Result(ctx context.Context) (resp ExpressRouteCircuitsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1747,12 +1631,9 @@ func (p *ExpressRouteCircuitsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ExpressRouteCircuitsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.Delete", token, client.pl); err != nil {
-		return ExpressRouteCircuitsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitsClientDeletePoller) Resume(token string, client *ExpressRouteCircuitsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.Delete", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitsClientListArpTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -1771,20 +1652,19 @@ func (p *ExpressRouteCircuitsClientListArpTablePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitsClientListArpTablePoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientListArpTableResponse, error) {
-	result := ExpressRouteCircuitsClientListArpTableResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsArpTableListResult)
-	return result, err
+func (p *ExpressRouteCircuitsClientListArpTablePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitsClientListArpTablePoller) Result(ctx context.Context) (resp ExpressRouteCircuitsClientListArpTableResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1805,12 +1685,9 @@ func (p *ExpressRouteCircuitsClientListArpTablePoller) ResumeToken() (string, er
 
 // Resume rehydrates a ExpressRouteCircuitsClientListArpTablePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitsClientListArpTablePoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientListArpTableResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListArpTable", token, client.pl); err != nil {
-		return ExpressRouteCircuitsClientListArpTableResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitsClientListArpTablePoller) Resume(token string, client *ExpressRouteCircuitsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListArpTable", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitsClientListRoutesTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -1829,20 +1706,19 @@ func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
-	result := ExpressRouteCircuitsClientListRoutesTableResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsRoutesTableListResult)
-	return result, err
+func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Result(ctx context.Context) (resp ExpressRouteCircuitsClientListRoutesTableResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1863,12 +1739,9 @@ func (p *ExpressRouteCircuitsClientListRoutesTablePoller) ResumeToken() (string,
 
 // Resume rehydrates a ExpressRouteCircuitsClientListRoutesTablePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTable", token, client.pl); err != nil {
-		return ExpressRouteCircuitsClientListRoutesTableResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitsClientListRoutesTablePoller) Resume(token string, client *ExpressRouteCircuitsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTable", token, client.pl)
+	return
 }
 
 // ExpressRouteCircuitsClientListRoutesTableSummaryPoller provides polling facilities until the operation reaches a terminal state.
@@ -1887,20 +1760,19 @@ func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Poll(ctx context.Context) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
-	result := ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsRoutesTableSummaryListResult)
-	return result, err
+func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Result(ctx context.Context) (resp ExpressRouteCircuitsClientListRoutesTableSummaryResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1921,12 +1793,9 @@ func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) ResumeToken() (
 
 // Resume rehydrates a ExpressRouteCircuitsClientListRoutesTableSummaryPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTableSummary", token, client.pl); err != nil {
-		return ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCircuitsClientListRoutesTableSummaryPoller) Resume(token string, client *ExpressRouteCircuitsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTableSummary", token, client.pl)
+	return
 }
 
 // ExpressRouteConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -1945,20 +1814,19 @@ func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
-	result := ExpressRouteConnectionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteConnection)
-	return result, err
+func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRouteConnectionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1979,12 +1847,9 @@ func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) ResumeToken() (strin
 
 // Resume rehydrates a ExpressRouteConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteConnectionsClient, token string) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRouteConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteConnectionsClientCreateOrUpdatePoller) Resume(token string, client *ExpressRouteConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteConnectionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRouteConnectionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2003,20 +1868,19 @@ func (p *ExpressRouteConnectionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteConnectionsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteConnectionsClientDeleteResponse, error) {
-	result := ExpressRouteConnectionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ExpressRouteConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteConnectionsClientDeletePoller) Result(ctx context.Context) (resp ExpressRouteConnectionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2037,12 +1901,9 @@ func (p *ExpressRouteConnectionsClientDeletePoller) ResumeToken() (string, error
 
 // Resume rehydrates a ExpressRouteConnectionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteConnectionsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteConnectionsClient, token string) (ExpressRouteConnectionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteConnectionsClient.Delete", token, client.pl); err != nil {
-		return ExpressRouteConnectionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteConnectionsClientDeletePoller) Resume(token string, client *ExpressRouteConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteConnectionsClient.Delete", token, client.pl)
+	return
 }
 
 // ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2061,20 +1922,19 @@ func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Done() b
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
-	result := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCrossConnectionPeering)
-	return result, err
+func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2095,12 +1955,9 @@ func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) ResumeTo
 
 // Resume rehydrates a ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionPeeringsClient, token string) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller) Resume(token string, client *ExpressRouteCrossConnectionPeeringsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRouteCrossConnectionPeeringsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2119,20 +1976,19 @@ func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
-	result := ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Result(ctx context.Context) (resp ExpressRouteCrossConnectionPeeringsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2153,12 +2009,9 @@ func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) ResumeToken() (s
 
 // Resume rehydrates a ExpressRouteCrossConnectionPeeringsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionPeeringsClient, token string) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.Delete", token, client.pl); err != nil {
-		return ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCrossConnectionPeeringsClientDeletePoller) Resume(token string, client *ExpressRouteCrossConnectionPeeringsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.Delete", token, client.pl)
+	return
 }
 
 // ExpressRouteCrossConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2177,20 +2030,19 @@ func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
-	result := ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCrossConnection)
-	return result, err
+func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2211,12 +2063,9 @@ func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) ResumeToken() (
 
 // Resume rehydrates a ExpressRouteCrossConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller) Resume(token string, client *ExpressRouteCrossConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRouteCrossConnectionsClientListArpTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -2235,20 +2084,19 @@ func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
-	result := ExpressRouteCrossConnectionsClientListArpTableResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsArpTableListResult)
-	return result, err
+func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Result(ctx context.Context) (resp ExpressRouteCrossConnectionsClientListArpTableResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2269,12 +2117,9 @@ func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) ResumeToken() (st
 
 // Resume rehydrates a ExpressRouteCrossConnectionsClientListArpTablePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListArpTable", token, client.pl); err != nil {
-		return ExpressRouteCrossConnectionsClientListArpTableResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCrossConnectionsClientListArpTablePoller) Resume(token string, client *ExpressRouteCrossConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListArpTable", token, client.pl)
+	return
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -2293,20 +2138,19 @@ func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
-	result := ExpressRouteCrossConnectionsClientListRoutesTableResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCircuitsRoutesTableListResult)
-	return result, err
+func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Result(ctx context.Context) (resp ExpressRouteCrossConnectionsClientListRoutesTableResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2327,12 +2171,9 @@ func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) ResumeToken() 
 
 // Resume rehydrates a ExpressRouteCrossConnectionsClientListRoutesTablePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTable", token, client.pl); err != nil {
-		return ExpressRouteCrossConnectionsClientListRoutesTableResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCrossConnectionsClientListRoutesTablePoller) Resume(token string, client *ExpressRouteCrossConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTable", token, client.pl)
+	return
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller provides polling facilities until the operation reaches a terminal state.
@@ -2351,20 +2192,19 @@ func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Done() 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Poll(ctx context.Context) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
-	result := ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
-	return result, err
+func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Result(ctx context.Context) (resp ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2385,12 +2225,9 @@ func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) ResumeT
 
 // Resume rehydrates a ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTableSummary", token, client.pl); err != nil {
-		return ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller) Resume(token string, client *ExpressRouteCrossConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTableSummary", token, client.pl)
+	return
 }
 
 // ExpressRouteGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2409,20 +2246,19 @@ func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
-	result := ExpressRouteGatewaysClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRouteGateway)
-	return result, err
+func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRouteGatewaysClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2443,12 +2279,9 @@ func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, 
 
 // Resume rehydrates a ExpressRouteGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRouteGatewaysClient, token string) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRouteGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteGatewaysClientCreateOrUpdatePoller) Resume(token string, client *ExpressRouteGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteGatewaysClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRouteGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2467,20 +2300,19 @@ func (p *ExpressRouteGatewaysClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRouteGatewaysClientDeletePoller) Poll(ctx context.Context) (ExpressRouteGatewaysClientDeleteResponse, error) {
-	result := ExpressRouteGatewaysClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ExpressRouteGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRouteGatewaysClientDeletePoller) Result(ctx context.Context) (resp ExpressRouteGatewaysClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2501,12 +2333,9 @@ func (p *ExpressRouteGatewaysClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ExpressRouteGatewaysClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRouteGatewaysClientDeletePoller) Resume(ctx context.Context, client *ExpressRouteGatewaysClient, token string) (ExpressRouteGatewaysClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteGatewaysClient.Delete", token, client.pl); err != nil {
-		return ExpressRouteGatewaysClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRouteGatewaysClientDeletePoller) Resume(token string, client *ExpressRouteGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRouteGatewaysClient.Delete", token, client.pl)
+	return
 }
 
 // ExpressRoutePortsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2525,20 +2354,19 @@ func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
-	result := ExpressRoutePortsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ExpressRoutePort)
-	return result, err
+func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ExpressRoutePortsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2559,12 +2387,9 @@ func (p *ExpressRoutePortsClientCreateOrUpdatePoller) ResumeToken() (string, err
 
 // Resume rehydrates a ExpressRoutePortsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ExpressRoutePortsClient, token string) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRoutePortsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ExpressRoutePortsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRoutePortsClientCreateOrUpdatePoller) Resume(token string, client *ExpressRoutePortsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRoutePortsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ExpressRoutePortsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2583,20 +2408,19 @@ func (p *ExpressRoutePortsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ExpressRoutePortsClientDeletePoller) Poll(ctx context.Context) (ExpressRoutePortsClientDeleteResponse, error) {
-	result := ExpressRoutePortsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ExpressRoutePortsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ExpressRoutePortsClientDeletePoller) Result(ctx context.Context) (resp ExpressRoutePortsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2617,12 +2441,9 @@ func (p *ExpressRoutePortsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ExpressRoutePortsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ExpressRoutePortsClientDeletePoller) Resume(ctx context.Context, client *ExpressRoutePortsClient, token string) (ExpressRoutePortsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRoutePortsClient.Delete", token, client.pl); err != nil {
-		return ExpressRoutePortsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ExpressRoutePortsClientDeletePoller) Resume(token string, client *ExpressRoutePortsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ExpressRoutePortsClient.Delete", token, client.pl)
+	return
 }
 
 // FirewallPoliciesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2641,20 +2462,19 @@ func (p *FirewallPoliciesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *FirewallPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
-	result := FirewallPoliciesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.FirewallPolicy)
-	return result, err
+func (p *FirewallPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *FirewallPoliciesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp FirewallPoliciesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2675,12 +2495,9 @@ func (p *FirewallPoliciesClientCreateOrUpdatePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a FirewallPoliciesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *FirewallPoliciesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *FirewallPoliciesClient, token string) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPoliciesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return FirewallPoliciesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *FirewallPoliciesClientCreateOrUpdatePoller) Resume(token string, client *FirewallPoliciesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPoliciesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // FirewallPoliciesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2699,20 +2516,19 @@ func (p *FirewallPoliciesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *FirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (FirewallPoliciesClientDeleteResponse, error) {
-	result := FirewallPoliciesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *FirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *FirewallPoliciesClientDeletePoller) Result(ctx context.Context) (resp FirewallPoliciesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2733,12 +2549,9 @@ func (p *FirewallPoliciesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a FirewallPoliciesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *FirewallPoliciesClientDeletePoller) Resume(ctx context.Context, client *FirewallPoliciesClient, token string) (FirewallPoliciesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPoliciesClient.Delete", token, client.pl); err != nil {
-		return FirewallPoliciesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *FirewallPoliciesClientDeletePoller) Resume(token string, client *FirewallPoliciesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPoliciesClient.Delete", token, client.pl)
+	return
 }
 
 // FirewallPolicyRuleGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2757,20 +2570,19 @@ func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
-	result := FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.FirewallPolicyRuleGroup)
-	return result, err
+func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2791,12 +2603,9 @@ func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) ResumeToken() (stri
 
 // Resume rehydrates a FirewallPolicyRuleGroupsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *FirewallPolicyRuleGroupsClient, token string) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller) Resume(token string, client *FirewallPolicyRuleGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // FirewallPolicyRuleGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2815,20 +2624,19 @@ func (p *FirewallPolicyRuleGroupsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *FirewallPolicyRuleGroupsClientDeletePoller) Poll(ctx context.Context) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
-	result := FirewallPolicyRuleGroupsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *FirewallPolicyRuleGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *FirewallPolicyRuleGroupsClientDeletePoller) Result(ctx context.Context) (resp FirewallPolicyRuleGroupsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2849,12 +2657,9 @@ func (p *FirewallPolicyRuleGroupsClientDeletePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a FirewallPolicyRuleGroupsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *FirewallPolicyRuleGroupsClientDeletePoller) Resume(ctx context.Context, client *FirewallPolicyRuleGroupsClient, token string) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.Delete", token, client.pl); err != nil {
-		return FirewallPolicyRuleGroupsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *FirewallPolicyRuleGroupsClientDeletePoller) Resume(token string, client *FirewallPolicyRuleGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.Delete", token, client.pl)
+	return
 }
 
 // FlowLogsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2873,20 +2678,19 @@ func (p *FlowLogsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *FlowLogsClientCreateOrUpdatePoller) Poll(ctx context.Context) (FlowLogsClientCreateOrUpdateResponse, error) {
-	result := FlowLogsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.FlowLog)
-	return result, err
+func (p *FlowLogsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *FlowLogsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp FlowLogsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2907,12 +2711,9 @@ func (p *FlowLogsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a FlowLogsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *FlowLogsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *FlowLogsClient, token string) (FlowLogsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("FlowLogsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return FlowLogsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *FlowLogsClientCreateOrUpdatePoller) Resume(token string, client *FlowLogsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("FlowLogsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // FlowLogsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -2931,20 +2732,19 @@ func (p *FlowLogsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *FlowLogsClientDeletePoller) Poll(ctx context.Context) (FlowLogsClientDeleteResponse, error) {
-	result := FlowLogsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *FlowLogsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *FlowLogsClientDeletePoller) Result(ctx context.Context) (resp FlowLogsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -2965,12 +2765,9 @@ func (p *FlowLogsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a FlowLogsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *FlowLogsClientDeletePoller) Resume(ctx context.Context, client *FlowLogsClient, token string) (FlowLogsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("FlowLogsClient.Delete", token, client.pl); err != nil {
-		return FlowLogsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *FlowLogsClientDeletePoller) Resume(token string, client *FlowLogsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("FlowLogsClient.Delete", token, client.pl)
+	return
 }
 
 // IPAllocationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -2989,20 +2786,19 @@ func (p *IPAllocationsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *IPAllocationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (IPAllocationsClientCreateOrUpdateResponse, error) {
-	result := IPAllocationsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.IPAllocation)
-	return result, err
+func (p *IPAllocationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *IPAllocationsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp IPAllocationsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3023,12 +2819,9 @@ func (p *IPAllocationsClientCreateOrUpdatePoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a IPAllocationsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *IPAllocationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *IPAllocationsClient, token string) (IPAllocationsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("IPAllocationsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return IPAllocationsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *IPAllocationsClientCreateOrUpdatePoller) Resume(token string, client *IPAllocationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("IPAllocationsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // IPAllocationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3047,20 +2840,19 @@ func (p *IPAllocationsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *IPAllocationsClientDeletePoller) Poll(ctx context.Context) (IPAllocationsClientDeleteResponse, error) {
-	result := IPAllocationsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *IPAllocationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *IPAllocationsClientDeletePoller) Result(ctx context.Context) (resp IPAllocationsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3081,12 +2873,9 @@ func (p *IPAllocationsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a IPAllocationsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *IPAllocationsClientDeletePoller) Resume(ctx context.Context, client *IPAllocationsClient, token string) (IPAllocationsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("IPAllocationsClient.Delete", token, client.pl); err != nil {
-		return IPAllocationsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *IPAllocationsClientDeletePoller) Resume(token string, client *IPAllocationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("IPAllocationsClient.Delete", token, client.pl)
+	return
 }
 
 // IPGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3105,20 +2894,19 @@ func (p *IPGroupsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *IPGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (IPGroupsClientCreateOrUpdateResponse, error) {
-	result := IPGroupsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.IPGroup)
-	return result, err
+func (p *IPGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *IPGroupsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp IPGroupsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3139,12 +2927,9 @@ func (p *IPGroupsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a IPGroupsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *IPGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *IPGroupsClient, token string) (IPGroupsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("IPGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return IPGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *IPGroupsClientCreateOrUpdatePoller) Resume(token string, client *IPGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("IPGroupsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // IPGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3163,20 +2948,19 @@ func (p *IPGroupsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *IPGroupsClientDeletePoller) Poll(ctx context.Context) (IPGroupsClientDeleteResponse, error) {
-	result := IPGroupsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *IPGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *IPGroupsClientDeletePoller) Result(ctx context.Context) (resp IPGroupsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3197,12 +2981,9 @@ func (p *IPGroupsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a IPGroupsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *IPGroupsClientDeletePoller) Resume(ctx context.Context, client *IPGroupsClient, token string) (IPGroupsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("IPGroupsClient.Delete", token, client.pl); err != nil {
-		return IPGroupsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *IPGroupsClientDeletePoller) Resume(token string, client *IPGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("IPGroupsClient.Delete", token, client.pl)
+	return
 }
 
 // InboundNatRulesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3221,20 +3002,19 @@ func (p *InboundNatRulesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *InboundNatRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (InboundNatRulesClientCreateOrUpdateResponse, error) {
-	result := InboundNatRulesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.InboundNatRule)
-	return result, err
+func (p *InboundNatRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *InboundNatRulesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp InboundNatRulesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3255,12 +3035,9 @@ func (p *InboundNatRulesClientCreateOrUpdatePoller) ResumeToken() (string, error
 
 // Resume rehydrates a InboundNatRulesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *InboundNatRulesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *InboundNatRulesClient, token string) (InboundNatRulesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("InboundNatRulesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return InboundNatRulesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *InboundNatRulesClientCreateOrUpdatePoller) Resume(token string, client *InboundNatRulesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("InboundNatRulesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // InboundNatRulesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3279,20 +3056,19 @@ func (p *InboundNatRulesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *InboundNatRulesClientDeletePoller) Poll(ctx context.Context) (InboundNatRulesClientDeleteResponse, error) {
-	result := InboundNatRulesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *InboundNatRulesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *InboundNatRulesClientDeletePoller) Result(ctx context.Context) (resp InboundNatRulesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3313,12 +3089,9 @@ func (p *InboundNatRulesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a InboundNatRulesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *InboundNatRulesClientDeletePoller) Resume(ctx context.Context, client *InboundNatRulesClient, token string) (InboundNatRulesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("InboundNatRulesClient.Delete", token, client.pl); err != nil {
-		return InboundNatRulesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *InboundNatRulesClientDeletePoller) Resume(token string, client *InboundNatRulesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("InboundNatRulesClient.Delete", token, client.pl)
+	return
 }
 
 // InterfaceTapConfigurationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3337,20 +3110,19 @@ func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
-	result := InterfaceTapConfigurationsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.InterfaceTapConfiguration)
-	return result, err
+func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp InterfaceTapConfigurationsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3371,12 +3143,9 @@ func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) ResumeToken() (st
 
 // Resume rehydrates a InterfaceTapConfigurationsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *InterfaceTapConfigurationsClient, token string) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return InterfaceTapConfigurationsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *InterfaceTapConfigurationsClientCreateOrUpdatePoller) Resume(token string, client *InterfaceTapConfigurationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // InterfaceTapConfigurationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3395,20 +3164,19 @@ func (p *InterfaceTapConfigurationsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *InterfaceTapConfigurationsClientDeletePoller) Poll(ctx context.Context) (InterfaceTapConfigurationsClientDeleteResponse, error) {
-	result := InterfaceTapConfigurationsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *InterfaceTapConfigurationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *InterfaceTapConfigurationsClientDeletePoller) Result(ctx context.Context) (resp InterfaceTapConfigurationsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3429,12 +3197,9 @@ func (p *InterfaceTapConfigurationsClientDeletePoller) ResumeToken() (string, er
 
 // Resume rehydrates a InterfaceTapConfigurationsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *InterfaceTapConfigurationsClientDeletePoller) Resume(ctx context.Context, client *InterfaceTapConfigurationsClient, token string) (InterfaceTapConfigurationsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.Delete", token, client.pl); err != nil {
-		return InterfaceTapConfigurationsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *InterfaceTapConfigurationsClientDeletePoller) Resume(token string, client *InterfaceTapConfigurationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.Delete", token, client.pl)
+	return
 }
 
 // InterfacesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3453,20 +3218,19 @@ func (p *InterfacesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *InterfacesClientCreateOrUpdatePoller) Poll(ctx context.Context) (InterfacesClientCreateOrUpdateResponse, error) {
-	result := InterfacesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Interface)
-	return result, err
+func (p *InterfacesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *InterfacesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp InterfacesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3487,12 +3251,9 @@ func (p *InterfacesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a InterfacesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *InterfacesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *InterfacesClient, token string) (InterfacesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return InterfacesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *InterfacesClientCreateOrUpdatePoller) Resume(token string, client *InterfacesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // InterfacesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3511,20 +3272,19 @@ func (p *InterfacesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *InterfacesClientDeletePoller) Poll(ctx context.Context) (InterfacesClientDeleteResponse, error) {
-	result := InterfacesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *InterfacesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *InterfacesClientDeletePoller) Result(ctx context.Context) (resp InterfacesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3545,12 +3305,9 @@ func (p *InterfacesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a InterfacesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *InterfacesClientDeletePoller) Resume(ctx context.Context, client *InterfacesClient, token string) (InterfacesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.Delete", token, client.pl); err != nil {
-		return InterfacesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *InterfacesClientDeletePoller) Resume(token string, client *InterfacesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.Delete", token, client.pl)
+	return
 }
 
 // InterfacesClientGetEffectiveRouteTablePoller provides polling facilities until the operation reaches a terminal state.
@@ -3569,20 +3326,19 @@ func (p *InterfacesClientGetEffectiveRouteTablePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *InterfacesClientGetEffectiveRouteTablePoller) Poll(ctx context.Context) (InterfacesClientGetEffectiveRouteTableResponse, error) {
-	result := InterfacesClientGetEffectiveRouteTableResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.EffectiveRouteListResult)
-	return result, err
+func (p *InterfacesClientGetEffectiveRouteTablePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *InterfacesClientGetEffectiveRouteTablePoller) Result(ctx context.Context) (resp InterfacesClientGetEffectiveRouteTableResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3603,12 +3359,9 @@ func (p *InterfacesClientGetEffectiveRouteTablePoller) ResumeToken() (string, er
 
 // Resume rehydrates a InterfacesClientGetEffectiveRouteTablePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *InterfacesClientGetEffectiveRouteTablePoller) Resume(ctx context.Context, client *InterfacesClient, token string) (InterfacesClientGetEffectiveRouteTableResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.GetEffectiveRouteTable", token, client.pl); err != nil {
-		return InterfacesClientGetEffectiveRouteTableResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *InterfacesClientGetEffectiveRouteTablePoller) Resume(token string, client *InterfacesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.GetEffectiveRouteTable", token, client.pl)
+	return
 }
 
 // InterfacesClientListEffectiveNetworkSecurityGroupsPoller provides polling facilities until the operation reaches a terminal state.
@@ -3627,20 +3380,19 @@ func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Poll(ctx context.Context) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
-	result := InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.EffectiveNetworkSecurityGroupListResult)
-	return result, err
+func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Result(ctx context.Context) (resp InterfacesClientListEffectiveNetworkSecurityGroupsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3661,12 +3413,9 @@ func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) ResumeToken()
 
 // Resume rehydrates a InterfacesClientListEffectiveNetworkSecurityGroupsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Resume(ctx context.Context, client *InterfacesClient, token string) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.ListEffectiveNetworkSecurityGroups", token, client.pl); err != nil {
-		return InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *InterfacesClientListEffectiveNetworkSecurityGroupsPoller) Resume(token string, client *InterfacesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("InterfacesClient.ListEffectiveNetworkSecurityGroups", token, client.pl)
+	return
 }
 
 // LoadBalancersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3685,20 +3434,19 @@ func (p *LoadBalancersClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LoadBalancersClientCreateOrUpdatePoller) Poll(ctx context.Context) (LoadBalancersClientCreateOrUpdateResponse, error) {
-	result := LoadBalancersClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.LoadBalancer)
-	return result, err
+func (p *LoadBalancersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LoadBalancersClientCreateOrUpdatePoller) Result(ctx context.Context) (resp LoadBalancersClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3719,12 +3467,9 @@ func (p *LoadBalancersClientCreateOrUpdatePoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a LoadBalancersClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LoadBalancersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *LoadBalancersClient, token string) (LoadBalancersClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LoadBalancersClient.CreateOrUpdate", token, client.pl); err != nil {
-		return LoadBalancersClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LoadBalancersClientCreateOrUpdatePoller) Resume(token string, client *LoadBalancersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LoadBalancersClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // LoadBalancersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3743,20 +3488,19 @@ func (p *LoadBalancersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LoadBalancersClientDeletePoller) Poll(ctx context.Context) (LoadBalancersClientDeleteResponse, error) {
-	result := LoadBalancersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LoadBalancersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LoadBalancersClientDeletePoller) Result(ctx context.Context) (resp LoadBalancersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3777,12 +3521,9 @@ func (p *LoadBalancersClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LoadBalancersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LoadBalancersClientDeletePoller) Resume(ctx context.Context, client *LoadBalancersClient, token string) (LoadBalancersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LoadBalancersClient.Delete", token, client.pl); err != nil {
-		return LoadBalancersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LoadBalancersClientDeletePoller) Resume(token string, client *LoadBalancersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LoadBalancersClient.Delete", token, client.pl)
+	return
 }
 
 // LocalNetworkGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -3801,20 +3542,19 @@ func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
-	result := LocalNetworkGatewaysClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.LocalNetworkGateway)
-	return result, err
+func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Result(ctx context.Context) (resp LocalNetworkGatewaysClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3835,12 +3575,9 @@ func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, 
 
 // Resume rehydrates a LocalNetworkGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *LocalNetworkGatewaysClient, token string) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LocalNetworkGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
-		return LocalNetworkGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LocalNetworkGatewaysClientCreateOrUpdatePoller) Resume(token string, client *LocalNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LocalNetworkGatewaysClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // LocalNetworkGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -3859,20 +3596,19 @@ func (p *LocalNetworkGatewaysClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *LocalNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (LocalNetworkGatewaysClientDeleteResponse, error) {
-	result := LocalNetworkGatewaysClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *LocalNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *LocalNetworkGatewaysClientDeletePoller) Result(ctx context.Context) (resp LocalNetworkGatewaysClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3893,12 +3629,9 @@ func (p *LocalNetworkGatewaysClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a LocalNetworkGatewaysClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *LocalNetworkGatewaysClientDeletePoller) Resume(ctx context.Context, client *LocalNetworkGatewaysClient, token string) (LocalNetworkGatewaysClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("LocalNetworkGatewaysClient.Delete", token, client.pl); err != nil {
-		return LocalNetworkGatewaysClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *LocalNetworkGatewaysClientDeletePoller) Resume(token string, client *LocalNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("LocalNetworkGatewaysClient.Delete", token, client.pl)
+	return
 }
 
 // ManagementClientDeleteBastionShareableLinkPoller provides polling facilities until the operation reaches a terminal state.
@@ -3917,20 +3650,19 @@ func (p *ManagementClientDeleteBastionShareableLinkPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ManagementClientDeleteBastionShareableLinkPoller) Poll(ctx context.Context) (ManagementClientDeleteBastionShareableLinkResponse, error) {
-	result := ManagementClientDeleteBastionShareableLinkResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ManagementClientDeleteBastionShareableLinkPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ManagementClientDeleteBastionShareableLinkPoller) Result(ctx context.Context) (resp ManagementClientDeleteBastionShareableLinkResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -3951,12 +3683,9 @@ func (p *ManagementClientDeleteBastionShareableLinkPoller) ResumeToken() (string
 
 // Resume rehydrates a ManagementClientDeleteBastionShareableLinkPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ManagementClientDeleteBastionShareableLinkPoller) Resume(ctx context.Context, client *ManagementClient, token string) (ManagementClientDeleteBastionShareableLinkResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.DeleteBastionShareableLink", token, client.pl); err != nil {
-		return ManagementClientDeleteBastionShareableLinkResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ManagementClientDeleteBastionShareableLinkPoller) Resume(token string, client *ManagementClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.DeleteBastionShareableLink", token, client.pl)
+	return
 }
 
 // ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller provides polling facilities until the operation reaches a terminal state.
@@ -3975,20 +3704,19 @@ func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePolle
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) Poll(ctx context.Context) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
-	result := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNProfileResponse)
-	return result, err
+func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) Result(ctx context.Context) (resp ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4009,12 +3737,9 @@ func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePolle
 
 // Resume rehydrates a ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) Resume(ctx context.Context, client *ManagementClient, token string) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", token, client.pl); err != nil {
-		return ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller) Resume(token string, client *ManagementClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", token, client.pl)
+	return
 }
 
 // ManagementClientGetActiveSessionsPoller provides polling facilities until the operation reaches a terminal state.
@@ -4034,24 +3759,19 @@ func (p *ManagementClientGetActiveSessionsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ManagementClientGetActiveSessionsPoller) Poll(ctx context.Context) (*ManagementClientGetActiveSessionsPager, error) {
-	result := &ManagementClientGetActiveSessionsPager{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return nil, err
-	}
-	if !p.Done() {
-		return nil, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.current.BastionActiveSessionListResult)
-	if err != nil {
-		return nil, err
-	}
-	result.client = p.client
-	return result, err
+func (p *ManagementClientGetActiveSessionsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ManagementClientGetActiveSessionsPoller) Result(ctx context.Context) (resp *ManagementClientGetActiveSessionsPager, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4075,13 +3795,10 @@ func (p *ManagementClientGetActiveSessionsPoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a ManagementClientGetActiveSessionsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ManagementClientGetActiveSessionsPoller) Resume(ctx context.Context, client *ManagementClient, token string) (*ManagementClientGetActiveSessionsPager, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.GetActiveSessions", token, client.pl); err != nil {
-		return nil, err
-	}
+func (p *ManagementClientGetActiveSessionsPoller) Resume(token string, client *ManagementClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.GetActiveSessions", token, client.pl)
 	p.client = client
-	return p.Poll(ctx)
+	return
 }
 
 // ManagementClientPutBastionShareableLinkPoller provides polling facilities until the operation reaches a terminal state.
@@ -4101,24 +3818,19 @@ func (p *ManagementClientPutBastionShareableLinkPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ManagementClientPutBastionShareableLinkPoller) Poll(ctx context.Context) (*ManagementClientPutBastionShareableLinkPager, error) {
-	result := &ManagementClientPutBastionShareableLinkPager{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return nil, err
-	}
-	if !p.Done() {
-		return nil, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.current.BastionShareableLinkListResult)
-	if err != nil {
-		return nil, err
-	}
-	result.client = p.client
-	return result, err
+func (p *ManagementClientPutBastionShareableLinkPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ManagementClientPutBastionShareableLinkPoller) Result(ctx context.Context) (resp *ManagementClientPutBastionShareableLinkPager, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4142,13 +3854,10 @@ func (p *ManagementClientPutBastionShareableLinkPoller) ResumeToken() (string, e
 
 // Resume rehydrates a ManagementClientPutBastionShareableLinkPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ManagementClientPutBastionShareableLinkPoller) Resume(ctx context.Context, client *ManagementClient, token string) (*ManagementClientPutBastionShareableLinkPager, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.PutBastionShareableLink", token, client.pl); err != nil {
-		return nil, err
-	}
+func (p *ManagementClientPutBastionShareableLinkPoller) Resume(token string, client *ManagementClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ManagementClient.PutBastionShareableLink", token, client.pl)
 	p.client = client
-	return p.Poll(ctx)
+	return
 }
 
 // NatGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4167,20 +3876,19 @@ func (p *NatGatewaysClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *NatGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (NatGatewaysClientCreateOrUpdateResponse, error) {
-	result := NatGatewaysClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.NatGateway)
-	return result, err
+func (p *NatGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *NatGatewaysClientCreateOrUpdatePoller) Result(ctx context.Context) (resp NatGatewaysClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4201,12 +3909,9 @@ func (p *NatGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a NatGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *NatGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *NatGatewaysClient, token string) (NatGatewaysClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("NatGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
-		return NatGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *NatGatewaysClientCreateOrUpdatePoller) Resume(token string, client *NatGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("NatGatewaysClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // NatGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4225,20 +3930,19 @@ func (p *NatGatewaysClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *NatGatewaysClientDeletePoller) Poll(ctx context.Context) (NatGatewaysClientDeleteResponse, error) {
-	result := NatGatewaysClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *NatGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *NatGatewaysClientDeletePoller) Result(ctx context.Context) (resp NatGatewaysClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4259,12 +3963,9 @@ func (p *NatGatewaysClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a NatGatewaysClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *NatGatewaysClientDeletePoller) Resume(ctx context.Context, client *NatGatewaysClient, token string) (NatGatewaysClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("NatGatewaysClient.Delete", token, client.pl); err != nil {
-		return NatGatewaysClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *NatGatewaysClientDeletePoller) Resume(token string, client *NatGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("NatGatewaysClient.Delete", token, client.pl)
+	return
 }
 
 // P2SVPNGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4283,20 +3984,19 @@ func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
-	result := P2SVPNGatewaysClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.P2SVPNGateway)
-	return result, err
+func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Result(ctx context.Context) (resp P2SVPNGatewaysClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4317,12 +4017,9 @@ func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error)
 
 // Resume rehydrates a P2SVPNGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
-		return P2SVPNGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *P2SVPNGatewaysClientCreateOrUpdatePoller) Resume(token string, client *P2SVPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // P2SVPNGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4341,20 +4038,19 @@ func (p *P2SVPNGatewaysClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *P2SVPNGatewaysClientDeletePoller) Poll(ctx context.Context) (P2SVPNGatewaysClientDeleteResponse, error) {
-	result := P2SVPNGatewaysClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *P2SVPNGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *P2SVPNGatewaysClientDeletePoller) Result(ctx context.Context) (resp P2SVPNGatewaysClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4375,12 +4071,9 @@ func (p *P2SVPNGatewaysClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a P2SVPNGatewaysClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *P2SVPNGatewaysClientDeletePoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.Delete", token, client.pl); err != nil {
-		return P2SVPNGatewaysClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *P2SVPNGatewaysClientDeletePoller) Resume(token string, client *P2SVPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.Delete", token, client.pl)
+	return
 }
 
 // P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller provides polling facilities until the operation reaches a terminal state.
@@ -4399,20 +4092,19 @@ func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Poll(ctx context.Context) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
-	result := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Result(ctx context.Context) (resp P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4433,12 +4125,9 @@ func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) ResumeToken() (s
 
 // Resume rehydrates a P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.DisconnectP2SVPNConnections", token, client.pl); err != nil {
-		return P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller) Resume(token string, client *P2SVPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.DisconnectP2SVPNConnections", token, client.pl)
+	return
 }
 
 // P2SVPNGatewaysClientGenerateVPNProfilePoller provides polling facilities until the operation reaches a terminal state.
@@ -4457,20 +4146,19 @@ func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
-	result := P2SVPNGatewaysClientGenerateVPNProfileResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNProfileResponse)
-	return result, err
+func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Result(ctx context.Context) (resp P2SVPNGatewaysClientGenerateVPNProfileResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4491,12 +4179,9 @@ func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) ResumeToken() (string, er
 
 // Resume rehydrates a P2SVPNGatewaysClientGenerateVPNProfilePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GenerateVPNProfile", token, client.pl); err != nil {
-		return P2SVPNGatewaysClientGenerateVPNProfileResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *P2SVPNGatewaysClientGenerateVPNProfilePoller) Resume(token string, client *P2SVPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GenerateVPNProfile", token, client.pl)
+	return
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller provides polling facilities until the operation reaches a terminal state.
@@ -4515,20 +4200,19 @@ func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Done() boo
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Poll(ctx context.Context) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
-	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.P2SVPNConnectionHealth)
-	return result, err
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Result(ctx context.Context) (resp P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4549,12 +4233,9 @@ func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) ResumeToke
 
 // Resume rehydrates a P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed", token, client.pl); err != nil {
-		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller) Resume(token string, client *P2SVPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed", token, client.pl)
+	return
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller provides polling facilities until the operation reaches a terminal state.
@@ -4573,20 +4254,19 @@ func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Poll(ctx context.Context) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
-	result := P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.P2SVPNGateway)
-	return result, err
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Result(ctx context.Context) (resp P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4607,12 +4287,9 @@ func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) ResumeToken() (str
 
 // Resume rehydrates a P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealth", token, client.pl); err != nil {
-		return P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller) Resume(token string, client *P2SVPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealth", token, client.pl)
+	return
 }
 
 // PacketCapturesClientCreatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4631,20 +4308,19 @@ func (p *PacketCapturesClientCreatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PacketCapturesClientCreatePoller) Poll(ctx context.Context) (PacketCapturesClientCreateResponse, error) {
-	result := PacketCapturesClientCreateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PacketCaptureResult)
-	return result, err
+func (p *PacketCapturesClientCreatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PacketCapturesClientCreatePoller) Result(ctx context.Context) (resp PacketCapturesClientCreateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4665,12 +4341,9 @@ func (p *PacketCapturesClientCreatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PacketCapturesClientCreatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PacketCapturesClientCreatePoller) Resume(ctx context.Context, client *PacketCapturesClient, token string) (PacketCapturesClientCreateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Create", token, client.pl); err != nil {
-		return PacketCapturesClientCreateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PacketCapturesClientCreatePoller) Resume(token string, client *PacketCapturesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Create", token, client.pl)
+	return
 }
 
 // PacketCapturesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4689,20 +4362,19 @@ func (p *PacketCapturesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PacketCapturesClientDeletePoller) Poll(ctx context.Context) (PacketCapturesClientDeleteResponse, error) {
-	result := PacketCapturesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *PacketCapturesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PacketCapturesClientDeletePoller) Result(ctx context.Context) (resp PacketCapturesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4723,12 +4395,9 @@ func (p *PacketCapturesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PacketCapturesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PacketCapturesClientDeletePoller) Resume(ctx context.Context, client *PacketCapturesClient, token string) (PacketCapturesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Delete", token, client.pl); err != nil {
-		return PacketCapturesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PacketCapturesClientDeletePoller) Resume(token string, client *PacketCapturesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Delete", token, client.pl)
+	return
 }
 
 // PacketCapturesClientGetStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -4747,20 +4416,19 @@ func (p *PacketCapturesClientGetStatusPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PacketCapturesClientGetStatusPoller) Poll(ctx context.Context) (PacketCapturesClientGetStatusResponse, error) {
-	result := PacketCapturesClientGetStatusResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PacketCaptureQueryStatusResult)
-	return result, err
+func (p *PacketCapturesClientGetStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PacketCapturesClientGetStatusPoller) Result(ctx context.Context) (resp PacketCapturesClientGetStatusResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4781,12 +4449,9 @@ func (p *PacketCapturesClientGetStatusPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PacketCapturesClientGetStatusPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PacketCapturesClientGetStatusPoller) Resume(ctx context.Context, client *PacketCapturesClient, token string) (PacketCapturesClientGetStatusResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.GetStatus", token, client.pl); err != nil {
-		return PacketCapturesClientGetStatusResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PacketCapturesClientGetStatusPoller) Resume(token string, client *PacketCapturesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.GetStatus", token, client.pl)
+	return
 }
 
 // PacketCapturesClientStopPoller provides polling facilities until the operation reaches a terminal state.
@@ -4805,20 +4470,19 @@ func (p *PacketCapturesClientStopPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PacketCapturesClientStopPoller) Poll(ctx context.Context) (PacketCapturesClientStopResponse, error) {
-	result := PacketCapturesClientStopResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *PacketCapturesClientStopPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PacketCapturesClientStopPoller) Result(ctx context.Context) (resp PacketCapturesClientStopResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4839,12 +4503,9 @@ func (p *PacketCapturesClientStopPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PacketCapturesClientStopPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PacketCapturesClientStopPoller) Resume(ctx context.Context, client *PacketCapturesClient, token string) (PacketCapturesClientStopResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Stop", token, client.pl); err != nil {
-		return PacketCapturesClientStopResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PacketCapturesClientStopPoller) Resume(token string, client *PacketCapturesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PacketCapturesClient.Stop", token, client.pl)
+	return
 }
 
 // PrivateDNSZoneGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4863,20 +4524,19 @@ func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
-	result := PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PrivateDNSZoneGroup)
-	return result, err
+func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp PrivateDNSZoneGroupsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4897,12 +4557,9 @@ func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) ResumeToken() (string, 
 
 // Resume rehydrates a PrivateDNSZoneGroupsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PrivateDNSZoneGroupsClient, token string) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateDNSZoneGroupsClientCreateOrUpdatePoller) Resume(token string, client *PrivateDNSZoneGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // PrivateDNSZoneGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -4921,20 +4578,19 @@ func (p *PrivateDNSZoneGroupsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateDNSZoneGroupsClientDeletePoller) Poll(ctx context.Context) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
-	result := PrivateDNSZoneGroupsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *PrivateDNSZoneGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateDNSZoneGroupsClientDeletePoller) Result(ctx context.Context) (resp PrivateDNSZoneGroupsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -4955,12 +4611,9 @@ func (p *PrivateDNSZoneGroupsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PrivateDNSZoneGroupsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateDNSZoneGroupsClientDeletePoller) Resume(ctx context.Context, client *PrivateDNSZoneGroupsClient, token string) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.Delete", token, client.pl); err != nil {
-		return PrivateDNSZoneGroupsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateDNSZoneGroupsClientDeletePoller) Resume(token string, client *PrivateDNSZoneGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.Delete", token, client.pl)
+	return
 }
 
 // PrivateEndpointsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -4979,20 +4632,19 @@ func (p *PrivateEndpointsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateEndpointsClientCreateOrUpdatePoller) Poll(ctx context.Context) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
-	result := PrivateEndpointsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PrivateEndpoint)
-	return result, err
+func (p *PrivateEndpointsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateEndpointsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp PrivateEndpointsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5013,12 +4665,9 @@ func (p *PrivateEndpointsClientCreateOrUpdatePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a PrivateEndpointsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateEndpointsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PrivateEndpointsClient, token string) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateEndpointsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return PrivateEndpointsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateEndpointsClientCreateOrUpdatePoller) Resume(token string, client *PrivateEndpointsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateEndpointsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // PrivateEndpointsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5037,20 +4686,19 @@ func (p *PrivateEndpointsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateEndpointsClientDeletePoller) Poll(ctx context.Context) (PrivateEndpointsClientDeleteResponse, error) {
-	result := PrivateEndpointsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *PrivateEndpointsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateEndpointsClientDeletePoller) Result(ctx context.Context) (resp PrivateEndpointsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5071,12 +4719,9 @@ func (p *PrivateEndpointsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PrivateEndpointsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateEndpointsClientDeletePoller) Resume(ctx context.Context, client *PrivateEndpointsClient, token string) (PrivateEndpointsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateEndpointsClient.Delete", token, client.pl); err != nil {
-		return PrivateEndpointsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateEndpointsClientDeletePoller) Resume(token string, client *PrivateEndpointsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateEndpointsClient.Delete", token, client.pl)
+	return
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller provides polling facilities until the operation reaches a terminal state.
@@ -5095,20 +4740,19 @@ func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGro
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) Poll(ctx context.Context) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
-	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PrivateLinkServiceVisibility)
-	return result, err
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) Result(ctx context.Context) (resp PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5129,12 +4773,9 @@ func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGro
 
 // Resume rehydrates a PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup", token, client.pl); err != nil {
-		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller) Resume(token string, client *PrivateLinkServicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup", token, client.pl)
+	return
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller provides polling facilities until the operation reaches a terminal state.
@@ -5153,20 +4794,19 @@ func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Done(
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Poll(ctx context.Context) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
-	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PrivateLinkServiceVisibility)
-	return result, err
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Result(ctx context.Context) (resp PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5187,12 +4827,9 @@ func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Resum
 
 // Resume rehydrates a PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility", token, client.pl); err != nil {
-		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller) Resume(token string, client *PrivateLinkServicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility", token, client.pl)
+	return
 }
 
 // PrivateLinkServicesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5211,20 +4848,19 @@ func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
-	result := PrivateLinkServicesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PrivateLinkService)
-	return result, err
+func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp PrivateLinkServicesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5245,12 +4881,9 @@ func (p *PrivateLinkServicesClientCreateOrUpdatePoller) ResumeToken() (string, e
 
 // Resume rehydrates a PrivateLinkServicesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return PrivateLinkServicesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateLinkServicesClientCreateOrUpdatePoller) Resume(token string, client *PrivateLinkServicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // PrivateLinkServicesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5269,20 +4902,19 @@ func (p *PrivateLinkServicesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateLinkServicesClientDeletePoller) Poll(ctx context.Context) (PrivateLinkServicesClientDeleteResponse, error) {
-	result := PrivateLinkServicesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *PrivateLinkServicesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateLinkServicesClientDeletePoller) Result(ctx context.Context) (resp PrivateLinkServicesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5303,12 +4935,9 @@ func (p *PrivateLinkServicesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PrivateLinkServicesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateLinkServicesClientDeletePoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.Delete", token, client.pl); err != nil {
-		return PrivateLinkServicesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateLinkServicesClientDeletePoller) Resume(token string, client *PrivateLinkServicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.Delete", token, client.pl)
+	return
 }
 
 // PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller provides polling facilities until the operation reaches a terminal state.
@@ -5327,20 +4956,19 @@ func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Done() 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Poll(ctx context.Context) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
-	result := PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Result(ctx context.Context) (resp PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5361,12 +4989,9 @@ func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) ResumeT
 
 // Resume rehydrates a PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.DeletePrivateEndpointConnection", token, client.pl); err != nil {
-		return PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller) Resume(token string, client *PrivateLinkServicesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.DeletePrivateEndpointConnection", token, client.pl)
+	return
 }
 
 // ProfilesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5385,20 +5010,19 @@ func (p *ProfilesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ProfilesClientDeletePoller) Poll(ctx context.Context) (ProfilesClientDeleteResponse, error) {
-	result := ProfilesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ProfilesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ProfilesClientDeletePoller) Result(ctx context.Context) (resp ProfilesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5419,12 +5043,9 @@ func (p *ProfilesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a ProfilesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ProfilesClientDeletePoller) Resume(ctx context.Context, client *ProfilesClient, token string) (ProfilesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ProfilesClient.Delete", token, client.pl); err != nil {
-		return ProfilesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ProfilesClientDeletePoller) Resume(token string, client *ProfilesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ProfilesClient.Delete", token, client.pl)
+	return
 }
 
 // PublicIPAddressesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5443,20 +5064,19 @@ func (p *PublicIPAddressesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PublicIPAddressesClientCreateOrUpdatePoller) Poll(ctx context.Context) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
-	result := PublicIPAddressesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PublicIPAddress)
-	return result, err
+func (p *PublicIPAddressesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PublicIPAddressesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp PublicIPAddressesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5477,12 +5097,9 @@ func (p *PublicIPAddressesClientCreateOrUpdatePoller) ResumeToken() (string, err
 
 // Resume rehydrates a PublicIPAddressesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PublicIPAddressesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PublicIPAddressesClient, token string) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPAddressesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return PublicIPAddressesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PublicIPAddressesClientCreateOrUpdatePoller) Resume(token string, client *PublicIPAddressesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPAddressesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // PublicIPAddressesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5501,20 +5118,19 @@ func (p *PublicIPAddressesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PublicIPAddressesClientDeletePoller) Poll(ctx context.Context) (PublicIPAddressesClientDeleteResponse, error) {
-	result := PublicIPAddressesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *PublicIPAddressesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PublicIPAddressesClientDeletePoller) Result(ctx context.Context) (resp PublicIPAddressesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5535,12 +5151,9 @@ func (p *PublicIPAddressesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PublicIPAddressesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PublicIPAddressesClientDeletePoller) Resume(ctx context.Context, client *PublicIPAddressesClient, token string) (PublicIPAddressesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPAddressesClient.Delete", token, client.pl); err != nil {
-		return PublicIPAddressesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PublicIPAddressesClientDeletePoller) Resume(token string, client *PublicIPAddressesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPAddressesClient.Delete", token, client.pl)
+	return
 }
 
 // PublicIPPrefixesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5559,20 +5172,19 @@ func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Poll(ctx context.Context) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
-	result := PublicIPPrefixesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PublicIPPrefix)
-	return result, err
+func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp PublicIPPrefixesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5593,12 +5205,9 @@ func (p *PublicIPPrefixesClientCreateOrUpdatePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a PublicIPPrefixesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *PublicIPPrefixesClient, token string) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPPrefixesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return PublicIPPrefixesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PublicIPPrefixesClientCreateOrUpdatePoller) Resume(token string, client *PublicIPPrefixesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPPrefixesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // PublicIPPrefixesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5617,20 +5226,19 @@ func (p *PublicIPPrefixesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *PublicIPPrefixesClientDeletePoller) Poll(ctx context.Context) (PublicIPPrefixesClientDeleteResponse, error) {
-	result := PublicIPPrefixesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *PublicIPPrefixesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *PublicIPPrefixesClientDeletePoller) Result(ctx context.Context) (resp PublicIPPrefixesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5651,12 +5259,9 @@ func (p *PublicIPPrefixesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a PublicIPPrefixesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *PublicIPPrefixesClientDeletePoller) Resume(ctx context.Context, client *PublicIPPrefixesClient, token string) (PublicIPPrefixesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPPrefixesClient.Delete", token, client.pl); err != nil {
-		return PublicIPPrefixesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *PublicIPPrefixesClientDeletePoller) Resume(token string, client *PublicIPPrefixesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("PublicIPPrefixesClient.Delete", token, client.pl)
+	return
 }
 
 // RouteFilterRulesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5675,20 +5280,19 @@ func (p *RouteFilterRulesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RouteFilterRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
-	result := RouteFilterRulesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.RouteFilterRule)
-	return result, err
+func (p *RouteFilterRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RouteFilterRulesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp RouteFilterRulesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5709,12 +5313,9 @@ func (p *RouteFilterRulesClientCreateOrUpdatePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a RouteFilterRulesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RouteFilterRulesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RouteFilterRulesClient, token string) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteFilterRulesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return RouteFilterRulesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RouteFilterRulesClientCreateOrUpdatePoller) Resume(token string, client *RouteFilterRulesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RouteFilterRulesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // RouteFilterRulesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5733,20 +5334,19 @@ func (p *RouteFilterRulesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RouteFilterRulesClientDeletePoller) Poll(ctx context.Context) (RouteFilterRulesClientDeleteResponse, error) {
-	result := RouteFilterRulesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *RouteFilterRulesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RouteFilterRulesClientDeletePoller) Result(ctx context.Context) (resp RouteFilterRulesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5767,12 +5367,9 @@ func (p *RouteFilterRulesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RouteFilterRulesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RouteFilterRulesClientDeletePoller) Resume(ctx context.Context, client *RouteFilterRulesClient, token string) (RouteFilterRulesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteFilterRulesClient.Delete", token, client.pl); err != nil {
-		return RouteFilterRulesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RouteFilterRulesClientDeletePoller) Resume(token string, client *RouteFilterRulesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RouteFilterRulesClient.Delete", token, client.pl)
+	return
 }
 
 // RouteFiltersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5791,20 +5388,19 @@ func (p *RouteFiltersClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RouteFiltersClientCreateOrUpdatePoller) Poll(ctx context.Context) (RouteFiltersClientCreateOrUpdateResponse, error) {
-	result := RouteFiltersClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.RouteFilter)
-	return result, err
+func (p *RouteFiltersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RouteFiltersClientCreateOrUpdatePoller) Result(ctx context.Context) (resp RouteFiltersClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5825,12 +5421,9 @@ func (p *RouteFiltersClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RouteFiltersClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RouteFiltersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RouteFiltersClient, token string) (RouteFiltersClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteFiltersClient.CreateOrUpdate", token, client.pl); err != nil {
-		return RouteFiltersClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RouteFiltersClientCreateOrUpdatePoller) Resume(token string, client *RouteFiltersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RouteFiltersClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // RouteFiltersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5849,20 +5442,19 @@ func (p *RouteFiltersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RouteFiltersClientDeletePoller) Poll(ctx context.Context) (RouteFiltersClientDeleteResponse, error) {
-	result := RouteFiltersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *RouteFiltersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RouteFiltersClientDeletePoller) Result(ctx context.Context) (resp RouteFiltersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5883,12 +5475,9 @@ func (p *RouteFiltersClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RouteFiltersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RouteFiltersClientDeletePoller) Resume(ctx context.Context, client *RouteFiltersClient, token string) (RouteFiltersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteFiltersClient.Delete", token, client.pl); err != nil {
-		return RouteFiltersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RouteFiltersClientDeletePoller) Resume(token string, client *RouteFiltersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RouteFiltersClient.Delete", token, client.pl)
+	return
 }
 
 // RouteTablesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -5907,20 +5496,19 @@ func (p *RouteTablesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RouteTablesClientCreateOrUpdatePoller) Poll(ctx context.Context) (RouteTablesClientCreateOrUpdateResponse, error) {
-	result := RouteTablesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.RouteTable)
-	return result, err
+func (p *RouteTablesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RouteTablesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp RouteTablesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5941,12 +5529,9 @@ func (p *RouteTablesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RouteTablesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RouteTablesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RouteTablesClient, token string) (RouteTablesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteTablesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return RouteTablesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RouteTablesClientCreateOrUpdatePoller) Resume(token string, client *RouteTablesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RouteTablesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // RouteTablesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -5965,20 +5550,19 @@ func (p *RouteTablesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RouteTablesClientDeletePoller) Poll(ctx context.Context) (RouteTablesClientDeleteResponse, error) {
-	result := RouteTablesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *RouteTablesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RouteTablesClientDeletePoller) Result(ctx context.Context) (resp RouteTablesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -5999,12 +5583,9 @@ func (p *RouteTablesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RouteTablesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RouteTablesClientDeletePoller) Resume(ctx context.Context, client *RouteTablesClient, token string) (RouteTablesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RouteTablesClient.Delete", token, client.pl); err != nil {
-		return RouteTablesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RouteTablesClientDeletePoller) Resume(token string, client *RouteTablesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RouteTablesClient.Delete", token, client.pl)
+	return
 }
 
 // RoutesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6023,20 +5604,19 @@ func (p *RoutesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RoutesClientCreateOrUpdatePoller) Poll(ctx context.Context) (RoutesClientCreateOrUpdateResponse, error) {
-	result := RoutesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Route)
-	return result, err
+func (p *RoutesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RoutesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp RoutesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6057,12 +5637,9 @@ func (p *RoutesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RoutesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RoutesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *RoutesClient, token string) (RoutesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RoutesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return RoutesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RoutesClientCreateOrUpdatePoller) Resume(token string, client *RoutesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RoutesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // RoutesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6081,20 +5658,19 @@ func (p *RoutesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *RoutesClientDeletePoller) Poll(ctx context.Context) (RoutesClientDeleteResponse, error) {
-	result := RoutesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *RoutesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *RoutesClientDeletePoller) Result(ctx context.Context) (resp RoutesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6115,12 +5691,9 @@ func (p *RoutesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a RoutesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *RoutesClientDeletePoller) Resume(ctx context.Context, client *RoutesClient, token string) (RoutesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("RoutesClient.Delete", token, client.pl); err != nil {
-		return RoutesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *RoutesClientDeletePoller) Resume(token string, client *RoutesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("RoutesClient.Delete", token, client.pl)
+	return
 }
 
 // SecurityGroupsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6139,20 +5712,19 @@ func (p *SecurityGroupsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (SecurityGroupsClientCreateOrUpdateResponse, error) {
-	result := SecurityGroupsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SecurityGroup)
-	return result, err
+func (p *SecurityGroupsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SecurityGroupsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp SecurityGroupsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6173,12 +5745,9 @@ func (p *SecurityGroupsClientCreateOrUpdatePoller) ResumeToken() (string, error)
 
 // Resume rehydrates a SecurityGroupsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SecurityGroupsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SecurityGroupsClient, token string) (SecurityGroupsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityGroupsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return SecurityGroupsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SecurityGroupsClientCreateOrUpdatePoller) Resume(token string, client *SecurityGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SecurityGroupsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // SecurityGroupsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6197,20 +5766,19 @@ func (p *SecurityGroupsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SecurityGroupsClientDeletePoller) Poll(ctx context.Context) (SecurityGroupsClientDeleteResponse, error) {
-	result := SecurityGroupsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SecurityGroupsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SecurityGroupsClientDeletePoller) Result(ctx context.Context) (resp SecurityGroupsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6231,12 +5799,9 @@ func (p *SecurityGroupsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SecurityGroupsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SecurityGroupsClientDeletePoller) Resume(ctx context.Context, client *SecurityGroupsClient, token string) (SecurityGroupsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityGroupsClient.Delete", token, client.pl); err != nil {
-		return SecurityGroupsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SecurityGroupsClientDeletePoller) Resume(token string, client *SecurityGroupsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SecurityGroupsClient.Delete", token, client.pl)
+	return
 }
 
 // SecurityPartnerProvidersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6255,20 +5820,19 @@ func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Poll(ctx context.Context) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
-	result := SecurityPartnerProvidersClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SecurityPartnerProvider)
-	return result, err
+func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Result(ctx context.Context) (resp SecurityPartnerProvidersClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6289,12 +5853,9 @@ func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) ResumeToken() (stri
 
 // Resume rehydrates a SecurityPartnerProvidersClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SecurityPartnerProvidersClient, token string) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityPartnerProvidersClient.CreateOrUpdate", token, client.pl); err != nil {
-		return SecurityPartnerProvidersClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SecurityPartnerProvidersClientCreateOrUpdatePoller) Resume(token string, client *SecurityPartnerProvidersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SecurityPartnerProvidersClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // SecurityPartnerProvidersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6313,20 +5874,19 @@ func (p *SecurityPartnerProvidersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SecurityPartnerProvidersClientDeletePoller) Poll(ctx context.Context) (SecurityPartnerProvidersClientDeleteResponse, error) {
-	result := SecurityPartnerProvidersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SecurityPartnerProvidersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SecurityPartnerProvidersClientDeletePoller) Result(ctx context.Context) (resp SecurityPartnerProvidersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6347,12 +5907,9 @@ func (p *SecurityPartnerProvidersClientDeletePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a SecurityPartnerProvidersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SecurityPartnerProvidersClientDeletePoller) Resume(ctx context.Context, client *SecurityPartnerProvidersClient, token string) (SecurityPartnerProvidersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityPartnerProvidersClient.Delete", token, client.pl); err != nil {
-		return SecurityPartnerProvidersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SecurityPartnerProvidersClientDeletePoller) Resume(token string, client *SecurityPartnerProvidersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SecurityPartnerProvidersClient.Delete", token, client.pl)
+	return
 }
 
 // SecurityRulesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6371,20 +5928,19 @@ func (p *SecurityRulesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SecurityRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (SecurityRulesClientCreateOrUpdateResponse, error) {
-	result := SecurityRulesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SecurityRule)
-	return result, err
+func (p *SecurityRulesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SecurityRulesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp SecurityRulesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6405,12 +5961,9 @@ func (p *SecurityRulesClientCreateOrUpdatePoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a SecurityRulesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SecurityRulesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SecurityRulesClient, token string) (SecurityRulesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityRulesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return SecurityRulesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SecurityRulesClientCreateOrUpdatePoller) Resume(token string, client *SecurityRulesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SecurityRulesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // SecurityRulesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6429,20 +5982,19 @@ func (p *SecurityRulesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SecurityRulesClientDeletePoller) Poll(ctx context.Context) (SecurityRulesClientDeleteResponse, error) {
-	result := SecurityRulesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SecurityRulesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SecurityRulesClientDeletePoller) Result(ctx context.Context) (resp SecurityRulesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6463,12 +6015,9 @@ func (p *SecurityRulesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SecurityRulesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SecurityRulesClientDeletePoller) Resume(ctx context.Context, client *SecurityRulesClient, token string) (SecurityRulesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SecurityRulesClient.Delete", token, client.pl); err != nil {
-		return SecurityRulesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SecurityRulesClientDeletePoller) Resume(token string, client *SecurityRulesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SecurityRulesClient.Delete", token, client.pl)
+	return
 }
 
 // ServiceEndpointPoliciesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6487,20 +6036,19 @@ func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
-	result := ServiceEndpointPoliciesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ServiceEndpointPolicy)
-	return result, err
+func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ServiceEndpointPoliciesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6521,12 +6069,9 @@ func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) ResumeToken() (strin
 
 // Resume rehydrates a ServiceEndpointPoliciesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ServiceEndpointPoliciesClient, token string) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ServiceEndpointPoliciesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ServiceEndpointPoliciesClientCreateOrUpdatePoller) Resume(token string, client *ServiceEndpointPoliciesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ServiceEndpointPoliciesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6545,20 +6090,19 @@ func (p *ServiceEndpointPoliciesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ServiceEndpointPoliciesClientDeletePoller) Poll(ctx context.Context) (ServiceEndpointPoliciesClientDeleteResponse, error) {
-	result := ServiceEndpointPoliciesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ServiceEndpointPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ServiceEndpointPoliciesClientDeletePoller) Result(ctx context.Context) (resp ServiceEndpointPoliciesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6579,12 +6123,9 @@ func (p *ServiceEndpointPoliciesClientDeletePoller) ResumeToken() (string, error
 
 // Resume rehydrates a ServiceEndpointPoliciesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ServiceEndpointPoliciesClientDeletePoller) Resume(ctx context.Context, client *ServiceEndpointPoliciesClient, token string) (ServiceEndpointPoliciesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.Delete", token, client.pl); err != nil {
-		return ServiceEndpointPoliciesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ServiceEndpointPoliciesClientDeletePoller) Resume(token string, client *ServiceEndpointPoliciesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.Delete", token, client.pl)
+	return
 }
 
 // ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6603,20 +6144,19 @@ func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Done() bool
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
-	result := ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ServiceEndpointPolicyDefinition)
-	return result, err
+func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6637,12 +6177,9 @@ func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) ResumeToken
 
 // Resume rehydrates a ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *ServiceEndpointPolicyDefinitionsClient, token string) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller) Resume(token string, client *ServiceEndpointPolicyDefinitionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // ServiceEndpointPolicyDefinitionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6661,20 +6198,19 @@ func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Poll(ctx context.Context) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
-	result := ServiceEndpointPolicyDefinitionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Result(ctx context.Context) (resp ServiceEndpointPolicyDefinitionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6695,12 +6231,9 @@ func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) ResumeToken() (stri
 
 // Resume rehydrates a ServiceEndpointPolicyDefinitionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Resume(ctx context.Context, client *ServiceEndpointPolicyDefinitionsClient, token string) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.Delete", token, client.pl); err != nil {
-		return ServiceEndpointPolicyDefinitionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *ServiceEndpointPolicyDefinitionsClientDeletePoller) Resume(token string, client *ServiceEndpointPolicyDefinitionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.Delete", token, client.pl)
+	return
 }
 
 // SubnetsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6719,20 +6252,19 @@ func (p *SubnetsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SubnetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (SubnetsClientCreateOrUpdateResponse, error) {
-	result := SubnetsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Subnet)
-	return result, err
+func (p *SubnetsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SubnetsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp SubnetsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6753,12 +6285,9 @@ func (p *SubnetsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SubnetsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SubnetsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *SubnetsClient, token string) (SubnetsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return SubnetsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SubnetsClientCreateOrUpdatePoller) Resume(token string, client *SubnetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // SubnetsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -6777,20 +6306,19 @@ func (p *SubnetsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SubnetsClientDeletePoller) Poll(ctx context.Context) (SubnetsClientDeleteResponse, error) {
-	result := SubnetsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SubnetsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SubnetsClientDeletePoller) Result(ctx context.Context) (resp SubnetsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6811,12 +6339,9 @@ func (p *SubnetsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a SubnetsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SubnetsClientDeletePoller) Resume(ctx context.Context, client *SubnetsClient, token string) (SubnetsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.Delete", token, client.pl); err != nil {
-		return SubnetsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SubnetsClientDeletePoller) Resume(token string, client *SubnetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.Delete", token, client.pl)
+	return
 }
 
 // SubnetsClientPrepareNetworkPoliciesPoller provides polling facilities until the operation reaches a terminal state.
@@ -6835,20 +6360,19 @@ func (p *SubnetsClientPrepareNetworkPoliciesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SubnetsClientPrepareNetworkPoliciesPoller) Poll(ctx context.Context) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
-	result := SubnetsClientPrepareNetworkPoliciesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SubnetsClientPrepareNetworkPoliciesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SubnetsClientPrepareNetworkPoliciesPoller) Result(ctx context.Context) (resp SubnetsClientPrepareNetworkPoliciesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6869,12 +6393,9 @@ func (p *SubnetsClientPrepareNetworkPoliciesPoller) ResumeToken() (string, error
 
 // Resume rehydrates a SubnetsClientPrepareNetworkPoliciesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SubnetsClientPrepareNetworkPoliciesPoller) Resume(ctx context.Context, client *SubnetsClient, token string) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.PrepareNetworkPolicies", token, client.pl); err != nil {
-		return SubnetsClientPrepareNetworkPoliciesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SubnetsClientPrepareNetworkPoliciesPoller) Resume(token string, client *SubnetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.PrepareNetworkPolicies", token, client.pl)
+	return
 }
 
 // SubnetsClientUnprepareNetworkPoliciesPoller provides polling facilities until the operation reaches a terminal state.
@@ -6893,20 +6414,19 @@ func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Poll(ctx context.Context) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
-	result := SubnetsClientUnprepareNetworkPoliciesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Result(ctx context.Context) (resp SubnetsClientUnprepareNetworkPoliciesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6927,12 +6447,9 @@ func (p *SubnetsClientUnprepareNetworkPoliciesPoller) ResumeToken() (string, err
 
 // Resume rehydrates a SubnetsClientUnprepareNetworkPoliciesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Resume(ctx context.Context, client *SubnetsClient, token string) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.UnprepareNetworkPolicies", token, client.pl); err != nil {
-		return SubnetsClientUnprepareNetworkPoliciesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *SubnetsClientUnprepareNetworkPoliciesPoller) Resume(token string, client *SubnetsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("SubnetsClient.UnprepareNetworkPolicies", token, client.pl)
+	return
 }
 
 // VPNConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -6951,20 +6468,19 @@ func (p *VPNConnectionsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VPNConnectionsClientCreateOrUpdateResponse, error) {
-	result := VPNConnectionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNConnection)
-	return result, err
+func (p *VPNConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNConnectionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VPNConnectionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -6985,12 +6501,9 @@ func (p *VPNConnectionsClientCreateOrUpdatePoller) ResumeToken() (string, error)
 
 // Resume rehydrates a VPNConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VPNConnectionsClient, token string) (VPNConnectionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VPNConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNConnectionsClientCreateOrUpdatePoller) Resume(token string, client *VPNConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNConnectionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VPNConnectionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7009,20 +6522,19 @@ func (p *VPNConnectionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNConnectionsClientDeletePoller) Poll(ctx context.Context) (VPNConnectionsClientDeleteResponse, error) {
-	result := VPNConnectionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VPNConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNConnectionsClientDeletePoller) Result(ctx context.Context) (resp VPNConnectionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7043,12 +6555,9 @@ func (p *VPNConnectionsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VPNConnectionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNConnectionsClientDeletePoller) Resume(ctx context.Context, client *VPNConnectionsClient, token string) (VPNConnectionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNConnectionsClient.Delete", token, client.pl); err != nil {
-		return VPNConnectionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNConnectionsClientDeletePoller) Resume(token string, client *VPNConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNConnectionsClient.Delete", token, client.pl)
+	return
 }
 
 // VPNGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7067,20 +6576,19 @@ func (p *VPNGatewaysClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (VPNGatewaysClientCreateOrUpdateResponse, error) {
-	result := VPNGatewaysClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNGateway)
-	return result, err
+func (p *VPNGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNGatewaysClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VPNGatewaysClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7101,12 +6609,9 @@ func (p *VPNGatewaysClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VPNGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VPNGatewaysClient, token string) (VPNGatewaysClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VPNGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNGatewaysClientCreateOrUpdatePoller) Resume(token string, client *VPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VPNGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7125,20 +6630,19 @@ func (p *VPNGatewaysClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNGatewaysClientDeletePoller) Poll(ctx context.Context) (VPNGatewaysClientDeleteResponse, error) {
-	result := VPNGatewaysClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VPNGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNGatewaysClientDeletePoller) Result(ctx context.Context) (resp VPNGatewaysClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7159,12 +6663,9 @@ func (p *VPNGatewaysClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VPNGatewaysClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNGatewaysClientDeletePoller) Resume(ctx context.Context, client *VPNGatewaysClient, token string) (VPNGatewaysClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.Delete", token, client.pl); err != nil {
-		return VPNGatewaysClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNGatewaysClientDeletePoller) Resume(token string, client *VPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.Delete", token, client.pl)
+	return
 }
 
 // VPNGatewaysClientResetPoller provides polling facilities until the operation reaches a terminal state.
@@ -7183,20 +6684,19 @@ func (p *VPNGatewaysClientResetPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNGatewaysClientResetPoller) Poll(ctx context.Context) (VPNGatewaysClientResetResponse, error) {
-	result := VPNGatewaysClientResetResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNGateway)
-	return result, err
+func (p *VPNGatewaysClientResetPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNGatewaysClientResetPoller) Result(ctx context.Context) (resp VPNGatewaysClientResetResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7217,12 +6717,9 @@ func (p *VPNGatewaysClientResetPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VPNGatewaysClientResetPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNGatewaysClientResetPoller) Resume(ctx context.Context, client *VPNGatewaysClient, token string) (VPNGatewaysClientResetResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.Reset", token, client.pl); err != nil {
-		return VPNGatewaysClientResetResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNGatewaysClientResetPoller) Resume(token string, client *VPNGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNGatewaysClient.Reset", token, client.pl)
+	return
 }
 
 // VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller provides polling facilities until the operation reaches a terminal state.
@@ -7241,20 +6738,19 @@ func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Done()
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Poll(ctx context.Context) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
-	result := VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNServerConfigurationsResponse)
-	return result, err
+func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Result(ctx context.Context) (resp VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7275,12 +6771,9 @@ func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Resume
 
 // Resume rehydrates a VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Resume(ctx context.Context, client *VPNServerConfigurationsAssociatedWithVirtualWanClient, token string) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsAssociatedWithVirtualWanClient.List", token, client.pl); err != nil {
-		return VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller) Resume(token string, client *VPNServerConfigurationsAssociatedWithVirtualWanClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsAssociatedWithVirtualWanClient.List", token, client.pl)
+	return
 }
 
 // VPNServerConfigurationsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7299,20 +6792,19 @@ func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
-	result := VPNServerConfigurationsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNServerConfiguration)
-	return result, err
+func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VPNServerConfigurationsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7333,12 +6825,9 @@ func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) ResumeToken() (strin
 
 // Resume rehydrates a VPNServerConfigurationsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VPNServerConfigurationsClient, token string) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VPNServerConfigurationsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNServerConfigurationsClientCreateOrUpdatePoller) Resume(token string, client *VPNServerConfigurationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VPNServerConfigurationsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7357,20 +6846,19 @@ func (p *VPNServerConfigurationsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNServerConfigurationsClientDeletePoller) Poll(ctx context.Context) (VPNServerConfigurationsClientDeleteResponse, error) {
-	result := VPNServerConfigurationsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VPNServerConfigurationsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNServerConfigurationsClientDeletePoller) Result(ctx context.Context) (resp VPNServerConfigurationsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7391,12 +6879,9 @@ func (p *VPNServerConfigurationsClientDeletePoller) ResumeToken() (string, error
 
 // Resume rehydrates a VPNServerConfigurationsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNServerConfigurationsClientDeletePoller) Resume(ctx context.Context, client *VPNServerConfigurationsClient, token string) (VPNServerConfigurationsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsClient.Delete", token, client.pl); err != nil {
-		return VPNServerConfigurationsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNServerConfigurationsClientDeletePoller) Resume(token string, client *VPNServerConfigurationsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNServerConfigurationsClient.Delete", token, client.pl)
+	return
 }
 
 // VPNSitesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7415,20 +6900,19 @@ func (p *VPNSitesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNSitesClientCreateOrUpdatePoller) Poll(ctx context.Context) (VPNSitesClientCreateOrUpdateResponse, error) {
-	result := VPNSitesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNSite)
-	return result, err
+func (p *VPNSitesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNSitesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VPNSitesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7449,12 +6933,9 @@ func (p *VPNSitesClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VPNSitesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNSitesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VPNSitesClient, token string) (VPNSitesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VPNSitesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNSitesClientCreateOrUpdatePoller) Resume(token string, client *VPNSitesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VPNSitesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7473,20 +6954,19 @@ func (p *VPNSitesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNSitesClientDeletePoller) Poll(ctx context.Context) (VPNSitesClientDeleteResponse, error) {
-	result := VPNSitesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VPNSitesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNSitesClientDeletePoller) Result(ctx context.Context) (resp VPNSitesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7507,12 +6987,9 @@ func (p *VPNSitesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VPNSitesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNSitesClientDeletePoller) Resume(ctx context.Context, client *VPNSitesClient, token string) (VPNSitesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesClient.Delete", token, client.pl); err != nil {
-		return VPNSitesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNSitesClientDeletePoller) Resume(token string, client *VPNSitesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesClient.Delete", token, client.pl)
+	return
 }
 
 // VPNSitesConfigurationClientDownloadPoller provides polling facilities until the operation reaches a terminal state.
@@ -7531,20 +7008,19 @@ func (p *VPNSitesConfigurationClientDownloadPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VPNSitesConfigurationClientDownloadPoller) Poll(ctx context.Context) (VPNSitesConfigurationClientDownloadResponse, error) {
-	result := VPNSitesConfigurationClientDownloadResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VPNSitesConfigurationClientDownloadPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VPNSitesConfigurationClientDownloadPoller) Result(ctx context.Context) (resp VPNSitesConfigurationClientDownloadResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7565,12 +7041,9 @@ func (p *VPNSitesConfigurationClientDownloadPoller) ResumeToken() (string, error
 
 // Resume rehydrates a VPNSitesConfigurationClientDownloadPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VPNSitesConfigurationClientDownloadPoller) Resume(ctx context.Context, client *VPNSitesConfigurationClient, token string) (VPNSitesConfigurationClientDownloadResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesConfigurationClient.Download", token, client.pl); err != nil {
-		return VPNSitesConfigurationClientDownloadResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VPNSitesConfigurationClientDownloadPoller) Resume(token string, client *VPNSitesConfigurationClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VPNSitesConfigurationClient.Download", token, client.pl)
+	return
 }
 
 // VirtualAppliancesClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7589,20 +7062,19 @@ func (p *VirtualAppliancesClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualAppliancesClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
-	result := VirtualAppliancesClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualAppliance)
-	return result, err
+func (p *VirtualAppliancesClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualAppliancesClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualAppliancesClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7623,12 +7095,9 @@ func (p *VirtualAppliancesClientCreateOrUpdatePoller) ResumeToken() (string, err
 
 // Resume rehydrates a VirtualAppliancesClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualAppliancesClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualAppliancesClient, token string) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualAppliancesClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualAppliancesClientCreateOrUpdatePoller) Resume(token string, client *VirtualAppliancesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualAppliancesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7647,20 +7116,19 @@ func (p *VirtualAppliancesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualAppliancesClientDeletePoller) Poll(ctx context.Context) (VirtualAppliancesClientDeleteResponse, error) {
-	result := VirtualAppliancesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualAppliancesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualAppliancesClientDeletePoller) Result(ctx context.Context) (resp VirtualAppliancesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7681,12 +7149,9 @@ func (p *VirtualAppliancesClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualAppliancesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualAppliancesClientDeletePoller) Resume(ctx context.Context, client *VirtualAppliancesClient, token string) (VirtualAppliancesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.Delete", token, client.pl); err != nil {
-		return VirtualAppliancesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualAppliancesClientDeletePoller) Resume(token string, client *VirtualAppliancesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualHubRouteTableV2SClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7705,20 +7170,19 @@ func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
-	result := VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualHubRouteTableV2)
-	return result, err
+func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualHubRouteTableV2SClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7739,12 +7203,9 @@ func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) ResumeToken() (strin
 
 // Resume rehydrates a VirtualHubRouteTableV2SClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualHubRouteTableV2SClient, token string) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualHubRouteTableV2SClientCreateOrUpdatePoller) Resume(token string, client *VirtualHubRouteTableV2SClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualHubRouteTableV2SClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7763,20 +7224,19 @@ func (p *VirtualHubRouteTableV2SClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualHubRouteTableV2SClientDeletePoller) Poll(ctx context.Context) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
-	result := VirtualHubRouteTableV2SClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualHubRouteTableV2SClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualHubRouteTableV2SClientDeletePoller) Result(ctx context.Context) (resp VirtualHubRouteTableV2SClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7797,12 +7257,9 @@ func (p *VirtualHubRouteTableV2SClientDeletePoller) ResumeToken() (string, error
 
 // Resume rehydrates a VirtualHubRouteTableV2SClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualHubRouteTableV2SClientDeletePoller) Resume(ctx context.Context, client *VirtualHubRouteTableV2SClient, token string) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.Delete", token, client.pl); err != nil {
-		return VirtualHubRouteTableV2SClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualHubRouteTableV2SClientDeletePoller) Resume(token string, client *VirtualHubRouteTableV2SClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualHubsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7821,20 +7278,19 @@ func (p *VirtualHubsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualHubsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualHubsClientCreateOrUpdateResponse, error) {
-	result := VirtualHubsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualHub)
-	return result, err
+func (p *VirtualHubsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualHubsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualHubsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7855,12 +7311,9 @@ func (p *VirtualHubsClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualHubsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualHubsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualHubsClient, token string) (VirtualHubsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualHubsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualHubsClientCreateOrUpdatePoller) Resume(token string, client *VirtualHubsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualHubsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7879,20 +7332,19 @@ func (p *VirtualHubsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualHubsClientDeletePoller) Poll(ctx context.Context) (VirtualHubsClientDeleteResponse, error) {
-	result := VirtualHubsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualHubsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualHubsClientDeletePoller) Result(ctx context.Context) (resp VirtualHubsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7913,12 +7365,9 @@ func (p *VirtualHubsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualHubsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualHubsClientDeletePoller) Resume(ctx context.Context, client *VirtualHubsClient, token string) (VirtualHubsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubsClient.Delete", token, client.pl); err != nil {
-		return VirtualHubsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualHubsClientDeletePoller) Resume(token string, client *VirtualHubsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualHubsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -7937,20 +7386,19 @@ func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Done() bool
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGatewayConnection)
-	return result, err
+func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -7971,12 +7419,9 @@ func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) ResumeToken
 
 // Resume rehydrates a VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller) Resume(token string, client *VirtualNetworkGatewayConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewayConnectionsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -7995,20 +7440,19 @@ func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Result(ctx context.Context) (resp VirtualNetworkGatewayConnectionsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8029,12 +7473,9 @@ func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) ResumeToken() (stri
 
 // Resume rehydrates a VirtualNetworkGatewayConnectionsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.Delete", token, client.pl); err != nil {
-		return VirtualNetworkGatewayConnectionsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewayConnectionsClientDeletePoller) Resume(token string, client *VirtualNetworkGatewayConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller provides polling facilities until the operation reaches a terminal state.
@@ -8053,20 +7494,19 @@ func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Done() bool
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ConnectionResetSharedKey)
-	return result, err
+func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Result(ctx context.Context) (resp VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8087,12 +7527,9 @@ func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) ResumeToken
 
 // Resume rehydrates a VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.ResetSharedKey", token, client.pl); err != nil {
-		return VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller) Resume(token string, client *VirtualNetworkGatewayConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.ResetSharedKey", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller provides polling facilities until the operation reaches a terminal state.
@@ -8111,20 +7548,19 @@ func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ConnectionSharedKey)
-	return result, err
+func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Result(ctx context.Context) (resp VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8145,12 +7581,9 @@ func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) ResumeToken()
 
 // Resume rehydrates a VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.SetSharedKey", token, client.pl); err != nil {
-		return VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller) Resume(token string, client *VirtualNetworkGatewayConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.SetSharedKey", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -8169,20 +7602,19 @@ func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Done() 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Value)
-	return result, err
+func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Result(ctx context.Context) (resp VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8203,12 +7635,9 @@ func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) ResumeT
 
 // Resume rehydrates a VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StartPacketCapture", token, client.pl); err != nil {
-		return VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller) Resume(token string, client *VirtualNetworkGatewayConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StartPacketCapture", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -8227,20 +7656,19 @@ func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Done() b
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Value)
-	return result, err
+func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Result(ctx context.Context) (resp VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8261,12 +7689,9 @@ func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) ResumeTo
 
 // Resume rehydrates a VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StopPacketCapture", token, client.pl); err != nil {
-		return VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller) Resume(token string, client *VirtualNetworkGatewayConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StopPacketCapture", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewayConnectionsClientUpdateTagsPoller provides polling facilities until the operation reaches a terminal state.
@@ -8285,20 +7710,19 @@ func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Poll(ctx context.Context) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
-	result := VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGatewayConnection)
-	return result, err
+func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Result(ctx context.Context) (resp VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8319,12 +7743,9 @@ func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) ResumeToken() (
 
 // Resume rehydrates a VirtualNetworkGatewayConnectionsClientUpdateTagsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.UpdateTags", token, client.pl); err != nil {
-		return VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller) Resume(token string, client *VirtualNetworkGatewayConnectionsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.UpdateTags", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -8343,20 +7764,19 @@ func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
-	result := VirtualNetworkGatewaysClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGateway)
-	return result, err
+func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8377,12 +7797,9 @@ func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) ResumeToken() (string
 
 // Resume rehydrates a VirtualNetworkGatewaysClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientCreateOrUpdatePoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -8401,20 +7818,19 @@ func (p *VirtualNetworkGatewaysClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientDeleteResponse, error) {
-	result := VirtualNetworkGatewaysClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualNetworkGatewaysClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientDeletePoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8435,12 +7851,9 @@ func (p *VirtualNetworkGatewaysClientDeletePoller) ResumeToken() (string, error)
 
 // Resume rehydrates a VirtualNetworkGatewaysClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Delete", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientDeletePoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller provides polling facilities until the operation reaches a terminal state.
@@ -8459,20 +7872,19 @@ func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectio
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
-	result := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8493,12 +7905,9 @@ func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectio
 
 // Resume rehydrates a VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientGenerateVPNProfilePoller provides polling facilities until the operation reaches a terminal state.
@@ -8517,20 +7926,19 @@ func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
-	result := VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Value)
-	return result, err
+func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientGenerateVPNProfileResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8551,12 +7959,9 @@ func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) ResumeToken() (st
 
 // Resume rehydrates a VirtualNetworkGatewaysClientGenerateVPNProfilePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GenerateVPNProfile", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientGenerateVPNProfilePoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GenerateVPNProfile", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller provides polling facilities until the operation reaches a terminal state.
@@ -8575,20 +7980,19 @@ func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Done() bool
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
-	result := VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Value)
-	return result, err
+func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8609,12 +8013,9 @@ func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) ResumeToken
 
 // Resume rehydrates a VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Generatevpnclientpackage", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Generatevpnclientpackage", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller provides polling facilities until the operation reaches a terminal state.
@@ -8633,20 +8034,19 @@ func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
-	result := VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GatewayRouteListResult)
-	return result, err
+func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8667,12 +8067,9 @@ func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) ResumeToken() (s
 
 // Resume rehydrates a VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetAdvertisedRoutes", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetAdvertisedRoutes", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientGetBgpPeerStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -8691,20 +8088,19 @@ func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
-	result := VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.BgpPeerStatusListResult)
-	return result, err
+func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8725,12 +8121,9 @@ func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) ResumeToken() (stri
 
 // Resume rehydrates a VirtualNetworkGatewaysClientGetBgpPeerStatusPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetBgpPeerStatus", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetBgpPeerStatus", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientGetLearnedRoutesPoller provides polling facilities until the operation reaches a terminal state.
@@ -8749,20 +8142,19 @@ func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
-	result := VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.GatewayRouteListResult)
-	return result, err
+func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientGetLearnedRoutesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8783,12 +8175,9 @@ func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) ResumeToken() (stri
 
 // Resume rehydrates a VirtualNetworkGatewaysClientGetLearnedRoutesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetLearnedRoutes", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientGetLearnedRoutesPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetLearnedRoutes", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller provides polling facilities until the operation reaches a terminal state.
@@ -8807,20 +8196,19 @@ func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Done() bool 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
-	result := VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Value)
-	return result, err
+func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8841,12 +8229,9 @@ func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) ResumeToken(
 
 // Resume rehydrates a VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVPNProfilePackageURL", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVPNProfilePackageURL", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller provides polling facilities until the operation reaches a terminal state.
@@ -8865,20 +8250,19 @@ func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Done() 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
-	result := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNClientConnectionHealthDetailListResult)
-	return result, err
+func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8899,12 +8283,9 @@ func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) ResumeT
 
 // Resume rehydrates a VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller provides polling facilities until the operation reaches a terminal state.
@@ -8923,20 +8304,19 @@ func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Done() b
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
-	result := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNClientIPsecParameters)
-	return result, err
+func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -8957,12 +8337,9 @@ func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) ResumeTo
 
 // Resume rehydrates a VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientResetPoller provides polling facilities until the operation reaches a terminal state.
@@ -8981,20 +8358,19 @@ func (p *VirtualNetworkGatewaysClientResetPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientResetPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientResetResponse, error) {
-	result := VirtualNetworkGatewaysClientResetResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGateway)
-	return result, err
+func (p *VirtualNetworkGatewaysClientResetPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientResetPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientResetResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9015,12 +8391,9 @@ func (p *VirtualNetworkGatewaysClientResetPoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a VirtualNetworkGatewaysClientResetPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientResetPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientResetResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Reset", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientResetResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientResetPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Reset", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller provides polling facilities until the operation reaches a terminal state.
@@ -9039,20 +8412,19 @@ func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Done() bool 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
-	result := VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9073,12 +8445,9 @@ func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) ResumeToken(
 
 // Resume rehydrates a VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.ResetVPNClientSharedKey", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.ResetVPNClientSharedKey", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller provides polling facilities until the operation reaches a terminal state.
@@ -9097,20 +8466,19 @@ func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Done() b
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
-	result := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VPNClientIPsecParameters)
-	return result, err
+func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9131,12 +8499,9 @@ func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) ResumeTo
 
 // Resume rehydrates a VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientStartPacketCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -9155,20 +8520,19 @@ func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
-	result := VirtualNetworkGatewaysClientStartPacketCaptureResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Value)
-	return result, err
+func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientStartPacketCaptureResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9189,12 +8553,9 @@ func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) ResumeToken() (st
 
 // Resume rehydrates a VirtualNetworkGatewaysClientStartPacketCapturePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StartPacketCapture", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientStartPacketCaptureResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientStartPacketCapturePoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StartPacketCapture", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientStopPacketCapturePoller provides polling facilities until the operation reaches a terminal state.
@@ -9213,20 +8574,19 @@ func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
-	result := VirtualNetworkGatewaysClientStopPacketCaptureResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.Value)
-	return result, err
+func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientStopPacketCaptureResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9247,12 +8607,9 @@ func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) ResumeToken() (str
 
 // Resume rehydrates a VirtualNetworkGatewaysClientStopPacketCapturePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StopPacketCapture", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientStopPacketCaptureResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientStopPacketCapturePoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StopPacketCapture", token, client.pl)
+	return
 }
 
 // VirtualNetworkGatewaysClientUpdateTagsPoller provides polling facilities until the operation reaches a terminal state.
@@ -9271,20 +8628,19 @@ func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Poll(ctx context.Context) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
-	result := VirtualNetworkGatewaysClientUpdateTagsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkGateway)
-	return result, err
+func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Result(ctx context.Context) (resp VirtualNetworkGatewaysClientUpdateTagsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9305,12 +8661,9 @@ func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) ResumeToken() (string, er
 
 // Resume rehydrates a VirtualNetworkGatewaysClientUpdateTagsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.UpdateTags", token, client.pl); err != nil {
-		return VirtualNetworkGatewaysClientUpdateTagsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkGatewaysClientUpdateTagsPoller) Resume(token string, client *VirtualNetworkGatewaysClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.UpdateTags", token, client.pl)
+	return
 }
 
 // VirtualNetworkPeeringsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -9329,20 +8682,19 @@ func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
-	result := VirtualNetworkPeeringsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkPeering)
-	return result, err
+func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualNetworkPeeringsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9363,12 +8715,9 @@ func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) ResumeToken() (string
 
 // Resume rehydrates a VirtualNetworkPeeringsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworkPeeringsClient, token string) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualNetworkPeeringsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkPeeringsClientCreateOrUpdatePoller) Resume(token string, client *VirtualNetworkPeeringsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualNetworkPeeringsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -9387,20 +8736,19 @@ func (p *VirtualNetworkPeeringsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkPeeringsClientDeletePoller) Poll(ctx context.Context) (VirtualNetworkPeeringsClientDeleteResponse, error) {
-	result := VirtualNetworkPeeringsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualNetworkPeeringsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkPeeringsClientDeletePoller) Result(ctx context.Context) (resp VirtualNetworkPeeringsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9421,12 +8769,9 @@ func (p *VirtualNetworkPeeringsClientDeletePoller) ResumeToken() (string, error)
 
 // Resume rehydrates a VirtualNetworkPeeringsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkPeeringsClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworkPeeringsClient, token string) (VirtualNetworkPeeringsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.Delete", token, client.pl); err != nil {
-		return VirtualNetworkPeeringsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkPeeringsClientDeletePoller) Resume(token string, client *VirtualNetworkPeeringsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualNetworkTapsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -9445,20 +8790,19 @@ func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
-	result := VirtualNetworkTapsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetworkTap)
-	return result, err
+func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualNetworkTapsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9479,12 +8823,9 @@ func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) ResumeToken() (string, er
 
 // Resume rehydrates a VirtualNetworkTapsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworkTapsClient, token string) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkTapsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualNetworkTapsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkTapsClientCreateOrUpdatePoller) Resume(token string, client *VirtualNetworkTapsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkTapsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualNetworkTapsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -9503,20 +8844,19 @@ func (p *VirtualNetworkTapsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworkTapsClientDeletePoller) Poll(ctx context.Context) (VirtualNetworkTapsClientDeleteResponse, error) {
-	result := VirtualNetworkTapsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualNetworkTapsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworkTapsClientDeletePoller) Result(ctx context.Context) (resp VirtualNetworkTapsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9537,12 +8877,9 @@ func (p *VirtualNetworkTapsClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualNetworkTapsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworkTapsClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworkTapsClient, token string) (VirtualNetworkTapsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkTapsClient.Delete", token, client.pl); err != nil {
-		return VirtualNetworkTapsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworkTapsClientDeletePoller) Resume(token string, client *VirtualNetworkTapsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworkTapsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualNetworksClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -9561,20 +8898,19 @@ func (p *VirtualNetworksClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworksClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualNetworksClientCreateOrUpdateResponse, error) {
-	result := VirtualNetworksClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualNetwork)
-	return result, err
+func (p *VirtualNetworksClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworksClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualNetworksClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9595,12 +8931,9 @@ func (p *VirtualNetworksClientCreateOrUpdatePoller) ResumeToken() (string, error
 
 // Resume rehydrates a VirtualNetworksClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworksClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualNetworksClient, token string) (VirtualNetworksClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworksClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualNetworksClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworksClientCreateOrUpdatePoller) Resume(token string, client *VirtualNetworksClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworksClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualNetworksClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -9619,20 +8952,19 @@ func (p *VirtualNetworksClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualNetworksClientDeletePoller) Poll(ctx context.Context) (VirtualNetworksClientDeleteResponse, error) {
-	result := VirtualNetworksClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualNetworksClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualNetworksClientDeletePoller) Result(ctx context.Context) (resp VirtualNetworksClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9653,12 +8985,9 @@ func (p *VirtualNetworksClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualNetworksClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualNetworksClientDeletePoller) Resume(ctx context.Context, client *VirtualNetworksClient, token string) (VirtualNetworksClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworksClient.Delete", token, client.pl); err != nil {
-		return VirtualNetworksClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualNetworksClientDeletePoller) Resume(token string, client *VirtualNetworksClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualNetworksClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualRouterPeeringsClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -9677,20 +9006,19 @@ func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
-	result := VirtualRouterPeeringsClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualRouterPeering)
-	return result, err
+func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualRouterPeeringsClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9711,12 +9039,9 @@ func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) ResumeToken() (string,
 
 // Resume rehydrates a VirtualRouterPeeringsClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualRouterPeeringsClient, token string) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRouterPeeringsClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualRouterPeeringsClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualRouterPeeringsClientCreateOrUpdatePoller) Resume(token string, client *VirtualRouterPeeringsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRouterPeeringsClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualRouterPeeringsClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -9735,20 +9060,19 @@ func (p *VirtualRouterPeeringsClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualRouterPeeringsClientDeletePoller) Poll(ctx context.Context) (VirtualRouterPeeringsClientDeleteResponse, error) {
-	result := VirtualRouterPeeringsClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualRouterPeeringsClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualRouterPeeringsClientDeletePoller) Result(ctx context.Context) (resp VirtualRouterPeeringsClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9769,12 +9093,9 @@ func (p *VirtualRouterPeeringsClientDeletePoller) ResumeToken() (string, error) 
 
 // Resume rehydrates a VirtualRouterPeeringsClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualRouterPeeringsClientDeletePoller) Resume(ctx context.Context, client *VirtualRouterPeeringsClient, token string) (VirtualRouterPeeringsClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRouterPeeringsClient.Delete", token, client.pl); err != nil {
-		return VirtualRouterPeeringsClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualRouterPeeringsClientDeletePoller) Resume(token string, client *VirtualRouterPeeringsClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRouterPeeringsClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualRoutersClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -9793,20 +9114,19 @@ func (p *VirtualRoutersClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualRoutersClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualRoutersClientCreateOrUpdateResponse, error) {
-	result := VirtualRoutersClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualRouter)
-	return result, err
+func (p *VirtualRoutersClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualRoutersClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualRoutersClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9827,12 +9147,9 @@ func (p *VirtualRoutersClientCreateOrUpdatePoller) ResumeToken() (string, error)
 
 // Resume rehydrates a VirtualRoutersClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualRoutersClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualRoutersClient, token string) (VirtualRoutersClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRoutersClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualRoutersClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualRoutersClientCreateOrUpdatePoller) Resume(token string, client *VirtualRoutersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRoutersClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualRoutersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -9851,20 +9168,19 @@ func (p *VirtualRoutersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualRoutersClientDeletePoller) Poll(ctx context.Context) (VirtualRoutersClientDeleteResponse, error) {
-	result := VirtualRoutersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualRoutersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualRoutersClientDeletePoller) Result(ctx context.Context) (resp VirtualRoutersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9885,12 +9201,9 @@ func (p *VirtualRoutersClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualRoutersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualRoutersClientDeletePoller) Resume(ctx context.Context, client *VirtualRoutersClient, token string) (VirtualRoutersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRoutersClient.Delete", token, client.pl); err != nil {
-		return VirtualRoutersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualRoutersClientDeletePoller) Resume(token string, client *VirtualRoutersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualRoutersClient.Delete", token, client.pl)
+	return
 }
 
 // VirtualWansClientCreateOrUpdatePoller provides polling facilities until the operation reaches a terminal state.
@@ -9909,20 +9222,19 @@ func (p *VirtualWansClientCreateOrUpdatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualWansClientCreateOrUpdatePoller) Poll(ctx context.Context) (VirtualWansClientCreateOrUpdateResponse, error) {
-	result := VirtualWansClientCreateOrUpdateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VirtualWAN)
-	return result, err
+func (p *VirtualWansClientCreateOrUpdatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualWansClientCreateOrUpdatePoller) Result(ctx context.Context) (resp VirtualWansClientCreateOrUpdateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -9943,12 +9255,9 @@ func (p *VirtualWansClientCreateOrUpdatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualWansClientCreateOrUpdatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualWansClientCreateOrUpdatePoller) Resume(ctx context.Context, client *VirtualWansClient, token string) (VirtualWansClientCreateOrUpdateResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualWansClient.CreateOrUpdate", token, client.pl); err != nil {
-		return VirtualWansClientCreateOrUpdateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualWansClientCreateOrUpdatePoller) Resume(token string, client *VirtualWansClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualWansClient.CreateOrUpdate", token, client.pl)
+	return
 }
 
 // VirtualWansClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -9967,20 +9276,19 @@ func (p *VirtualWansClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *VirtualWansClientDeletePoller) Poll(ctx context.Context) (VirtualWansClientDeleteResponse, error) {
-	result := VirtualWansClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *VirtualWansClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *VirtualWansClientDeletePoller) Result(ctx context.Context) (resp VirtualWansClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10001,12 +9309,9 @@ func (p *VirtualWansClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a VirtualWansClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *VirtualWansClientDeletePoller) Resume(ctx context.Context, client *VirtualWansClient, token string) (VirtualWansClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("VirtualWansClient.Delete", token, client.pl); err != nil {
-		return VirtualWansClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *VirtualWansClientDeletePoller) Resume(token string, client *VirtualWansClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("VirtualWansClient.Delete", token, client.pl)
+	return
 }
 
 // WatchersClientCheckConnectivityPoller provides polling facilities until the operation reaches a terminal state.
@@ -10025,20 +9330,19 @@ func (p *WatchersClientCheckConnectivityPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientCheckConnectivityPoller) Poll(ctx context.Context) (WatchersClientCheckConnectivityResponse, error) {
-	result := WatchersClientCheckConnectivityResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ConnectivityInformation)
-	return result, err
+func (p *WatchersClientCheckConnectivityPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientCheckConnectivityPoller) Result(ctx context.Context) (resp WatchersClientCheckConnectivityResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10059,12 +9363,9 @@ func (p *WatchersClientCheckConnectivityPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a WatchersClientCheckConnectivityPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientCheckConnectivityPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientCheckConnectivityResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.CheckConnectivity", token, client.pl); err != nil {
-		return WatchersClientCheckConnectivityResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientCheckConnectivityPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.CheckConnectivity", token, client.pl)
+	return
 }
 
 // WatchersClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -10083,20 +9384,19 @@ func (p *WatchersClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientDeletePoller) Poll(ctx context.Context) (WatchersClientDeleteResponse, error) {
-	result := WatchersClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *WatchersClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientDeletePoller) Result(ctx context.Context) (resp WatchersClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10117,12 +9417,9 @@ func (p *WatchersClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a WatchersClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientDeletePoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.Delete", token, client.pl); err != nil {
-		return WatchersClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientDeletePoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.Delete", token, client.pl)
+	return
 }
 
 // WatchersClientGetAzureReachabilityReportPoller provides polling facilities until the operation reaches a terminal state.
@@ -10141,20 +9438,19 @@ func (p *WatchersClientGetAzureReachabilityReportPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientGetAzureReachabilityReportPoller) Poll(ctx context.Context) (WatchersClientGetAzureReachabilityReportResponse, error) {
-	result := WatchersClientGetAzureReachabilityReportResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.AzureReachabilityReport)
-	return result, err
+func (p *WatchersClientGetAzureReachabilityReportPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientGetAzureReachabilityReportPoller) Result(ctx context.Context) (resp WatchersClientGetAzureReachabilityReportResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10175,12 +9471,9 @@ func (p *WatchersClientGetAzureReachabilityReportPoller) ResumeToken() (string, 
 
 // Resume rehydrates a WatchersClientGetAzureReachabilityReportPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientGetAzureReachabilityReportPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetAzureReachabilityReportResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetAzureReachabilityReport", token, client.pl); err != nil {
-		return WatchersClientGetAzureReachabilityReportResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientGetAzureReachabilityReportPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetAzureReachabilityReport", token, client.pl)
+	return
 }
 
 // WatchersClientGetFlowLogStatusPoller provides polling facilities until the operation reaches a terminal state.
@@ -10199,20 +9492,19 @@ func (p *WatchersClientGetFlowLogStatusPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientGetFlowLogStatusPoller) Poll(ctx context.Context) (WatchersClientGetFlowLogStatusResponse, error) {
-	result := WatchersClientGetFlowLogStatusResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.FlowLogInformation)
-	return result, err
+func (p *WatchersClientGetFlowLogStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientGetFlowLogStatusPoller) Result(ctx context.Context) (resp WatchersClientGetFlowLogStatusResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10233,12 +9525,9 @@ func (p *WatchersClientGetFlowLogStatusPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a WatchersClientGetFlowLogStatusPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientGetFlowLogStatusPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetFlowLogStatusResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetFlowLogStatus", token, client.pl); err != nil {
-		return WatchersClientGetFlowLogStatusResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientGetFlowLogStatusPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetFlowLogStatus", token, client.pl)
+	return
 }
 
 // WatchersClientGetNetworkConfigurationDiagnosticPoller provides polling facilities until the operation reaches a terminal state.
@@ -10257,20 +9546,19 @@ func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Poll(ctx context.Context) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
-	result := WatchersClientGetNetworkConfigurationDiagnosticResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.ConfigurationDiagnosticResponse)
-	return result, err
+func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Result(ctx context.Context) (resp WatchersClientGetNetworkConfigurationDiagnosticResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10291,12 +9579,9 @@ func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) ResumeToken() (s
 
 // Resume rehydrates a WatchersClientGetNetworkConfigurationDiagnosticPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetNetworkConfigurationDiagnostic", token, client.pl); err != nil {
-		return WatchersClientGetNetworkConfigurationDiagnosticResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientGetNetworkConfigurationDiagnosticPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetNetworkConfigurationDiagnostic", token, client.pl)
+	return
 }
 
 // WatchersClientGetNextHopPoller provides polling facilities until the operation reaches a terminal state.
@@ -10315,20 +9600,19 @@ func (p *WatchersClientGetNextHopPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientGetNextHopPoller) Poll(ctx context.Context) (WatchersClientGetNextHopResponse, error) {
-	result := WatchersClientGetNextHopResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.NextHopResult)
-	return result, err
+func (p *WatchersClientGetNextHopPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientGetNextHopPoller) Result(ctx context.Context) (resp WatchersClientGetNextHopResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10349,12 +9633,9 @@ func (p *WatchersClientGetNextHopPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a WatchersClientGetNextHopPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientGetNextHopPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetNextHopResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetNextHop", token, client.pl); err != nil {
-		return WatchersClientGetNextHopResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientGetNextHopPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetNextHop", token, client.pl)
+	return
 }
 
 // WatchersClientGetTroubleshootingPoller provides polling facilities until the operation reaches a terminal state.
@@ -10373,20 +9654,19 @@ func (p *WatchersClientGetTroubleshootingPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientGetTroubleshootingPoller) Poll(ctx context.Context) (WatchersClientGetTroubleshootingResponse, error) {
-	result := WatchersClientGetTroubleshootingResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.TroubleshootingResult)
-	return result, err
+func (p *WatchersClientGetTroubleshootingPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientGetTroubleshootingPoller) Result(ctx context.Context) (resp WatchersClientGetTroubleshootingResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10407,12 +9687,9 @@ func (p *WatchersClientGetTroubleshootingPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a WatchersClientGetTroubleshootingPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientGetTroubleshootingPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetTroubleshootingResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshooting", token, client.pl); err != nil {
-		return WatchersClientGetTroubleshootingResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientGetTroubleshootingPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshooting", token, client.pl)
+	return
 }
 
 // WatchersClientGetTroubleshootingResultPoller provides polling facilities until the operation reaches a terminal state.
@@ -10431,20 +9708,19 @@ func (p *WatchersClientGetTroubleshootingResultPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientGetTroubleshootingResultPoller) Poll(ctx context.Context) (WatchersClientGetTroubleshootingResultResponse, error) {
-	result := WatchersClientGetTroubleshootingResultResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.TroubleshootingResult)
-	return result, err
+func (p *WatchersClientGetTroubleshootingResultPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientGetTroubleshootingResultPoller) Result(ctx context.Context) (resp WatchersClientGetTroubleshootingResultResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10465,12 +9741,9 @@ func (p *WatchersClientGetTroubleshootingResultPoller) ResumeToken() (string, er
 
 // Resume rehydrates a WatchersClientGetTroubleshootingResultPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientGetTroubleshootingResultPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetTroubleshootingResultResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshootingResult", token, client.pl); err != nil {
-		return WatchersClientGetTroubleshootingResultResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientGetTroubleshootingResultPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshootingResult", token, client.pl)
+	return
 }
 
 // WatchersClientGetVMSecurityRulesPoller provides polling facilities until the operation reaches a terminal state.
@@ -10489,20 +9762,19 @@ func (p *WatchersClientGetVMSecurityRulesPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientGetVMSecurityRulesPoller) Poll(ctx context.Context) (WatchersClientGetVMSecurityRulesResponse, error) {
-	result := WatchersClientGetVMSecurityRulesResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SecurityGroupViewResult)
-	return result, err
+func (p *WatchersClientGetVMSecurityRulesPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientGetVMSecurityRulesPoller) Result(ctx context.Context) (resp WatchersClientGetVMSecurityRulesResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10523,12 +9795,9 @@ func (p *WatchersClientGetVMSecurityRulesPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a WatchersClientGetVMSecurityRulesPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientGetVMSecurityRulesPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientGetVMSecurityRulesResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetVMSecurityRules", token, client.pl); err != nil {
-		return WatchersClientGetVMSecurityRulesResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientGetVMSecurityRulesPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.GetVMSecurityRules", token, client.pl)
+	return
 }
 
 // WatchersClientListAvailableProvidersPoller provides polling facilities until the operation reaches a terminal state.
@@ -10547,20 +9816,19 @@ func (p *WatchersClientListAvailableProvidersPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientListAvailableProvidersPoller) Poll(ctx context.Context) (WatchersClientListAvailableProvidersResponse, error) {
-	result := WatchersClientListAvailableProvidersResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.AvailableProvidersList)
-	return result, err
+func (p *WatchersClientListAvailableProvidersPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientListAvailableProvidersPoller) Result(ctx context.Context) (resp WatchersClientListAvailableProvidersResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10581,12 +9849,9 @@ func (p *WatchersClientListAvailableProvidersPoller) ResumeToken() (string, erro
 
 // Resume rehydrates a WatchersClientListAvailableProvidersPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientListAvailableProvidersPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientListAvailableProvidersResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.ListAvailableProviders", token, client.pl); err != nil {
-		return WatchersClientListAvailableProvidersResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientListAvailableProvidersPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.ListAvailableProviders", token, client.pl)
+	return
 }
 
 // WatchersClientSetFlowLogConfigurationPoller provides polling facilities until the operation reaches a terminal state.
@@ -10605,20 +9870,19 @@ func (p *WatchersClientSetFlowLogConfigurationPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientSetFlowLogConfigurationPoller) Poll(ctx context.Context) (WatchersClientSetFlowLogConfigurationResponse, error) {
-	result := WatchersClientSetFlowLogConfigurationResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.FlowLogInformation)
-	return result, err
+func (p *WatchersClientSetFlowLogConfigurationPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientSetFlowLogConfigurationPoller) Result(ctx context.Context) (resp WatchersClientSetFlowLogConfigurationResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10639,12 +9903,9 @@ func (p *WatchersClientSetFlowLogConfigurationPoller) ResumeToken() (string, err
 
 // Resume rehydrates a WatchersClientSetFlowLogConfigurationPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientSetFlowLogConfigurationPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientSetFlowLogConfigurationResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.SetFlowLogConfiguration", token, client.pl); err != nil {
-		return WatchersClientSetFlowLogConfigurationResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientSetFlowLogConfigurationPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.SetFlowLogConfiguration", token, client.pl)
+	return
 }
 
 // WatchersClientVerifyIPFlowPoller provides polling facilities until the operation reaches a terminal state.
@@ -10663,20 +9924,19 @@ func (p *WatchersClientVerifyIPFlowPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WatchersClientVerifyIPFlowPoller) Poll(ctx context.Context) (WatchersClientVerifyIPFlowResponse, error) {
-	result := WatchersClientVerifyIPFlowResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.VerificationIPFlowResult)
-	return result, err
+func (p *WatchersClientVerifyIPFlowPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WatchersClientVerifyIPFlowPoller) Result(ctx context.Context) (resp WatchersClientVerifyIPFlowResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10697,12 +9957,9 @@ func (p *WatchersClientVerifyIPFlowPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a WatchersClientVerifyIPFlowPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WatchersClientVerifyIPFlowPoller) Resume(ctx context.Context, client *WatchersClient, token string) (WatchersClientVerifyIPFlowResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.VerifyIPFlow", token, client.pl); err != nil {
-		return WatchersClientVerifyIPFlowResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WatchersClientVerifyIPFlowPoller) Resume(token string, client *WatchersClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WatchersClient.VerifyIPFlow", token, client.pl)
+	return
 }
 
 // WebApplicationFirewallPoliciesClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -10721,20 +9978,19 @@ func (p *WebApplicationFirewallPoliciesClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *WebApplicationFirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
-	result := WebApplicationFirewallPoliciesClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *WebApplicationFirewallPoliciesClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *WebApplicationFirewallPoliciesClientDeletePoller) Result(ctx context.Context) (resp WebApplicationFirewallPoliciesClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -10755,10 +10011,7 @@ func (p *WebApplicationFirewallPoliciesClientDeletePoller) ResumeToken() (string
 
 // Resume rehydrates a WebApplicationFirewallPoliciesClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *WebApplicationFirewallPoliciesClientDeletePoller) Resume(ctx context.Context, client *WebApplicationFirewallPoliciesClient, token string) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = armruntime.NewPollerFromResumeToken("WebApplicationFirewallPoliciesClient.Delete", token, client.pl); err != nil {
-		return WebApplicationFirewallPoliciesClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *WebApplicationFirewallPoliciesClientDeletePoller) Resume(token string, client *WebApplicationFirewallPoliciesClient) (err error) {
+	p.pt, err = armruntime.NewPollerFromResumeToken("WebApplicationFirewallPoliciesClient.Delete", token, client.pl)
+	return
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
@@ -58,20 +58,16 @@ func NewPrivateDNSZoneGroupsClient(subscriptionID string, credential azcore.Toke
 // parameters - Parameters supplied to the create or update private dns zone group operation.
 // options - PrivateDNSZoneGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the PrivateDNSZoneGroupsClient.BeginCreateOrUpdate
 // method.
-func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDNSZoneGroupName string, parameters PrivateDNSZoneGroup, options *PrivateDNSZoneGroupsClientBeginCreateOrUpdateOptions) (PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse, error) {
+func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDNSZoneGroupName string, parameters PrivateDNSZoneGroup, options *PrivateDNSZoneGroupsClientBeginCreateOrUpdateOptions) (*PrivateDNSZoneGroupsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, privateEndpointName, privateDNSZoneGroupName, parameters, options)
 	if err != nil {
-		return PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateDNSZoneGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateDNSZoneGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateDNSZoneGroupsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a private dns zone group in the specified private endpoint.
@@ -128,20 +124,16 @@ func (client *PrivateDNSZoneGroupsClient) createOrUpdateCreateRequest(ctx contex
 // privateDNSZoneGroupName - The name of the private dns zone group.
 // options - PrivateDNSZoneGroupsClientBeginDeleteOptions contains the optional parameters for the PrivateDNSZoneGroupsClient.BeginDelete
 // method.
-func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDNSZoneGroupName string, options *PrivateDNSZoneGroupsClientBeginDeleteOptions) (PrivateDNSZoneGroupsClientDeletePollerResponse, error) {
+func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDNSZoneGroupName string, options *PrivateDNSZoneGroupsClientBeginDeleteOptions) (*PrivateDNSZoneGroupsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, privateEndpointName, privateDNSZoneGroupName, options)
 	if err != nil {
-		return PrivateDNSZoneGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateDNSZoneGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateDNSZoneGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return PrivateDNSZoneGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateDNSZoneGroupsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateDNSZoneGroupsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified private dns zone group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
@@ -57,20 +57,16 @@ func NewPrivateEndpointsClient(subscriptionID string, credential azcore.TokenCre
 // parameters - Parameters supplied to the create or update private endpoint operation.
 // options - PrivateEndpointsClientBeginCreateOrUpdateOptions contains the optional parameters for the PrivateEndpointsClient.BeginCreateOrUpdate
 // method.
-func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint, options *PrivateEndpointsClientBeginCreateOrUpdateOptions) (PrivateEndpointsClientCreateOrUpdatePollerResponse, error) {
+func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint, options *PrivateEndpointsClientBeginCreateOrUpdateOptions) (*PrivateEndpointsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, privateEndpointName, parameters, options)
 	if err != nil {
-		return PrivateEndpointsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateEndpointsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateEndpointsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return PrivateEndpointsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateEndpointsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateEndpointsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates an private endpoint in the specified resource group.
@@ -122,20 +118,16 @@ func (client *PrivateEndpointsClient) createOrUpdateCreateRequest(ctx context.Co
 // privateEndpointName - The name of the private endpoint.
 // options - PrivateEndpointsClientBeginDeleteOptions contains the optional parameters for the PrivateEndpointsClient.BeginDelete
 // method.
-func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsClientBeginDeleteOptions) (PrivateEndpointsClientDeletePollerResponse, error) {
+func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsClientBeginDeleteOptions) (*PrivateEndpointsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, privateEndpointName, options)
 	if err != nil {
-		return PrivateEndpointsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateEndpointsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateEndpointsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return PrivateEndpointsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateEndpointsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateEndpointsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified private endpoint.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
@@ -56,20 +56,16 @@ func NewPrivateLinkServicesClient(subscriptionID string, credential azcore.Token
 // parameters - The request body of CheckPrivateLinkService API call.
 // options - PrivateLinkServicesClientBeginCheckPrivateLinkServiceVisibilityOptions contains the optional parameters for the
 // PrivateLinkServicesClient.BeginCheckPrivateLinkServiceVisibility method.
-func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesClientBeginCheckPrivateLinkServiceVisibilityOptions) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse, error) {
+func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesClientBeginCheckPrivateLinkServiceVisibilityOptions) (*PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller, error) {
 	resp, err := client.checkPrivateLinkServiceVisibility(ctx, location, parameters, options)
 	if err != nil {
-		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility", "location", resp, client.pl)
 	if err != nil {
-		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller{pt: pt}, nil
 }
 
 // CheckPrivateLinkServiceVisibility - Checks whether the subscription is visible to private link service.
@@ -119,20 +115,16 @@ func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityCreate
 // parameters - The request body of CheckPrivateLinkService API call.
 // options - PrivateLinkServicesClientBeginCheckPrivateLinkServiceVisibilityByResourceGroupOptions contains the optional parameters
 // for the PrivateLinkServicesClient.BeginCheckPrivateLinkServiceVisibilityByResourceGroup method.
-func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesClientBeginCheckPrivateLinkServiceVisibilityByResourceGroupOptions) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse, error) {
+func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesClientBeginCheckPrivateLinkServiceVisibilityByResourceGroupOptions) (*PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller, error) {
 	resp, err := client.checkPrivateLinkServiceVisibilityByResourceGroup(ctx, location, resourceGroupName, parameters, options)
 	if err != nil {
-		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup", "location", resp, client.pl)
 	if err != nil {
-		return PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller{pt: pt}, nil
 }
 
 // CheckPrivateLinkServiceVisibilityByResourceGroup - Checks whether the subscription is visible to private link service in
@@ -186,20 +178,16 @@ func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityByReso
 // parameters - Parameters supplied to the create or update private link service operation.
 // options - PrivateLinkServicesClientBeginCreateOrUpdateOptions contains the optional parameters for the PrivateLinkServicesClient.BeginCreateOrUpdate
 // method.
-func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService, options *PrivateLinkServicesClientBeginCreateOrUpdateOptions) (PrivateLinkServicesClientCreateOrUpdatePollerResponse, error) {
+func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService, options *PrivateLinkServicesClientBeginCreateOrUpdateOptions) (*PrivateLinkServicesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, serviceName, parameters, options)
 	if err != nil {
-		return PrivateLinkServicesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateLinkServicesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return PrivateLinkServicesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateLinkServicesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateLinkServicesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates an private link service in the specified resource group.
@@ -251,20 +239,16 @@ func (client *PrivateLinkServicesClient) createOrUpdateCreateRequest(ctx context
 // serviceName - The name of the private link service.
 // options - PrivateLinkServicesClientBeginDeleteOptions contains the optional parameters for the PrivateLinkServicesClient.BeginDelete
 // method.
-func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesClientBeginDeleteOptions) (PrivateLinkServicesClientDeletePollerResponse, error) {
+func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesClientBeginDeleteOptions) (*PrivateLinkServicesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, serviceName, options)
 	if err != nil {
-		return PrivateLinkServicesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateLinkServicesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return PrivateLinkServicesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateLinkServicesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateLinkServicesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified private link service.
@@ -317,20 +301,16 @@ func (client *PrivateLinkServicesClient) deleteCreateRequest(ctx context.Context
 // peConnectionName - The name of the private end point connection.
 // options - PrivateLinkServicesClientBeginDeletePrivateEndpointConnectionOptions contains the optional parameters for the
 // PrivateLinkServicesClient.BeginDeletePrivateEndpointConnection method.
-func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesClientBeginDeletePrivateEndpointConnectionOptions) (PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse, error) {
+func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesClientBeginDeletePrivateEndpointConnectionOptions) (*PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller, error) {
 	resp, err := client.deletePrivateEndpointConnection(ctx, resourceGroupName, serviceName, peConnectionName, options)
 	if err != nil {
-		return PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse{}, err
+		return nil, err
 	}
-	result := PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse{}
 	pt, err := armruntime.NewPoller("PrivateLinkServicesClient.DeletePrivateEndpointConnection", "location", resp, client.pl)
 	if err != nil {
-		return PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller{pt: pt}, nil
 }
 
 // DeletePrivateEndpointConnection - Delete private end point connection for a private link service in a subscription.

--- a/test/network/2020-03-01/armnetwork/zz_generated_profiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_profiles_client.go
@@ -111,20 +111,16 @@ func (client *ProfilesClient) createOrUpdateHandleResponse(resp *http.Response) 
 // resourceGroupName - The name of the resource group.
 // networkProfileName - The name of the NetworkProfile.
 // options - ProfilesClientBeginDeleteOptions contains the optional parameters for the ProfilesClient.BeginDelete method.
-func (client *ProfilesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string, options *ProfilesClientBeginDeleteOptions) (ProfilesClientDeletePollerResponse, error) {
+func (client *ProfilesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string, options *ProfilesClientBeginDeleteOptions) (*ProfilesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkProfileName, options)
 	if err != nil {
-		return ProfilesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ProfilesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ProfilesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ProfilesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ProfilesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ProfilesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified network profile.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
@@ -57,20 +57,16 @@ func NewPublicIPAddressesClient(subscriptionID string, credential azcore.TokenCr
 // parameters - Parameters supplied to the create or update public IP address operation.
 // options - PublicIPAddressesClientBeginCreateOrUpdateOptions contains the optional parameters for the PublicIPAddressesClient.BeginCreateOrUpdate
 // method.
-func (client *PublicIPAddressesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, options *PublicIPAddressesClientBeginCreateOrUpdateOptions) (PublicIPAddressesClientCreateOrUpdatePollerResponse, error) {
+func (client *PublicIPAddressesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, options *PublicIPAddressesClientBeginCreateOrUpdateOptions) (*PublicIPAddressesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, publicIPAddressName, parameters, options)
 	if err != nil {
-		return PublicIPAddressesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := PublicIPAddressesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PublicIPAddressesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return PublicIPAddressesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PublicIPAddressesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PublicIPAddressesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a static or dynamic public IP address.
@@ -122,20 +118,16 @@ func (client *PublicIPAddressesClient) createOrUpdateCreateRequest(ctx context.C
 // publicIPAddressName - The name of the subnet.
 // options - PublicIPAddressesClientBeginDeleteOptions contains the optional parameters for the PublicIPAddressesClient.BeginDelete
 // method.
-func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesClientBeginDeleteOptions) (PublicIPAddressesClientDeletePollerResponse, error) {
+func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesClientBeginDeleteOptions) (*PublicIPAddressesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, publicIPAddressName, options)
 	if err != nil {
-		return PublicIPAddressesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := PublicIPAddressesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PublicIPAddressesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return PublicIPAddressesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PublicIPAddressesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PublicIPAddressesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified public IP address.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
@@ -57,20 +57,16 @@ func NewPublicIPPrefixesClient(subscriptionID string, credential azcore.TokenCre
 // parameters - Parameters supplied to the create or update public IP prefix operation.
 // options - PublicIPPrefixesClientBeginCreateOrUpdateOptions contains the optional parameters for the PublicIPPrefixesClient.BeginCreateOrUpdate
 // method.
-func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix, options *PublicIPPrefixesClientBeginCreateOrUpdateOptions) (PublicIPPrefixesClientCreateOrUpdatePollerResponse, error) {
+func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix, options *PublicIPPrefixesClientBeginCreateOrUpdateOptions) (*PublicIPPrefixesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, publicIPPrefixName, parameters, options)
 	if err != nil {
-		return PublicIPPrefixesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := PublicIPPrefixesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("PublicIPPrefixesClient.CreateOrUpdate", "location", resp, client.pl)
 	if err != nil {
-		return PublicIPPrefixesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PublicIPPrefixesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PublicIPPrefixesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a static or dynamic public IP prefix.
@@ -122,20 +118,16 @@ func (client *PublicIPPrefixesClient) createOrUpdateCreateRequest(ctx context.Co
 // publicIPPrefixName - The name of the PublicIpPrefix.
 // options - PublicIPPrefixesClientBeginDeleteOptions contains the optional parameters for the PublicIPPrefixesClient.BeginDelete
 // method.
-func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesClientBeginDeleteOptions) (PublicIPPrefixesClientDeletePollerResponse, error) {
+func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesClientBeginDeleteOptions) (*PublicIPPrefixesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, publicIPPrefixName, options)
 	if err != nil {
-		return PublicIPPrefixesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := PublicIPPrefixesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("PublicIPPrefixesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return PublicIPPrefixesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &PublicIPPrefixesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &PublicIPPrefixesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified public IP prefix.

--- a/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
@@ -8,85 +8,9 @@
 
 package armnetwork
 
-import (
-	"context"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"time"
-)
-
-// ApplicationGatewaysClientBackendHealthOnDemandPollerResponse contains the response from method ApplicationGatewaysClient.BackendHealthOnDemand.
-type ApplicationGatewaysClientBackendHealthOnDemandPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ApplicationGatewaysClientBackendHealthOnDemandPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ApplicationGatewaysClientBackendHealthOnDemandPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientBackendHealthOnDemandResponse, error) {
-	respType := ApplicationGatewaysClientBackendHealthOnDemandResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGatewayBackendHealthOnDemand)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ApplicationGatewaysClientBackendHealthOnDemandPollerResponse from the provided client and resume token.
-func (l *ApplicationGatewaysClientBackendHealthOnDemandPollerResponse) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealthOnDemand", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ApplicationGatewaysClientBackendHealthOnDemandPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ApplicationGatewaysClientBackendHealthOnDemandResponse contains the response from method ApplicationGatewaysClient.BackendHealthOnDemand.
 type ApplicationGatewaysClientBackendHealthOnDemandResponse struct {
 	ApplicationGatewayBackendHealthOnDemand
-}
-
-// ApplicationGatewaysClientBackendHealthPollerResponse contains the response from method ApplicationGatewaysClient.BackendHealth.
-type ApplicationGatewaysClientBackendHealthPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ApplicationGatewaysClientBackendHealthPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ApplicationGatewaysClientBackendHealthPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientBackendHealthResponse, error) {
-	respType := ApplicationGatewaysClientBackendHealthResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGatewayBackendHealth)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ApplicationGatewaysClientBackendHealthPollerResponse from the provided client and resume token.
-func (l *ApplicationGatewaysClientBackendHealthPollerResponse) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealth", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ApplicationGatewaysClientBackendHealthPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ApplicationGatewaysClientBackendHealthResponse contains the response from method ApplicationGatewaysClient.BackendHealth.
@@ -94,79 +18,9 @@ type ApplicationGatewaysClientBackendHealthResponse struct {
 	ApplicationGatewayBackendHealth
 }
 
-// ApplicationGatewaysClientCreateOrUpdatePollerResponse contains the response from method ApplicationGatewaysClient.CreateOrUpdate.
-type ApplicationGatewaysClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ApplicationGatewaysClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ApplicationGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientCreateOrUpdateResponse, error) {
-	respType := ApplicationGatewaysClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ApplicationGatewaysClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ApplicationGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ApplicationGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ApplicationGatewaysClientCreateOrUpdateResponse contains the response from method ApplicationGatewaysClient.CreateOrUpdate.
 type ApplicationGatewaysClientCreateOrUpdateResponse struct {
 	ApplicationGateway
-}
-
-// ApplicationGatewaysClientDeletePollerResponse contains the response from method ApplicationGatewaysClient.Delete.
-type ApplicationGatewaysClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ApplicationGatewaysClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ApplicationGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientDeleteResponse, error) {
-	respType := ApplicationGatewaysClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ApplicationGatewaysClientDeletePollerResponse from the provided client and resume token.
-func (l *ApplicationGatewaysClientDeletePollerResponse) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ApplicationGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ApplicationGatewaysClientDeleteResponse contains the response from method ApplicationGatewaysClient.Delete.
@@ -227,79 +81,9 @@ type ApplicationGatewaysClientListResponse struct {
 	ApplicationGatewayListResult
 }
 
-// ApplicationGatewaysClientStartPollerResponse contains the response from method ApplicationGatewaysClient.Start.
-type ApplicationGatewaysClientStartPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ApplicationGatewaysClientStartPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ApplicationGatewaysClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientStartResponse, error) {
-	respType := ApplicationGatewaysClientStartResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ApplicationGatewaysClientStartPollerResponse from the provided client and resume token.
-func (l *ApplicationGatewaysClientStartPollerResponse) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Start", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ApplicationGatewaysClientStartPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ApplicationGatewaysClientStartResponse contains the response from method ApplicationGatewaysClient.Start.
 type ApplicationGatewaysClientStartResponse struct {
 	// placeholder for future response values
-}
-
-// ApplicationGatewaysClientStopPollerResponse contains the response from method ApplicationGatewaysClient.Stop.
-type ApplicationGatewaysClientStopPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ApplicationGatewaysClientStopPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ApplicationGatewaysClientStopPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewaysClientStopResponse, error) {
-	respType := ApplicationGatewaysClientStopResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ApplicationGatewaysClientStopPollerResponse from the provided client and resume token.
-func (l *ApplicationGatewaysClientStopPollerResponse) Resume(ctx context.Context, client *ApplicationGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ApplicationGatewaysClient.Stop", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ApplicationGatewaysClientStopPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ApplicationGatewaysClientStopResponse contains the response from method ApplicationGatewaysClient.Stop.
@@ -312,79 +96,9 @@ type ApplicationGatewaysClientUpdateTagsResponse struct {
 	ApplicationGateway
 }
 
-// ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse contains the response from method ApplicationSecurityGroupsClient.CreateOrUpdate.
-type ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ApplicationSecurityGroupsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationSecurityGroupsClientCreateOrUpdateResponse, error) {
-	respType := ApplicationSecurityGroupsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ApplicationSecurityGroup)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ApplicationSecurityGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ApplicationSecurityGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ApplicationSecurityGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ApplicationSecurityGroupsClientCreateOrUpdateResponse contains the response from method ApplicationSecurityGroupsClient.CreateOrUpdate.
 type ApplicationSecurityGroupsClientCreateOrUpdateResponse struct {
 	ApplicationSecurityGroup
-}
-
-// ApplicationSecurityGroupsClientDeletePollerResponse contains the response from method ApplicationSecurityGroupsClient.Delete.
-type ApplicationSecurityGroupsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ApplicationSecurityGroupsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ApplicationSecurityGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ApplicationSecurityGroupsClientDeleteResponse, error) {
-	respType := ApplicationSecurityGroupsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ApplicationSecurityGroupsClientDeletePollerResponse from the provided client and resume token.
-func (l *ApplicationSecurityGroupsClientDeletePollerResponse) Resume(ctx context.Context, client *ApplicationSecurityGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ApplicationSecurityGroupsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ApplicationSecurityGroupsClientDeleteResponse contains the response from method ApplicationSecurityGroupsClient.Delete.
@@ -452,79 +166,9 @@ type AzureFirewallFqdnTagsClientListAllResponse struct {
 	AzureFirewallFqdnTagListResult
 }
 
-// AzureFirewallsClientCreateOrUpdatePollerResponse contains the response from method AzureFirewallsClient.CreateOrUpdate.
-type AzureFirewallsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *AzureFirewallsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l AzureFirewallsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientCreateOrUpdateResponse, error) {
-	respType := AzureFirewallsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureFirewall)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a AzureFirewallsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *AzureFirewallsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *AzureFirewallsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("AzureFirewallsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &AzureFirewallsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // AzureFirewallsClientCreateOrUpdateResponse contains the response from method AzureFirewallsClient.CreateOrUpdate.
 type AzureFirewallsClientCreateOrUpdateResponse struct {
 	AzureFirewall
-}
-
-// AzureFirewallsClientDeletePollerResponse contains the response from method AzureFirewallsClient.Delete.
-type AzureFirewallsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *AzureFirewallsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l AzureFirewallsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientDeleteResponse, error) {
-	respType := AzureFirewallsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a AzureFirewallsClientDeletePollerResponse from the provided client and resume token.
-func (l *AzureFirewallsClientDeletePollerResponse) Resume(ctx context.Context, client *AzureFirewallsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("AzureFirewallsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &AzureFirewallsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // AzureFirewallsClientDeleteResponse contains the response from method AzureFirewallsClient.Delete.
@@ -547,119 +191,14 @@ type AzureFirewallsClientListResponse struct {
 	AzureFirewallListResult
 }
 
-// AzureFirewallsClientUpdateTagsPollerResponse contains the response from method AzureFirewallsClient.UpdateTags.
-type AzureFirewallsClientUpdateTagsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *AzureFirewallsClientUpdateTagsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l AzureFirewallsClientUpdateTagsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallsClientUpdateTagsResponse, error) {
-	respType := AzureFirewallsClientUpdateTagsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureFirewall)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a AzureFirewallsClientUpdateTagsPollerResponse from the provided client and resume token.
-func (l *AzureFirewallsClientUpdateTagsPollerResponse) Resume(ctx context.Context, client *AzureFirewallsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("AzureFirewallsClient.UpdateTags", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &AzureFirewallsClientUpdateTagsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // AzureFirewallsClientUpdateTagsResponse contains the response from method AzureFirewallsClient.UpdateTags.
 type AzureFirewallsClientUpdateTagsResponse struct {
 	AzureFirewall
 }
 
-// BastionHostsClientCreateOrUpdatePollerResponse contains the response from method BastionHostsClient.CreateOrUpdate.
-type BastionHostsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *BastionHostsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l BastionHostsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BastionHostsClientCreateOrUpdateResponse, error) {
-	respType := BastionHostsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BastionHost)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a BastionHostsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *BastionHostsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *BastionHostsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("BastionHostsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &BastionHostsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // BastionHostsClientCreateOrUpdateResponse contains the response from method BastionHostsClient.CreateOrUpdate.
 type BastionHostsClientCreateOrUpdateResponse struct {
 	BastionHost
-}
-
-// BastionHostsClientDeletePollerResponse contains the response from method BastionHostsClient.Delete.
-type BastionHostsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *BastionHostsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l BastionHostsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (BastionHostsClientDeleteResponse, error) {
-	respType := BastionHostsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a BastionHostsClientDeletePollerResponse from the provided client and resume token.
-func (l *BastionHostsClientDeletePollerResponse) Resume(ctx context.Context, client *BastionHostsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("BastionHostsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &BastionHostsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // BastionHostsClientDeleteResponse contains the response from method BastionHostsClient.Delete.
@@ -687,79 +226,9 @@ type BgpServiceCommunitiesClientListResponse struct {
 	BgpServiceCommunityListResult
 }
 
-// ConnectionMonitorsClientCreateOrUpdatePollerResponse contains the response from method ConnectionMonitorsClient.CreateOrUpdate.
-type ConnectionMonitorsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ConnectionMonitorsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ConnectionMonitorsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientCreateOrUpdateResponse, error) {
-	respType := ConnectionMonitorsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionMonitorResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ConnectionMonitorsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ConnectionMonitorsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ConnectionMonitorsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ConnectionMonitorsClientCreateOrUpdateResponse contains the response from method ConnectionMonitorsClient.CreateOrUpdate.
 type ConnectionMonitorsClientCreateOrUpdateResponse struct {
 	ConnectionMonitorResult
-}
-
-// ConnectionMonitorsClientDeletePollerResponse contains the response from method ConnectionMonitorsClient.Delete.
-type ConnectionMonitorsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ConnectionMonitorsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ConnectionMonitorsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientDeleteResponse, error) {
-	respType := ConnectionMonitorsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ConnectionMonitorsClientDeletePollerResponse from the provided client and resume token.
-func (l *ConnectionMonitorsClientDeletePollerResponse) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ConnectionMonitorsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ConnectionMonitorsClientDeleteResponse contains the response from method ConnectionMonitorsClient.Delete.
@@ -777,119 +246,14 @@ type ConnectionMonitorsClientListResponse struct {
 	ConnectionMonitorListResult
 }
 
-// ConnectionMonitorsClientQueryPollerResponse contains the response from method ConnectionMonitorsClient.Query.
-type ConnectionMonitorsClientQueryPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ConnectionMonitorsClientQueryPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ConnectionMonitorsClientQueryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientQueryResponse, error) {
-	respType := ConnectionMonitorsClientQueryResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionMonitorQueryResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ConnectionMonitorsClientQueryPollerResponse from the provided client and resume token.
-func (l *ConnectionMonitorsClientQueryPollerResponse) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Query", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ConnectionMonitorsClientQueryPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ConnectionMonitorsClientQueryResponse contains the response from method ConnectionMonitorsClient.Query.
 type ConnectionMonitorsClientQueryResponse struct {
 	ConnectionMonitorQueryResult
 }
 
-// ConnectionMonitorsClientStartPollerResponse contains the response from method ConnectionMonitorsClient.Start.
-type ConnectionMonitorsClientStartPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ConnectionMonitorsClientStartPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ConnectionMonitorsClientStartPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientStartResponse, error) {
-	respType := ConnectionMonitorsClientStartResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ConnectionMonitorsClientStartPollerResponse from the provided client and resume token.
-func (l *ConnectionMonitorsClientStartPollerResponse) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Start", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ConnectionMonitorsClientStartPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ConnectionMonitorsClientStartResponse contains the response from method ConnectionMonitorsClient.Start.
 type ConnectionMonitorsClientStartResponse struct {
 	// placeholder for future response values
-}
-
-// ConnectionMonitorsClientStopPollerResponse contains the response from method ConnectionMonitorsClient.Stop.
-type ConnectionMonitorsClientStopPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ConnectionMonitorsClientStopPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ConnectionMonitorsClientStopPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorsClientStopResponse, error) {
-	respType := ConnectionMonitorsClientStopResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ConnectionMonitorsClientStopPollerResponse from the provided client and resume token.
-func (l *ConnectionMonitorsClientStopPollerResponse) Resume(ctx context.Context, client *ConnectionMonitorsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ConnectionMonitorsClient.Stop", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ConnectionMonitorsClientStopPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ConnectionMonitorsClientStopResponse contains the response from method ConnectionMonitorsClient.Stop.
@@ -902,79 +266,9 @@ type ConnectionMonitorsClientUpdateTagsResponse struct {
 	ConnectionMonitorResult
 }
 
-// DdosCustomPoliciesClientCreateOrUpdatePollerResponse contains the response from method DdosCustomPoliciesClient.CreateOrUpdate.
-type DdosCustomPoliciesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DdosCustomPoliciesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DdosCustomPoliciesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DdosCustomPoliciesClientCreateOrUpdateResponse, error) {
-	respType := DdosCustomPoliciesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DdosCustomPolicy)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DdosCustomPoliciesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *DdosCustomPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *DdosCustomPoliciesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DdosCustomPoliciesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DdosCustomPoliciesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DdosCustomPoliciesClientCreateOrUpdateResponse contains the response from method DdosCustomPoliciesClient.CreateOrUpdate.
 type DdosCustomPoliciesClientCreateOrUpdateResponse struct {
 	DdosCustomPolicy
-}
-
-// DdosCustomPoliciesClientDeletePollerResponse contains the response from method DdosCustomPoliciesClient.Delete.
-type DdosCustomPoliciesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DdosCustomPoliciesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DdosCustomPoliciesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DdosCustomPoliciesClientDeleteResponse, error) {
-	respType := DdosCustomPoliciesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DdosCustomPoliciesClientDeletePollerResponse from the provided client and resume token.
-func (l *DdosCustomPoliciesClientDeletePollerResponse) Resume(ctx context.Context, client *DdosCustomPoliciesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DdosCustomPoliciesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DdosCustomPoliciesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DdosCustomPoliciesClientDeleteResponse contains the response from method DdosCustomPoliciesClient.Delete.
@@ -992,79 +286,9 @@ type DdosCustomPoliciesClientUpdateTagsResponse struct {
 	DdosCustomPolicy
 }
 
-// DdosProtectionPlansClientCreateOrUpdatePollerResponse contains the response from method DdosProtectionPlansClient.CreateOrUpdate.
-type DdosProtectionPlansClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DdosProtectionPlansClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DdosProtectionPlansClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DdosProtectionPlansClientCreateOrUpdateResponse, error) {
-	respType := DdosProtectionPlansClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DdosProtectionPlan)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DdosProtectionPlansClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *DdosProtectionPlansClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *DdosProtectionPlansClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DdosProtectionPlansClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DdosProtectionPlansClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // DdosProtectionPlansClientCreateOrUpdateResponse contains the response from method DdosProtectionPlansClient.CreateOrUpdate.
 type DdosProtectionPlansClientCreateOrUpdateResponse struct {
 	DdosProtectionPlan
-}
-
-// DdosProtectionPlansClientDeletePollerResponse contains the response from method DdosProtectionPlansClient.Delete.
-type DdosProtectionPlansClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *DdosProtectionPlansClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l DdosProtectionPlansClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (DdosProtectionPlansClientDeleteResponse, error) {
-	respType := DdosProtectionPlansClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a DdosProtectionPlansClientDeletePollerResponse from the provided client and resume token.
-func (l *DdosProtectionPlansClientDeletePollerResponse) Resume(ctx context.Context, client *DdosProtectionPlansClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("DdosProtectionPlansClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &DdosProtectionPlansClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // DdosProtectionPlansClientDeleteResponse contains the response from method DdosProtectionPlansClient.Delete.
@@ -1102,80 +326,9 @@ type DefaultSecurityRulesClientListResponse struct {
 	SecurityRuleListResult
 }
 
-// ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate.
-type ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitAuthorization)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse from the provided client and resume
-// token.
-func (l *ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitAuthorizationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitAuthorizationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate.
 type ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse struct {
 	ExpressRouteCircuitAuthorization
-}
-
-// ExpressRouteCircuitAuthorizationsClientDeletePollerResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.Delete.
-type ExpressRouteCircuitAuthorizationsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitAuthorizationsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitAuthorizationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitAuthorizationsClientDeleteResponse, error) {
-	respType := ExpressRouteCircuitAuthorizationsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitAuthorizationsClientDeletePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCircuitAuthorizationsClientDeletePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitAuthorizationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitAuthorizationsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteCircuitAuthorizationsClientDeleteResponse contains the response from method ExpressRouteCircuitAuthorizationsClient.Delete.
@@ -1193,80 +346,9 @@ type ExpressRouteCircuitAuthorizationsClientListResponse struct {
 	AuthorizationListResult
 }
 
-// ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitConnectionsClient.CreateOrUpdate.
-type ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitConnection)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse from the provided client and resume
-// token.
-func (l *ExpressRouteCircuitConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitConnectionsClient.CreateOrUpdate.
 type ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse struct {
 	ExpressRouteCircuitConnection
-}
-
-// ExpressRouteCircuitConnectionsClientDeletePollerResponse contains the response from method ExpressRouteCircuitConnectionsClient.Delete.
-type ExpressRouteCircuitConnectionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitConnectionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitConnectionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitConnectionsClientDeleteResponse, error) {
-	respType := ExpressRouteCircuitConnectionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitConnectionsClientDeletePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCircuitConnectionsClientDeletePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitConnectionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteCircuitConnectionsClientDeleteResponse contains the response from method ExpressRouteCircuitConnectionsClient.Delete.
@@ -1284,79 +366,9 @@ type ExpressRouteCircuitConnectionsClientListResponse struct {
 	ExpressRouteCircuitConnectionListResult
 }
 
-// ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitPeeringsClient.CreateOrUpdate.
-type ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitPeering)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCircuitPeeringsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitPeeringsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitPeeringsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitPeeringsClient.CreateOrUpdate.
 type ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse struct {
 	ExpressRouteCircuitPeering
-}
-
-// ExpressRouteCircuitPeeringsClientDeletePollerResponse contains the response from method ExpressRouteCircuitPeeringsClient.Delete.
-type ExpressRouteCircuitPeeringsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitPeeringsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitPeeringsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitPeeringsClientDeleteResponse, error) {
-	respType := ExpressRouteCircuitPeeringsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitPeeringsClientDeletePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCircuitPeeringsClientDeletePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitPeeringsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitPeeringsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteCircuitPeeringsClientDeleteResponse contains the response from method ExpressRouteCircuitPeeringsClient.Delete.
@@ -1374,79 +386,9 @@ type ExpressRouteCircuitPeeringsClientListResponse struct {
 	ExpressRouteCircuitPeeringListResult
 }
 
-// ExpressRouteCircuitsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCircuitsClient.CreateOrUpdate.
-type ExpressRouteCircuitsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCircuitsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuit)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCircuitsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCircuitsClientCreateOrUpdateResponse contains the response from method ExpressRouteCircuitsClient.CreateOrUpdate.
 type ExpressRouteCircuitsClientCreateOrUpdateResponse struct {
 	ExpressRouteCircuit
-}
-
-// ExpressRouteCircuitsClientDeletePollerResponse contains the response from method ExpressRouteCircuitsClient.Delete.
-type ExpressRouteCircuitsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientDeleteResponse, error) {
-	respType := ExpressRouteCircuitsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitsClientDeletePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCircuitsClientDeletePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteCircuitsClientDeleteResponse contains the response from method ExpressRouteCircuitsClient.Delete.
@@ -1474,41 +416,6 @@ type ExpressRouteCircuitsClientListAllResponse struct {
 	ExpressRouteCircuitListResult
 }
 
-// ExpressRouteCircuitsClientListArpTablePollerResponse contains the response from method ExpressRouteCircuitsClient.ListArpTable.
-type ExpressRouteCircuitsClientListArpTablePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitsClientListArpTablePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitsClientListArpTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListArpTableResponse, error) {
-	respType := ExpressRouteCircuitsClientListArpTableResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsArpTableListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitsClientListArpTablePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCircuitsClientListArpTablePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListArpTable", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitsClientListArpTablePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCircuitsClientListArpTableResponse contains the response from method ExpressRouteCircuitsClient.ListArpTable.
 type ExpressRouteCircuitsClientListArpTableResponse struct {
 	ExpressRouteCircuitsArpTableListResult
@@ -1519,80 +426,9 @@ type ExpressRouteCircuitsClientListResponse struct {
 	ExpressRouteCircuitListResult
 }
 
-// ExpressRouteCircuitsClientListRoutesTablePollerResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTable.
-type ExpressRouteCircuitsClientListRoutesTablePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitsClientListRoutesTablePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitsClientListRoutesTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListRoutesTableResponse, error) {
-	respType := ExpressRouteCircuitsClientListRoutesTableResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitsClientListRoutesTablePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCircuitsClientListRoutesTablePollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTable", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitsClientListRoutesTablePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCircuitsClientListRoutesTableResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTable.
 type ExpressRouteCircuitsClientListRoutesTableResponse struct {
 	ExpressRouteCircuitsRoutesTableListResult
-}
-
-// ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTableSummary.
-type ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCircuitsClientListRoutesTableSummaryPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsClientListRoutesTableSummaryResponse, error) {
-	respType := ExpressRouteCircuitsClientListRoutesTableSummaryResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableSummaryListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse from the provided client and resume
-// token.
-func (l *ExpressRouteCircuitsClientListRoutesTableSummaryPollerResponse) Resume(ctx context.Context, client *ExpressRouteCircuitsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTableSummary", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCircuitsClientListRoutesTableSummaryPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteCircuitsClientListRoutesTableSummaryResponse contains the response from method ExpressRouteCircuitsClient.ListRoutesTableSummary.
@@ -1605,79 +441,9 @@ type ExpressRouteCircuitsClientUpdateTagsResponse struct {
 	ExpressRouteCircuit
 }
 
-// ExpressRouteConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteConnectionsClient.CreateOrUpdate.
-type ExpressRouteConnectionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteConnectionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteConnectionsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteConnectionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteConnection)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteConnectionsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ExpressRouteConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRouteConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteConnectionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteConnectionsClient.CreateOrUpdate.
 type ExpressRouteConnectionsClientCreateOrUpdateResponse struct {
 	ExpressRouteConnection
-}
-
-// ExpressRouteConnectionsClientDeletePollerResponse contains the response from method ExpressRouteConnectionsClient.Delete.
-type ExpressRouteConnectionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteConnectionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteConnectionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteConnectionsClientDeleteResponse, error) {
-	respType := ExpressRouteConnectionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteConnectionsClientDeletePollerResponse from the provided client and resume token.
-func (l *ExpressRouteConnectionsClientDeletePollerResponse) Resume(ctx context.Context, client *ExpressRouteConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteConnectionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteConnectionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteConnectionsClientDeleteResponse contains the response from method ExpressRouteConnectionsClient.Delete.
@@ -1695,80 +461,9 @@ type ExpressRouteConnectionsClientListResponse struct {
 	ExpressRouteConnectionList
 }
 
-// ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate.
-type ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnectionPeering)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse from the provided client and
-// resume token.
-func (l *ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRouteCrossConnectionPeeringsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCrossConnectionPeeringsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate.
 type ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse struct {
 	ExpressRouteCrossConnectionPeering
-}
-
-// ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.Delete.
-type ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCrossConnectionPeeringsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionPeeringsClientDeleteResponse, error) {
-	respType := ExpressRouteCrossConnectionPeeringsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCrossConnectionPeeringsClientDeletePollerResponse) Resume(ctx context.Context, client *ExpressRouteCrossConnectionPeeringsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCrossConnectionPeeringsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteCrossConnectionPeeringsClientDeleteResponse contains the response from method ExpressRouteCrossConnectionPeeringsClient.Delete.
@@ -1786,42 +481,6 @@ type ExpressRouteCrossConnectionPeeringsClientListResponse struct {
 	ExpressRouteCrossConnectionPeeringList
 }
 
-// ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.CreateOrUpdate.
-type ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCrossConnectionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteCrossConnectionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnection)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse from the provided client and resume
-// token.
-func (l *ExpressRouteCrossConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCrossConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCrossConnectionsClientCreateOrUpdateResponse contains the response from method ExpressRouteCrossConnectionsClient.CreateOrUpdate.
 type ExpressRouteCrossConnectionsClientCreateOrUpdateResponse struct {
 	ExpressRouteCrossConnection
@@ -1830,41 +489,6 @@ type ExpressRouteCrossConnectionsClientCreateOrUpdateResponse struct {
 // ExpressRouteCrossConnectionsClientGetResponse contains the response from method ExpressRouteCrossConnectionsClient.Get.
 type ExpressRouteCrossConnectionsClientGetResponse struct {
 	ExpressRouteCrossConnection
-}
-
-// ExpressRouteCrossConnectionsClientListArpTablePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListArpTable.
-type ExpressRouteCrossConnectionsClientListArpTablePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCrossConnectionsClientListArpTablePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCrossConnectionsClientListArpTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListArpTableResponse, error) {
-	respType := ExpressRouteCrossConnectionsClientListArpTableResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsArpTableListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCrossConnectionsClientListArpTablePollerResponse from the provided client and resume token.
-func (l *ExpressRouteCrossConnectionsClientListArpTablePollerResponse) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListArpTable", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCrossConnectionsClientListArpTablePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteCrossConnectionsClientListArpTableResponse contains the response from method ExpressRouteCrossConnectionsClient.ListArpTable.
@@ -1882,81 +506,9 @@ type ExpressRouteCrossConnectionsClientListResponse struct {
 	ExpressRouteCrossConnectionListResult
 }
 
-// ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTable.
-type ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCrossConnectionsClientListRoutesTablePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListRoutesTableResponse, error) {
-	respType := ExpressRouteCrossConnectionsClientListRoutesTableResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCircuitsRoutesTableListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse from the provided client and resume
-// token.
-func (l *ExpressRouteCrossConnectionsClientListRoutesTablePollerResponse) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTable", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCrossConnectionsClientListRoutesTablePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteCrossConnectionsClientListRoutesTableResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTable.
 type ExpressRouteCrossConnectionsClientListRoutesTableResponse struct {
 	ExpressRouteCircuitsRoutesTableListResult
-}
-
-// ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTableSummary.
-type ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse, error) {
-	respType := ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse from the provided client and
-// resume token.
-func (l *ExpressRouteCrossConnectionsClientListRoutesTableSummaryPollerResponse) Resume(ctx context.Context, client *ExpressRouteCrossConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTableSummary", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteCrossConnectionsClientListRoutesTableSummaryPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse contains the response from method ExpressRouteCrossConnectionsClient.ListRoutesTableSummary.
@@ -1969,79 +521,9 @@ type ExpressRouteCrossConnectionsClientUpdateTagsResponse struct {
 	ExpressRouteCrossConnection
 }
 
-// ExpressRouteGatewaysClientCreateOrUpdatePollerResponse contains the response from method ExpressRouteGatewaysClient.CreateOrUpdate.
-type ExpressRouteGatewaysClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteGatewaysClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteGatewaysClientCreateOrUpdateResponse, error) {
-	respType := ExpressRouteGatewaysClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRouteGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteGatewaysClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ExpressRouteGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRouteGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteGatewaysClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRouteGatewaysClientCreateOrUpdateResponse contains the response from method ExpressRouteGatewaysClient.CreateOrUpdate.
 type ExpressRouteGatewaysClientCreateOrUpdateResponse struct {
 	ExpressRouteGateway
-}
-
-// ExpressRouteGatewaysClientDeletePollerResponse contains the response from method ExpressRouteGatewaysClient.Delete.
-type ExpressRouteGatewaysClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRouteGatewaysClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRouteGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteGatewaysClientDeleteResponse, error) {
-	respType := ExpressRouteGatewaysClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRouteGatewaysClientDeletePollerResponse from the provided client and resume token.
-func (l *ExpressRouteGatewaysClientDeletePollerResponse) Resume(ctx context.Context, client *ExpressRouteGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRouteGatewaysClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRouteGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRouteGatewaysClientDeleteResponse contains the response from method ExpressRouteGatewaysClient.Delete.
@@ -2074,79 +556,9 @@ type ExpressRouteLinksClientListResponse struct {
 	ExpressRouteLinkListResult
 }
 
-// ExpressRoutePortsClientCreateOrUpdatePollerResponse contains the response from method ExpressRoutePortsClient.CreateOrUpdate.
-type ExpressRoutePortsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRoutePortsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRoutePortsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRoutePortsClientCreateOrUpdateResponse, error) {
-	respType := ExpressRoutePortsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ExpressRoutePort)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRoutePortsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ExpressRoutePortsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ExpressRoutePortsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRoutePortsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRoutePortsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ExpressRoutePortsClientCreateOrUpdateResponse contains the response from method ExpressRoutePortsClient.CreateOrUpdate.
 type ExpressRoutePortsClientCreateOrUpdateResponse struct {
 	ExpressRoutePort
-}
-
-// ExpressRoutePortsClientDeletePollerResponse contains the response from method ExpressRoutePortsClient.Delete.
-type ExpressRoutePortsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ExpressRoutePortsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ExpressRoutePortsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ExpressRoutePortsClientDeleteResponse, error) {
-	respType := ExpressRoutePortsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ExpressRoutePortsClientDeletePollerResponse from the provided client and resume token.
-func (l *ExpressRoutePortsClientDeletePollerResponse) Resume(ctx context.Context, client *ExpressRoutePortsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ExpressRoutePortsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ExpressRoutePortsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ExpressRoutePortsClientDeleteResponse contains the response from method ExpressRoutePortsClient.Delete.
@@ -2189,79 +601,9 @@ type ExpressRouteServiceProvidersClientListResponse struct {
 	ExpressRouteServiceProviderListResult
 }
 
-// FirewallPoliciesClientCreateOrUpdatePollerResponse contains the response from method FirewallPoliciesClient.CreateOrUpdate.
-type FirewallPoliciesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *FirewallPoliciesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l FirewallPoliciesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPoliciesClientCreateOrUpdateResponse, error) {
-	respType := FirewallPoliciesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FirewallPolicy)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a FirewallPoliciesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *FirewallPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *FirewallPoliciesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("FirewallPoliciesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &FirewallPoliciesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // FirewallPoliciesClientCreateOrUpdateResponse contains the response from method FirewallPoliciesClient.CreateOrUpdate.
 type FirewallPoliciesClientCreateOrUpdateResponse struct {
 	FirewallPolicy
-}
-
-// FirewallPoliciesClientDeletePollerResponse contains the response from method FirewallPoliciesClient.Delete.
-type FirewallPoliciesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *FirewallPoliciesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l FirewallPoliciesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPoliciesClientDeleteResponse, error) {
-	respType := FirewallPoliciesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a FirewallPoliciesClientDeletePollerResponse from the provided client and resume token.
-func (l *FirewallPoliciesClientDeletePollerResponse) Resume(ctx context.Context, client *FirewallPoliciesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("FirewallPoliciesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &FirewallPoliciesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // FirewallPoliciesClientDeleteResponse contains the response from method FirewallPoliciesClient.Delete.
@@ -2284,79 +626,9 @@ type FirewallPoliciesClientListResponse struct {
 	FirewallPolicyListResult
 }
 
-// FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse contains the response from method FirewallPolicyRuleGroupsClient.CreateOrUpdate.
-type FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *FirewallPolicyRuleGroupsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPolicyRuleGroupsClientCreateOrUpdateResponse, error) {
-	respType := FirewallPolicyRuleGroupsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FirewallPolicyRuleGroup)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *FirewallPolicyRuleGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *FirewallPolicyRuleGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &FirewallPolicyRuleGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // FirewallPolicyRuleGroupsClientCreateOrUpdateResponse contains the response from method FirewallPolicyRuleGroupsClient.CreateOrUpdate.
 type FirewallPolicyRuleGroupsClientCreateOrUpdateResponse struct {
 	FirewallPolicyRuleGroup
-}
-
-// FirewallPolicyRuleGroupsClientDeletePollerResponse contains the response from method FirewallPolicyRuleGroupsClient.Delete.
-type FirewallPolicyRuleGroupsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *FirewallPolicyRuleGroupsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l FirewallPolicyRuleGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FirewallPolicyRuleGroupsClientDeleteResponse, error) {
-	respType := FirewallPolicyRuleGroupsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a FirewallPolicyRuleGroupsClientDeletePollerResponse from the provided client and resume token.
-func (l *FirewallPolicyRuleGroupsClientDeletePollerResponse) Resume(ctx context.Context, client *FirewallPolicyRuleGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &FirewallPolicyRuleGroupsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // FirewallPolicyRuleGroupsClientDeleteResponse contains the response from method FirewallPolicyRuleGroupsClient.Delete.
@@ -2374,79 +646,9 @@ type FirewallPolicyRuleGroupsClientListResponse struct {
 	FirewallPolicyRuleGroupListResult
 }
 
-// FlowLogsClientCreateOrUpdatePollerResponse contains the response from method FlowLogsClient.CreateOrUpdate.
-type FlowLogsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *FlowLogsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l FlowLogsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FlowLogsClientCreateOrUpdateResponse, error) {
-	respType := FlowLogsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLog)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a FlowLogsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *FlowLogsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *FlowLogsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("FlowLogsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &FlowLogsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // FlowLogsClientCreateOrUpdateResponse contains the response from method FlowLogsClient.CreateOrUpdate.
 type FlowLogsClientCreateOrUpdateResponse struct {
 	FlowLog
-}
-
-// FlowLogsClientDeletePollerResponse contains the response from method FlowLogsClient.Delete.
-type FlowLogsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *FlowLogsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l FlowLogsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (FlowLogsClientDeleteResponse, error) {
-	respType := FlowLogsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a FlowLogsClientDeletePollerResponse from the provided client and resume token.
-func (l *FlowLogsClientDeletePollerResponse) Resume(ctx context.Context, client *FlowLogsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("FlowLogsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &FlowLogsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // FlowLogsClientDeleteResponse contains the response from method FlowLogsClient.Delete.
@@ -2474,79 +676,9 @@ type HubVirtualNetworkConnectionsClientListResponse struct {
 	ListHubVirtualNetworkConnectionsResult
 }
 
-// IPAllocationsClientCreateOrUpdatePollerResponse contains the response from method IPAllocationsClient.CreateOrUpdate.
-type IPAllocationsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *IPAllocationsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l IPAllocationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (IPAllocationsClientCreateOrUpdateResponse, error) {
-	respType := IPAllocationsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.IPAllocation)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a IPAllocationsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *IPAllocationsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *IPAllocationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("IPAllocationsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &IPAllocationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // IPAllocationsClientCreateOrUpdateResponse contains the response from method IPAllocationsClient.CreateOrUpdate.
 type IPAllocationsClientCreateOrUpdateResponse struct {
 	IPAllocation
-}
-
-// IPAllocationsClientDeletePollerResponse contains the response from method IPAllocationsClient.Delete.
-type IPAllocationsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *IPAllocationsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l IPAllocationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (IPAllocationsClientDeleteResponse, error) {
-	respType := IPAllocationsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a IPAllocationsClientDeletePollerResponse from the provided client and resume token.
-func (l *IPAllocationsClientDeletePollerResponse) Resume(ctx context.Context, client *IPAllocationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("IPAllocationsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &IPAllocationsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // IPAllocationsClientDeleteResponse contains the response from method IPAllocationsClient.Delete.
@@ -2574,79 +706,9 @@ type IPAllocationsClientUpdateTagsResponse struct {
 	IPAllocation
 }
 
-// IPGroupsClientCreateOrUpdatePollerResponse contains the response from method IPGroupsClient.CreateOrUpdate.
-type IPGroupsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *IPGroupsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l IPGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (IPGroupsClientCreateOrUpdateResponse, error) {
-	respType := IPGroupsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.IPGroup)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a IPGroupsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *IPGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *IPGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("IPGroupsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &IPGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // IPGroupsClientCreateOrUpdateResponse contains the response from method IPGroupsClient.CreateOrUpdate.
 type IPGroupsClientCreateOrUpdateResponse struct {
 	IPGroup
-}
-
-// IPGroupsClientDeletePollerResponse contains the response from method IPGroupsClient.Delete.
-type IPGroupsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *IPGroupsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l IPGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (IPGroupsClientDeleteResponse, error) {
-	respType := IPGroupsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a IPGroupsClientDeletePollerResponse from the provided client and resume token.
-func (l *IPGroupsClientDeletePollerResponse) Resume(ctx context.Context, client *IPGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("IPGroupsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &IPGroupsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // IPGroupsClientDeleteResponse contains the response from method IPGroupsClient.Delete.
@@ -2674,79 +736,9 @@ type IPGroupsClientUpdateGroupsResponse struct {
 	IPGroup
 }
 
-// InboundNatRulesClientCreateOrUpdatePollerResponse contains the response from method InboundNatRulesClient.CreateOrUpdate.
-type InboundNatRulesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *InboundNatRulesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l InboundNatRulesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InboundNatRulesClientCreateOrUpdateResponse, error) {
-	respType := InboundNatRulesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.InboundNatRule)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a InboundNatRulesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *InboundNatRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *InboundNatRulesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("InboundNatRulesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &InboundNatRulesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // InboundNatRulesClientCreateOrUpdateResponse contains the response from method InboundNatRulesClient.CreateOrUpdate.
 type InboundNatRulesClientCreateOrUpdateResponse struct {
 	InboundNatRule
-}
-
-// InboundNatRulesClientDeletePollerResponse contains the response from method InboundNatRulesClient.Delete.
-type InboundNatRulesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *InboundNatRulesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l InboundNatRulesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InboundNatRulesClientDeleteResponse, error) {
-	respType := InboundNatRulesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a InboundNatRulesClientDeletePollerResponse from the provided client and resume token.
-func (l *InboundNatRulesClientDeletePollerResponse) Resume(ctx context.Context, client *InboundNatRulesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("InboundNatRulesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &InboundNatRulesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // InboundNatRulesClientDeleteResponse contains the response from method InboundNatRulesClient.Delete.
@@ -2779,79 +771,9 @@ type InterfaceLoadBalancersClientListResponse struct {
 	InterfaceLoadBalancerListResult
 }
 
-// InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse contains the response from method InterfaceTapConfigurationsClient.CreateOrUpdate.
-type InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *InterfaceTapConfigurationsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfaceTapConfigurationsClientCreateOrUpdateResponse, error) {
-	respType := InterfaceTapConfigurationsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.InterfaceTapConfiguration)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *InterfaceTapConfigurationsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *InterfaceTapConfigurationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &InterfaceTapConfigurationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // InterfaceTapConfigurationsClientCreateOrUpdateResponse contains the response from method InterfaceTapConfigurationsClient.CreateOrUpdate.
 type InterfaceTapConfigurationsClientCreateOrUpdateResponse struct {
 	InterfaceTapConfiguration
-}
-
-// InterfaceTapConfigurationsClientDeletePollerResponse contains the response from method InterfaceTapConfigurationsClient.Delete.
-type InterfaceTapConfigurationsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *InterfaceTapConfigurationsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l InterfaceTapConfigurationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfaceTapConfigurationsClientDeleteResponse, error) {
-	respType := InterfaceTapConfigurationsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a InterfaceTapConfigurationsClientDeletePollerResponse from the provided client and resume token.
-func (l *InterfaceTapConfigurationsClientDeletePollerResponse) Resume(ctx context.Context, client *InterfaceTapConfigurationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("InterfaceTapConfigurationsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &InterfaceTapConfigurationsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // InterfaceTapConfigurationsClientDeleteResponse contains the response from method InterfaceTapConfigurationsClient.Delete.
@@ -2869,119 +791,14 @@ type InterfaceTapConfigurationsClientListResponse struct {
 	InterfaceTapConfigurationListResult
 }
 
-// InterfacesClientCreateOrUpdatePollerResponse contains the response from method InterfacesClient.CreateOrUpdate.
-type InterfacesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *InterfacesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l InterfacesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientCreateOrUpdateResponse, error) {
-	respType := InterfacesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Interface)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a InterfacesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *InterfacesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *InterfacesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("InterfacesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &InterfacesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // InterfacesClientCreateOrUpdateResponse contains the response from method InterfacesClient.CreateOrUpdate.
 type InterfacesClientCreateOrUpdateResponse struct {
 	Interface
 }
 
-// InterfacesClientDeletePollerResponse contains the response from method InterfacesClient.Delete.
-type InterfacesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *InterfacesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l InterfacesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientDeleteResponse, error) {
-	respType := InterfacesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a InterfacesClientDeletePollerResponse from the provided client and resume token.
-func (l *InterfacesClientDeletePollerResponse) Resume(ctx context.Context, client *InterfacesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("InterfacesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &InterfacesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // InterfacesClientDeleteResponse contains the response from method InterfacesClient.Delete.
 type InterfacesClientDeleteResponse struct {
 	// placeholder for future response values
-}
-
-// InterfacesClientGetEffectiveRouteTablePollerResponse contains the response from method InterfacesClient.GetEffectiveRouteTable.
-type InterfacesClientGetEffectiveRouteTablePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *InterfacesClientGetEffectiveRouteTablePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l InterfacesClientGetEffectiveRouteTablePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientGetEffectiveRouteTableResponse, error) {
-	respType := InterfacesClientGetEffectiveRouteTableResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.EffectiveRouteListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a InterfacesClientGetEffectiveRouteTablePollerResponse from the provided client and resume token.
-func (l *InterfacesClientGetEffectiveRouteTablePollerResponse) Resume(ctx context.Context, client *InterfacesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("InterfacesClient.GetEffectiveRouteTable", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &InterfacesClientGetEffectiveRouteTablePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // InterfacesClientGetEffectiveRouteTableResponse contains the response from method InterfacesClient.GetEffectiveRouteTable.
@@ -3007,42 +824,6 @@ type InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse struct {
 // InterfacesClientListAllResponse contains the response from method InterfacesClient.ListAll.
 type InterfacesClientListAllResponse struct {
 	InterfaceListResult
-}
-
-// InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse contains the response from method InterfacesClient.ListEffectiveNetworkSecurityGroups.
-type InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *InterfacesClientListEffectiveNetworkSecurityGroupsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (InterfacesClientListEffectiveNetworkSecurityGroupsResponse, error) {
-	respType := InterfacesClientListEffectiveNetworkSecurityGroupsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.EffectiveNetworkSecurityGroupListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse from the provided client and resume
-// token.
-func (l *InterfacesClientListEffectiveNetworkSecurityGroupsPollerResponse) Resume(ctx context.Context, client *InterfacesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("InterfacesClient.ListEffectiveNetworkSecurityGroups", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &InterfacesClientListEffectiveNetworkSecurityGroupsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // InterfacesClientListEffectiveNetworkSecurityGroupsResponse contains the response from method InterfacesClient.ListEffectiveNetworkSecurityGroups.
@@ -3130,79 +911,9 @@ type LoadBalancerProbesClientListResponse struct {
 	LoadBalancerProbeListResult
 }
 
-// LoadBalancersClientCreateOrUpdatePollerResponse contains the response from method LoadBalancersClient.CreateOrUpdate.
-type LoadBalancersClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LoadBalancersClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l LoadBalancersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LoadBalancersClientCreateOrUpdateResponse, error) {
-	respType := LoadBalancersClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LoadBalancer)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LoadBalancersClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *LoadBalancersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *LoadBalancersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LoadBalancersClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LoadBalancersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LoadBalancersClientCreateOrUpdateResponse contains the response from method LoadBalancersClient.CreateOrUpdate.
 type LoadBalancersClientCreateOrUpdateResponse struct {
 	LoadBalancer
-}
-
-// LoadBalancersClientDeletePollerResponse contains the response from method LoadBalancersClient.Delete.
-type LoadBalancersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LoadBalancersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l LoadBalancersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LoadBalancersClientDeleteResponse, error) {
-	respType := LoadBalancersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LoadBalancersClientDeletePollerResponse from the provided client and resume token.
-func (l *LoadBalancersClientDeletePollerResponse) Resume(ctx context.Context, client *LoadBalancersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LoadBalancersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LoadBalancersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LoadBalancersClientDeleteResponse contains the response from method LoadBalancersClient.Delete.
@@ -3230,79 +941,9 @@ type LoadBalancersClientUpdateTagsResponse struct {
 	LoadBalancer
 }
 
-// LocalNetworkGatewaysClientCreateOrUpdatePollerResponse contains the response from method LocalNetworkGatewaysClient.CreateOrUpdate.
-type LocalNetworkGatewaysClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LocalNetworkGatewaysClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l LocalNetworkGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LocalNetworkGatewaysClientCreateOrUpdateResponse, error) {
-	respType := LocalNetworkGatewaysClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LocalNetworkGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LocalNetworkGatewaysClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *LocalNetworkGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *LocalNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LocalNetworkGatewaysClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LocalNetworkGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // LocalNetworkGatewaysClientCreateOrUpdateResponse contains the response from method LocalNetworkGatewaysClient.CreateOrUpdate.
 type LocalNetworkGatewaysClientCreateOrUpdateResponse struct {
 	LocalNetworkGateway
-}
-
-// LocalNetworkGatewaysClientDeletePollerResponse contains the response from method LocalNetworkGatewaysClient.Delete.
-type LocalNetworkGatewaysClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *LocalNetworkGatewaysClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l LocalNetworkGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (LocalNetworkGatewaysClientDeleteResponse, error) {
-	respType := LocalNetworkGatewaysClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a LocalNetworkGatewaysClientDeletePollerResponse from the provided client and resume token.
-func (l *LocalNetworkGatewaysClientDeletePollerResponse) Resume(ctx context.Context, client *LocalNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("LocalNetworkGatewaysClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &LocalNetworkGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // LocalNetworkGatewaysClientDeleteResponse contains the response from method LocalNetworkGatewaysClient.Delete.
@@ -3330,41 +971,6 @@ type ManagementClientCheckDNSNameAvailabilityResponse struct {
 	DNSNameAvailabilityResult
 }
 
-// ManagementClientDeleteBastionShareableLinkPollerResponse contains the response from method ManagementClient.DeleteBastionShareableLink.
-type ManagementClientDeleteBastionShareableLinkPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ManagementClientDeleteBastionShareableLinkPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ManagementClientDeleteBastionShareableLinkPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ManagementClientDeleteBastionShareableLinkResponse, error) {
-	respType := ManagementClientDeleteBastionShareableLinkResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ManagementClientDeleteBastionShareableLinkPollerResponse from the provided client and resume token.
-func (l *ManagementClientDeleteBastionShareableLinkPollerResponse) Resume(ctx context.Context, client *ManagementClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ManagementClient.DeleteBastionShareableLink", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ManagementClientDeleteBastionShareableLinkPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ManagementClientDeleteBastionShareableLinkResponse contains the response from method ManagementClient.DeleteBastionShareableLink.
 type ManagementClientDeleteBastionShareableLinkResponse struct {
 	// placeholder for future response values
@@ -3375,82 +981,9 @@ type ManagementClientDisconnectActiveSessionsResponse struct {
 	BastionSessionDeleteResult
 }
 
-// ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse contains the response from method ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile.
-type ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse, error) {
-	respType := ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNProfileResponse)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse from the provided
-// client and resume token.
-func (l *ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePollerResponse) Resume(ctx context.Context, client *ManagementClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofilePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse contains the response from method ManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile.
 type ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse struct {
 	VPNProfileResponse
-}
-
-// ManagementClientGetActiveSessionsPollerResponse contains the response from method ManagementClient.GetActiveSessions.
-type ManagementClientGetActiveSessionsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ManagementClientGetActiveSessionsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ManagementClientGetActiveSessionsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (*ManagementClientGetActiveSessionsPager, error) {
-	respType := &ManagementClientGetActiveSessionsPager{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.BastionActiveSessionListResult)
-	if err != nil {
-		return respType, err
-	}
-	respType.client = l.Poller.client
-	return respType, nil
-}
-
-// Resume rehydrates a ManagementClientGetActiveSessionsPollerResponse from the provided client and resume token.
-func (l *ManagementClientGetActiveSessionsPollerResponse) Resume(ctx context.Context, client *ManagementClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ManagementClient.GetActiveSessions", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ManagementClientGetActiveSessionsPoller{
-		pt:     pt,
-		client: client,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ManagementClientGetActiveSessionsResponse contains the response from method ManagementClient.GetActiveSessions.
@@ -3463,43 +996,6 @@ type ManagementClientGetBastionShareableLinkResponse struct {
 	BastionShareableLinkListResult
 }
 
-// ManagementClientPutBastionShareableLinkPollerResponse contains the response from method ManagementClient.PutBastionShareableLink.
-type ManagementClientPutBastionShareableLinkPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ManagementClientPutBastionShareableLinkPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ManagementClientPutBastionShareableLinkPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (*ManagementClientPutBastionShareableLinkPager, error) {
-	respType := &ManagementClientPutBastionShareableLinkPager{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.current.BastionShareableLinkListResult)
-	if err != nil {
-		return respType, err
-	}
-	respType.client = l.Poller.client
-	return respType, nil
-}
-
-// Resume rehydrates a ManagementClientPutBastionShareableLinkPollerResponse from the provided client and resume token.
-func (l *ManagementClientPutBastionShareableLinkPollerResponse) Resume(ctx context.Context, client *ManagementClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ManagementClient.PutBastionShareableLink", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ManagementClientPutBastionShareableLinkPoller{
-		pt:     pt,
-		client: client,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ManagementClientPutBastionShareableLinkResponse contains the response from method ManagementClient.PutBastionShareableLink.
 type ManagementClientPutBastionShareableLinkResponse struct {
 	BastionShareableLinkListResult
@@ -3510,79 +1006,9 @@ type ManagementClientSupportedSecurityProvidersResponse struct {
 	VirtualWanSecurityProviders
 }
 
-// NatGatewaysClientCreateOrUpdatePollerResponse contains the response from method NatGatewaysClient.CreateOrUpdate.
-type NatGatewaysClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *NatGatewaysClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l NatGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NatGatewaysClientCreateOrUpdateResponse, error) {
-	respType := NatGatewaysClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NatGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a NatGatewaysClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *NatGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *NatGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NatGatewaysClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &NatGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // NatGatewaysClientCreateOrUpdateResponse contains the response from method NatGatewaysClient.CreateOrUpdate.
 type NatGatewaysClientCreateOrUpdateResponse struct {
 	NatGateway
-}
-
-// NatGatewaysClientDeletePollerResponse contains the response from method NatGatewaysClient.Delete.
-type NatGatewaysClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *NatGatewaysClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l NatGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (NatGatewaysClientDeleteResponse, error) {
-	respType := NatGatewaysClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a NatGatewaysClientDeletePollerResponse from the provided client and resume token.
-func (l *NatGatewaysClientDeletePollerResponse) Resume(ctx context.Context, client *NatGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("NatGatewaysClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &NatGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // NatGatewaysClientDeleteResponse contains the response from method NatGatewaysClient.Delete.
@@ -3615,79 +1041,9 @@ type OperationsClientListResponse struct {
 	OperationListResult
 }
 
-// P2SVPNGatewaysClientCreateOrUpdatePollerResponse contains the response from method P2SVPNGatewaysClient.CreateOrUpdate.
-type P2SVPNGatewaysClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *P2SVPNGatewaysClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l P2SVPNGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientCreateOrUpdateResponse, error) {
-	respType := P2SVPNGatewaysClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a P2SVPNGatewaysClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *P2SVPNGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &P2SVPNGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // P2SVPNGatewaysClientCreateOrUpdateResponse contains the response from method P2SVPNGatewaysClient.CreateOrUpdate.
 type P2SVPNGatewaysClientCreateOrUpdateResponse struct {
 	P2SVPNGateway
-}
-
-// P2SVPNGatewaysClientDeletePollerResponse contains the response from method P2SVPNGatewaysClient.Delete.
-type P2SVPNGatewaysClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *P2SVPNGatewaysClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l P2SVPNGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientDeleteResponse, error) {
-	respType := P2SVPNGatewaysClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a P2SVPNGatewaysClientDeletePollerResponse from the provided client and resume token.
-func (l *P2SVPNGatewaysClientDeletePollerResponse) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &P2SVPNGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // P2SVPNGatewaysClientDeleteResponse contains the response from method P2SVPNGatewaysClient.Delete.
@@ -3695,79 +1051,9 @@ type P2SVPNGatewaysClientDeleteResponse struct {
 	// placeholder for future response values
 }
 
-// P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse contains the response from method P2SVPNGatewaysClient.DisconnectP2SVPNConnections.
-type P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse, error) {
-	respType := P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse from the provided client and resume token.
-func (l *P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPollerResponse) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.DisconnectP2SVPNConnections", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &P2SVPNGatewaysClientDisconnectP2SVPNConnectionsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse contains the response from method P2SVPNGatewaysClient.DisconnectP2SVPNConnections.
 type P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse struct {
 	// placeholder for future response values
-}
-
-// P2SVPNGatewaysClientGenerateVPNProfilePollerResponse contains the response from method P2SVPNGatewaysClient.GenerateVPNProfile.
-type P2SVPNGatewaysClientGenerateVPNProfilePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *P2SVPNGatewaysClientGenerateVPNProfilePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l P2SVPNGatewaysClientGenerateVPNProfilePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGenerateVPNProfileResponse, error) {
-	respType := P2SVPNGatewaysClientGenerateVPNProfileResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNProfileResponse)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a P2SVPNGatewaysClientGenerateVPNProfilePollerResponse from the provided client and resume token.
-func (l *P2SVPNGatewaysClientGenerateVPNProfilePollerResponse) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GenerateVPNProfile", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &P2SVPNGatewaysClientGenerateVPNProfilePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // P2SVPNGatewaysClientGenerateVPNProfileResponse contains the response from method P2SVPNGatewaysClient.GenerateVPNProfile.
@@ -3775,80 +1061,9 @@ type P2SVPNGatewaysClientGenerateVPNProfileResponse struct {
 	VPNProfileResponse
 }
 
-// P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed.
-type P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse, error) {
-	respType := P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNConnectionHealth)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse from the provided client and resume
-// token.
-func (l *P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPollerResponse) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed.
 type P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse struct {
 	P2SVPNConnectionHealth
-}
-
-// P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealth.
-type P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse, error) {
-	respType := P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.P2SVPNGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse from the provided client and resume token.
-func (l *P2SVPNGatewaysClientGetP2SVPNConnectionHealthPollerResponse) Resume(ctx context.Context, client *P2SVPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealth", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &P2SVPNGatewaysClientGetP2SVPNConnectionHealthPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse contains the response from method P2SVPNGatewaysClient.GetP2SVPNConnectionHealth.
@@ -3876,79 +1091,9 @@ type P2SVPNGatewaysClientUpdateTagsResponse struct {
 	P2SVPNGateway
 }
 
-// PacketCapturesClientCreatePollerResponse contains the response from method PacketCapturesClient.Create.
-type PacketCapturesClientCreatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PacketCapturesClientCreatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PacketCapturesClientCreatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientCreateResponse, error) {
-	respType := PacketCapturesClientCreateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PacketCaptureResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PacketCapturesClientCreatePollerResponse from the provided client and resume token.
-func (l *PacketCapturesClientCreatePollerResponse) Resume(ctx context.Context, client *PacketCapturesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PacketCapturesClient.Create", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PacketCapturesClientCreatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // PacketCapturesClientCreateResponse contains the response from method PacketCapturesClient.Create.
 type PacketCapturesClientCreateResponse struct {
 	PacketCaptureResult
-}
-
-// PacketCapturesClientDeletePollerResponse contains the response from method PacketCapturesClient.Delete.
-type PacketCapturesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PacketCapturesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PacketCapturesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientDeleteResponse, error) {
-	respType := PacketCapturesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PacketCapturesClientDeletePollerResponse from the provided client and resume token.
-func (l *PacketCapturesClientDeletePollerResponse) Resume(ctx context.Context, client *PacketCapturesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PacketCapturesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PacketCapturesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PacketCapturesClientDeleteResponse contains the response from method PacketCapturesClient.Delete.
@@ -3961,41 +1106,6 @@ type PacketCapturesClientGetResponse struct {
 	PacketCaptureResult
 }
 
-// PacketCapturesClientGetStatusPollerResponse contains the response from method PacketCapturesClient.GetStatus.
-type PacketCapturesClientGetStatusPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PacketCapturesClientGetStatusPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PacketCapturesClientGetStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientGetStatusResponse, error) {
-	respType := PacketCapturesClientGetStatusResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PacketCaptureQueryStatusResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PacketCapturesClientGetStatusPollerResponse from the provided client and resume token.
-func (l *PacketCapturesClientGetStatusPollerResponse) Resume(ctx context.Context, client *PacketCapturesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PacketCapturesClient.GetStatus", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PacketCapturesClientGetStatusPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // PacketCapturesClientGetStatusResponse contains the response from method PacketCapturesClient.GetStatus.
 type PacketCapturesClientGetStatusResponse struct {
 	PacketCaptureQueryStatusResult
@@ -4004,41 +1114,6 @@ type PacketCapturesClientGetStatusResponse struct {
 // PacketCapturesClientListResponse contains the response from method PacketCapturesClient.List.
 type PacketCapturesClientListResponse struct {
 	PacketCaptureListResult
-}
-
-// PacketCapturesClientStopPollerResponse contains the response from method PacketCapturesClient.Stop.
-type PacketCapturesClientStopPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PacketCapturesClientStopPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PacketCapturesClientStopPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PacketCapturesClientStopResponse, error) {
-	respType := PacketCapturesClientStopResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PacketCapturesClientStopPollerResponse from the provided client and resume token.
-func (l *PacketCapturesClientStopPollerResponse) Resume(ctx context.Context, client *PacketCapturesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PacketCapturesClient.Stop", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PacketCapturesClientStopPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PacketCapturesClientStopResponse contains the response from method PacketCapturesClient.Stop.
@@ -4056,79 +1131,9 @@ type PeerExpressRouteCircuitConnectionsClientListResponse struct {
 	PeerExpressRouteCircuitConnectionListResult
 }
 
-// PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse contains the response from method PrivateDNSZoneGroupsClient.CreateOrUpdate.
-type PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateDNSZoneGroupsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateDNSZoneGroupsClientCreateOrUpdateResponse, error) {
-	respType := PrivateDNSZoneGroupsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateDNSZoneGroup)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *PrivateDNSZoneGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *PrivateDNSZoneGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateDNSZoneGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // PrivateDNSZoneGroupsClientCreateOrUpdateResponse contains the response from method PrivateDNSZoneGroupsClient.CreateOrUpdate.
 type PrivateDNSZoneGroupsClientCreateOrUpdateResponse struct {
 	PrivateDNSZoneGroup
-}
-
-// PrivateDNSZoneGroupsClientDeletePollerResponse contains the response from method PrivateDNSZoneGroupsClient.Delete.
-type PrivateDNSZoneGroupsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateDNSZoneGroupsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateDNSZoneGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateDNSZoneGroupsClientDeleteResponse, error) {
-	respType := PrivateDNSZoneGroupsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateDNSZoneGroupsClientDeletePollerResponse from the provided client and resume token.
-func (l *PrivateDNSZoneGroupsClientDeletePollerResponse) Resume(ctx context.Context, client *PrivateDNSZoneGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateDNSZoneGroupsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PrivateDNSZoneGroupsClientDeleteResponse contains the response from method PrivateDNSZoneGroupsClient.Delete.
@@ -4146,79 +1151,9 @@ type PrivateDNSZoneGroupsClientListResponse struct {
 	PrivateDNSZoneGroupListResult
 }
 
-// PrivateEndpointsClientCreateOrUpdatePollerResponse contains the response from method PrivateEndpointsClient.CreateOrUpdate.
-type PrivateEndpointsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateEndpointsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateEndpointsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateEndpointsClientCreateOrUpdateResponse, error) {
-	respType := PrivateEndpointsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateEndpoint)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateEndpointsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *PrivateEndpointsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *PrivateEndpointsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateEndpointsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateEndpointsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // PrivateEndpointsClientCreateOrUpdateResponse contains the response from method PrivateEndpointsClient.CreateOrUpdate.
 type PrivateEndpointsClientCreateOrUpdateResponse struct {
 	PrivateEndpoint
-}
-
-// PrivateEndpointsClientDeletePollerResponse contains the response from method PrivateEndpointsClient.Delete.
-type PrivateEndpointsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateEndpointsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateEndpointsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateEndpointsClientDeleteResponse, error) {
-	respType := PrivateEndpointsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateEndpointsClientDeletePollerResponse from the provided client and resume token.
-func (l *PrivateEndpointsClientDeletePollerResponse) Resume(ctx context.Context, client *PrivateEndpointsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateEndpointsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateEndpointsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PrivateEndpointsClientDeleteResponse contains the response from method PrivateEndpointsClient.Delete.
@@ -4241,82 +1176,9 @@ type PrivateEndpointsClientListResponse struct {
 	PrivateEndpointListResult
 }
 
-// PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse contains the response from method
-// PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup.
-type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse, error) {
-	respType := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkServiceVisibility)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse from the provided
-// client and resume token.
-func (l *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPollerResponse) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup.
 type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse struct {
 	PrivateLinkServiceVisibility
-}
-
-// PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility.
-type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse, error) {
-	respType := PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkServiceVisibility)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse from the provided client and
-// resume token.
-func (l *PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPollerResponse) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse contains the response from method PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility.
@@ -4324,115 +1186,9 @@ type PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse struct {
 	PrivateLinkServiceVisibility
 }
 
-// PrivateLinkServicesClientCreateOrUpdatePollerResponse contains the response from method PrivateLinkServicesClient.CreateOrUpdate.
-type PrivateLinkServicesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateLinkServicesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateLinkServicesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientCreateOrUpdateResponse, error) {
-	respType := PrivateLinkServicesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PrivateLinkService)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateLinkServicesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *PrivateLinkServicesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateLinkServicesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // PrivateLinkServicesClientCreateOrUpdateResponse contains the response from method PrivateLinkServicesClient.CreateOrUpdate.
 type PrivateLinkServicesClientCreateOrUpdateResponse struct {
 	PrivateLinkService
-}
-
-// PrivateLinkServicesClientDeletePollerResponse contains the response from method PrivateLinkServicesClient.Delete.
-type PrivateLinkServicesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateLinkServicesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateLinkServicesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientDeleteResponse, error) {
-	respType := PrivateLinkServicesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateLinkServicesClientDeletePollerResponse from the provided client and resume token.
-func (l *PrivateLinkServicesClientDeletePollerResponse) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateLinkServicesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
-// PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse contains the response from method PrivateLinkServicesClient.DeletePrivateEndpointConnection.
-type PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse, error) {
-	respType := PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse from the provided client and
-// resume token.
-func (l *PrivateLinkServicesClientDeletePrivateEndpointConnectionPollerResponse) Resume(ctx context.Context, client *PrivateLinkServicesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PrivateLinkServicesClient.DeletePrivateEndpointConnection", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PrivateLinkServicesClientDeletePrivateEndpointConnectionPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse contains the response from method PrivateLinkServicesClient.DeletePrivateEndpointConnection.
@@ -4490,41 +1246,6 @@ type ProfilesClientCreateOrUpdateResponse struct {
 	Profile
 }
 
-// ProfilesClientDeletePollerResponse contains the response from method ProfilesClient.Delete.
-type ProfilesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ProfilesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ProfilesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ProfilesClientDeleteResponse, error) {
-	respType := ProfilesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ProfilesClientDeletePollerResponse from the provided client and resume token.
-func (l *ProfilesClientDeletePollerResponse) Resume(ctx context.Context, client *ProfilesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ProfilesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ProfilesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ProfilesClientDeleteResponse contains the response from method ProfilesClient.Delete.
 type ProfilesClientDeleteResponse struct {
 	// placeholder for future response values
@@ -4550,79 +1271,9 @@ type ProfilesClientUpdateTagsResponse struct {
 	Profile
 }
 
-// PublicIPAddressesClientCreateOrUpdatePollerResponse contains the response from method PublicIPAddressesClient.CreateOrUpdate.
-type PublicIPAddressesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PublicIPAddressesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PublicIPAddressesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPAddressesClientCreateOrUpdateResponse, error) {
-	respType := PublicIPAddressesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PublicIPAddress)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PublicIPAddressesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *PublicIPAddressesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *PublicIPAddressesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PublicIPAddressesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PublicIPAddressesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // PublicIPAddressesClientCreateOrUpdateResponse contains the response from method PublicIPAddressesClient.CreateOrUpdate.
 type PublicIPAddressesClientCreateOrUpdateResponse struct {
 	PublicIPAddress
-}
-
-// PublicIPAddressesClientDeletePollerResponse contains the response from method PublicIPAddressesClient.Delete.
-type PublicIPAddressesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PublicIPAddressesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PublicIPAddressesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPAddressesClientDeleteResponse, error) {
-	respType := PublicIPAddressesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PublicIPAddressesClientDeletePollerResponse from the provided client and resume token.
-func (l *PublicIPAddressesClientDeletePollerResponse) Resume(ctx context.Context, client *PublicIPAddressesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PublicIPAddressesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PublicIPAddressesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PublicIPAddressesClientDeleteResponse contains the response from method PublicIPAddressesClient.Delete.
@@ -4665,79 +1316,9 @@ type PublicIPAddressesClientUpdateTagsResponse struct {
 	PublicIPAddress
 }
 
-// PublicIPPrefixesClientCreateOrUpdatePollerResponse contains the response from method PublicIPPrefixesClient.CreateOrUpdate.
-type PublicIPPrefixesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PublicIPPrefixesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PublicIPPrefixesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPPrefixesClientCreateOrUpdateResponse, error) {
-	respType := PublicIPPrefixesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PublicIPPrefix)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PublicIPPrefixesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *PublicIPPrefixesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *PublicIPPrefixesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PublicIPPrefixesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PublicIPPrefixesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // PublicIPPrefixesClientCreateOrUpdateResponse contains the response from method PublicIPPrefixesClient.CreateOrUpdate.
 type PublicIPPrefixesClientCreateOrUpdateResponse struct {
 	PublicIPPrefix
-}
-
-// PublicIPPrefixesClientDeletePollerResponse contains the response from method PublicIPPrefixesClient.Delete.
-type PublicIPPrefixesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *PublicIPPrefixesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l PublicIPPrefixesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (PublicIPPrefixesClientDeleteResponse, error) {
-	respType := PublicIPPrefixesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a PublicIPPrefixesClientDeletePollerResponse from the provided client and resume token.
-func (l *PublicIPPrefixesClientDeletePollerResponse) Resume(ctx context.Context, client *PublicIPPrefixesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("PublicIPPrefixesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &PublicIPPrefixesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // PublicIPPrefixesClientDeleteResponse contains the response from method PublicIPPrefixesClient.Delete.
@@ -4770,79 +1351,9 @@ type ResourceNavigationLinksClientListResponse struct {
 	ResourceNavigationLinksListResult
 }
 
-// RouteFilterRulesClientCreateOrUpdatePollerResponse contains the response from method RouteFilterRulesClient.CreateOrUpdate.
-type RouteFilterRulesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RouteFilterRulesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RouteFilterRulesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFilterRulesClientCreateOrUpdateResponse, error) {
-	respType := RouteFilterRulesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteFilterRule)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RouteFilterRulesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *RouteFilterRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *RouteFilterRulesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RouteFilterRulesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RouteFilterRulesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // RouteFilterRulesClientCreateOrUpdateResponse contains the response from method RouteFilterRulesClient.CreateOrUpdate.
 type RouteFilterRulesClientCreateOrUpdateResponse struct {
 	RouteFilterRule
-}
-
-// RouteFilterRulesClientDeletePollerResponse contains the response from method RouteFilterRulesClient.Delete.
-type RouteFilterRulesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RouteFilterRulesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RouteFilterRulesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFilterRulesClientDeleteResponse, error) {
-	respType := RouteFilterRulesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RouteFilterRulesClientDeletePollerResponse from the provided client and resume token.
-func (l *RouteFilterRulesClientDeletePollerResponse) Resume(ctx context.Context, client *RouteFilterRulesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RouteFilterRulesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RouteFilterRulesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // RouteFilterRulesClientDeleteResponse contains the response from method RouteFilterRulesClient.Delete.
@@ -4860,79 +1371,9 @@ type RouteFilterRulesClientListByRouteFilterResponse struct {
 	RouteFilterRuleListResult
 }
 
-// RouteFiltersClientCreateOrUpdatePollerResponse contains the response from method RouteFiltersClient.CreateOrUpdate.
-type RouteFiltersClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RouteFiltersClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RouteFiltersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFiltersClientCreateOrUpdateResponse, error) {
-	respType := RouteFiltersClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteFilter)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RouteFiltersClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *RouteFiltersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *RouteFiltersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RouteFiltersClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RouteFiltersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // RouteFiltersClientCreateOrUpdateResponse contains the response from method RouteFiltersClient.CreateOrUpdate.
 type RouteFiltersClientCreateOrUpdateResponse struct {
 	RouteFilter
-}
-
-// RouteFiltersClientDeletePollerResponse contains the response from method RouteFiltersClient.Delete.
-type RouteFiltersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RouteFiltersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RouteFiltersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteFiltersClientDeleteResponse, error) {
-	respType := RouteFiltersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RouteFiltersClientDeletePollerResponse from the provided client and resume token.
-func (l *RouteFiltersClientDeletePollerResponse) Resume(ctx context.Context, client *RouteFiltersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RouteFiltersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RouteFiltersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // RouteFiltersClientDeleteResponse contains the response from method RouteFiltersClient.Delete.
@@ -4960,79 +1401,9 @@ type RouteFiltersClientUpdateTagsResponse struct {
 	RouteFilter
 }
 
-// RouteTablesClientCreateOrUpdatePollerResponse contains the response from method RouteTablesClient.CreateOrUpdate.
-type RouteTablesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RouteTablesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RouteTablesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteTablesClientCreateOrUpdateResponse, error) {
-	respType := RouteTablesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.RouteTable)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RouteTablesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *RouteTablesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *RouteTablesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RouteTablesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RouteTablesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // RouteTablesClientCreateOrUpdateResponse contains the response from method RouteTablesClient.CreateOrUpdate.
 type RouteTablesClientCreateOrUpdateResponse struct {
 	RouteTable
-}
-
-// RouteTablesClientDeletePollerResponse contains the response from method RouteTablesClient.Delete.
-type RouteTablesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RouteTablesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RouteTablesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RouteTablesClientDeleteResponse, error) {
-	respType := RouteTablesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RouteTablesClientDeletePollerResponse from the provided client and resume token.
-func (l *RouteTablesClientDeletePollerResponse) Resume(ctx context.Context, client *RouteTablesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RouteTablesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RouteTablesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // RouteTablesClientDeleteResponse contains the response from method RouteTablesClient.Delete.
@@ -5060,79 +1431,9 @@ type RouteTablesClientUpdateTagsResponse struct {
 	RouteTable
 }
 
-// RoutesClientCreateOrUpdatePollerResponse contains the response from method RoutesClient.CreateOrUpdate.
-type RoutesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RoutesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RoutesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RoutesClientCreateOrUpdateResponse, error) {
-	respType := RoutesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Route)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RoutesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *RoutesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *RoutesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RoutesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RoutesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // RoutesClientCreateOrUpdateResponse contains the response from method RoutesClient.CreateOrUpdate.
 type RoutesClientCreateOrUpdateResponse struct {
 	Route
-}
-
-// RoutesClientDeletePollerResponse contains the response from method RoutesClient.Delete.
-type RoutesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *RoutesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l RoutesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (RoutesClientDeleteResponse, error) {
-	respType := RoutesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a RoutesClientDeletePollerResponse from the provided client and resume token.
-func (l *RoutesClientDeletePollerResponse) Resume(ctx context.Context, client *RoutesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("RoutesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &RoutesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // RoutesClientDeleteResponse contains the response from method RoutesClient.Delete.
@@ -5150,79 +1451,9 @@ type RoutesClientListResponse struct {
 	RouteListResult
 }
 
-// SecurityGroupsClientCreateOrUpdatePollerResponse contains the response from method SecurityGroupsClient.CreateOrUpdate.
-type SecurityGroupsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SecurityGroupsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SecurityGroupsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityGroupsClientCreateOrUpdateResponse, error) {
-	respType := SecurityGroupsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityGroup)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SecurityGroupsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *SecurityGroupsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *SecurityGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SecurityGroupsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SecurityGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SecurityGroupsClientCreateOrUpdateResponse contains the response from method SecurityGroupsClient.CreateOrUpdate.
 type SecurityGroupsClientCreateOrUpdateResponse struct {
 	SecurityGroup
-}
-
-// SecurityGroupsClientDeletePollerResponse contains the response from method SecurityGroupsClient.Delete.
-type SecurityGroupsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SecurityGroupsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SecurityGroupsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityGroupsClientDeleteResponse, error) {
-	respType := SecurityGroupsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SecurityGroupsClientDeletePollerResponse from the provided client and resume token.
-func (l *SecurityGroupsClientDeletePollerResponse) Resume(ctx context.Context, client *SecurityGroupsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SecurityGroupsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SecurityGroupsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SecurityGroupsClientDeleteResponse contains the response from method SecurityGroupsClient.Delete.
@@ -5250,79 +1481,9 @@ type SecurityGroupsClientUpdateTagsResponse struct {
 	SecurityGroup
 }
 
-// SecurityPartnerProvidersClientCreateOrUpdatePollerResponse contains the response from method SecurityPartnerProvidersClient.CreateOrUpdate.
-type SecurityPartnerProvidersClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SecurityPartnerProvidersClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SecurityPartnerProvidersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityPartnerProvidersClientCreateOrUpdateResponse, error) {
-	respType := SecurityPartnerProvidersClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityPartnerProvider)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SecurityPartnerProvidersClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *SecurityPartnerProvidersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *SecurityPartnerProvidersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SecurityPartnerProvidersClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SecurityPartnerProvidersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SecurityPartnerProvidersClientCreateOrUpdateResponse contains the response from method SecurityPartnerProvidersClient.CreateOrUpdate.
 type SecurityPartnerProvidersClientCreateOrUpdateResponse struct {
 	SecurityPartnerProvider
-}
-
-// SecurityPartnerProvidersClientDeletePollerResponse contains the response from method SecurityPartnerProvidersClient.Delete.
-type SecurityPartnerProvidersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SecurityPartnerProvidersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SecurityPartnerProvidersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityPartnerProvidersClientDeleteResponse, error) {
-	respType := SecurityPartnerProvidersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SecurityPartnerProvidersClientDeletePollerResponse from the provided client and resume token.
-func (l *SecurityPartnerProvidersClientDeletePollerResponse) Resume(ctx context.Context, client *SecurityPartnerProvidersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SecurityPartnerProvidersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SecurityPartnerProvidersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SecurityPartnerProvidersClientDeleteResponse contains the response from method SecurityPartnerProvidersClient.Delete.
@@ -5350,79 +1511,9 @@ type SecurityPartnerProvidersClientUpdateTagsResponse struct {
 	SecurityPartnerProvider
 }
 
-// SecurityRulesClientCreateOrUpdatePollerResponse contains the response from method SecurityRulesClient.CreateOrUpdate.
-type SecurityRulesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SecurityRulesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SecurityRulesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityRulesClientCreateOrUpdateResponse, error) {
-	respType := SecurityRulesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityRule)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SecurityRulesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *SecurityRulesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *SecurityRulesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SecurityRulesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SecurityRulesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SecurityRulesClientCreateOrUpdateResponse contains the response from method SecurityRulesClient.CreateOrUpdate.
 type SecurityRulesClientCreateOrUpdateResponse struct {
 	SecurityRule
-}
-
-// SecurityRulesClientDeletePollerResponse contains the response from method SecurityRulesClient.Delete.
-type SecurityRulesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SecurityRulesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SecurityRulesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SecurityRulesClientDeleteResponse, error) {
-	respType := SecurityRulesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SecurityRulesClientDeletePollerResponse from the provided client and resume token.
-func (l *SecurityRulesClientDeletePollerResponse) Resume(ctx context.Context, client *SecurityRulesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SecurityRulesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SecurityRulesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SecurityRulesClientDeleteResponse contains the response from method SecurityRulesClient.Delete.
@@ -5445,79 +1536,9 @@ type ServiceAssociationLinksClientListResponse struct {
 	ServiceAssociationLinksListResult
 }
 
-// ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse contains the response from method ServiceEndpointPoliciesClient.CreateOrUpdate.
-type ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ServiceEndpointPoliciesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPoliciesClientCreateOrUpdateResponse, error) {
-	respType := ServiceEndpointPoliciesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ServiceEndpointPolicy)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ServiceEndpointPoliciesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ServiceEndpointPoliciesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ServiceEndpointPoliciesClientCreateOrUpdateResponse contains the response from method ServiceEndpointPoliciesClient.CreateOrUpdate.
 type ServiceEndpointPoliciesClientCreateOrUpdateResponse struct {
 	ServiceEndpointPolicy
-}
-
-// ServiceEndpointPoliciesClientDeletePollerResponse contains the response from method ServiceEndpointPoliciesClient.Delete.
-type ServiceEndpointPoliciesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ServiceEndpointPoliciesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ServiceEndpointPoliciesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPoliciesClientDeleteResponse, error) {
-	respType := ServiceEndpointPoliciesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ServiceEndpointPoliciesClientDeletePollerResponse from the provided client and resume token.
-func (l *ServiceEndpointPoliciesClientDeletePollerResponse) Resume(ctx context.Context, client *ServiceEndpointPoliciesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ServiceEndpointPoliciesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ServiceEndpointPoliciesClientDeleteResponse contains the response from method ServiceEndpointPoliciesClient.Delete.
@@ -5545,80 +1566,9 @@ type ServiceEndpointPoliciesClientUpdateTagsResponse struct {
 	ServiceEndpointPolicy
 }
 
-// ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate.
-type ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse, error) {
-	respType := ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ServiceEndpointPolicyDefinition)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse from the provided client and resume
-// token.
-func (l *ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *ServiceEndpointPolicyDefinitionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate.
 type ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse struct {
 	ServiceEndpointPolicyDefinition
-}
-
-// ServiceEndpointPolicyDefinitionsClientDeletePollerResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.Delete.
-type ServiceEndpointPolicyDefinitionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *ServiceEndpointPolicyDefinitionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l ServiceEndpointPolicyDefinitionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPolicyDefinitionsClientDeleteResponse, error) {
-	respType := ServiceEndpointPolicyDefinitionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a ServiceEndpointPolicyDefinitionsClientDeletePollerResponse from the provided client and resume token.
-func (l *ServiceEndpointPolicyDefinitionsClientDeletePollerResponse) Resume(ctx context.Context, client *ServiceEndpointPolicyDefinitionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &ServiceEndpointPolicyDefinitionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // ServiceEndpointPolicyDefinitionsClientDeleteResponse contains the response from method ServiceEndpointPolicyDefinitionsClient.Delete.
@@ -5641,79 +1591,9 @@ type ServiceTagsClientListResponse struct {
 	ServiceTagsListResult
 }
 
-// SubnetsClientCreateOrUpdatePollerResponse contains the response from method SubnetsClient.CreateOrUpdate.
-type SubnetsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SubnetsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SubnetsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientCreateOrUpdateResponse, error) {
-	respType := SubnetsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Subnet)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SubnetsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *SubnetsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *SubnetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SubnetsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SubnetsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SubnetsClientCreateOrUpdateResponse contains the response from method SubnetsClient.CreateOrUpdate.
 type SubnetsClientCreateOrUpdateResponse struct {
 	Subnet
-}
-
-// SubnetsClientDeletePollerResponse contains the response from method SubnetsClient.Delete.
-type SubnetsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SubnetsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SubnetsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientDeleteResponse, error) {
-	respType := SubnetsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SubnetsClientDeletePollerResponse from the provided client and resume token.
-func (l *SubnetsClientDeletePollerResponse) Resume(ctx context.Context, client *SubnetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SubnetsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SubnetsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SubnetsClientDeleteResponse contains the response from method SubnetsClient.Delete.
@@ -5731,79 +1611,9 @@ type SubnetsClientListResponse struct {
 	SubnetListResult
 }
 
-// SubnetsClientPrepareNetworkPoliciesPollerResponse contains the response from method SubnetsClient.PrepareNetworkPolicies.
-type SubnetsClientPrepareNetworkPoliciesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SubnetsClientPrepareNetworkPoliciesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SubnetsClientPrepareNetworkPoliciesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientPrepareNetworkPoliciesResponse, error) {
-	respType := SubnetsClientPrepareNetworkPoliciesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SubnetsClientPrepareNetworkPoliciesPollerResponse from the provided client and resume token.
-func (l *SubnetsClientPrepareNetworkPoliciesPollerResponse) Resume(ctx context.Context, client *SubnetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SubnetsClient.PrepareNetworkPolicies", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SubnetsClientPrepareNetworkPoliciesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // SubnetsClientPrepareNetworkPoliciesResponse contains the response from method SubnetsClient.PrepareNetworkPolicies.
 type SubnetsClientPrepareNetworkPoliciesResponse struct {
 	// placeholder for future response values
-}
-
-// SubnetsClientUnprepareNetworkPoliciesPollerResponse contains the response from method SubnetsClient.UnprepareNetworkPolicies.
-type SubnetsClientUnprepareNetworkPoliciesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *SubnetsClientUnprepareNetworkPoliciesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l SubnetsClientUnprepareNetworkPoliciesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (SubnetsClientUnprepareNetworkPoliciesResponse, error) {
-	respType := SubnetsClientUnprepareNetworkPoliciesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a SubnetsClientUnprepareNetworkPoliciesPollerResponse from the provided client and resume token.
-func (l *SubnetsClientUnprepareNetworkPoliciesPollerResponse) Resume(ctx context.Context, client *SubnetsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("SubnetsClient.UnprepareNetworkPolicies", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &SubnetsClientUnprepareNetworkPoliciesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // SubnetsClientUnprepareNetworkPoliciesResponse contains the response from method SubnetsClient.UnprepareNetworkPolicies.
@@ -5816,79 +1626,9 @@ type UsagesClientListResponse struct {
 	UsagesListResult
 }
 
-// VPNConnectionsClientCreateOrUpdatePollerResponse contains the response from method VPNConnectionsClient.CreateOrUpdate.
-type VPNConnectionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNConnectionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNConnectionsClientCreateOrUpdateResponse, error) {
-	respType := VPNConnectionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNConnection)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNConnectionsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VPNConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VPNConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNConnectionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VPNConnectionsClientCreateOrUpdateResponse contains the response from method VPNConnectionsClient.CreateOrUpdate.
 type VPNConnectionsClientCreateOrUpdateResponse struct {
 	VPNConnection
-}
-
-// VPNConnectionsClientDeletePollerResponse contains the response from method VPNConnectionsClient.Delete.
-type VPNConnectionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNConnectionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNConnectionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNConnectionsClientDeleteResponse, error) {
-	respType := VPNConnectionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNConnectionsClientDeletePollerResponse from the provided client and resume token.
-func (l *VPNConnectionsClientDeletePollerResponse) Resume(ctx context.Context, client *VPNConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNConnectionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNConnectionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VPNConnectionsClientDeleteResponse contains the response from method VPNConnectionsClient.Delete.
@@ -5906,79 +1646,9 @@ type VPNConnectionsClientListByVPNGatewayResponse struct {
 	ListVPNConnectionsResult
 }
 
-// VPNGatewaysClientCreateOrUpdatePollerResponse contains the response from method VPNGatewaysClient.CreateOrUpdate.
-type VPNGatewaysClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNGatewaysClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientCreateOrUpdateResponse, error) {
-	respType := VPNGatewaysClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNGatewaysClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VPNGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNGatewaysClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VPNGatewaysClientCreateOrUpdateResponse contains the response from method VPNGatewaysClient.CreateOrUpdate.
 type VPNGatewaysClientCreateOrUpdateResponse struct {
 	VPNGateway
-}
-
-// VPNGatewaysClientDeletePollerResponse contains the response from method VPNGatewaysClient.Delete.
-type VPNGatewaysClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNGatewaysClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientDeleteResponse, error) {
-	respType := VPNGatewaysClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNGatewaysClientDeletePollerResponse from the provided client and resume token.
-func (l *VPNGatewaysClientDeletePollerResponse) Resume(ctx context.Context, client *VPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNGatewaysClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VPNGatewaysClientDeleteResponse contains the response from method VPNGatewaysClient.Delete.
@@ -6001,41 +1671,6 @@ type VPNGatewaysClientListResponse struct {
 	ListVPNGatewaysResult
 }
 
-// VPNGatewaysClientResetPollerResponse contains the response from method VPNGatewaysClient.Reset.
-type VPNGatewaysClientResetPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNGatewaysClientResetPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNGatewaysClientResetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewaysClientResetResponse, error) {
-	respType := VPNGatewaysClientResetResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNGatewaysClientResetPollerResponse from the provided client and resume token.
-func (l *VPNGatewaysClientResetPollerResponse) Resume(ctx context.Context, client *VPNGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNGatewaysClient.Reset", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNGatewaysClientResetPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VPNGatewaysClientResetResponse contains the response from method VPNGatewaysClient.Reset.
 type VPNGatewaysClientResetResponse struct {
 	VPNGateway
@@ -6051,120 +1686,14 @@ type VPNLinkConnectionsClientListByVPNConnectionResponse struct {
 	ListVPNSiteLinkConnectionsResult
 }
 
-// VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse contains the response from method VPNServerConfigurationsAssociatedWithVirtualWanClient.List.
-type VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse, error) {
-	respType := VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNServerConfigurationsResponse)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse from the provided client and
-// resume token.
-func (l *VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse) Resume(ctx context.Context, client *VPNServerConfigurationsAssociatedWithVirtualWanClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNServerConfigurationsAssociatedWithVirtualWanClient.List", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse contains the response from method VPNServerConfigurationsAssociatedWithVirtualWanClient.List.
 type VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse struct {
 	VPNServerConfigurationsResponse
 }
 
-// VPNServerConfigurationsClientCreateOrUpdatePollerResponse contains the response from method VPNServerConfigurationsClient.CreateOrUpdate.
-type VPNServerConfigurationsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNServerConfigurationsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNServerConfigurationsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsClientCreateOrUpdateResponse, error) {
-	respType := VPNServerConfigurationsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNServerConfiguration)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNServerConfigurationsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VPNServerConfigurationsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VPNServerConfigurationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNServerConfigurationsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNServerConfigurationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VPNServerConfigurationsClientCreateOrUpdateResponse contains the response from method VPNServerConfigurationsClient.CreateOrUpdate.
 type VPNServerConfigurationsClientCreateOrUpdateResponse struct {
 	VPNServerConfiguration
-}
-
-// VPNServerConfigurationsClientDeletePollerResponse contains the response from method VPNServerConfigurationsClient.Delete.
-type VPNServerConfigurationsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNServerConfigurationsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNServerConfigurationsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsClientDeleteResponse, error) {
-	respType := VPNServerConfigurationsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNServerConfigurationsClientDeletePollerResponse from the provided client and resume token.
-func (l *VPNServerConfigurationsClientDeletePollerResponse) Resume(ctx context.Context, client *VPNServerConfigurationsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNServerConfigurationsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNServerConfigurationsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VPNServerConfigurationsClientDeleteResponse contains the response from method VPNServerConfigurationsClient.Delete.
@@ -6207,79 +1736,9 @@ type VPNSiteLinksClientListByVPNSiteResponse struct {
 	ListVPNSiteLinksResult
 }
 
-// VPNSitesClientCreateOrUpdatePollerResponse contains the response from method VPNSitesClient.CreateOrUpdate.
-type VPNSitesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNSitesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNSitesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesClientCreateOrUpdateResponse, error) {
-	respType := VPNSitesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNSite)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNSitesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VPNSitesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VPNSitesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNSitesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNSitesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VPNSitesClientCreateOrUpdateResponse contains the response from method VPNSitesClient.CreateOrUpdate.
 type VPNSitesClientCreateOrUpdateResponse struct {
 	VPNSite
-}
-
-// VPNSitesClientDeletePollerResponse contains the response from method VPNSitesClient.Delete.
-type VPNSitesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNSitesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNSitesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesClientDeleteResponse, error) {
-	respType := VPNSitesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNSitesClientDeletePollerResponse from the provided client and resume token.
-func (l *VPNSitesClientDeletePollerResponse) Resume(ctx context.Context, client *VPNSitesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNSitesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNSitesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VPNSitesClientDeleteResponse contains the response from method VPNSitesClient.Delete.
@@ -6307,119 +1766,14 @@ type VPNSitesClientUpdateTagsResponse struct {
 	VPNSite
 }
 
-// VPNSitesConfigurationClientDownloadPollerResponse contains the response from method VPNSitesConfigurationClient.Download.
-type VPNSitesConfigurationClientDownloadPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VPNSitesConfigurationClientDownloadPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VPNSitesConfigurationClientDownloadPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VPNSitesConfigurationClientDownloadResponse, error) {
-	respType := VPNSitesConfigurationClientDownloadResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VPNSitesConfigurationClientDownloadPollerResponse from the provided client and resume token.
-func (l *VPNSitesConfigurationClientDownloadPollerResponse) Resume(ctx context.Context, client *VPNSitesConfigurationClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VPNSitesConfigurationClient.Download", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VPNSitesConfigurationClientDownloadPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VPNSitesConfigurationClientDownloadResponse contains the response from method VPNSitesConfigurationClient.Download.
 type VPNSitesConfigurationClientDownloadResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualAppliancesClientCreateOrUpdatePollerResponse contains the response from method VirtualAppliancesClient.CreateOrUpdate.
-type VirtualAppliancesClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualAppliancesClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualAppliancesClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualAppliancesClientCreateOrUpdateResponse, error) {
-	respType := VirtualAppliancesClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualAppliance)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualAppliancesClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualAppliancesClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualAppliancesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualAppliancesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualAppliancesClientCreateOrUpdateResponse contains the response from method VirtualAppliancesClient.CreateOrUpdate.
 type VirtualAppliancesClientCreateOrUpdateResponse struct {
 	VirtualAppliance
-}
-
-// VirtualAppliancesClientDeletePollerResponse contains the response from method VirtualAppliancesClient.Delete.
-type VirtualAppliancesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualAppliancesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualAppliancesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualAppliancesClientDeleteResponse, error) {
-	respType := VirtualAppliancesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualAppliancesClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualAppliancesClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualAppliancesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualAppliancesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualAppliancesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualAppliancesClientDeleteResponse contains the response from method VirtualAppliancesClient.Delete.
@@ -6447,79 +1801,9 @@ type VirtualAppliancesClientUpdateTagsResponse struct {
 	VirtualAppliance
 }
 
-// VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse contains the response from method VirtualHubRouteTableV2SClient.CreateOrUpdate.
-type VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualHubRouteTableV2SClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubRouteTableV2SClientCreateOrUpdateResponse, error) {
-	respType := VirtualHubRouteTableV2SClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualHubRouteTableV2)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualHubRouteTableV2SClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualHubRouteTableV2SClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualHubRouteTableV2SClientCreateOrUpdateResponse contains the response from method VirtualHubRouteTableV2SClient.CreateOrUpdate.
 type VirtualHubRouteTableV2SClientCreateOrUpdateResponse struct {
 	VirtualHubRouteTableV2
-}
-
-// VirtualHubRouteTableV2SClientDeletePollerResponse contains the response from method VirtualHubRouteTableV2SClient.Delete.
-type VirtualHubRouteTableV2SClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualHubRouteTableV2SClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualHubRouteTableV2SClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubRouteTableV2SClientDeleteResponse, error) {
-	respType := VirtualHubRouteTableV2SClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualHubRouteTableV2SClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualHubRouteTableV2SClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualHubRouteTableV2SClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualHubRouteTableV2SClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualHubRouteTableV2SClientDeleteResponse contains the response from method VirtualHubRouteTableV2SClient.Delete.
@@ -6537,79 +1821,9 @@ type VirtualHubRouteTableV2SClientListResponse struct {
 	ListVirtualHubRouteTableV2SResult
 }
 
-// VirtualHubsClientCreateOrUpdatePollerResponse contains the response from method VirtualHubsClient.CreateOrUpdate.
-type VirtualHubsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualHubsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualHubsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubsClientCreateOrUpdateResponse, error) {
-	respType := VirtualHubsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualHub)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualHubsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualHubsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualHubsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualHubsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualHubsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualHubsClientCreateOrUpdateResponse contains the response from method VirtualHubsClient.CreateOrUpdate.
 type VirtualHubsClientCreateOrUpdateResponse struct {
 	VirtualHub
-}
-
-// VirtualHubsClientDeletePollerResponse contains the response from method VirtualHubsClient.Delete.
-type VirtualHubsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualHubsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualHubsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubsClientDeleteResponse, error) {
-	respType := VirtualHubsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualHubsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualHubsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualHubsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualHubsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualHubsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualHubsClientDeleteResponse contains the response from method VirtualHubsClient.Delete.
@@ -6637,80 +1851,9 @@ type VirtualHubsClientUpdateTagsResponse struct {
 	VirtualHub
 }
 
-// VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.CreateOrUpdate.
-type VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGatewayConnection)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse from the provided client and resume
-// token.
-func (l *VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse contains the response from method VirtualNetworkGatewayConnectionsClient.CreateOrUpdate.
 type VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse struct {
 	VirtualNetworkGatewayConnection
-}
-
-// VirtualNetworkGatewayConnectionsClientDeletePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.Delete.
-type VirtualNetworkGatewayConnectionsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewayConnectionsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewayConnectionsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientDeleteResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewayConnectionsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewayConnectionsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewayConnectionsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientDeleteResponse contains the response from method VirtualNetworkGatewayConnectionsClient.Delete.
@@ -6733,81 +1876,9 @@ type VirtualNetworkGatewayConnectionsClientListResponse struct {
 	VirtualNetworkGatewayConnectionListResult
 }
 
-// VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.ResetSharedKey.
-type VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionResetSharedKey)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse from the provided client and resume
-// token.
-func (l *VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.ResetSharedKey", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse contains the response from method VirtualNetworkGatewayConnectionsClient.ResetSharedKey.
 type VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse struct {
 	ConnectionResetSharedKey
-}
-
-// VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.SetSharedKey.
-type VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectionSharedKey)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse from the provided client and resume
-// token.
-func (l *VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.SetSharedKey", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse contains the response from method VirtualNetworkGatewayConnectionsClient.SetSharedKey.
@@ -6815,81 +1886,9 @@ type VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse struct {
 	ConnectionSharedKey
 }
 
-// VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StartPacketCapture.
-type VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse from the provided client and
-// resume token.
-func (l *VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StartPacketCapture", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StartPacketCapture.
 type VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse struct {
 	Value *string
-}
-
-// VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StopPacketCapture.
-type VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse from the provided client and
-// resume token.
-func (l *VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StopPacketCapture", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse contains the response from method VirtualNetworkGatewayConnectionsClient.StopPacketCapture.
@@ -6897,80 +1896,9 @@ type VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse struct {
 	Value *string
 }
 
-// VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse contains the response from method VirtualNetworkGatewayConnectionsClient.UpdateTags.
-type VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewayConnectionsClientUpdateTagsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionsClientUpdateTagsResponse, error) {
-	respType := VirtualNetworkGatewayConnectionsClientUpdateTagsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGatewayConnection)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse from the provided client and resume
-// token.
-func (l *VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewayConnectionsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.UpdateTags", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewayConnectionsClientUpdateTagsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewayConnectionsClientUpdateTagsResponse contains the response from method VirtualNetworkGatewayConnectionsClient.UpdateTags.
 type VirtualNetworkGatewayConnectionsClientUpdateTagsResponse struct {
 	VirtualNetworkGatewayConnection
-}
-
-// VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkGatewaysClient.CreateOrUpdate.
-type VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworkGatewaysClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewaysClientCreateOrUpdateResponse contains the response from method VirtualNetworkGatewaysClient.CreateOrUpdate.
@@ -6978,81 +1906,9 @@ type VirtualNetworkGatewaysClientCreateOrUpdateResponse struct {
 	VirtualNetworkGateway
 }
 
-// VirtualNetworkGatewaysClientDeletePollerResponse contains the response from method VirtualNetworkGatewaysClient.Delete.
-type VirtualNetworkGatewaysClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientDeleteResponse, error) {
-	respType := VirtualNetworkGatewaysClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientDeleteResponse contains the response from method VirtualNetworkGatewaysClient.Delete.
 type VirtualNetworkGatewaysClientDeleteResponse struct {
 	// placeholder for future response values
-}
-
-// VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse contains the response from method
-// VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections.
-type VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse, error) {
-	respType := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse from the provided
-// client and resume token.
-func (l *VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse contains the response from method VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections.
@@ -7060,80 +1916,9 @@ type VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsRe
 	// placeholder for future response values
 }
 
-// VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse contains the response from method VirtualNetworkGatewaysClient.GenerateVPNProfile.
-type VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientGenerateVPNProfilePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGenerateVPNProfileResponse, error) {
-	respType := VirtualNetworkGatewaysClientGenerateVPNProfileResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GenerateVPNProfile", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientGenerateVPNProfilePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientGenerateVPNProfileResponse contains the response from method VirtualNetworkGatewaysClient.GenerateVPNProfile.
 type VirtualNetworkGatewaysClientGenerateVPNProfileResponse struct {
 	Value *string
-}
-
-// VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse contains the response from method VirtualNetworkGatewaysClient.Generatevpnclientpackage.
-type VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse, error) {
-	respType := VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse from the provided client and resume
-// token.
-func (l *VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Generatevpnclientpackage", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse contains the response from method VirtualNetworkGatewaysClient.Generatevpnclientpackage.
@@ -7141,119 +1926,14 @@ type VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse struct {
 	Value *string
 }
 
-// VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetAdvertisedRoutes.
-type VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GatewayRouteListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetAdvertisedRoutes", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse contains the response from method VirtualNetworkGatewaysClient.GetAdvertisedRoutes.
 type VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse struct {
 	GatewayRouteListResult
 }
 
-// VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetBgpPeerStatus.
-type VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientGetBgpPeerStatusPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetBgpPeerStatusResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetBgpPeerStatusResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.BgpPeerStatusListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetBgpPeerStatus", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientGetBgpPeerStatusPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientGetBgpPeerStatusResponse contains the response from method VirtualNetworkGatewaysClient.GetBgpPeerStatus.
 type VirtualNetworkGatewaysClientGetBgpPeerStatusResponse struct {
 	BgpPeerStatusListResult
-}
-
-// VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetLearnedRoutes.
-type VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientGetLearnedRoutesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetLearnedRoutesResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetLearnedRoutesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.GatewayRouteListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetLearnedRoutes", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientGetLearnedRoutesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewaysClientGetLearnedRoutesResponse contains the response from method VirtualNetworkGatewaysClient.GetLearnedRoutes.
@@ -7266,122 +1946,14 @@ type VirtualNetworkGatewaysClientGetResponse struct {
 	VirtualNetworkGateway
 }
 
-// VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVPNProfilePackageURL.
-type VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse from the provided client and resume
-// token.
-func (l *VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVPNProfilePackageURL", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse contains the response from method VirtualNetworkGatewaysClient.GetVPNProfilePackageURL.
 type VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse struct {
 	Value *string
 }
 
-// VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth.
-type VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientConnectionHealthDetailListResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse from the provided client and
-// resume token.
-func (l *VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth.
 type VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse struct {
 	VPNClientConnectionHealthDetailListResult
-}
-
-// VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters.
-type VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse, error) {
-	respType := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientIPsecParameters)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse from the provided client and
-// resume token.
-func (l *VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse contains the response from method VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters.
@@ -7399,80 +1971,9 @@ type VirtualNetworkGatewaysClientListResponse struct {
 	VirtualNetworkGatewayListResult
 }
 
-// VirtualNetworkGatewaysClientResetPollerResponse contains the response from method VirtualNetworkGatewaysClient.Reset.
-type VirtualNetworkGatewaysClientResetPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientResetPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientResetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientResetResponse, error) {
-	respType := VirtualNetworkGatewaysClientResetResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientResetPollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientResetPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Reset", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientResetPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientResetResponse contains the response from method VirtualNetworkGatewaysClient.Reset.
 type VirtualNetworkGatewaysClientResetResponse struct {
 	VirtualNetworkGateway
-}
-
-// VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse contains the response from method VirtualNetworkGatewaysClient.ResetVPNClientSharedKey.
-type VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse, error) {
-	respType := VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse from the provided client and resume
-// token.
-func (l *VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.ResetVPNClientSharedKey", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse contains the response from method VirtualNetworkGatewaysClient.ResetVPNClientSharedKey.
@@ -7480,120 +1981,14 @@ type VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse struct {
 	// placeholder for future response values
 }
 
-// VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse contains the response from method VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters.
-type VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse, error) {
-	respType := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VPNClientIPsecParameters)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse from the provided client and
-// resume token.
-func (l *VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse contains the response from method VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters.
 type VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse struct {
 	VPNClientIPsecParameters
 }
 
-// VirtualNetworkGatewaysClientStartPacketCapturePollerResponse contains the response from method VirtualNetworkGatewaysClient.StartPacketCapture.
-type VirtualNetworkGatewaysClientStartPacketCapturePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientStartPacketCapturePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientStartPacketCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientStartPacketCaptureResponse, error) {
-	respType := VirtualNetworkGatewaysClientStartPacketCaptureResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientStartPacketCapturePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientStartPacketCapturePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StartPacketCapture", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientStartPacketCapturePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientStartPacketCaptureResponse contains the response from method VirtualNetworkGatewaysClient.StartPacketCapture.
 type VirtualNetworkGatewaysClientStartPacketCaptureResponse struct {
 	Value *string
-}
-
-// VirtualNetworkGatewaysClientStopPacketCapturePollerResponse contains the response from method VirtualNetworkGatewaysClient.StopPacketCapture.
-type VirtualNetworkGatewaysClientStopPacketCapturePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientStopPacketCapturePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientStopPacketCapturePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientStopPacketCaptureResponse, error) {
-	respType := VirtualNetworkGatewaysClientStopPacketCaptureResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.Value)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientStopPacketCapturePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientStopPacketCapturePollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StopPacketCapture", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientStopPacketCapturePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkGatewaysClientStopPacketCaptureResponse contains the response from method VirtualNetworkGatewaysClient.StopPacketCapture.
@@ -7606,41 +2001,6 @@ type VirtualNetworkGatewaysClientSupportedVPNDevicesResponse struct {
 	Value *string
 }
 
-// VirtualNetworkGatewaysClientUpdateTagsPollerResponse contains the response from method VirtualNetworkGatewaysClient.UpdateTags.
-type VirtualNetworkGatewaysClientUpdateTagsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkGatewaysClientUpdateTagsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkGatewaysClientUpdateTagsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewaysClientUpdateTagsResponse, error) {
-	respType := VirtualNetworkGatewaysClientUpdateTagsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkGateway)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkGatewaysClientUpdateTagsPollerResponse from the provided client and resume token.
-func (l *VirtualNetworkGatewaysClientUpdateTagsPollerResponse) Resume(ctx context.Context, client *VirtualNetworkGatewaysClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.UpdateTags", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkGatewaysClientUpdateTagsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkGatewaysClientUpdateTagsResponse contains the response from method VirtualNetworkGatewaysClient.UpdateTags.
 type VirtualNetworkGatewaysClientUpdateTagsResponse struct {
 	VirtualNetworkGateway
@@ -7651,79 +2011,9 @@ type VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse struct {
 	Value *string
 }
 
-// VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkPeeringsClient.CreateOrUpdate.
-type VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkPeeringsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkPeeringsClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworkPeeringsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkPeering)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualNetworkPeeringsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkPeeringsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkPeeringsClientCreateOrUpdateResponse contains the response from method VirtualNetworkPeeringsClient.CreateOrUpdate.
 type VirtualNetworkPeeringsClientCreateOrUpdateResponse struct {
 	VirtualNetworkPeering
-}
-
-// VirtualNetworkPeeringsClientDeletePollerResponse contains the response from method VirtualNetworkPeeringsClient.Delete.
-type VirtualNetworkPeeringsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkPeeringsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkPeeringsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkPeeringsClientDeleteResponse, error) {
-	respType := VirtualNetworkPeeringsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkPeeringsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkPeeringsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualNetworkPeeringsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkPeeringsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkPeeringsClientDeleteResponse contains the response from method VirtualNetworkPeeringsClient.Delete.
@@ -7741,79 +2031,9 @@ type VirtualNetworkPeeringsClientListResponse struct {
 	VirtualNetworkPeeringListResult
 }
 
-// VirtualNetworkTapsClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworkTapsClient.CreateOrUpdate.
-type VirtualNetworkTapsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkTapsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkTapsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkTapsClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworkTapsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetworkTap)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkTapsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkTapsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualNetworkTapsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkTapsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkTapsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworkTapsClientCreateOrUpdateResponse contains the response from method VirtualNetworkTapsClient.CreateOrUpdate.
 type VirtualNetworkTapsClientCreateOrUpdateResponse struct {
 	VirtualNetworkTap
-}
-
-// VirtualNetworkTapsClientDeletePollerResponse contains the response from method VirtualNetworkTapsClient.Delete.
-type VirtualNetworkTapsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworkTapsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworkTapsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkTapsClientDeleteResponse, error) {
-	respType := VirtualNetworkTapsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworkTapsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualNetworkTapsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualNetworkTapsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworkTapsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworkTapsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworkTapsClientDeleteResponse contains the response from method VirtualNetworkTapsClient.Delete.
@@ -7846,79 +2066,9 @@ type VirtualNetworksClientCheckIPAddressAvailabilityResponse struct {
 	IPAddressAvailabilityResult
 }
 
-// VirtualNetworksClientCreateOrUpdatePollerResponse contains the response from method VirtualNetworksClient.CreateOrUpdate.
-type VirtualNetworksClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworksClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworksClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworksClientCreateOrUpdateResponse, error) {
-	respType := VirtualNetworksClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualNetwork)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworksClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualNetworksClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualNetworksClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworksClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworksClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualNetworksClientCreateOrUpdateResponse contains the response from method VirtualNetworksClient.CreateOrUpdate.
 type VirtualNetworksClientCreateOrUpdateResponse struct {
 	VirtualNetwork
-}
-
-// VirtualNetworksClientDeletePollerResponse contains the response from method VirtualNetworksClient.Delete.
-type VirtualNetworksClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualNetworksClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualNetworksClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworksClientDeleteResponse, error) {
-	respType := VirtualNetworksClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualNetworksClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualNetworksClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualNetworksClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualNetworksClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualNetworksClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualNetworksClientDeleteResponse contains the response from method VirtualNetworksClient.Delete.
@@ -7951,79 +2101,9 @@ type VirtualNetworksClientUpdateTagsResponse struct {
 	VirtualNetwork
 }
 
-// VirtualRouterPeeringsClientCreateOrUpdatePollerResponse contains the response from method VirtualRouterPeeringsClient.CreateOrUpdate.
-type VirtualRouterPeeringsClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualRouterPeeringsClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualRouterPeeringsClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRouterPeeringsClientCreateOrUpdateResponse, error) {
-	respType := VirtualRouterPeeringsClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualRouterPeering)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualRouterPeeringsClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualRouterPeeringsClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualRouterPeeringsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualRouterPeeringsClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualRouterPeeringsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualRouterPeeringsClientCreateOrUpdateResponse contains the response from method VirtualRouterPeeringsClient.CreateOrUpdate.
 type VirtualRouterPeeringsClientCreateOrUpdateResponse struct {
 	VirtualRouterPeering
-}
-
-// VirtualRouterPeeringsClientDeletePollerResponse contains the response from method VirtualRouterPeeringsClient.Delete.
-type VirtualRouterPeeringsClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualRouterPeeringsClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualRouterPeeringsClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRouterPeeringsClientDeleteResponse, error) {
-	respType := VirtualRouterPeeringsClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualRouterPeeringsClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualRouterPeeringsClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualRouterPeeringsClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualRouterPeeringsClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualRouterPeeringsClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualRouterPeeringsClientDeleteResponse contains the response from method VirtualRouterPeeringsClient.Delete.
@@ -8041,79 +2121,9 @@ type VirtualRouterPeeringsClientListResponse struct {
 	VirtualRouterPeeringListResult
 }
 
-// VirtualRoutersClientCreateOrUpdatePollerResponse contains the response from method VirtualRoutersClient.CreateOrUpdate.
-type VirtualRoutersClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualRoutersClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualRoutersClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRoutersClientCreateOrUpdateResponse, error) {
-	respType := VirtualRoutersClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualRouter)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualRoutersClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualRoutersClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualRoutersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualRoutersClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualRoutersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualRoutersClientCreateOrUpdateResponse contains the response from method VirtualRoutersClient.CreateOrUpdate.
 type VirtualRoutersClientCreateOrUpdateResponse struct {
 	VirtualRouter
-}
-
-// VirtualRoutersClientDeletePollerResponse contains the response from method VirtualRoutersClient.Delete.
-type VirtualRoutersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualRoutersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualRoutersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualRoutersClientDeleteResponse, error) {
-	respType := VirtualRoutersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualRoutersClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualRoutersClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualRoutersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualRoutersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualRoutersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualRoutersClientDeleteResponse contains the response from method VirtualRoutersClient.Delete.
@@ -8136,79 +2146,9 @@ type VirtualRoutersClientListResponse struct {
 	VirtualRouterListResult
 }
 
-// VirtualWansClientCreateOrUpdatePollerResponse contains the response from method VirtualWansClient.CreateOrUpdate.
-type VirtualWansClientCreateOrUpdatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualWansClientCreateOrUpdatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualWansClientCreateOrUpdatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualWansClientCreateOrUpdateResponse, error) {
-	respType := VirtualWansClientCreateOrUpdateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VirtualWAN)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualWansClientCreateOrUpdatePollerResponse from the provided client and resume token.
-func (l *VirtualWansClientCreateOrUpdatePollerResponse) Resume(ctx context.Context, client *VirtualWansClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualWansClient.CreateOrUpdate", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualWansClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // VirtualWansClientCreateOrUpdateResponse contains the response from method VirtualWansClient.CreateOrUpdate.
 type VirtualWansClientCreateOrUpdateResponse struct {
 	VirtualWAN
-}
-
-// VirtualWansClientDeletePollerResponse contains the response from method VirtualWansClient.Delete.
-type VirtualWansClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *VirtualWansClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l VirtualWansClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (VirtualWansClientDeleteResponse, error) {
-	respType := VirtualWansClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a VirtualWansClientDeletePollerResponse from the provided client and resume token.
-func (l *VirtualWansClientDeletePollerResponse) Resume(ctx context.Context, client *VirtualWansClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("VirtualWansClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &VirtualWansClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // VirtualWansClientDeleteResponse contains the response from method VirtualWansClient.Delete.
@@ -8236,41 +2176,6 @@ type VirtualWansClientUpdateTagsResponse struct {
 	VirtualWAN
 }
 
-// WatchersClientCheckConnectivityPollerResponse contains the response from method WatchersClient.CheckConnectivity.
-type WatchersClientCheckConnectivityPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientCheckConnectivityPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientCheckConnectivityPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientCheckConnectivityResponse, error) {
-	respType := WatchersClientCheckConnectivityResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConnectivityInformation)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientCheckConnectivityPollerResponse from the provided client and resume token.
-func (l *WatchersClientCheckConnectivityPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.CheckConnectivity", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientCheckConnectivityPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // WatchersClientCheckConnectivityResponse contains the response from method WatchersClient.CheckConnectivity.
 type WatchersClientCheckConnectivityResponse struct {
 	ConnectivityInformation
@@ -8281,79 +2186,9 @@ type WatchersClientCreateOrUpdateResponse struct {
 	Watcher
 }
 
-// WatchersClientDeletePollerResponse contains the response from method WatchersClient.Delete.
-type WatchersClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientDeleteResponse, error) {
-	respType := WatchersClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientDeletePollerResponse from the provided client and resume token.
-func (l *WatchersClientDeletePollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // WatchersClientDeleteResponse contains the response from method WatchersClient.Delete.
 type WatchersClientDeleteResponse struct {
 	// placeholder for future response values
-}
-
-// WatchersClientGetAzureReachabilityReportPollerResponse contains the response from method WatchersClient.GetAzureReachabilityReport.
-type WatchersClientGetAzureReachabilityReportPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientGetAzureReachabilityReportPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientGetAzureReachabilityReportPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetAzureReachabilityReportResponse, error) {
-	respType := WatchersClientGetAzureReachabilityReportResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AzureReachabilityReport)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientGetAzureReachabilityReportPollerResponse from the provided client and resume token.
-func (l *WatchersClientGetAzureReachabilityReportPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetAzureReachabilityReport", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientGetAzureReachabilityReportPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // WatchersClientGetAzureReachabilityReportResponse contains the response from method WatchersClient.GetAzureReachabilityReport.
@@ -8361,119 +2196,14 @@ type WatchersClientGetAzureReachabilityReportResponse struct {
 	AzureReachabilityReport
 }
 
-// WatchersClientGetFlowLogStatusPollerResponse contains the response from method WatchersClient.GetFlowLogStatus.
-type WatchersClientGetFlowLogStatusPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientGetFlowLogStatusPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientGetFlowLogStatusPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetFlowLogStatusResponse, error) {
-	respType := WatchersClientGetFlowLogStatusResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLogInformation)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientGetFlowLogStatusPollerResponse from the provided client and resume token.
-func (l *WatchersClientGetFlowLogStatusPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetFlowLogStatus", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientGetFlowLogStatusPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // WatchersClientGetFlowLogStatusResponse contains the response from method WatchersClient.GetFlowLogStatus.
 type WatchersClientGetFlowLogStatusResponse struct {
 	FlowLogInformation
 }
 
-// WatchersClientGetNetworkConfigurationDiagnosticPollerResponse contains the response from method WatchersClient.GetNetworkConfigurationDiagnostic.
-type WatchersClientGetNetworkConfigurationDiagnosticPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientGetNetworkConfigurationDiagnosticPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientGetNetworkConfigurationDiagnosticPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetNetworkConfigurationDiagnosticResponse, error) {
-	respType := WatchersClientGetNetworkConfigurationDiagnosticResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.ConfigurationDiagnosticResponse)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientGetNetworkConfigurationDiagnosticPollerResponse from the provided client and resume token.
-func (l *WatchersClientGetNetworkConfigurationDiagnosticPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetNetworkConfigurationDiagnostic", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientGetNetworkConfigurationDiagnosticPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // WatchersClientGetNetworkConfigurationDiagnosticResponse contains the response from method WatchersClient.GetNetworkConfigurationDiagnostic.
 type WatchersClientGetNetworkConfigurationDiagnosticResponse struct {
 	ConfigurationDiagnosticResponse
-}
-
-// WatchersClientGetNextHopPollerResponse contains the response from method WatchersClient.GetNextHop.
-type WatchersClientGetNextHopPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientGetNextHopPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientGetNextHopPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetNextHopResponse, error) {
-	respType := WatchersClientGetNextHopResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NextHopResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientGetNextHopPollerResponse from the provided client and resume token.
-func (l *WatchersClientGetNextHopPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetNextHop", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientGetNextHopPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // WatchersClientGetNextHopResponse contains the response from method WatchersClient.GetNextHop.
@@ -8491,119 +2221,14 @@ type WatchersClientGetTopologyResponse struct {
 	Topology
 }
 
-// WatchersClientGetTroubleshootingPollerResponse contains the response from method WatchersClient.GetTroubleshooting.
-type WatchersClientGetTroubleshootingPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientGetTroubleshootingPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientGetTroubleshootingPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetTroubleshootingResponse, error) {
-	respType := WatchersClientGetTroubleshootingResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TroubleshootingResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientGetTroubleshootingPollerResponse from the provided client and resume token.
-func (l *WatchersClientGetTroubleshootingPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshooting", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientGetTroubleshootingPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // WatchersClientGetTroubleshootingResponse contains the response from method WatchersClient.GetTroubleshooting.
 type WatchersClientGetTroubleshootingResponse struct {
 	TroubleshootingResult
 }
 
-// WatchersClientGetTroubleshootingResultPollerResponse contains the response from method WatchersClient.GetTroubleshootingResult.
-type WatchersClientGetTroubleshootingResultPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientGetTroubleshootingResultPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientGetTroubleshootingResultPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetTroubleshootingResultResponse, error) {
-	respType := WatchersClientGetTroubleshootingResultResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TroubleshootingResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientGetTroubleshootingResultPollerResponse from the provided client and resume token.
-func (l *WatchersClientGetTroubleshootingResultPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetTroubleshootingResult", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientGetTroubleshootingResultPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // WatchersClientGetTroubleshootingResultResponse contains the response from method WatchersClient.GetTroubleshootingResult.
 type WatchersClientGetTroubleshootingResultResponse struct {
 	TroubleshootingResult
-}
-
-// WatchersClientGetVMSecurityRulesPollerResponse contains the response from method WatchersClient.GetVMSecurityRules.
-type WatchersClientGetVMSecurityRulesPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientGetVMSecurityRulesPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientGetVMSecurityRulesPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientGetVMSecurityRulesResponse, error) {
-	respType := WatchersClientGetVMSecurityRulesResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SecurityGroupViewResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientGetVMSecurityRulesPollerResponse from the provided client and resume token.
-func (l *WatchersClientGetVMSecurityRulesPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.GetVMSecurityRules", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientGetVMSecurityRulesPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // WatchersClientGetVMSecurityRulesResponse contains the response from method WatchersClient.GetVMSecurityRules.
@@ -8616,41 +2241,6 @@ type WatchersClientListAllResponse struct {
 	WatcherListResult
 }
 
-// WatchersClientListAvailableProvidersPollerResponse contains the response from method WatchersClient.ListAvailableProviders.
-type WatchersClientListAvailableProvidersPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientListAvailableProvidersPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientListAvailableProvidersPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientListAvailableProvidersResponse, error) {
-	respType := WatchersClientListAvailableProvidersResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.AvailableProvidersList)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientListAvailableProvidersPollerResponse from the provided client and resume token.
-func (l *WatchersClientListAvailableProvidersPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.ListAvailableProviders", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientListAvailableProvidersPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // WatchersClientListAvailableProvidersResponse contains the response from method WatchersClient.ListAvailableProviders.
 type WatchersClientListAvailableProvidersResponse struct {
 	AvailableProvidersList
@@ -8659,41 +2249,6 @@ type WatchersClientListAvailableProvidersResponse struct {
 // WatchersClientListResponse contains the response from method WatchersClient.List.
 type WatchersClientListResponse struct {
 	WatcherListResult
-}
-
-// WatchersClientSetFlowLogConfigurationPollerResponse contains the response from method WatchersClient.SetFlowLogConfiguration.
-type WatchersClientSetFlowLogConfigurationPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientSetFlowLogConfigurationPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientSetFlowLogConfigurationPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientSetFlowLogConfigurationResponse, error) {
-	respType := WatchersClientSetFlowLogConfigurationResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.FlowLogInformation)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientSetFlowLogConfigurationPollerResponse from the provided client and resume token.
-func (l *WatchersClientSetFlowLogConfigurationPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.SetFlowLogConfiguration", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientSetFlowLogConfigurationPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // WatchersClientSetFlowLogConfigurationResponse contains the response from method WatchersClient.SetFlowLogConfiguration.
@@ -8706,41 +2261,6 @@ type WatchersClientUpdateTagsResponse struct {
 	Watcher
 }
 
-// WatchersClientVerifyIPFlowPollerResponse contains the response from method WatchersClient.VerifyIPFlow.
-type WatchersClientVerifyIPFlowPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WatchersClientVerifyIPFlowPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WatchersClientVerifyIPFlowPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WatchersClientVerifyIPFlowResponse, error) {
-	respType := WatchersClientVerifyIPFlowResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.VerificationIPFlowResult)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WatchersClientVerifyIPFlowPollerResponse from the provided client and resume token.
-func (l *WatchersClientVerifyIPFlowPollerResponse) Resume(ctx context.Context, client *WatchersClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WatchersClient.VerifyIPFlow", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WatchersClientVerifyIPFlowPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // WatchersClientVerifyIPFlowResponse contains the response from method WatchersClient.VerifyIPFlow.
 type WatchersClientVerifyIPFlowResponse struct {
 	VerificationIPFlowResult
@@ -8749,41 +2269,6 @@ type WatchersClientVerifyIPFlowResponse struct {
 // WebApplicationFirewallPoliciesClientCreateOrUpdateResponse contains the response from method WebApplicationFirewallPoliciesClient.CreateOrUpdate.
 type WebApplicationFirewallPoliciesClientCreateOrUpdateResponse struct {
 	WebApplicationFirewallPolicy
-}
-
-// WebApplicationFirewallPoliciesClientDeletePollerResponse contains the response from method WebApplicationFirewallPoliciesClient.Delete.
-type WebApplicationFirewallPoliciesClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *WebApplicationFirewallPoliciesClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-// A good starting value is 30 seconds. Note that some resources might benefit from a different value.
-func (l WebApplicationFirewallPoliciesClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (WebApplicationFirewallPoliciesClientDeleteResponse, error) {
-	respType := WebApplicationFirewallPoliciesClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a WebApplicationFirewallPoliciesClientDeletePollerResponse from the provided client and resume token.
-func (l *WebApplicationFirewallPoliciesClientDeletePollerResponse) Resume(ctx context.Context, client *WebApplicationFirewallPoliciesClient, token string) error {
-	pt, err := armruntime.NewPollerFromResumeToken("WebApplicationFirewallPoliciesClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &WebApplicationFirewallPoliciesClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // WebApplicationFirewallPoliciesClientDeleteResponse contains the response from method WebApplicationFirewallPoliciesClient.Delete.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
@@ -58,20 +58,16 @@ func NewRouteFilterRulesClient(subscriptionID string, credential azcore.TokenCre
 // routeFilterRuleParameters - Parameters supplied to the create or update route filter rule operation.
 // options - RouteFilterRulesClientBeginCreateOrUpdateOptions contains the optional parameters for the RouteFilterRulesClient.BeginCreateOrUpdate
 // method.
-func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule, options *RouteFilterRulesClientBeginCreateOrUpdateOptions) (RouteFilterRulesClientCreateOrUpdatePollerResponse, error) {
+func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule, options *RouteFilterRulesClientBeginCreateOrUpdateOptions) (*RouteFilterRulesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters, options)
 	if err != nil {
-		return RouteFilterRulesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := RouteFilterRulesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteFilterRulesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return RouteFilterRulesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RouteFilterRulesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RouteFilterRulesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a route in the specified route filter.
@@ -128,20 +124,16 @@ func (client *RouteFilterRulesClient) createOrUpdateCreateRequest(ctx context.Co
 // ruleName - The name of the rule.
 // options - RouteFilterRulesClientBeginDeleteOptions contains the optional parameters for the RouteFilterRulesClient.BeginDelete
 // method.
-func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesClientBeginDeleteOptions) (RouteFilterRulesClientDeletePollerResponse, error) {
+func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesClientBeginDeleteOptions) (*RouteFilterRulesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, routeFilterName, ruleName, options)
 	if err != nil {
-		return RouteFilterRulesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := RouteFilterRulesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteFilterRulesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return RouteFilterRulesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RouteFilterRulesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RouteFilterRulesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified rule from a route filter.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
@@ -57,20 +57,16 @@ func NewRouteFiltersClient(subscriptionID string, credential azcore.TokenCredent
 // routeFilterParameters - Parameters supplied to the create or update route filter operation.
 // options - RouteFiltersClientBeginCreateOrUpdateOptions contains the optional parameters for the RouteFiltersClient.BeginCreateOrUpdate
 // method.
-func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter, options *RouteFiltersClientBeginCreateOrUpdateOptions) (RouteFiltersClientCreateOrUpdatePollerResponse, error) {
+func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter, options *RouteFiltersClientBeginCreateOrUpdateOptions) (*RouteFiltersClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, routeFilterName, routeFilterParameters, options)
 	if err != nil {
-		return RouteFiltersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := RouteFiltersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteFiltersClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return RouteFiltersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RouteFiltersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RouteFiltersClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a route filter in a specified resource group.
@@ -122,20 +118,16 @@ func (client *RouteFiltersClient) createOrUpdateCreateRequest(ctx context.Contex
 // routeFilterName - The name of the route filter.
 // options - RouteFiltersClientBeginDeleteOptions contains the optional parameters for the RouteFiltersClient.BeginDelete
 // method.
-func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersClientBeginDeleteOptions) (RouteFiltersClientDeletePollerResponse, error) {
+func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersClientBeginDeleteOptions) (*RouteFiltersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, routeFilterName, options)
 	if err != nil {
-		return RouteFiltersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := RouteFiltersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteFiltersClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return RouteFiltersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RouteFiltersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RouteFiltersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified route filter.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
@@ -58,20 +58,16 @@ func NewRoutesClient(subscriptionID string, credential azcore.TokenCredential, o
 // routeParameters - Parameters supplied to the create or update route operation.
 // options - RoutesClientBeginCreateOrUpdateOptions contains the optional parameters for the RoutesClient.BeginCreateOrUpdate
 // method.
-func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route, options *RoutesClientBeginCreateOrUpdateOptions) (RoutesClientCreateOrUpdatePollerResponse, error) {
+func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route, options *RoutesClientBeginCreateOrUpdateOptions) (*RoutesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, routeTableName, routeName, routeParameters, options)
 	if err != nil {
-		return RoutesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := RoutesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RoutesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return RoutesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RoutesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RoutesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a route in the specified route table.
@@ -127,20 +123,16 @@ func (client *RoutesClient) createOrUpdateCreateRequest(ctx context.Context, res
 // routeTableName - The name of the route table.
 // routeName - The name of the route.
 // options - RoutesClientBeginDeleteOptions contains the optional parameters for the RoutesClient.BeginDelete method.
-func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesClientBeginDeleteOptions) (RoutesClientDeletePollerResponse, error) {
+func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesClientBeginDeleteOptions) (*RoutesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, routeTableName, routeName, options)
 	if err != nil {
-		return RoutesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := RoutesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RoutesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return RoutesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RoutesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RoutesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified route from a route table.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
@@ -57,20 +57,16 @@ func NewRouteTablesClient(subscriptionID string, credential azcore.TokenCredenti
 // parameters - Parameters supplied to the create or update route table operation.
 // options - RouteTablesClientBeginCreateOrUpdateOptions contains the optional parameters for the RouteTablesClient.BeginCreateOrUpdate
 // method.
-func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable, options *RouteTablesClientBeginCreateOrUpdateOptions) (RouteTablesClientCreateOrUpdatePollerResponse, error) {
+func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable, options *RouteTablesClientBeginCreateOrUpdateOptions) (*RouteTablesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, routeTableName, parameters, options)
 	if err != nil {
-		return RouteTablesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := RouteTablesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteTablesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return RouteTablesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RouteTablesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RouteTablesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Create or updates a route table in a specified resource group.
@@ -121,20 +117,16 @@ func (client *RouteTablesClient) createOrUpdateCreateRequest(ctx context.Context
 // resourceGroupName - The name of the resource group.
 // routeTableName - The name of the route table.
 // options - RouteTablesClientBeginDeleteOptions contains the optional parameters for the RouteTablesClient.BeginDelete method.
-func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesClientBeginDeleteOptions) (RouteTablesClientDeletePollerResponse, error) {
+func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesClientBeginDeleteOptions) (*RouteTablesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, routeTableName, options)
 	if err != nil {
-		return RouteTablesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := RouteTablesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("RouteTablesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return RouteTablesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &RouteTablesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &RouteTablesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified route table.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitygroups_client.go
@@ -57,20 +57,16 @@ func NewSecurityGroupsClient(subscriptionID string, credential azcore.TokenCrede
 // parameters - Parameters supplied to the create or update network security group operation.
 // options - SecurityGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the SecurityGroupsClient.BeginCreateOrUpdate
 // method.
-func (client *SecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, options *SecurityGroupsClientBeginCreateOrUpdateOptions) (SecurityGroupsClientCreateOrUpdatePollerResponse, error) {
+func (client *SecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, options *SecurityGroupsClientBeginCreateOrUpdateOptions) (*SecurityGroupsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkSecurityGroupName, parameters, options)
 	if err != nil {
-		return SecurityGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := SecurityGroupsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityGroupsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return SecurityGroupsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SecurityGroupsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SecurityGroupsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a network security group in the specified resource group.
@@ -122,20 +118,16 @@ func (client *SecurityGroupsClient) createOrUpdateCreateRequest(ctx context.Cont
 // networkSecurityGroupName - The name of the network security group.
 // options - SecurityGroupsClientBeginDeleteOptions contains the optional parameters for the SecurityGroupsClient.BeginDelete
 // method.
-func (client *SecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *SecurityGroupsClientBeginDeleteOptions) (SecurityGroupsClientDeletePollerResponse, error) {
+func (client *SecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *SecurityGroupsClientBeginDeleteOptions) (*SecurityGroupsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkSecurityGroupName, options)
 	if err != nil {
-		return SecurityGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := SecurityGroupsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityGroupsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return SecurityGroupsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SecurityGroupsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SecurityGroupsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified network security group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
@@ -57,20 +57,16 @@ func NewSecurityPartnerProvidersClient(subscriptionID string, credential azcore.
 // parameters - Parameters supplied to the create or update Security Partner Provider operation.
 // options - SecurityPartnerProvidersClientBeginCreateOrUpdateOptions contains the optional parameters for the SecurityPartnerProvidersClient.BeginCreateOrUpdate
 // method.
-func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider, options *SecurityPartnerProvidersClientBeginCreateOrUpdateOptions) (SecurityPartnerProvidersClientCreateOrUpdatePollerResponse, error) {
+func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider, options *SecurityPartnerProvidersClientBeginCreateOrUpdateOptions) (*SecurityPartnerProvidersClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, securityPartnerProviderName, parameters, options)
 	if err != nil {
-		return SecurityPartnerProvidersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := SecurityPartnerProvidersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityPartnerProvidersClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return SecurityPartnerProvidersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SecurityPartnerProvidersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SecurityPartnerProvidersClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Security Partner Provider.
@@ -122,20 +118,16 @@ func (client *SecurityPartnerProvidersClient) createOrUpdateCreateRequest(ctx co
 // securityPartnerProviderName - The name of the Security Partner Provider.
 // options - SecurityPartnerProvidersClientBeginDeleteOptions contains the optional parameters for the SecurityPartnerProvidersClient.BeginDelete
 // method.
-func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersClientBeginDeleteOptions) (SecurityPartnerProvidersClientDeletePollerResponse, error) {
+func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersClientBeginDeleteOptions) (*SecurityPartnerProvidersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, securityPartnerProviderName, options)
 	if err != nil {
-		return SecurityPartnerProvidersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := SecurityPartnerProvidersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityPartnerProvidersClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return SecurityPartnerProvidersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SecurityPartnerProvidersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SecurityPartnerProvidersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified Security Partner Provider.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
@@ -58,20 +58,16 @@ func NewSecurityRulesClient(subscriptionID string, credential azcore.TokenCreden
 // securityRuleParameters - Parameters supplied to the create or update network security rule operation.
 // options - SecurityRulesClientBeginCreateOrUpdateOptions contains the optional parameters for the SecurityRulesClient.BeginCreateOrUpdate
 // method.
-func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, options *SecurityRulesClientBeginCreateOrUpdateOptions) (SecurityRulesClientCreateOrUpdatePollerResponse, error) {
+func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, options *SecurityRulesClientBeginCreateOrUpdateOptions) (*SecurityRulesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters, options)
 	if err != nil {
-		return SecurityRulesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := SecurityRulesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityRulesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return SecurityRulesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SecurityRulesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SecurityRulesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a security rule in the specified network security group.
@@ -128,20 +124,16 @@ func (client *SecurityRulesClient) createOrUpdateCreateRequest(ctx context.Conte
 // securityRuleName - The name of the security rule.
 // options - SecurityRulesClientBeginDeleteOptions contains the optional parameters for the SecurityRulesClient.BeginDelete
 // method.
-func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesClientBeginDeleteOptions) (SecurityRulesClientDeletePollerResponse, error) {
+func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesClientBeginDeleteOptions) (*SecurityRulesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, options)
 	if err != nil {
-		return SecurityRulesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := SecurityRulesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SecurityRulesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return SecurityRulesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SecurityRulesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SecurityRulesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified network security rule.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
@@ -57,20 +57,16 @@ func NewServiceEndpointPoliciesClient(subscriptionID string, credential azcore.T
 // parameters - Parameters supplied to the create or update service endpoint policy operation.
 // options - ServiceEndpointPoliciesClientBeginCreateOrUpdateOptions contains the optional parameters for the ServiceEndpointPoliciesClient.BeginCreateOrUpdate
 // method.
-func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy, options *ServiceEndpointPoliciesClientBeginCreateOrUpdateOptions) (ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse, error) {
+func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy, options *ServiceEndpointPoliciesClientBeginCreateOrUpdateOptions) (*ServiceEndpointPoliciesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, serviceEndpointPolicyName, parameters, options)
 	if err != nil {
-		return ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ServiceEndpointPoliciesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ServiceEndpointPoliciesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ServiceEndpointPoliciesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ServiceEndpointPoliciesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a service Endpoint Policies.
@@ -122,20 +118,16 @@ func (client *ServiceEndpointPoliciesClient) createOrUpdateCreateRequest(ctx con
 // serviceEndpointPolicyName - The name of the service endpoint policy.
 // options - ServiceEndpointPoliciesClientBeginDeleteOptions contains the optional parameters for the ServiceEndpointPoliciesClient.BeginDelete
 // method.
-func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesClientBeginDeleteOptions) (ServiceEndpointPoliciesClientDeletePollerResponse, error) {
+func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesClientBeginDeleteOptions) (*ServiceEndpointPoliciesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, serviceEndpointPolicyName, options)
 	if err != nil {
-		return ServiceEndpointPoliciesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ServiceEndpointPoliciesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ServiceEndpointPoliciesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ServiceEndpointPoliciesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ServiceEndpointPoliciesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ServiceEndpointPoliciesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified service endpoint policy.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
@@ -58,20 +58,16 @@ func NewServiceEndpointPolicyDefinitionsClient(subscriptionID string, credential
 // serviceEndpointPolicyDefinitions - Parameters supplied to the create or update service endpoint policy operation.
 // options - ServiceEndpointPolicyDefinitionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ServiceEndpointPolicyDefinitionsClient.BeginCreateOrUpdate
 // method.
-func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition, options *ServiceEndpointPolicyDefinitionsClientBeginCreateOrUpdateOptions) (ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse, error) {
+func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition, options *ServiceEndpointPolicyDefinitionsClientBeginCreateOrUpdateOptions) (*ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, serviceEndpointPolicyDefinitions, options)
 	if err != nil {
-		return ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ServiceEndpointPolicyDefinitionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a service endpoint policy definition in the specified service endpoint policy.
@@ -128,20 +124,16 @@ func (client *ServiceEndpointPolicyDefinitionsClient) createOrUpdateCreateReques
 // serviceEndpointPolicyDefinitionName - The name of the service endpoint policy definition.
 // options - ServiceEndpointPolicyDefinitionsClientBeginDeleteOptions contains the optional parameters for the ServiceEndpointPolicyDefinitionsClient.BeginDelete
 // method.
-func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsClientBeginDeleteOptions) (ServiceEndpointPolicyDefinitionsClientDeletePollerResponse, error) {
+func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsClientBeginDeleteOptions) (*ServiceEndpointPolicyDefinitionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, options)
 	if err != nil {
-		return ServiceEndpointPolicyDefinitionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := ServiceEndpointPolicyDefinitionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("ServiceEndpointPolicyDefinitionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return ServiceEndpointPolicyDefinitionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &ServiceEndpointPolicyDefinitionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &ServiceEndpointPolicyDefinitionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified ServiceEndpoint policy definitions.

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
@@ -58,20 +58,16 @@ func NewSubnetsClient(subscriptionID string, credential azcore.TokenCredential, 
 // subnetParameters - Parameters supplied to the create or update subnet operation.
 // options - SubnetsClientBeginCreateOrUpdateOptions contains the optional parameters for the SubnetsClient.BeginCreateOrUpdate
 // method.
-func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, options *SubnetsClientBeginCreateOrUpdateOptions) (SubnetsClientCreateOrUpdatePollerResponse, error) {
+func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, options *SubnetsClientBeginCreateOrUpdateOptions) (*SubnetsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters, options)
 	if err != nil {
-		return SubnetsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := SubnetsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("SubnetsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return SubnetsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SubnetsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SubnetsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a subnet in the specified virtual network.
@@ -127,20 +123,16 @@ func (client *SubnetsClient) createOrUpdateCreateRequest(ctx context.Context, re
 // virtualNetworkName - The name of the virtual network.
 // subnetName - The name of the subnet.
 // options - SubnetsClientBeginDeleteOptions contains the optional parameters for the SubnetsClient.BeginDelete method.
-func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsClientBeginDeleteOptions) (SubnetsClientDeletePollerResponse, error) {
+func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsClientBeginDeleteOptions) (*SubnetsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualNetworkName, subnetName, options)
 	if err != nil {
-		return SubnetsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := SubnetsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("SubnetsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return SubnetsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SubnetsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SubnetsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified subnet.
@@ -313,20 +305,16 @@ func (client *SubnetsClient) listHandleResponse(resp *http.Response) (SubnetsCli
 // prepareNetworkPoliciesRequestParameters - Parameters supplied to prepare subnet by applying network intent policies.
 // options - SubnetsClientBeginPrepareNetworkPoliciesOptions contains the optional parameters for the SubnetsClient.BeginPrepareNetworkPolicies
 // method.
-func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest, options *SubnetsClientBeginPrepareNetworkPoliciesOptions) (SubnetsClientPrepareNetworkPoliciesPollerResponse, error) {
+func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest, options *SubnetsClientBeginPrepareNetworkPoliciesOptions) (*SubnetsClientPrepareNetworkPoliciesPoller, error) {
 	resp, err := client.prepareNetworkPolicies(ctx, resourceGroupName, virtualNetworkName, subnetName, prepareNetworkPoliciesRequestParameters, options)
 	if err != nil {
-		return SubnetsClientPrepareNetworkPoliciesPollerResponse{}, err
+		return nil, err
 	}
-	result := SubnetsClientPrepareNetworkPoliciesPollerResponse{}
 	pt, err := armruntime.NewPoller("SubnetsClient.PrepareNetworkPolicies", "location", resp, client.pl)
 	if err != nil {
-		return SubnetsClientPrepareNetworkPoliciesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SubnetsClientPrepareNetworkPoliciesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SubnetsClientPrepareNetworkPoliciesPoller{pt: pt}, nil
 }
 
 // PrepareNetworkPolicies - Prepares a subnet by applying network intent policies.
@@ -384,20 +372,16 @@ func (client *SubnetsClient) prepareNetworkPoliciesCreateRequest(ctx context.Con
 // unprepareNetworkPoliciesRequestParameters - Parameters supplied to unprepare subnet to remove network intent policies.
 // options - SubnetsClientBeginUnprepareNetworkPoliciesOptions contains the optional parameters for the SubnetsClient.BeginUnprepareNetworkPolicies
 // method.
-func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest, options *SubnetsClientBeginUnprepareNetworkPoliciesOptions) (SubnetsClientUnprepareNetworkPoliciesPollerResponse, error) {
+func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest, options *SubnetsClientBeginUnprepareNetworkPoliciesOptions) (*SubnetsClientUnprepareNetworkPoliciesPoller, error) {
 	resp, err := client.unprepareNetworkPolicies(ctx, resourceGroupName, virtualNetworkName, subnetName, unprepareNetworkPoliciesRequestParameters, options)
 	if err != nil {
-		return SubnetsClientUnprepareNetworkPoliciesPollerResponse{}, err
+		return nil, err
 	}
-	result := SubnetsClientUnprepareNetworkPoliciesPollerResponse{}
 	pt, err := armruntime.NewPoller("SubnetsClient.UnprepareNetworkPolicies", "location", resp, client.pl)
 	if err != nil {
-		return SubnetsClientUnprepareNetworkPoliciesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &SubnetsClientUnprepareNetworkPoliciesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &SubnetsClientUnprepareNetworkPoliciesPoller{pt: pt}, nil
 }
 
 // UnprepareNetworkPolicies - Unprepares a subnet by removing network intent policies.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualappliances_client.go
@@ -57,20 +57,16 @@ func NewVirtualAppliancesClient(subscriptionID string, credential azcore.TokenCr
 // parameters - Parameters supplied to the create or update Network Virtual Appliance.
 // options - VirtualAppliancesClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualAppliancesClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters VirtualAppliance, options *VirtualAppliancesClientBeginCreateOrUpdateOptions) (VirtualAppliancesClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters VirtualAppliance, options *VirtualAppliancesClientBeginCreateOrUpdateOptions) (*VirtualAppliancesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, networkVirtualApplianceName, parameters, options)
 	if err != nil {
-		return VirtualAppliancesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualAppliancesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualAppliancesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualAppliancesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualAppliancesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualAppliancesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Network Virtual Appliance.
@@ -122,20 +118,16 @@ func (client *VirtualAppliancesClient) createOrUpdateCreateRequest(ctx context.C
 // networkVirtualApplianceName - The name of Network Virtual Appliance.
 // options - VirtualAppliancesClientBeginDeleteOptions contains the optional parameters for the VirtualAppliancesClient.BeginDelete
 // method.
-func (client *VirtualAppliancesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *VirtualAppliancesClientBeginDeleteOptions) (VirtualAppliancesClientDeletePollerResponse, error) {
+func (client *VirtualAppliancesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *VirtualAppliancesClientBeginDeleteOptions) (*VirtualAppliancesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkVirtualApplianceName, options)
 	if err != nil {
-		return VirtualAppliancesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualAppliancesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualAppliancesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualAppliancesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualAppliancesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualAppliancesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified Network Virtual Appliance.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
@@ -58,20 +58,16 @@ func NewVirtualHubRouteTableV2SClient(subscriptionID string, credential azcore.T
 // virtualHubRouteTableV2Parameters - Parameters supplied to create or update VirtualHubRouteTableV2.
 // options - VirtualHubRouteTableV2SClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubRouteTableV2SClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2, options *VirtualHubRouteTableV2SClientBeginCreateOrUpdateOptions) (VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2, options *VirtualHubRouteTableV2SClientBeginCreateOrUpdateOptions) (*VirtualHubRouteTableV2SClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualHubName, routeTableName, virtualHubRouteTableV2Parameters, options)
 	if err != nil {
-		return VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualHubRouteTableV2SClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualHubRouteTableV2SClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualHubRouteTableV2SClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualHubRouteTableV2SClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a VirtualHubRouteTableV2 resource if it doesn't exist else updates the existing VirtualHubRouteTableV2.
@@ -128,20 +124,16 @@ func (client *VirtualHubRouteTableV2SClient) createOrUpdateCreateRequest(ctx con
 // routeTableName - The name of the VirtualHubRouteTableV2.
 // options - VirtualHubRouteTableV2SClientBeginDeleteOptions contains the optional parameters for the VirtualHubRouteTableV2SClient.BeginDelete
 // method.
-func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SClientBeginDeleteOptions) (VirtualHubRouteTableV2SClientDeletePollerResponse, error) {
+func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SClientBeginDeleteOptions) (*VirtualHubRouteTableV2SClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualHubName, routeTableName, options)
 	if err != nil {
-		return VirtualHubRouteTableV2SClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualHubRouteTableV2SClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualHubRouteTableV2SClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualHubRouteTableV2SClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualHubRouteTableV2SClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualHubRouteTableV2SClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a VirtualHubRouteTableV2.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
@@ -57,20 +57,16 @@ func NewVirtualHubsClient(subscriptionID string, credential azcore.TokenCredenti
 // virtualHubParameters - Parameters supplied to create or update VirtualHub.
 // options - VirtualHubsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub, options *VirtualHubsClientBeginCreateOrUpdateOptions) (VirtualHubsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub, options *VirtualHubsClientBeginCreateOrUpdateOptions) (*VirtualHubsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualHubName, virtualHubParameters, options)
 	if err != nil {
-		return VirtualHubsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualHubsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualHubsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualHubsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualHubsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualHubsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a VirtualHub resource if it doesn't exist else updates the existing VirtualHub.
@@ -121,20 +117,16 @@ func (client *VirtualHubsClient) createOrUpdateCreateRequest(ctx context.Context
 // resourceGroupName - The resource group name of the VirtualHub.
 // virtualHubName - The name of the VirtualHub.
 // options - VirtualHubsClientBeginDeleteOptions contains the optional parameters for the VirtualHubsClient.BeginDelete method.
-func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsClientBeginDeleteOptions) (VirtualHubsClientDeletePollerResponse, error) {
+func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsClientBeginDeleteOptions) (*VirtualHubsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualHubName, options)
 	if err != nil {
-		return VirtualHubsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualHubsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualHubsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualHubsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualHubsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualHubsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a VirtualHub.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
@@ -57,20 +57,16 @@ func NewVirtualNetworkGatewayConnectionsClient(subscriptionID string, credential
 // parameters - Parameters supplied to the create or update virtual network gateway connection operation.
 // options - VirtualNetworkGatewayConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkGatewayConnectionsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, options *VirtualNetworkGatewayConnectionsClientBeginCreateOrUpdateOptions) (VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, options *VirtualNetworkGatewayConnectionsClientBeginCreateOrUpdateOptions) (*VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewayConnectionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a virtual network gateway connection in the specified resource group.
@@ -122,20 +118,16 @@ func (client *VirtualNetworkGatewayConnectionsClient) createOrUpdateCreateReques
 // virtualNetworkGatewayConnectionName - The name of the virtual network gateway connection.
 // options - VirtualNetworkGatewayConnectionsClientBeginDeleteOptions contains the optional parameters for the VirtualNetworkGatewayConnectionsClient.BeginDelete
 // method.
-func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsClientBeginDeleteOptions) (VirtualNetworkGatewayConnectionsClientDeletePollerResponse, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsClientBeginDeleteOptions) (*VirtualNetworkGatewayConnectionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, options)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewayConnectionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewayConnectionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified virtual network Gateway connection.
@@ -352,20 +344,16 @@ func (client *VirtualNetworkGatewayConnectionsClient) listHandleResponse(resp *h
 // resource provider.
 // options - VirtualNetworkGatewayConnectionsClientBeginResetSharedKeyOptions contains the optional parameters for the VirtualNetworkGatewayConnectionsClient.BeginResetSharedKey
 // method.
-func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, options *VirtualNetworkGatewayConnectionsClientBeginResetSharedKeyOptions) (VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, options *VirtualNetworkGatewayConnectionsClientBeginResetSharedKeyOptions) (*VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller, error) {
 	resp, err := client.resetSharedKey(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.ResetSharedKey", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientResetSharedKeyPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewayConnectionsClientResetSharedKeyPoller{pt: pt}, nil
 }
 
 // ResetSharedKey - The VirtualNetworkGatewayConnectionResetSharedKey operation resets the virtual network gateway connection
@@ -423,20 +411,16 @@ func (client *VirtualNetworkGatewayConnectionsClient) resetSharedKeyCreateReques
 // resource provider.
 // options - VirtualNetworkGatewayConnectionsClientBeginSetSharedKeyOptions contains the optional parameters for the VirtualNetworkGatewayConnectionsClient.BeginSetSharedKey
 // method.
-func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, options *VirtualNetworkGatewayConnectionsClientBeginSetSharedKeyOptions) (VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, options *VirtualNetworkGatewayConnectionsClientBeginSetSharedKeyOptions) (*VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller, error) {
 	resp, err := client.setSharedKey(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.SetSharedKey", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientSetSharedKeyPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewayConnectionsClientSetSharedKeyPoller{pt: pt}, nil
 }
 
 // SetSharedKey - The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual network gateway connection shared
@@ -490,20 +474,16 @@ func (client *VirtualNetworkGatewayConnectionsClient) setSharedKeyCreateRequest(
 // virtualNetworkGatewayConnectionName - The name of the virtual network gateway connection.
 // options - VirtualNetworkGatewayConnectionsClientBeginStartPacketCaptureOptions contains the optional parameters for the
 // VirtualNetworkGatewayConnectionsClient.BeginStartPacketCapture method.
-func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsClientBeginStartPacketCaptureOptions) (VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsClientBeginStartPacketCaptureOptions) (*VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller, error) {
 	resp, err := client.startPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, options)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.StartPacketCapture", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientStartPacketCapturePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewayConnectionsClientStartPacketCapturePoller{pt: pt}, nil
 }
 
 // StartPacketCapture - Starts packet capture on virtual network gateway connection in the specified resource group.
@@ -559,20 +539,16 @@ func (client *VirtualNetworkGatewayConnectionsClient) startPacketCaptureCreateRe
 // parameters - Virtual network gateway packet capture parameters supplied to stop packet capture on gateway connection.
 // options - VirtualNetworkGatewayConnectionsClientBeginStopPacketCaptureOptions contains the optional parameters for the
 // VirtualNetworkGatewayConnectionsClient.BeginStopPacketCapture method.
-func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VPNPacketCaptureStopParameters, options *VirtualNetworkGatewayConnectionsClientBeginStopPacketCaptureOptions) (VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VPNPacketCaptureStopParameters, options *VirtualNetworkGatewayConnectionsClientBeginStopPacketCaptureOptions) (*VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller, error) {
 	resp, err := client.stopPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.StopPacketCapture", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientStopPacketCapturePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewayConnectionsClientStopPacketCapturePoller{pt: pt}, nil
 }
 
 // StopPacketCapture - Stops packet capture on virtual network gateway connection in the specified resource group.
@@ -625,20 +601,16 @@ func (client *VirtualNetworkGatewayConnectionsClient) stopPacketCaptureCreateReq
 // parameters - Parameters supplied to update virtual network gateway connection tags.
 // options - VirtualNetworkGatewayConnectionsClientBeginUpdateTagsOptions contains the optional parameters for the VirtualNetworkGatewayConnectionsClient.BeginUpdateTags
 // method.
-func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject, options *VirtualNetworkGatewayConnectionsClientBeginUpdateTagsOptions) (VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject, options *VirtualNetworkGatewayConnectionsClientBeginUpdateTagsOptions) (*VirtualNetworkGatewayConnectionsClientUpdateTagsPoller, error) {
 	resp, err := client.updateTags(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewayConnectionsClient.UpdateTags", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewayConnectionsClientUpdateTagsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewayConnectionsClientUpdateTagsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewayConnectionsClientUpdateTagsPoller{pt: pt}, nil
 }
 
 // UpdateTags - Updates a virtual network gateway connection tags.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
@@ -57,20 +57,16 @@ func NewVirtualNetworkGatewaysClient(subscriptionID string, credential azcore.To
 // parameters - Parameters supplied to create or update virtual network gateway operation.
 // options - VirtualNetworkGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, options *VirtualNetworkGatewaysClientBeginCreateOrUpdateOptions) (VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, options *VirtualNetworkGatewaysClientBeginCreateOrUpdateOptions) (*VirtualNetworkGatewaysClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a virtual network gateway in the specified resource group.
@@ -122,20 +118,16 @@ func (client *VirtualNetworkGatewaysClient) createOrUpdateCreateRequest(ctx cont
 // virtualNetworkGatewayName - The name of the virtual network gateway.
 // options - VirtualNetworkGatewaysClientBeginDeleteOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginDelete
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginDeleteOptions) (VirtualNetworkGatewaysClientDeletePollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginDeleteOptions) (*VirtualNetworkGatewaysClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified virtual network gateway.
@@ -189,20 +181,16 @@ func (client *VirtualNetworkGatewaysClient) deleteCreateRequest(ctx context.Cont
 // request - The parameters are supplied to disconnect vpn connections.
 // options - VirtualNetworkGatewaysClientBeginDisconnectVirtualNetworkGatewayVPNConnectionsOptions contains the optional parameters
 // for the VirtualNetworkGatewaysClient.BeginDisconnectVirtualNetworkGatewayVPNConnections method.
-func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGatewayVPNConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVPNConnectionRequest, options *VirtualNetworkGatewaysClientBeginDisconnectVirtualNetworkGatewayVPNConnectionsOptions) (VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGatewayVPNConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVPNConnectionRequest, options *VirtualNetworkGatewaysClientBeginDisconnectVirtualNetworkGatewayVPNConnectionsOptions) (*VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller, error) {
 	resp, err := client.disconnectVirtualNetworkGatewayVPNConnections(ctx, resourceGroupName, virtualNetworkGatewayName, request, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsPoller{pt: pt}, nil
 }
 
 // DisconnectVirtualNetworkGatewayVPNConnections - Disconnect vpn connections of virtual network gateway in the specified
@@ -257,20 +245,16 @@ func (client *VirtualNetworkGatewaysClient) disconnectVirtualNetworkGatewayVPNCo
 // parameters - Parameters supplied to the generate virtual network gateway VPN client package operation.
 // options - VirtualNetworkGatewaysClientBeginGenerateVPNProfileOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginGenerateVPNProfile
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginGenerateVPNProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VPNClientParameters, options *VirtualNetworkGatewaysClientBeginGenerateVPNProfileOptions) (VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginGenerateVPNProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VPNClientParameters, options *VirtualNetworkGatewaysClientBeginGenerateVPNProfileOptions) (*VirtualNetworkGatewaysClientGenerateVPNProfilePoller, error) {
 	resp, err := client.generateVPNProfile(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GenerateVPNProfile", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGenerateVPNProfilePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientGenerateVPNProfilePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientGenerateVPNProfilePoller{pt: pt}, nil
 }
 
 // GenerateVPNProfile - Generates VPN profile for P2S client of the virtual network gateway in the specified resource group.
@@ -325,20 +309,16 @@ func (client *VirtualNetworkGatewaysClient) generateVPNProfileCreateRequest(ctx 
 // parameters - Parameters supplied to the generate virtual network gateway VPN client package operation.
 // options - VirtualNetworkGatewaysClientBeginGeneratevpnclientpackageOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginGeneratevpnclientpackage
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VPNClientParameters, options *VirtualNetworkGatewaysClientBeginGeneratevpnclientpackageOptions) (VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VPNClientParameters, options *VirtualNetworkGatewaysClientBeginGeneratevpnclientpackageOptions) (*VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller, error) {
 	resp, err := client.generatevpnclientpackage(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.Generatevpnclientpackage", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGeneratevpnclientpackagePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientGeneratevpnclientpackagePoller{pt: pt}, nil
 }
 
 // Generatevpnclientpackage - Generates VPN client package for P2S client of the virtual network gateway in the specified
@@ -449,20 +429,16 @@ func (client *VirtualNetworkGatewaysClient) getHandleResponse(resp *http.Respons
 // peer - The IP address of the peer.
 // options - VirtualNetworkGatewaysClientBeginGetAdvertisedRoutesOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginGetAdvertisedRoutes
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string, options *VirtualNetworkGatewaysClientBeginGetAdvertisedRoutesOptions) (VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string, options *VirtualNetworkGatewaysClientBeginGetAdvertisedRoutesOptions) (*VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller, error) {
 	resp, err := client.getAdvertisedRoutes(ctx, resourceGroupName, virtualNetworkGatewayName, peer, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetAdvertisedRoutes", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetAdvertisedRoutesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientGetAdvertisedRoutesPoller{pt: pt}, nil
 }
 
 // GetAdvertisedRoutes - This operation retrieves a list of routes the virtual network gateway is advertising to the specified
@@ -516,20 +492,16 @@ func (client *VirtualNetworkGatewaysClient) getAdvertisedRoutesCreateRequest(ctx
 // virtualNetworkGatewayName - The name of the virtual network gateway.
 // options - VirtualNetworkGatewaysClientBeginGetBgpPeerStatusOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginGetBgpPeerStatus
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetBgpPeerStatusOptions) (VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetBgpPeerStatusOptions) (*VirtualNetworkGatewaysClientGetBgpPeerStatusPoller, error) {
 	resp, err := client.getBgpPeerStatus(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetBgpPeerStatus", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetBgpPeerStatusPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientGetBgpPeerStatusPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientGetBgpPeerStatusPoller{pt: pt}, nil
 }
 
 // GetBgpPeerStatus - The GetBgpPeerStatus operation retrieves the status of all BGP peers.
@@ -585,20 +557,16 @@ func (client *VirtualNetworkGatewaysClient) getBgpPeerStatusCreateRequest(ctx co
 // virtualNetworkGatewayName - The name of the virtual network gateway.
 // options - VirtualNetworkGatewaysClientBeginGetLearnedRoutesOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginGetLearnedRoutes
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetLearnedRoutesOptions) (VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetLearnedRoutesOptions) (*VirtualNetworkGatewaysClientGetLearnedRoutesPoller, error) {
 	resp, err := client.getLearnedRoutes(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetLearnedRoutes", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetLearnedRoutesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientGetLearnedRoutesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientGetLearnedRoutesPoller{pt: pt}, nil
 }
 
 // GetLearnedRoutes - This operation retrieves a list of routes the virtual network gateway has learned, including routes
@@ -652,20 +620,16 @@ func (client *VirtualNetworkGatewaysClient) getLearnedRoutesCreateRequest(ctx co
 // virtualNetworkGatewayName - The name of the virtual network gateway.
 // options - VirtualNetworkGatewaysClientBeginGetVPNProfilePackageURLOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginGetVPNProfilePackageURL
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginGetVPNProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetVPNProfilePackageURLOptions) (VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginGetVPNProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetVPNProfilePackageURLOptions) (*VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller, error) {
 	resp, err := client.getVPNProfilePackageURL(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetVPNProfilePackageURL", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetVPNProfilePackageURLPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientGetVPNProfilePackageURLPoller{pt: pt}, nil
 }
 
 // GetVPNProfilePackageURL - Gets pre-generated VPN profile for P2S client of the virtual network gateway in the specified
@@ -719,20 +683,16 @@ func (client *VirtualNetworkGatewaysClient) getVPNProfilePackageURLCreateRequest
 // virtualNetworkGatewayName - The name of the virtual network gateway.
 // options - VirtualNetworkGatewaysClientBeginGetVpnclientConnectionHealthOptions contains the optional parameters for the
 // VirtualNetworkGatewaysClient.BeginGetVpnclientConnectionHealth method.
-func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetVpnclientConnectionHealthOptions) (VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetVpnclientConnectionHealthOptions) (*VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller, error) {
 	resp, err := client.getVpnclientConnectionHealth(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientGetVpnclientConnectionHealthPoller{pt: pt}, nil
 }
 
 // GetVpnclientConnectionHealth - Get VPN client connection health detail per P2S client connection of the virtual network
@@ -787,20 +747,16 @@ func (client *VirtualNetworkGatewaysClient) getVpnclientConnectionHealthCreateRe
 // virtualNetworkGatewayName - The virtual network gateway name.
 // options - VirtualNetworkGatewaysClientBeginGetVpnclientIPSecParametersOptions contains the optional parameters for the
 // VirtualNetworkGatewaysClient.BeginGetVpnclientIPSecParameters method.
-func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPSecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetVpnclientIPSecParametersOptions) (VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPSecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginGetVpnclientIPSecParametersOptions) (*VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller, error) {
 	resp, err := client.getVpnclientIPSecParameters(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientGetVpnclientIPSecParametersPoller{pt: pt}, nil
 }
 
 // GetVpnclientIPSecParameters - The Get VpnclientIpsecParameters operation retrieves information about the vpnclient ipsec
@@ -955,20 +911,16 @@ func (client *VirtualNetworkGatewaysClient) listConnectionsHandleResponse(resp *
 // virtualNetworkGatewayName - The name of the virtual network gateway.
 // options - VirtualNetworkGatewaysClientBeginResetOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginReset
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginResetOptions) (VirtualNetworkGatewaysClientResetPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginResetOptions) (*VirtualNetworkGatewaysClientResetPoller, error) {
 	resp, err := client.reset(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientResetPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientResetPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.Reset", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientResetPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientResetPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientResetPoller{pt: pt}, nil
 }
 
 // Reset - Resets the primary of the virtual network gateway in the specified resource group.
@@ -1024,20 +976,16 @@ func (client *VirtualNetworkGatewaysClient) resetCreateRequest(ctx context.Conte
 // virtualNetworkGatewayName - The name of the virtual network gateway.
 // options - VirtualNetworkGatewaysClientBeginResetVPNClientSharedKeyOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginResetVPNClientSharedKey
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginResetVPNClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginResetVPNClientSharedKeyOptions) (VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginResetVPNClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginResetVPNClientSharedKeyOptions) (*VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller, error) {
 	resp, err := client.resetVPNClientSharedKey(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.ResetVPNClientSharedKey", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientResetVPNClientSharedKeyPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientResetVPNClientSharedKeyPoller{pt: pt}, nil
 }
 
 // ResetVPNClientSharedKey - Resets the VPN client shared key of the virtual network gateway in the specified resource group.
@@ -1092,20 +1040,16 @@ func (client *VirtualNetworkGatewaysClient) resetVPNClientSharedKeyCreateRequest
 // operation through Network resource provider.
 // options - VirtualNetworkGatewaysClientBeginSetVpnclientIPSecParametersOptions contains the optional parameters for the
 // VirtualNetworkGatewaysClient.BeginSetVpnclientIPSecParameters method.
-func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPSecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIPSecParams VPNClientIPsecParameters, options *VirtualNetworkGatewaysClientBeginSetVpnclientIPSecParametersOptions) (VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPSecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIPSecParams VPNClientIPsecParameters, options *VirtualNetworkGatewaysClientBeginSetVpnclientIPSecParametersOptions) (*VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller, error) {
 	resp, err := client.setVpnclientIPSecParameters(ctx, resourceGroupName, virtualNetworkGatewayName, vpnclientIPSecParams, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientSetVpnclientIPSecParametersPoller{pt: pt}, nil
 }
 
 // SetVpnclientIPSecParameters - The Set VpnclientIpsecParameters operation sets the vpnclient ipsec policy for P2S client
@@ -1158,20 +1102,16 @@ func (client *VirtualNetworkGatewaysClient) setVpnclientIPSecParametersCreateReq
 // virtualNetworkGatewayName - The name of the virtual network gateway.
 // options - VirtualNetworkGatewaysClientBeginStartPacketCaptureOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginStartPacketCapture
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginStartPacketCaptureOptions) (VirtualNetworkGatewaysClientStartPacketCapturePollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysClientBeginStartPacketCaptureOptions) (*VirtualNetworkGatewaysClientStartPacketCapturePoller, error) {
 	resp, err := client.startPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientStartPacketCapturePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientStartPacketCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.StartPacketCapture", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientStartPacketCapturePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientStartPacketCapturePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientStartPacketCapturePoller{pt: pt}, nil
 }
 
 // StartPacketCapture - Starts packet capture on virtual network gateway in the specified resource group.
@@ -1227,20 +1167,16 @@ func (client *VirtualNetworkGatewaysClient) startPacketCaptureCreateRequest(ctx 
 // parameters - Virtual network gateway packet capture parameters supplied to stop packet capture on gateway.
 // options - VirtualNetworkGatewaysClientBeginStopPacketCaptureOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginStopPacketCapture
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VPNPacketCaptureStopParameters, options *VirtualNetworkGatewaysClientBeginStopPacketCaptureOptions) (VirtualNetworkGatewaysClientStopPacketCapturePollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VPNPacketCaptureStopParameters, options *VirtualNetworkGatewaysClientBeginStopPacketCaptureOptions) (*VirtualNetworkGatewaysClientStopPacketCapturePoller, error) {
 	resp, err := client.stopPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientStopPacketCapturePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientStopPacketCapturePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.StopPacketCapture", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientStopPacketCapturePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientStopPacketCapturePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientStopPacketCapturePoller{pt: pt}, nil
 }
 
 // StopPacketCapture - Stops packet capture on virtual network gateway in the specified resource group.
@@ -1349,20 +1285,16 @@ func (client *VirtualNetworkGatewaysClient) supportedVPNDevicesHandleResponse(re
 // parameters - Parameters supplied to update virtual network gateway tags.
 // options - VirtualNetworkGatewaysClientBeginUpdateTagsOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginUpdateTags
 // method.
-func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject, options *VirtualNetworkGatewaysClientBeginUpdateTagsOptions) (VirtualNetworkGatewaysClientUpdateTagsPollerResponse, error) {
+func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject, options *VirtualNetworkGatewaysClientBeginUpdateTagsOptions) (*VirtualNetworkGatewaysClientUpdateTagsPoller, error) {
 	resp, err := client.updateTags(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
-		return VirtualNetworkGatewaysClientUpdateTagsPollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkGatewaysClientUpdateTagsPollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkGatewaysClient.UpdateTags", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkGatewaysClientUpdateTagsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkGatewaysClientUpdateTagsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkGatewaysClientUpdateTagsPoller{pt: pt}, nil
 }
 
 // UpdateTags - Updates a virtual network gateway tags.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
@@ -58,20 +58,16 @@ func NewVirtualNetworkPeeringsClient(subscriptionID string, credential azcore.To
 // virtualNetworkPeeringParameters - Parameters supplied to the create or update virtual network peering operation.
 // options - VirtualNetworkPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkPeeringsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering, options *VirtualNetworkPeeringsClientBeginCreateOrUpdateOptions) (VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering, options *VirtualNetworkPeeringsClientBeginCreateOrUpdateOptions) (*VirtualNetworkPeeringsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, virtualNetworkPeeringParameters, options)
 	if err != nil {
-		return VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkPeeringsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkPeeringsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkPeeringsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkPeeringsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified virtual network.
@@ -128,20 +124,16 @@ func (client *VirtualNetworkPeeringsClient) createOrUpdateCreateRequest(ctx cont
 // virtualNetworkPeeringName - The name of the virtual network peering.
 // options - VirtualNetworkPeeringsClientBeginDeleteOptions contains the optional parameters for the VirtualNetworkPeeringsClient.BeginDelete
 // method.
-func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsClientBeginDeleteOptions) (VirtualNetworkPeeringsClientDeletePollerResponse, error) {
+func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsClientBeginDeleteOptions) (*VirtualNetworkPeeringsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, options)
 	if err != nil {
-		return VirtualNetworkPeeringsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkPeeringsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkPeeringsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkPeeringsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkPeeringsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkPeeringsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified virtual network peering.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
@@ -115,20 +115,16 @@ func (client *VirtualNetworksClient) checkIPAddressAvailabilityHandleResponse(re
 // parameters - Parameters supplied to the create or update virtual network operation.
 // options - VirtualNetworksClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworksClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, options *VirtualNetworksClientBeginCreateOrUpdateOptions) (VirtualNetworksClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, options *VirtualNetworksClientBeginCreateOrUpdateOptions) (*VirtualNetworksClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualNetworkName, parameters, options)
 	if err != nil {
-		return VirtualNetworksClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworksClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworksClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualNetworksClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworksClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworksClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a virtual network in the specified resource group.
@@ -180,20 +176,16 @@ func (client *VirtualNetworksClient) createOrUpdateCreateRequest(ctx context.Con
 // virtualNetworkName - The name of the virtual network.
 // options - VirtualNetworksClientBeginDeleteOptions contains the optional parameters for the VirtualNetworksClient.BeginDelete
 // method.
-func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksClientBeginDeleteOptions) (VirtualNetworksClientDeletePollerResponse, error) {
+func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksClientBeginDeleteOptions) (*VirtualNetworksClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualNetworkName, options)
 	if err != nil {
-		return VirtualNetworksClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworksClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworksClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworksClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworksClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworksClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified virtual network.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
@@ -57,20 +57,16 @@ func NewVirtualNetworkTapsClient(subscriptionID string, credential azcore.TokenC
 // parameters - Parameters supplied to the create or update virtual network tap operation.
 // options - VirtualNetworkTapsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkTapsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap, options *VirtualNetworkTapsClientBeginCreateOrUpdateOptions) (VirtualNetworkTapsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap, options *VirtualNetworkTapsClientBeginCreateOrUpdateOptions) (*VirtualNetworkTapsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, tapName, parameters, options)
 	if err != nil {
-		return VirtualNetworkTapsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkTapsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkTapsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkTapsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkTapsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkTapsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates a Virtual Network Tap.
@@ -122,20 +118,16 @@ func (client *VirtualNetworkTapsClient) createOrUpdateCreateRequest(ctx context.
 // tapName - The name of the virtual network tap.
 // options - VirtualNetworkTapsClientBeginDeleteOptions contains the optional parameters for the VirtualNetworkTapsClient.BeginDelete
 // method.
-func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsClientBeginDeleteOptions) (VirtualNetworkTapsClientDeletePollerResponse, error) {
+func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsClientBeginDeleteOptions) (*VirtualNetworkTapsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, tapName, options)
 	if err != nil {
-		return VirtualNetworkTapsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualNetworkTapsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualNetworkTapsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualNetworkTapsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualNetworkTapsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualNetworkTapsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified virtual network tap.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
@@ -58,20 +58,16 @@ func NewVirtualRouterPeeringsClient(subscriptionID string, credential azcore.Tok
 // parameters - Parameters supplied to the create or update Virtual Router Peering operation.
 // options - VirtualRouterPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualRouterPeeringsClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering, options *VirtualRouterPeeringsClientBeginCreateOrUpdateOptions) (VirtualRouterPeeringsClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering, options *VirtualRouterPeeringsClientBeginCreateOrUpdateOptions) (*VirtualRouterPeeringsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualRouterName, peeringName, parameters, options)
 	if err != nil {
-		return VirtualRouterPeeringsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualRouterPeeringsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualRouterPeeringsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualRouterPeeringsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualRouterPeeringsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualRouterPeeringsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Virtual Router Peering.
@@ -128,20 +124,16 @@ func (client *VirtualRouterPeeringsClient) createOrUpdateCreateRequest(ctx conte
 // peeringName - The name of the peering.
 // options - VirtualRouterPeeringsClientBeginDeleteOptions contains the optional parameters for the VirtualRouterPeeringsClient.BeginDelete
 // method.
-func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsClientBeginDeleteOptions) (VirtualRouterPeeringsClientDeletePollerResponse, error) {
+func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsClientBeginDeleteOptions) (*VirtualRouterPeeringsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualRouterName, peeringName, options)
 	if err != nil {
-		return VirtualRouterPeeringsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualRouterPeeringsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualRouterPeeringsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualRouterPeeringsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualRouterPeeringsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualRouterPeeringsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified peering from a Virtual Router.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
@@ -57,20 +57,16 @@ func NewVirtualRoutersClient(subscriptionID string, credential azcore.TokenCrede
 // parameters - Parameters supplied to the create or update Virtual Router.
 // options - VirtualRoutersClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualRoutersClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter, options *VirtualRoutersClientBeginCreateOrUpdateOptions) (VirtualRoutersClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter, options *VirtualRoutersClientBeginCreateOrUpdateOptions) (*VirtualRoutersClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualRouterName, parameters, options)
 	if err != nil {
-		return VirtualRoutersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualRoutersClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualRoutersClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualRoutersClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualRoutersClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualRoutersClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Virtual Router.
@@ -122,20 +118,16 @@ func (client *VirtualRoutersClient) createOrUpdateCreateRequest(ctx context.Cont
 // virtualRouterName - The name of the Virtual Router.
 // options - VirtualRoutersClientBeginDeleteOptions contains the optional parameters for the VirtualRoutersClient.BeginDelete
 // method.
-func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersClientBeginDeleteOptions) (VirtualRoutersClientDeletePollerResponse, error) {
+func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersClientBeginDeleteOptions) (*VirtualRoutersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualRouterName, options)
 	if err != nil {
-		return VirtualRoutersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualRoutersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualRoutersClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualRoutersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualRoutersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualRoutersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified Virtual Router.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
@@ -57,20 +57,16 @@ func NewVirtualWansClient(subscriptionID string, credential azcore.TokenCredenti
 // wanParameters - Parameters supplied to create or update VirtualWAN.
 // options - VirtualWansClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualWansClient.BeginCreateOrUpdate
 // method.
-func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualWANName string, wanParameters VirtualWAN, options *VirtualWansClientBeginCreateOrUpdateOptions) (VirtualWansClientCreateOrUpdatePollerResponse, error) {
+func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualWANName string, wanParameters VirtualWAN, options *VirtualWansClientBeginCreateOrUpdateOptions) (*VirtualWansClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, virtualWANName, wanParameters, options)
 	if err != nil {
-		return VirtualWansClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualWansClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualWansClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VirtualWansClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualWansClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualWansClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a VirtualWAN resource if it doesn't exist else updates the existing VirtualWAN.
@@ -121,20 +117,16 @@ func (client *VirtualWansClient) createOrUpdateCreateRequest(ctx context.Context
 // resourceGroupName - The resource group name of the VirtualWan.
 // virtualWANName - The name of the VirtualWAN being deleted.
 // options - VirtualWansClientBeginDeleteOptions contains the optional parameters for the VirtualWansClient.BeginDelete method.
-func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualWANName string, options *VirtualWansClientBeginDeleteOptions) (VirtualWansClientDeletePollerResponse, error) {
+func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualWANName string, options *VirtualWansClientBeginDeleteOptions) (*VirtualWansClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, virtualWANName, options)
 	if err != nil {
-		return VirtualWansClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VirtualWansClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VirtualWansClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VirtualWansClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VirtualWansClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VirtualWansClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a VirtualWAN.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
@@ -59,20 +59,16 @@ func NewVPNConnectionsClient(subscriptionID string, credential azcore.TokenCrede
 // vpnConnectionParameters - Parameters supplied to create or Update a VPN Connection.
 // options - VPNConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNConnectionsClient.BeginCreateOrUpdate
 // method.
-func (client *VPNConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VPNConnection, options *VPNConnectionsClientBeginCreateOrUpdateOptions) (VPNConnectionsClientCreateOrUpdatePollerResponse, error) {
+func (client *VPNConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VPNConnection, options *VPNConnectionsClientBeginCreateOrUpdateOptions) (*VPNConnectionsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, gatewayName, connectionName, vpnConnectionParameters, options)
 	if err != nil {
-		return VPNConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VPNConnectionsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNConnectionsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VPNConnectionsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNConnectionsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNConnectionsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a vpn connection to a scalable vpn gateway if it doesn't exist else updates the existing connection.
@@ -129,20 +125,16 @@ func (client *VPNConnectionsClient) createOrUpdateCreateRequest(ctx context.Cont
 // connectionName - The name of the connection.
 // options - VPNConnectionsClientBeginDeleteOptions contains the optional parameters for the VPNConnectionsClient.BeginDelete
 // method.
-func (client *VPNConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VPNConnectionsClientBeginDeleteOptions) (VPNConnectionsClientDeletePollerResponse, error) {
+func (client *VPNConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VPNConnectionsClientBeginDeleteOptions) (*VPNConnectionsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, gatewayName, connectionName, options)
 	if err != nil {
-		return VPNConnectionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VPNConnectionsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNConnectionsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VPNConnectionsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNConnectionsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNConnectionsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a vpn connection.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
@@ -57,20 +57,16 @@ func NewVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredenti
 // vpnGatewayParameters - Parameters supplied to create or Update a virtual wan vpn gateway.
 // options - VPNGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNGatewaysClient.BeginCreateOrUpdate
 // method.
-func (client *VPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VPNGateway, options *VPNGatewaysClientBeginCreateOrUpdateOptions) (VPNGatewaysClientCreateOrUpdatePollerResponse, error) {
+func (client *VPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VPNGateway, options *VPNGatewaysClientBeginCreateOrUpdateOptions) (*VPNGatewaysClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, gatewayName, vpnGatewayParameters, options)
 	if err != nil {
-		return VPNGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VPNGatewaysClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNGatewaysClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VPNGatewaysClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNGatewaysClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNGatewaysClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a virtual wan vpn gateway if it doesn't exist else updates the existing gateway.
@@ -121,20 +117,16 @@ func (client *VPNGatewaysClient) createOrUpdateCreateRequest(ctx context.Context
 // resourceGroupName - The resource group name of the VpnGateway.
 // gatewayName - The name of the gateway.
 // options - VPNGatewaysClientBeginDeleteOptions contains the optional parameters for the VPNGatewaysClient.BeginDelete method.
-func (client *VPNGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, options *VPNGatewaysClientBeginDeleteOptions) (VPNGatewaysClientDeletePollerResponse, error) {
+func (client *VPNGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, options *VPNGatewaysClientBeginDeleteOptions) (*VPNGatewaysClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
-		return VPNGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VPNGatewaysClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNGatewaysClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VPNGatewaysClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNGatewaysClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNGatewaysClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a virtual wan vpn gateway.
@@ -330,20 +322,16 @@ func (client *VPNGatewaysClient) listByResourceGroupHandleResponse(resp *http.Re
 // resourceGroupName - The resource group name of the VpnGateway.
 // gatewayName - The name of the gateway.
 // options - VPNGatewaysClientBeginResetOptions contains the optional parameters for the VPNGatewaysClient.BeginReset method.
-func (client *VPNGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, gatewayName string, options *VPNGatewaysClientBeginResetOptions) (VPNGatewaysClientResetPollerResponse, error) {
+func (client *VPNGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, gatewayName string, options *VPNGatewaysClientBeginResetOptions) (*VPNGatewaysClientResetPoller, error) {
 	resp, err := client.reset(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
-		return VPNGatewaysClientResetPollerResponse{}, err
+		return nil, err
 	}
-	result := VPNGatewaysClientResetPollerResponse{}
 	pt, err := armruntime.NewPoller("VPNGatewaysClient.Reset", "location", resp, client.pl)
 	if err != nil {
-		return VPNGatewaysClientResetPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNGatewaysClientResetPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNGatewaysClientResetPoller{pt: pt}, nil
 }
 
 // Reset - Resets the primary of the vpn gateway in the specified resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
@@ -57,20 +57,16 @@ func NewVPNServerConfigurationsClient(subscriptionID string, credential azcore.T
 // vpnServerConfigurationParameters - Parameters supplied to create or update VpnServerConfiguration.
 // options - VPNServerConfigurationsClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNServerConfigurationsClient.BeginCreateOrUpdate
 // method.
-func (client *VPNServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VPNServerConfiguration, options *VPNServerConfigurationsClientBeginCreateOrUpdateOptions) (VPNServerConfigurationsClientCreateOrUpdatePollerResponse, error) {
+func (client *VPNServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VPNServerConfiguration, options *VPNServerConfigurationsClientBeginCreateOrUpdateOptions) (*VPNServerConfigurationsClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, vpnServerConfigurationName, vpnServerConfigurationParameters, options)
 	if err != nil {
-		return VPNServerConfigurationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VPNServerConfigurationsClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNServerConfigurationsClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VPNServerConfigurationsClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNServerConfigurationsClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNServerConfigurationsClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a VpnServerConfiguration resource if it doesn't exist else updates the existing VpnServerConfiguration.
@@ -122,20 +118,16 @@ func (client *VPNServerConfigurationsClient) createOrUpdateCreateRequest(ctx con
 // vpnServerConfigurationName - The name of the VpnServerConfiguration being deleted.
 // options - VPNServerConfigurationsClientBeginDeleteOptions contains the optional parameters for the VPNServerConfigurationsClient.BeginDelete
 // method.
-func (client *VPNServerConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VPNServerConfigurationsClientBeginDeleteOptions) (VPNServerConfigurationsClientDeletePollerResponse, error) {
+func (client *VPNServerConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VPNServerConfigurationsClientBeginDeleteOptions) (*VPNServerConfigurationsClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, vpnServerConfigurationName, options)
 	if err != nil {
-		return VPNServerConfigurationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VPNServerConfigurationsClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNServerConfigurationsClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VPNServerConfigurationsClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNServerConfigurationsClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNServerConfigurationsClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a VpnServerConfiguration.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -56,20 +56,16 @@ func NewVPNServerConfigurationsAssociatedWithVirtualWanClient(subscriptionID str
 // virtualWANName - The name of the VirtualWAN whose associated VpnServerConfigurations is needed.
 // options - VPNServerConfigurationsAssociatedWithVirtualWanClientBeginListOptions contains the optional parameters for the
 // VPNServerConfigurationsAssociatedWithVirtualWanClient.BeginList method.
-func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) BeginList(ctx context.Context, resourceGroupName string, virtualWANName string, options *VPNServerConfigurationsAssociatedWithVirtualWanClientBeginListOptions) (VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse, error) {
+func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) BeginList(ctx context.Context, resourceGroupName string, virtualWANName string, options *VPNServerConfigurationsAssociatedWithVirtualWanClientBeginListOptions) (*VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller, error) {
 	resp, err := client.listOperation(ctx, resourceGroupName, virtualWANName, options)
 	if err != nil {
-		return VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse{}, err
+		return nil, err
 	}
-	result := VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse{}
 	pt, err := armruntime.NewPoller("VPNServerConfigurationsAssociatedWithVirtualWanClient.List", "location", resp, client.pl)
 	if err != nil {
-		return VPNServerConfigurationsAssociatedWithVirtualWanClientListPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNServerConfigurationsAssociatedWithVirtualWanClientListPoller{pt: pt}, nil
 }
 
 // List - Gives the list of VpnServerConfigurations associated with Virtual Wan in a resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
@@ -57,20 +57,16 @@ func NewVPNSitesClient(subscriptionID string, credential azcore.TokenCredential,
 // vpnSiteParameters - Parameters supplied to create or update VpnSite.
 // options - VPNSitesClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNSitesClient.BeginCreateOrUpdate
 // method.
-func (client *VPNSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VPNSite, options *VPNSitesClientBeginCreateOrUpdateOptions) (VPNSitesClientCreateOrUpdatePollerResponse, error) {
+func (client *VPNSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VPNSite, options *VPNSitesClientBeginCreateOrUpdateOptions) (*VPNSitesClientCreateOrUpdatePoller, error) {
 	resp, err := client.createOrUpdate(ctx, resourceGroupName, vpnSiteName, vpnSiteParameters, options)
 	if err != nil {
-		return VPNSitesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result := VPNSitesClientCreateOrUpdatePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNSitesClient.CreateOrUpdate", "azure-async-operation", resp, client.pl)
 	if err != nil {
-		return VPNSitesClientCreateOrUpdatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNSitesClientCreateOrUpdatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNSitesClientCreateOrUpdatePoller{pt: pt}, nil
 }
 
 // CreateOrUpdate - Creates a VpnSite resource if it doesn't exist else updates the existing VpnSite.
@@ -121,20 +117,16 @@ func (client *VPNSitesClient) createOrUpdateCreateRequest(ctx context.Context, r
 // resourceGroupName - The resource group name of the VpnSite.
 // vpnSiteName - The name of the VpnSite being deleted.
 // options - VPNSitesClientBeginDeleteOptions contains the optional parameters for the VPNSitesClient.BeginDelete method.
-func (client *VPNSitesClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VPNSitesClientBeginDeleteOptions) (VPNSitesClientDeletePollerResponse, error) {
+func (client *VPNSitesClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VPNSitesClientBeginDeleteOptions) (*VPNSitesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, vpnSiteName, options)
 	if err != nil {
-		return VPNSitesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := VPNSitesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("VPNSitesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return VPNSitesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNSitesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNSitesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes a VpnSite.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration_client.go
@@ -57,20 +57,16 @@ func NewVPNSitesConfigurationClient(subscriptionID string, credential azcore.Tok
 // request - Parameters supplied to download vpn-sites configuration.
 // options - VPNSitesConfigurationClientBeginDownloadOptions contains the optional parameters for the VPNSitesConfigurationClient.BeginDownload
 // method.
-func (client *VPNSitesConfigurationClient) BeginDownload(ctx context.Context, resourceGroupName string, virtualWANName string, request GetVPNSitesConfigurationRequest, options *VPNSitesConfigurationClientBeginDownloadOptions) (VPNSitesConfigurationClientDownloadPollerResponse, error) {
+func (client *VPNSitesConfigurationClient) BeginDownload(ctx context.Context, resourceGroupName string, virtualWANName string, request GetVPNSitesConfigurationRequest, options *VPNSitesConfigurationClientBeginDownloadOptions) (*VPNSitesConfigurationClientDownloadPoller, error) {
 	resp, err := client.download(ctx, resourceGroupName, virtualWANName, request, options)
 	if err != nil {
-		return VPNSitesConfigurationClientDownloadPollerResponse{}, err
+		return nil, err
 	}
-	result := VPNSitesConfigurationClientDownloadPollerResponse{}
 	pt, err := armruntime.NewPoller("VPNSitesConfigurationClient.Download", "location", resp, client.pl)
 	if err != nil {
-		return VPNSitesConfigurationClientDownloadPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &VPNSitesConfigurationClientDownloadPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &VPNSitesConfigurationClientDownloadPoller{pt: pt}, nil
 }
 
 // Download - Gives the sas-url to download the configurations for vpn-sites in a resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
@@ -58,20 +58,16 @@ func NewWatchersClient(subscriptionID string, credential azcore.TokenCredential,
 // parameters - Parameters that determine how the connectivity check will be performed.
 // options - WatchersClientBeginCheckConnectivityOptions contains the optional parameters for the WatchersClient.BeginCheckConnectivity
 // method.
-func (client *WatchersClient) BeginCheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *WatchersClientBeginCheckConnectivityOptions) (WatchersClientCheckConnectivityPollerResponse, error) {
+func (client *WatchersClient) BeginCheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *WatchersClientBeginCheckConnectivityOptions) (*WatchersClientCheckConnectivityPoller, error) {
 	resp, err := client.checkConnectivity(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientCheckConnectivityPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientCheckConnectivityPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.CheckConnectivity", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientCheckConnectivityPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientCheckConnectivityPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientCheckConnectivityPoller{pt: pt}, nil
 }
 
 // CheckConnectivity - Verifies the possibility of establishing a direct TCP connection from a virtual machine to a given
@@ -179,20 +175,16 @@ func (client *WatchersClient) createOrUpdateHandleResponse(resp *http.Response) 
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the network watcher.
 // options - WatchersClientBeginDeleteOptions contains the optional parameters for the WatchersClient.BeginDelete method.
-func (client *WatchersClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, options *WatchersClientBeginDeleteOptions) (WatchersClientDeletePollerResponse, error) {
+func (client *WatchersClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, options *WatchersClientBeginDeleteOptions) (*WatchersClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
-		return WatchersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes the specified network watcher resource.
@@ -301,20 +293,16 @@ func (client *WatchersClient) getHandleResponse(resp *http.Response) (WatchersCl
 // parameters - Parameters that determine Azure reachability report configuration.
 // options - WatchersClientBeginGetAzureReachabilityReportOptions contains the optional parameters for the WatchersClient.BeginGetAzureReachabilityReport
 // method.
-func (client *WatchersClient) BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *WatchersClientBeginGetAzureReachabilityReportOptions) (WatchersClientGetAzureReachabilityReportPollerResponse, error) {
+func (client *WatchersClient) BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *WatchersClientBeginGetAzureReachabilityReportOptions) (*WatchersClientGetAzureReachabilityReportPoller, error) {
 	resp, err := client.getAzureReachabilityReport(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientGetAzureReachabilityReportPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientGetAzureReachabilityReportPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetAzureReachabilityReport", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientGetAzureReachabilityReportPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientGetAzureReachabilityReportPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientGetAzureReachabilityReportPoller{pt: pt}, nil
 }
 
 // GetAzureReachabilityReport - NOTE: This feature is currently in preview and still being tested for stability. Gets the
@@ -368,20 +356,16 @@ func (client *WatchersClient) getAzureReachabilityReportCreateRequest(ctx contex
 // parameters - Parameters that define a resource to query flow log and traffic analytics (optional) status.
 // options - WatchersClientBeginGetFlowLogStatusOptions contains the optional parameters for the WatchersClient.BeginGetFlowLogStatus
 // method.
-func (client *WatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *WatchersClientBeginGetFlowLogStatusOptions) (WatchersClientGetFlowLogStatusPollerResponse, error) {
+func (client *WatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *WatchersClientBeginGetFlowLogStatusOptions) (*WatchersClientGetFlowLogStatusPoller, error) {
 	resp, err := client.getFlowLogStatus(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientGetFlowLogStatusPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientGetFlowLogStatusPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetFlowLogStatus", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientGetFlowLogStatusPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientGetFlowLogStatusPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientGetFlowLogStatusPoller{pt: pt}, nil
 }
 
 // GetFlowLogStatus - Queries status of flow log and traffic analytics (optional) on a specified resource.
@@ -438,20 +422,16 @@ func (client *WatchersClient) getFlowLogStatusCreateRequest(ctx context.Context,
 // parameters - Parameters to get network configuration diagnostic.
 // options - WatchersClientBeginGetNetworkConfigurationDiagnosticOptions contains the optional parameters for the WatchersClient.BeginGetNetworkConfigurationDiagnostic
 // method.
-func (client *WatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConfigurationDiagnosticParameters, options *WatchersClientBeginGetNetworkConfigurationDiagnosticOptions) (WatchersClientGetNetworkConfigurationDiagnosticPollerResponse, error) {
+func (client *WatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConfigurationDiagnosticParameters, options *WatchersClientBeginGetNetworkConfigurationDiagnosticOptions) (*WatchersClientGetNetworkConfigurationDiagnosticPoller, error) {
 	resp, err := client.getNetworkConfigurationDiagnostic(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientGetNetworkConfigurationDiagnosticPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientGetNetworkConfigurationDiagnosticPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetNetworkConfigurationDiagnostic", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientGetNetworkConfigurationDiagnosticPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientGetNetworkConfigurationDiagnosticPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientGetNetworkConfigurationDiagnosticPoller{pt: pt}, nil
 }
 
 // GetNetworkConfigurationDiagnostic - Gets Network Configuration Diagnostic data to help customers understand and debug network
@@ -508,20 +488,16 @@ func (client *WatchersClient) getNetworkConfigurationDiagnosticCreateRequest(ctx
 // parameters - Parameters that define the source and destination endpoint.
 // options - WatchersClientBeginGetNextHopOptions contains the optional parameters for the WatchersClient.BeginGetNextHop
 // method.
-func (client *WatchersClient) BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *WatchersClientBeginGetNextHopOptions) (WatchersClientGetNextHopPollerResponse, error) {
+func (client *WatchersClient) BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *WatchersClientBeginGetNextHopOptions) (*WatchersClientGetNextHopPoller, error) {
 	resp, err := client.getNextHop(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientGetNextHopPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientGetNextHopPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetNextHop", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientGetNextHopPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientGetNextHopPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientGetNextHopPoller{pt: pt}, nil
 }
 
 // GetNextHop - Gets the next hop from the specified VM.
@@ -630,20 +606,16 @@ func (client *WatchersClient) getTopologyHandleResponse(resp *http.Response) (Wa
 // parameters - Parameters that define the resource to troubleshoot.
 // options - WatchersClientBeginGetTroubleshootingOptions contains the optional parameters for the WatchersClient.BeginGetTroubleshooting
 // method.
-func (client *WatchersClient) BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *WatchersClientBeginGetTroubleshootingOptions) (WatchersClientGetTroubleshootingPollerResponse, error) {
+func (client *WatchersClient) BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *WatchersClientBeginGetTroubleshootingOptions) (*WatchersClientGetTroubleshootingPoller, error) {
 	resp, err := client.getTroubleshooting(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientGetTroubleshootingPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientGetTroubleshootingPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetTroubleshooting", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientGetTroubleshootingPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientGetTroubleshootingPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientGetTroubleshootingPoller{pt: pt}, nil
 }
 
 // GetTroubleshooting - Initiate troubleshooting on a specified resource.
@@ -696,20 +668,16 @@ func (client *WatchersClient) getTroubleshootingCreateRequest(ctx context.Contex
 // parameters - Parameters that define the resource to query the troubleshooting result.
 // options - WatchersClientBeginGetTroubleshootingResultOptions contains the optional parameters for the WatchersClient.BeginGetTroubleshootingResult
 // method.
-func (client *WatchersClient) BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *WatchersClientBeginGetTroubleshootingResultOptions) (WatchersClientGetTroubleshootingResultPollerResponse, error) {
+func (client *WatchersClient) BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *WatchersClientBeginGetTroubleshootingResultOptions) (*WatchersClientGetTroubleshootingResultPoller, error) {
 	resp, err := client.getTroubleshootingResult(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientGetTroubleshootingResultPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientGetTroubleshootingResultPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetTroubleshootingResult", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientGetTroubleshootingResultPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientGetTroubleshootingResultPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientGetTroubleshootingResultPoller{pt: pt}, nil
 }
 
 // GetTroubleshootingResult - Get the last completed troubleshooting result on a specified resource.
@@ -762,20 +730,16 @@ func (client *WatchersClient) getTroubleshootingResultCreateRequest(ctx context.
 // parameters - Parameters that define the VM to check security groups for.
 // options - WatchersClientBeginGetVMSecurityRulesOptions contains the optional parameters for the WatchersClient.BeginGetVMSecurityRules
 // method.
-func (client *WatchersClient) BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *WatchersClientBeginGetVMSecurityRulesOptions) (WatchersClientGetVMSecurityRulesPollerResponse, error) {
+func (client *WatchersClient) BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *WatchersClientBeginGetVMSecurityRulesOptions) (*WatchersClientGetVMSecurityRulesPoller, error) {
 	resp, err := client.getVMSecurityRules(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientGetVMSecurityRulesPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientGetVMSecurityRulesPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.GetVMSecurityRules", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientGetVMSecurityRulesPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientGetVMSecurityRulesPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientGetVMSecurityRulesPoller{pt: pt}, nil
 }
 
 // GetVMSecurityRules - Gets the configured and effective security group rules on the specified VM.
@@ -912,20 +876,16 @@ func (client *WatchersClient) listAllHandleResponse(resp *http.Response) (Watche
 // parameters - Parameters that scope the list of available providers.
 // options - WatchersClientBeginListAvailableProvidersOptions contains the optional parameters for the WatchersClient.BeginListAvailableProviders
 // method.
-func (client *WatchersClient) BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *WatchersClientBeginListAvailableProvidersOptions) (WatchersClientListAvailableProvidersPollerResponse, error) {
+func (client *WatchersClient) BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *WatchersClientBeginListAvailableProvidersOptions) (*WatchersClientListAvailableProvidersPoller, error) {
 	resp, err := client.listAvailableProviders(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientListAvailableProvidersPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientListAvailableProvidersPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.ListAvailableProviders", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientListAvailableProvidersPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientListAvailableProvidersPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientListAvailableProvidersPoller{pt: pt}, nil
 }
 
 // ListAvailableProviders - NOTE: This feature is currently in preview and still being tested for stability. Lists all available
@@ -979,20 +939,16 @@ func (client *WatchersClient) listAvailableProvidersCreateRequest(ctx context.Co
 // parameters - Parameters that define the configuration of flow log.
 // options - WatchersClientBeginSetFlowLogConfigurationOptions contains the optional parameters for the WatchersClient.BeginSetFlowLogConfiguration
 // method.
-func (client *WatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *WatchersClientBeginSetFlowLogConfigurationOptions) (WatchersClientSetFlowLogConfigurationPollerResponse, error) {
+func (client *WatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *WatchersClientBeginSetFlowLogConfigurationOptions) (*WatchersClientSetFlowLogConfigurationPoller, error) {
 	resp, err := client.setFlowLogConfiguration(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientSetFlowLogConfigurationPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientSetFlowLogConfigurationPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.SetFlowLogConfiguration", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientSetFlowLogConfigurationPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientSetFlowLogConfigurationPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientSetFlowLogConfigurationPoller{pt: pt}, nil
 }
 
 // SetFlowLogConfiguration - Configures flow log and traffic analytics (optional) on a specified resource.
@@ -1101,20 +1057,16 @@ func (client *WatchersClient) updateTagsHandleResponse(resp *http.Response) (Wat
 // parameters - Parameters that define the IP flow to be verified.
 // options - WatchersClientBeginVerifyIPFlowOptions contains the optional parameters for the WatchersClient.BeginVerifyIPFlow
 // method.
-func (client *WatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *WatchersClientBeginVerifyIPFlowOptions) (WatchersClientVerifyIPFlowPollerResponse, error) {
+func (client *WatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *WatchersClientBeginVerifyIPFlowOptions) (*WatchersClientVerifyIPFlowPoller, error) {
 	resp, err := client.verifyIPFlow(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
-		return WatchersClientVerifyIPFlowPollerResponse{}, err
+		return nil, err
 	}
-	result := WatchersClientVerifyIPFlowPollerResponse{}
 	pt, err := armruntime.NewPoller("WatchersClient.VerifyIPFlow", "location", resp, client.pl)
 	if err != nil {
-		return WatchersClientVerifyIPFlowPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WatchersClientVerifyIPFlowPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WatchersClientVerifyIPFlowPoller{pt: pt}, nil
 }
 
 // VerifyIPFlow - Verify IP flow from the specified VM to a location given the currently configured NSG rules.

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
@@ -113,20 +113,16 @@ func (client *WebApplicationFirewallPoliciesClient) createOrUpdateHandleResponse
 // policyName - The name of the policy.
 // options - WebApplicationFirewallPoliciesClientBeginDeleteOptions contains the optional parameters for the WebApplicationFirewallPoliciesClient.BeginDelete
 // method.
-func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesClientBeginDeleteOptions) (WebApplicationFirewallPoliciesClientDeletePollerResponse, error) {
+func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesClientBeginDeleteOptions) (*WebApplicationFirewallPoliciesClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, resourceGroupName, policyName, options)
 	if err != nil {
-		return WebApplicationFirewallPoliciesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := WebApplicationFirewallPoliciesClientDeletePollerResponse{}
 	pt, err := armruntime.NewPoller("WebApplicationFirewallPoliciesClient.Delete", "location", resp, client.pl)
 	if err != nil {
-		return WebApplicationFirewallPoliciesClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &WebApplicationFirewallPoliciesClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &WebApplicationFirewallPoliciesClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Deletes Policy.

--- a/test/storage/2020-06-12/azblob/go.mod
+++ b/test/storage/2020-06-12/azblob/go.mod
@@ -2,4 +2,4 @@ module azstorage
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/storage/2020-06-12/azblob/go.sum
+++ b/test/storage/2020-06-12/azblob/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/synapse/2019-06-01/azartifacts/go.mod
+++ b/test/synapse/2019-06-01/azartifacts/go.mod
@@ -2,4 +2,4 @@ module azartifacts
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/synapse/2019-06-01/azartifacts/go.sum
+++ b/test/synapse/2019-06-01/azartifacts/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
@@ -40,20 +40,16 @@ func newDataFlowClient(endpoint string, pl runtime.Pipeline) *dataFlowClient {
 // dataFlow - Data flow resource definition.
 // options - dataFlowClientBeginCreateOrUpdateDataFlowOptions contains the optional parameters for the dataFlowClient.BeginCreateOrUpdateDataFlow
 // method.
-func (client *dataFlowClient) BeginCreateOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *dataFlowClientBeginCreateOrUpdateDataFlowOptions) (dataFlowClientCreateOrUpdateDataFlowPollerResponse, error) {
+func (client *dataFlowClient) BeginCreateOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *dataFlowClientBeginCreateOrUpdateDataFlowOptions) (*dataFlowClientCreateOrUpdateDataFlowPoller, error) {
 	resp, err := client.createOrUpdateDataFlow(ctx, dataFlowName, dataFlow, options)
 	if err != nil {
-		return dataFlowClientCreateOrUpdateDataFlowPollerResponse{}, err
+		return nil, err
 	}
-	result := dataFlowClientCreateOrUpdateDataFlowPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowClient.CreateOrUpdateDataFlow", resp, client.pl)
 	if err != nil {
-		return dataFlowClientCreateOrUpdateDataFlowPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &dataFlowClientCreateOrUpdateDataFlowPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &dataFlowClientCreateOrUpdateDataFlowPoller{pt: pt}, nil
 }
 
 // CreateOrUpdateDataFlow - Creates or updates a data flow.
@@ -99,20 +95,16 @@ func (client *dataFlowClient) createOrUpdateDataFlowCreateRequest(ctx context.Co
 // dataFlowName - The data flow name.
 // options - dataFlowClientBeginDeleteDataFlowOptions contains the optional parameters for the dataFlowClient.BeginDeleteDataFlow
 // method.
-func (client *dataFlowClient) BeginDeleteDataFlow(ctx context.Context, dataFlowName string, options *dataFlowClientBeginDeleteDataFlowOptions) (dataFlowClientDeleteDataFlowPollerResponse, error) {
+func (client *dataFlowClient) BeginDeleteDataFlow(ctx context.Context, dataFlowName string, options *dataFlowClientBeginDeleteDataFlowOptions) (*dataFlowClientDeleteDataFlowPoller, error) {
 	resp, err := client.deleteDataFlow(ctx, dataFlowName, options)
 	if err != nil {
-		return dataFlowClientDeleteDataFlowPollerResponse{}, err
+		return nil, err
 	}
-	result := dataFlowClientDeleteDataFlowPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowClient.DeleteDataFlow", resp, client.pl)
 	if err != nil {
-		return dataFlowClientDeleteDataFlowPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &dataFlowClientDeleteDataFlowPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &dataFlowClientDeleteDataFlowPoller{pt: pt}, nil
 }
 
 // DeleteDataFlow - Deletes a data flow.
@@ -244,20 +236,16 @@ func (client *dataFlowClient) getDataFlowsByWorkspaceHandleResponse(resp *http.R
 // request - proposed new name.
 // options - dataFlowClientBeginRenameDataFlowOptions contains the optional parameters for the dataFlowClient.BeginRenameDataFlow
 // method.
-func (client *dataFlowClient) BeginRenameDataFlow(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *dataFlowClientBeginRenameDataFlowOptions) (dataFlowClientRenameDataFlowPollerResponse, error) {
+func (client *dataFlowClient) BeginRenameDataFlow(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *dataFlowClientBeginRenameDataFlowOptions) (*dataFlowClientRenameDataFlowPoller, error) {
 	resp, err := client.renameDataFlow(ctx, dataFlowName, request, options)
 	if err != nil {
-		return dataFlowClientRenameDataFlowPollerResponse{}, err
+		return nil, err
 	}
-	result := dataFlowClientRenameDataFlowPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowClient.RenameDataFlow", resp, client.pl)
 	if err != nil {
-		return dataFlowClientRenameDataFlowPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &dataFlowClientRenameDataFlowPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &dataFlowClientRenameDataFlowPoller{pt: pt}, nil
 }
 
 // RenameDataFlow - Renames a dataflow.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
@@ -79,20 +79,16 @@ func (client *dataFlowDebugSessionClient) addDataFlowHandleResponse(resp *http.R
 // request - Data flow debug session definition
 // options - dataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions contains the optional parameters for the dataFlowDebugSessionClient.BeginCreateDataFlowDebugSession
 // method.
-func (client *dataFlowDebugSessionClient) BeginCreateDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *dataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions) (dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse, error) {
+func (client *dataFlowDebugSessionClient) BeginCreateDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *dataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions) (*dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller, error) {
 	resp, err := client.createDataFlowDebugSession(ctx, request, options)
 	if err != nil {
-		return dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse{}, err
+		return nil, err
 	}
-	result := dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowDebugSessionClient.CreateDataFlowDebugSession", resp, client.pl)
 	if err != nil {
-		return dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller{pt: pt}, nil
 }
 
 // CreateDataFlowDebugSession - Creates a data flow debug session.
@@ -165,20 +161,16 @@ func (client *dataFlowDebugSessionClient) deleteDataFlowDebugSessionCreateReques
 // request - Data flow debug command definition.
 // options - dataFlowDebugSessionClientBeginExecuteCommandOptions contains the optional parameters for the dataFlowDebugSessionClient.BeginExecuteCommand
 // method.
-func (client *dataFlowDebugSessionClient) BeginExecuteCommand(ctx context.Context, request DataFlowDebugCommandRequest, options *dataFlowDebugSessionClientBeginExecuteCommandOptions) (dataFlowDebugSessionClientExecuteCommandPollerResponse, error) {
+func (client *dataFlowDebugSessionClient) BeginExecuteCommand(ctx context.Context, request DataFlowDebugCommandRequest, options *dataFlowDebugSessionClientBeginExecuteCommandOptions) (*dataFlowDebugSessionClientExecuteCommandPoller, error) {
 	resp, err := client.executeCommand(ctx, request, options)
 	if err != nil {
-		return dataFlowDebugSessionClientExecuteCommandPollerResponse{}, err
+		return nil, err
 	}
-	result := dataFlowDebugSessionClientExecuteCommandPollerResponse{}
 	pt, err := runtime.NewPoller("dataFlowDebugSessionClient.ExecuteCommand", resp, client.pl)
 	if err != nil {
-		return dataFlowDebugSessionClientExecuteCommandPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &dataFlowDebugSessionClientExecuteCommandPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &dataFlowDebugSessionClientExecuteCommandPoller{pt: pt}, nil
 }
 
 // ExecuteCommand - Execute a data flow debug command.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
@@ -40,20 +40,16 @@ func newDatasetClient(endpoint string, pl runtime.Pipeline) *datasetClient {
 // dataset - Dataset resource definition.
 // options - datasetClientBeginCreateOrUpdateDatasetOptions contains the optional parameters for the datasetClient.BeginCreateOrUpdateDataset
 // method.
-func (client *datasetClient) BeginCreateOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, options *datasetClientBeginCreateOrUpdateDatasetOptions) (datasetClientCreateOrUpdateDatasetPollerResponse, error) {
+func (client *datasetClient) BeginCreateOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, options *datasetClientBeginCreateOrUpdateDatasetOptions) (*datasetClientCreateOrUpdateDatasetPoller, error) {
 	resp, err := client.createOrUpdateDataset(ctx, datasetName, dataset, options)
 	if err != nil {
-		return datasetClientCreateOrUpdateDatasetPollerResponse{}, err
+		return nil, err
 	}
-	result := datasetClientCreateOrUpdateDatasetPollerResponse{}
 	pt, err := runtime.NewPoller("datasetClient.CreateOrUpdateDataset", resp, client.pl)
 	if err != nil {
-		return datasetClientCreateOrUpdateDatasetPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &datasetClientCreateOrUpdateDatasetPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &datasetClientCreateOrUpdateDatasetPoller{pt: pt}, nil
 }
 
 // CreateOrUpdateDataset - Creates or updates a dataset.
@@ -99,20 +95,16 @@ func (client *datasetClient) createOrUpdateDatasetCreateRequest(ctx context.Cont
 // datasetName - The dataset name.
 // options - datasetClientBeginDeleteDatasetOptions contains the optional parameters for the datasetClient.BeginDeleteDataset
 // method.
-func (client *datasetClient) BeginDeleteDataset(ctx context.Context, datasetName string, options *datasetClientBeginDeleteDatasetOptions) (datasetClientDeleteDatasetPollerResponse, error) {
+func (client *datasetClient) BeginDeleteDataset(ctx context.Context, datasetName string, options *datasetClientBeginDeleteDatasetOptions) (*datasetClientDeleteDatasetPoller, error) {
 	resp, err := client.deleteDataset(ctx, datasetName, options)
 	if err != nil {
-		return datasetClientDeleteDatasetPollerResponse{}, err
+		return nil, err
 	}
-	result := datasetClientDeleteDatasetPollerResponse{}
 	pt, err := runtime.NewPoller("datasetClient.DeleteDataset", resp, client.pl)
 	if err != nil {
-		return datasetClientDeleteDatasetPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &datasetClientDeleteDatasetPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &datasetClientDeleteDatasetPoller{pt: pt}, nil
 }
 
 // DeleteDataset - Deletes a dataset.
@@ -244,20 +236,16 @@ func (client *datasetClient) getDatasetsByWorkspaceHandleResponse(resp *http.Res
 // request - proposed new name.
 // options - datasetClientBeginRenameDatasetOptions contains the optional parameters for the datasetClient.BeginRenameDataset
 // method.
-func (client *datasetClient) BeginRenameDataset(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *datasetClientBeginRenameDatasetOptions) (datasetClientRenameDatasetPollerResponse, error) {
+func (client *datasetClient) BeginRenameDataset(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *datasetClientBeginRenameDatasetOptions) (*datasetClientRenameDatasetPoller, error) {
 	resp, err := client.renameDataset(ctx, datasetName, request, options)
 	if err != nil {
-		return datasetClientRenameDatasetPollerResponse{}, err
+		return nil, err
 	}
-	result := datasetClientRenameDatasetPollerResponse{}
 	pt, err := runtime.NewPoller("datasetClient.RenameDataset", resp, client.pl)
 	if err != nil {
-		return datasetClientRenameDatasetPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &datasetClientRenameDatasetPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &datasetClientRenameDatasetPoller{pt: pt}, nil
 }
 
 // RenameDataset - Renames a dataset.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
@@ -83,20 +83,16 @@ func (client *libraryClient) appendCreateRequest(ctx context.Context, libraryNam
 // If the operation fails it returns an *azcore.ResponseError type.
 // libraryName - file name to upload. Minimum length of the filename should be 1 excluding the extension length.
 // options - libraryClientBeginCreateOptions contains the optional parameters for the libraryClient.BeginCreate method.
-func (client *libraryClient) BeginCreate(ctx context.Context, libraryName string, options *libraryClientBeginCreateOptions) (libraryClientCreatePollerResponse, error) {
+func (client *libraryClient) BeginCreate(ctx context.Context, libraryName string, options *libraryClientBeginCreateOptions) (*libraryClientCreatePoller, error) {
 	resp, err := client.create(ctx, libraryName, options)
 	if err != nil {
-		return libraryClientCreatePollerResponse{}, err
+		return nil, err
 	}
-	result := libraryClientCreatePollerResponse{}
 	pt, err := runtime.NewPoller("libraryClient.Create", resp, client.pl)
 	if err != nil {
-		return libraryClientCreatePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &libraryClientCreatePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &libraryClientCreatePoller{pt: pt}, nil
 }
 
 // Create - Creates a library with the library name.
@@ -138,20 +134,16 @@ func (client *libraryClient) createCreateRequest(ctx context.Context, libraryNam
 // If the operation fails it returns an *azcore.ResponseError type.
 // libraryName - file name to upload. Minimum length of the filename should be 1 excluding the extension length.
 // options - libraryClientBeginDeleteOptions contains the optional parameters for the libraryClient.BeginDelete method.
-func (client *libraryClient) BeginDelete(ctx context.Context, libraryName string, options *libraryClientBeginDeleteOptions) (libraryClientDeletePollerResponse, error) {
+func (client *libraryClient) BeginDelete(ctx context.Context, libraryName string, options *libraryClientBeginDeleteOptions) (*libraryClientDeletePoller, error) {
 	resp, err := client.deleteOperation(ctx, libraryName, options)
 	if err != nil {
-		return libraryClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result := libraryClientDeletePollerResponse{}
 	pt, err := runtime.NewPoller("libraryClient.Delete", resp, client.pl)
 	if err != nil {
-		return libraryClientDeletePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &libraryClientDeletePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &libraryClientDeletePoller{pt: pt}, nil
 }
 
 // Delete - Delete Library
@@ -193,20 +185,16 @@ func (client *libraryClient) deleteCreateRequest(ctx context.Context, libraryNam
 // If the operation fails it returns an *azcore.ResponseError type.
 // libraryName - file name to upload. Minimum length of the filename should be 1 excluding the extension length.
 // options - libraryClientBeginFlushOptions contains the optional parameters for the libraryClient.BeginFlush method.
-func (client *libraryClient) BeginFlush(ctx context.Context, libraryName string, options *libraryClientBeginFlushOptions) (libraryClientFlushPollerResponse, error) {
+func (client *libraryClient) BeginFlush(ctx context.Context, libraryName string, options *libraryClientBeginFlushOptions) (*libraryClientFlushPoller, error) {
 	resp, err := client.flush(ctx, libraryName, options)
 	if err != nil {
-		return libraryClientFlushPollerResponse{}, err
+		return nil, err
 	}
-	result := libraryClientFlushPollerResponse{}
 	pt, err := runtime.NewPoller("libraryClient.Flush", resp, client.pl)
 	if err != nil {
-		return libraryClientFlushPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &libraryClientFlushPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &libraryClientFlushPoller{pt: pt}, nil
 }
 
 // Flush - Flush Library

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
@@ -40,20 +40,16 @@ func newLinkedServiceClient(endpoint string, pl runtime.Pipeline) *linkedService
 // linkedService - Linked service resource definition.
 // options - linkedServiceClientBeginCreateOrUpdateLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginCreateOrUpdateLinkedService
 // method.
-func (client *linkedServiceClient) BeginCreateOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *linkedServiceClientBeginCreateOrUpdateLinkedServiceOptions) (linkedServiceClientCreateOrUpdateLinkedServicePollerResponse, error) {
+func (client *linkedServiceClient) BeginCreateOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *linkedServiceClientBeginCreateOrUpdateLinkedServiceOptions) (*linkedServiceClientCreateOrUpdateLinkedServicePoller, error) {
 	resp, err := client.createOrUpdateLinkedService(ctx, linkedServiceName, linkedService, options)
 	if err != nil {
-		return linkedServiceClientCreateOrUpdateLinkedServicePollerResponse{}, err
+		return nil, err
 	}
-	result := linkedServiceClientCreateOrUpdateLinkedServicePollerResponse{}
 	pt, err := runtime.NewPoller("linkedServiceClient.CreateOrUpdateLinkedService", resp, client.pl)
 	if err != nil {
-		return linkedServiceClientCreateOrUpdateLinkedServicePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &linkedServiceClientCreateOrUpdateLinkedServicePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &linkedServiceClientCreateOrUpdateLinkedServicePoller{pt: pt}, nil
 }
 
 // CreateOrUpdateLinkedService - Creates or updates a linked service.
@@ -99,20 +95,16 @@ func (client *linkedServiceClient) createOrUpdateLinkedServiceCreateRequest(ctx 
 // linkedServiceName - The linked service name.
 // options - linkedServiceClientBeginDeleteLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginDeleteLinkedService
 // method.
-func (client *linkedServiceClient) BeginDeleteLinkedService(ctx context.Context, linkedServiceName string, options *linkedServiceClientBeginDeleteLinkedServiceOptions) (linkedServiceClientDeleteLinkedServicePollerResponse, error) {
+func (client *linkedServiceClient) BeginDeleteLinkedService(ctx context.Context, linkedServiceName string, options *linkedServiceClientBeginDeleteLinkedServiceOptions) (*linkedServiceClientDeleteLinkedServicePoller, error) {
 	resp, err := client.deleteLinkedService(ctx, linkedServiceName, options)
 	if err != nil {
-		return linkedServiceClientDeleteLinkedServicePollerResponse{}, err
+		return nil, err
 	}
-	result := linkedServiceClientDeleteLinkedServicePollerResponse{}
 	pt, err := runtime.NewPoller("linkedServiceClient.DeleteLinkedService", resp, client.pl)
 	if err != nil {
-		return linkedServiceClientDeleteLinkedServicePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &linkedServiceClientDeleteLinkedServicePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &linkedServiceClientDeleteLinkedServicePoller{pt: pt}, nil
 }
 
 // DeleteLinkedService - Deletes a linked service.
@@ -245,20 +237,16 @@ func (client *linkedServiceClient) getLinkedServicesByWorkspaceHandleResponse(re
 // request - proposed new name.
 // options - linkedServiceClientBeginRenameLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginRenameLinkedService
 // method.
-func (client *linkedServiceClient) BeginRenameLinkedService(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *linkedServiceClientBeginRenameLinkedServiceOptions) (linkedServiceClientRenameLinkedServicePollerResponse, error) {
+func (client *linkedServiceClient) BeginRenameLinkedService(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *linkedServiceClientBeginRenameLinkedServiceOptions) (*linkedServiceClientRenameLinkedServicePoller, error) {
 	resp, err := client.renameLinkedService(ctx, linkedServiceName, request, options)
 	if err != nil {
-		return linkedServiceClientRenameLinkedServicePollerResponse{}, err
+		return nil, err
 	}
-	result := linkedServiceClientRenameLinkedServicePollerResponse{}
 	pt, err := runtime.NewPoller("linkedServiceClient.RenameLinkedService", resp, client.pl)
 	if err != nil {
-		return linkedServiceClientRenameLinkedServicePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &linkedServiceClientRenameLinkedServicePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &linkedServiceClientRenameLinkedServicePoller{pt: pt}, nil
 }
 
 // RenameLinkedService - Renames a linked service.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
@@ -40,20 +40,16 @@ func newNotebookClient(endpoint string, pl runtime.Pipeline) *notebookClient {
 // notebook - Note book resource definition.
 // options - notebookClientBeginCreateOrUpdateNotebookOptions contains the optional parameters for the notebookClient.BeginCreateOrUpdateNotebook
 // method.
-func (client *notebookClient) BeginCreateOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, options *notebookClientBeginCreateOrUpdateNotebookOptions) (notebookClientCreateOrUpdateNotebookPollerResponse, error) {
+func (client *notebookClient) BeginCreateOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, options *notebookClientBeginCreateOrUpdateNotebookOptions) (*notebookClientCreateOrUpdateNotebookPoller, error) {
 	resp, err := client.createOrUpdateNotebook(ctx, notebookName, notebook, options)
 	if err != nil {
-		return notebookClientCreateOrUpdateNotebookPollerResponse{}, err
+		return nil, err
 	}
-	result := notebookClientCreateOrUpdateNotebookPollerResponse{}
 	pt, err := runtime.NewPoller("notebookClient.CreateOrUpdateNotebook", resp, client.pl)
 	if err != nil {
-		return notebookClientCreateOrUpdateNotebookPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &notebookClientCreateOrUpdateNotebookPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &notebookClientCreateOrUpdateNotebookPoller{pt: pt}, nil
 }
 
 // CreateOrUpdateNotebook - Creates or updates a Note Book.
@@ -99,20 +95,16 @@ func (client *notebookClient) createOrUpdateNotebookCreateRequest(ctx context.Co
 // notebookName - The notebook name.
 // options - notebookClientBeginDeleteNotebookOptions contains the optional parameters for the notebookClient.BeginDeleteNotebook
 // method.
-func (client *notebookClient) BeginDeleteNotebook(ctx context.Context, notebookName string, options *notebookClientBeginDeleteNotebookOptions) (notebookClientDeleteNotebookPollerResponse, error) {
+func (client *notebookClient) BeginDeleteNotebook(ctx context.Context, notebookName string, options *notebookClientBeginDeleteNotebookOptions) (*notebookClientDeleteNotebookPoller, error) {
 	resp, err := client.deleteNotebook(ctx, notebookName, options)
 	if err != nil {
-		return notebookClientDeleteNotebookPollerResponse{}, err
+		return nil, err
 	}
-	result := notebookClientDeleteNotebookPollerResponse{}
 	pt, err := runtime.NewPoller("notebookClient.DeleteNotebook", resp, client.pl)
 	if err != nil {
-		return notebookClientDeleteNotebookPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &notebookClientDeleteNotebookPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &notebookClientDeleteNotebookPoller{pt: pt}, nil
 }
 
 // DeleteNotebook - Deletes a Note book.
@@ -283,20 +275,16 @@ func (client *notebookClient) getNotebooksByWorkspaceHandleResponse(resp *http.R
 // request - proposed new name.
 // options - notebookClientBeginRenameNotebookOptions contains the optional parameters for the notebookClient.BeginRenameNotebook
 // method.
-func (client *notebookClient) BeginRenameNotebook(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *notebookClientBeginRenameNotebookOptions) (notebookClientRenameNotebookPollerResponse, error) {
+func (client *notebookClient) BeginRenameNotebook(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *notebookClientBeginRenameNotebookOptions) (*notebookClientRenameNotebookPoller, error) {
 	resp, err := client.renameNotebook(ctx, notebookName, request, options)
 	if err != nil {
-		return notebookClientRenameNotebookPollerResponse{}, err
+		return nil, err
 	}
-	result := notebookClientRenameNotebookPollerResponse{}
 	pt, err := runtime.NewPoller("notebookClient.RenameNotebook", resp, client.pl)
 	if err != nil {
-		return notebookClientRenameNotebookPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &notebookClientRenameNotebookPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &notebookClientRenameNotebookPoller{pt: pt}, nil
 }
 
 // RenameNotebook - Renames a notebook.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
@@ -41,20 +41,16 @@ func newPipelineClient(endpoint string, pl runtime.Pipeline) *pipelineClient {
 // pipeline - Pipeline resource definition.
 // options - pipelineClientBeginCreateOrUpdatePipelineOptions contains the optional parameters for the pipelineClient.BeginCreateOrUpdatePipeline
 // method.
-func (client *pipelineClient) BeginCreateOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, options *pipelineClientBeginCreateOrUpdatePipelineOptions) (pipelineClientCreateOrUpdatePipelinePollerResponse, error) {
+func (client *pipelineClient) BeginCreateOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, options *pipelineClientBeginCreateOrUpdatePipelineOptions) (*pipelineClientCreateOrUpdatePipelinePoller, error) {
 	resp, err := client.createOrUpdatePipeline(ctx, pipelineName, pipeline, options)
 	if err != nil {
-		return pipelineClientCreateOrUpdatePipelinePollerResponse{}, err
+		return nil, err
 	}
-	result := pipelineClientCreateOrUpdatePipelinePollerResponse{}
 	pt, err := runtime.NewPoller("pipelineClient.CreateOrUpdatePipeline", resp, client.pl)
 	if err != nil {
-		return pipelineClientCreateOrUpdatePipelinePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &pipelineClientCreateOrUpdatePipelinePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &pipelineClientCreateOrUpdatePipelinePoller{pt: pt}, nil
 }
 
 // CreateOrUpdatePipeline - Creates or updates a pipeline.
@@ -159,20 +155,16 @@ func (client *pipelineClient) createPipelineRunHandleResponse(resp *http.Respons
 // pipelineName - The pipeline name.
 // options - pipelineClientBeginDeletePipelineOptions contains the optional parameters for the pipelineClient.BeginDeletePipeline
 // method.
-func (client *pipelineClient) BeginDeletePipeline(ctx context.Context, pipelineName string, options *pipelineClientBeginDeletePipelineOptions) (pipelineClientDeletePipelinePollerResponse, error) {
+func (client *pipelineClient) BeginDeletePipeline(ctx context.Context, pipelineName string, options *pipelineClientBeginDeletePipelineOptions) (*pipelineClientDeletePipelinePoller, error) {
 	resp, err := client.deletePipeline(ctx, pipelineName, options)
 	if err != nil {
-		return pipelineClientDeletePipelinePollerResponse{}, err
+		return nil, err
 	}
-	result := pipelineClientDeletePipelinePollerResponse{}
 	pt, err := runtime.NewPoller("pipelineClient.DeletePipeline", resp, client.pl)
 	if err != nil {
-		return pipelineClientDeletePipelinePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &pipelineClientDeletePipelinePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &pipelineClientDeletePipelinePoller{pt: pt}, nil
 }
 
 // DeletePipeline - Deletes a pipeline.
@@ -304,20 +296,16 @@ func (client *pipelineClient) getPipelinesByWorkspaceHandleResponse(resp *http.R
 // request - proposed new name.
 // options - pipelineClientBeginRenamePipelineOptions contains the optional parameters for the pipelineClient.BeginRenamePipeline
 // method.
-func (client *pipelineClient) BeginRenamePipeline(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *pipelineClientBeginRenamePipelineOptions) (pipelineClientRenamePipelinePollerResponse, error) {
+func (client *pipelineClient) BeginRenamePipeline(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *pipelineClientBeginRenamePipelineOptions) (*pipelineClientRenamePipelinePoller, error) {
 	resp, err := client.renamePipeline(ctx, pipelineName, request, options)
 	if err != nil {
-		return pipelineClientRenamePipelinePollerResponse{}, err
+		return nil, err
 	}
-	result := pipelineClientRenamePipelinePollerResponse{}
 	pt, err := runtime.NewPoller("pipelineClient.RenamePipeline", resp, client.pl)
 	if err != nil {
-		return pipelineClientRenamePipelinePollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &pipelineClientRenamePipelinePoller{
-		pt: pt,
-	}
-	return result, nil
+	return &pipelineClientRenamePipelinePoller{pt: pt}, nil
 }
 
 // RenamePipeline - Renames a pipeline.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
@@ -11,7 +11,8 @@ package azartifacts
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"time"
 )
 
 // dataFlowClientCreateOrUpdateDataFlowPoller provides polling facilities until the operation reaches a terminal state.
@@ -24,36 +25,51 @@ func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Poll(ctx context.Context) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
+	result := dataFlowClientCreateOrUpdateDataFlowResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DataFlowResource)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final dataFlowClientCreateOrUpdateDataFlowResponse will be returned.
-func (p *dataFlowClientCreateOrUpdateDataFlowPoller) FinalResponse(ctx context.Context) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
-	respType := dataFlowClientCreateOrUpdateDataFlowResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DataFlowResource)
-	if err != nil {
-		return dataFlowClientCreateOrUpdateDataFlowResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *dataFlowClientCreateOrUpdateDataFlowPoller) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
+	result := dataFlowClientCreateOrUpdateDataFlowResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DataFlowResource)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *dataFlowClientCreateOrUpdateDataFlowPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a dataFlowClientCreateOrUpdateDataFlowPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Resume(ctx context.Context, client *dataFlowClient, token string) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.CreateOrUpdateDataFlow", token, client.pl); err != nil {
+		return dataFlowClientCreateOrUpdateDataFlowResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // dataFlowClientDeleteDataFlowPoller provides polling facilities until the operation reaches a terminal state.
@@ -66,36 +82,51 @@ func (p *dataFlowClientDeleteDataFlowPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *dataFlowClientDeleteDataFlowPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *dataFlowClientDeleteDataFlowPoller) Poll(ctx context.Context) (dataFlowClientDeleteDataFlowResponse, error) {
+	result := dataFlowClientDeleteDataFlowResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final dataFlowClientDeleteDataFlowResponse will be returned.
-func (p *dataFlowClientDeleteDataFlowPoller) FinalResponse(ctx context.Context) (dataFlowClientDeleteDataFlowResponse, error) {
-	respType := dataFlowClientDeleteDataFlowResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return dataFlowClientDeleteDataFlowResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *dataFlowClientDeleteDataFlowPoller) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientDeleteDataFlowResponse, error) {
+	result := dataFlowClientDeleteDataFlowResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *dataFlowClientDeleteDataFlowPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a dataFlowClientDeleteDataFlowPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *dataFlowClientDeleteDataFlowPoller) Resume(ctx context.Context, client *dataFlowClient, token string) (dataFlowClientDeleteDataFlowResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.DeleteDataFlow", token, client.pl); err != nil {
+		return dataFlowClientDeleteDataFlowResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // dataFlowClientRenameDataFlowPoller provides polling facilities until the operation reaches a terminal state.
@@ -108,36 +139,51 @@ func (p *dataFlowClientRenameDataFlowPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *dataFlowClientRenameDataFlowPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *dataFlowClientRenameDataFlowPoller) Poll(ctx context.Context) (dataFlowClientRenameDataFlowResponse, error) {
+	result := dataFlowClientRenameDataFlowResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final dataFlowClientRenameDataFlowResponse will be returned.
-func (p *dataFlowClientRenameDataFlowPoller) FinalResponse(ctx context.Context) (dataFlowClientRenameDataFlowResponse, error) {
-	respType := dataFlowClientRenameDataFlowResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return dataFlowClientRenameDataFlowResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *dataFlowClientRenameDataFlowPoller) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientRenameDataFlowResponse, error) {
+	result := dataFlowClientRenameDataFlowResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *dataFlowClientRenameDataFlowPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a dataFlowClientRenameDataFlowPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *dataFlowClientRenameDataFlowPoller) Resume(ctx context.Context, client *dataFlowClient, token string) (dataFlowClientRenameDataFlowResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.RenameDataFlow", token, client.pl); err != nil {
+		return dataFlowClientRenameDataFlowResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller provides polling facilities until the operation reaches a terminal state.
@@ -150,36 +196,51 @@ func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Done() bool
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Poll(ctx context.Context) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
+	result := dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.CreateDataFlowDebugSessionResponse)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse will be returned.
-func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) FinalResponse(ctx context.Context) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
-	respType := dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.CreateDataFlowDebugSessionResponse)
-	if err != nil {
-		return dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
+	result := dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.CreateDataFlowDebugSessionResponse)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Resume(ctx context.Context, client *dataFlowDebugSessionClient, token string) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowDebugSessionClient.CreateDataFlowDebugSession", token, client.pl); err != nil {
+		return dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // dataFlowDebugSessionClientExecuteCommandPoller provides polling facilities until the operation reaches a terminal state.
@@ -192,36 +253,51 @@ func (p *dataFlowDebugSessionClientExecuteCommandPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *dataFlowDebugSessionClientExecuteCommandPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *dataFlowDebugSessionClientExecuteCommandPoller) Poll(ctx context.Context) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
+	result := dataFlowDebugSessionClientExecuteCommandResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DataFlowDebugCommandResponse)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final dataFlowDebugSessionClientExecuteCommandResponse will be returned.
-func (p *dataFlowDebugSessionClientExecuteCommandPoller) FinalResponse(ctx context.Context) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
-	respType := dataFlowDebugSessionClientExecuteCommandResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DataFlowDebugCommandResponse)
-	if err != nil {
-		return dataFlowDebugSessionClientExecuteCommandResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *dataFlowDebugSessionClientExecuteCommandPoller) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
+	result := dataFlowDebugSessionClientExecuteCommandResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DataFlowDebugCommandResponse)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *dataFlowDebugSessionClientExecuteCommandPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a dataFlowDebugSessionClientExecuteCommandPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *dataFlowDebugSessionClientExecuteCommandPoller) Resume(ctx context.Context, client *dataFlowDebugSessionClient, token string) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowDebugSessionClient.ExecuteCommand", token, client.pl); err != nil {
+		return dataFlowDebugSessionClientExecuteCommandResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // datasetClientCreateOrUpdateDatasetPoller provides polling facilities until the operation reaches a terminal state.
@@ -234,36 +310,51 @@ func (p *datasetClientCreateOrUpdateDatasetPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *datasetClientCreateOrUpdateDatasetPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *datasetClientCreateOrUpdateDatasetPoller) Poll(ctx context.Context) (datasetClientCreateOrUpdateDatasetResponse, error) {
+	result := datasetClientCreateOrUpdateDatasetResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.DatasetResource)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final datasetClientCreateOrUpdateDatasetResponse will be returned.
-func (p *datasetClientCreateOrUpdateDatasetPoller) FinalResponse(ctx context.Context) (datasetClientCreateOrUpdateDatasetResponse, error) {
-	respType := datasetClientCreateOrUpdateDatasetResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.DatasetResource)
-	if err != nil {
-		return datasetClientCreateOrUpdateDatasetResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *datasetClientCreateOrUpdateDatasetPoller) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientCreateOrUpdateDatasetResponse, error) {
+	result := datasetClientCreateOrUpdateDatasetResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.DatasetResource)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *datasetClientCreateOrUpdateDatasetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a datasetClientCreateOrUpdateDatasetPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *datasetClientCreateOrUpdateDatasetPoller) Resume(ctx context.Context, client *datasetClient, token string) (datasetClientCreateOrUpdateDatasetResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.CreateOrUpdateDataset", token, client.pl); err != nil {
+		return datasetClientCreateOrUpdateDatasetResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // datasetClientDeleteDatasetPoller provides polling facilities until the operation reaches a terminal state.
@@ -276,36 +367,51 @@ func (p *datasetClientDeleteDatasetPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *datasetClientDeleteDatasetPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *datasetClientDeleteDatasetPoller) Poll(ctx context.Context) (datasetClientDeleteDatasetResponse, error) {
+	result := datasetClientDeleteDatasetResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final datasetClientDeleteDatasetResponse will be returned.
-func (p *datasetClientDeleteDatasetPoller) FinalResponse(ctx context.Context) (datasetClientDeleteDatasetResponse, error) {
-	respType := datasetClientDeleteDatasetResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return datasetClientDeleteDatasetResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *datasetClientDeleteDatasetPoller) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientDeleteDatasetResponse, error) {
+	result := datasetClientDeleteDatasetResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *datasetClientDeleteDatasetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a datasetClientDeleteDatasetPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *datasetClientDeleteDatasetPoller) Resume(ctx context.Context, client *datasetClient, token string) (datasetClientDeleteDatasetResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.DeleteDataset", token, client.pl); err != nil {
+		return datasetClientDeleteDatasetResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // datasetClientRenameDatasetPoller provides polling facilities until the operation reaches a terminal state.
@@ -318,36 +424,51 @@ func (p *datasetClientRenameDatasetPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *datasetClientRenameDatasetPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *datasetClientRenameDatasetPoller) Poll(ctx context.Context) (datasetClientRenameDatasetResponse, error) {
+	result := datasetClientRenameDatasetResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final datasetClientRenameDatasetResponse will be returned.
-func (p *datasetClientRenameDatasetPoller) FinalResponse(ctx context.Context) (datasetClientRenameDatasetResponse, error) {
-	respType := datasetClientRenameDatasetResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return datasetClientRenameDatasetResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *datasetClientRenameDatasetPoller) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientRenameDatasetResponse, error) {
+	result := datasetClientRenameDatasetResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *datasetClientRenameDatasetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a datasetClientRenameDatasetPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *datasetClientRenameDatasetPoller) Resume(ctx context.Context, client *datasetClient, token string) (datasetClientRenameDatasetResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.RenameDataset", token, client.pl); err != nil {
+		return datasetClientRenameDatasetResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // libraryClientCreatePoller provides polling facilities until the operation reaches a terminal state.
@@ -360,36 +481,51 @@ func (p *libraryClientCreatePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *libraryClientCreatePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *libraryClientCreatePoller) Poll(ctx context.Context) (libraryClientCreateResponse, error) {
+	result := libraryClientCreateResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.LibraryResourceInfo)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final libraryClientCreateResponse will be returned.
-func (p *libraryClientCreatePoller) FinalResponse(ctx context.Context) (libraryClientCreateResponse, error) {
-	respType := libraryClientCreateResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
-	if err != nil {
-		return libraryClientCreateResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *libraryClientCreatePoller) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientCreateResponse, error) {
+	result := libraryClientCreateResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.LibraryResourceInfo)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *libraryClientCreatePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a libraryClientCreatePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *libraryClientCreatePoller) Resume(ctx context.Context, client *libraryClient, token string) (libraryClientCreateResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Create", token, client.pl); err != nil {
+		return libraryClientCreateResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // libraryClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -402,36 +538,51 @@ func (p *libraryClientDeletePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *libraryClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *libraryClientDeletePoller) Poll(ctx context.Context) (libraryClientDeleteResponse, error) {
+	result := libraryClientDeleteResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.LibraryResourceInfo)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final libraryClientDeleteResponse will be returned.
-func (p *libraryClientDeletePoller) FinalResponse(ctx context.Context) (libraryClientDeleteResponse, error) {
-	respType := libraryClientDeleteResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
-	if err != nil {
-		return libraryClientDeleteResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *libraryClientDeletePoller) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientDeleteResponse, error) {
+	result := libraryClientDeleteResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.LibraryResourceInfo)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *libraryClientDeletePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a libraryClientDeletePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *libraryClientDeletePoller) Resume(ctx context.Context, client *libraryClient, token string) (libraryClientDeleteResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Delete", token, client.pl); err != nil {
+		return libraryClientDeleteResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // libraryClientFlushPoller provides polling facilities until the operation reaches a terminal state.
@@ -444,36 +595,51 @@ func (p *libraryClientFlushPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *libraryClientFlushPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *libraryClientFlushPoller) Poll(ctx context.Context) (libraryClientFlushResponse, error) {
+	result := libraryClientFlushResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.LibraryResourceInfo)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final libraryClientFlushResponse will be returned.
-func (p *libraryClientFlushPoller) FinalResponse(ctx context.Context) (libraryClientFlushResponse, error) {
-	respType := libraryClientFlushResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.LibraryResourceInfo)
-	if err != nil {
-		return libraryClientFlushResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *libraryClientFlushPoller) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientFlushResponse, error) {
+	result := libraryClientFlushResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.LibraryResourceInfo)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *libraryClientFlushPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a libraryClientFlushPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *libraryClientFlushPoller) Resume(ctx context.Context, client *libraryClient, token string) (libraryClientFlushResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Flush", token, client.pl); err != nil {
+		return libraryClientFlushResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // linkedServiceClientCreateOrUpdateLinkedServicePoller provides polling facilities until the operation reaches a terminal state.
@@ -486,36 +652,51 @@ func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Poll(ctx context.Context) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
+	result := linkedServiceClientCreateOrUpdateLinkedServiceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.LinkedServiceResource)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final linkedServiceClientCreateOrUpdateLinkedServiceResponse will be returned.
-func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) FinalResponse(ctx context.Context) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
-	respType := linkedServiceClientCreateOrUpdateLinkedServiceResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.LinkedServiceResource)
-	if err != nil {
-		return linkedServiceClientCreateOrUpdateLinkedServiceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
+	result := linkedServiceClientCreateOrUpdateLinkedServiceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.LinkedServiceResource)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a linkedServiceClientCreateOrUpdateLinkedServicePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Resume(ctx context.Context, client *linkedServiceClient, token string) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.CreateOrUpdateLinkedService", token, client.pl); err != nil {
+		return linkedServiceClientCreateOrUpdateLinkedServiceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // linkedServiceClientDeleteLinkedServicePoller provides polling facilities until the operation reaches a terminal state.
@@ -528,36 +709,51 @@ func (p *linkedServiceClientDeleteLinkedServicePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *linkedServiceClientDeleteLinkedServicePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *linkedServiceClientDeleteLinkedServicePoller) Poll(ctx context.Context) (linkedServiceClientDeleteLinkedServiceResponse, error) {
+	result := linkedServiceClientDeleteLinkedServiceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final linkedServiceClientDeleteLinkedServiceResponse will be returned.
-func (p *linkedServiceClientDeleteLinkedServicePoller) FinalResponse(ctx context.Context) (linkedServiceClientDeleteLinkedServiceResponse, error) {
-	respType := linkedServiceClientDeleteLinkedServiceResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return linkedServiceClientDeleteLinkedServiceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *linkedServiceClientDeleteLinkedServicePoller) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientDeleteLinkedServiceResponse, error) {
+	result := linkedServiceClientDeleteLinkedServiceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *linkedServiceClientDeleteLinkedServicePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a linkedServiceClientDeleteLinkedServicePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *linkedServiceClientDeleteLinkedServicePoller) Resume(ctx context.Context, client *linkedServiceClient, token string) (linkedServiceClientDeleteLinkedServiceResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.DeleteLinkedService", token, client.pl); err != nil {
+		return linkedServiceClientDeleteLinkedServiceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // linkedServiceClientRenameLinkedServicePoller provides polling facilities until the operation reaches a terminal state.
@@ -570,36 +766,51 @@ func (p *linkedServiceClientRenameLinkedServicePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *linkedServiceClientRenameLinkedServicePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *linkedServiceClientRenameLinkedServicePoller) Poll(ctx context.Context) (linkedServiceClientRenameLinkedServiceResponse, error) {
+	result := linkedServiceClientRenameLinkedServiceResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final linkedServiceClientRenameLinkedServiceResponse will be returned.
-func (p *linkedServiceClientRenameLinkedServicePoller) FinalResponse(ctx context.Context) (linkedServiceClientRenameLinkedServiceResponse, error) {
-	respType := linkedServiceClientRenameLinkedServiceResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return linkedServiceClientRenameLinkedServiceResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *linkedServiceClientRenameLinkedServicePoller) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientRenameLinkedServiceResponse, error) {
+	result := linkedServiceClientRenameLinkedServiceResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *linkedServiceClientRenameLinkedServicePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a linkedServiceClientRenameLinkedServicePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *linkedServiceClientRenameLinkedServicePoller) Resume(ctx context.Context, client *linkedServiceClient, token string) (linkedServiceClientRenameLinkedServiceResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.RenameLinkedService", token, client.pl); err != nil {
+		return linkedServiceClientRenameLinkedServiceResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // notebookClientCreateOrUpdateNotebookPoller provides polling facilities until the operation reaches a terminal state.
@@ -612,36 +823,51 @@ func (p *notebookClientCreateOrUpdateNotebookPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *notebookClientCreateOrUpdateNotebookPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *notebookClientCreateOrUpdateNotebookPoller) Poll(ctx context.Context) (notebookClientCreateOrUpdateNotebookResponse, error) {
+	result := notebookClientCreateOrUpdateNotebookResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.NotebookResource)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final notebookClientCreateOrUpdateNotebookResponse will be returned.
-func (p *notebookClientCreateOrUpdateNotebookPoller) FinalResponse(ctx context.Context) (notebookClientCreateOrUpdateNotebookResponse, error) {
-	respType := notebookClientCreateOrUpdateNotebookResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.NotebookResource)
-	if err != nil {
-		return notebookClientCreateOrUpdateNotebookResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *notebookClientCreateOrUpdateNotebookPoller) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientCreateOrUpdateNotebookResponse, error) {
+	result := notebookClientCreateOrUpdateNotebookResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.NotebookResource)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *notebookClientCreateOrUpdateNotebookPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a notebookClientCreateOrUpdateNotebookPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *notebookClientCreateOrUpdateNotebookPoller) Resume(ctx context.Context, client *notebookClient, token string) (notebookClientCreateOrUpdateNotebookResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.CreateOrUpdateNotebook", token, client.pl); err != nil {
+		return notebookClientCreateOrUpdateNotebookResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // notebookClientDeleteNotebookPoller provides polling facilities until the operation reaches a terminal state.
@@ -654,36 +880,51 @@ func (p *notebookClientDeleteNotebookPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *notebookClientDeleteNotebookPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *notebookClientDeleteNotebookPoller) Poll(ctx context.Context) (notebookClientDeleteNotebookResponse, error) {
+	result := notebookClientDeleteNotebookResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final notebookClientDeleteNotebookResponse will be returned.
-func (p *notebookClientDeleteNotebookPoller) FinalResponse(ctx context.Context) (notebookClientDeleteNotebookResponse, error) {
-	respType := notebookClientDeleteNotebookResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return notebookClientDeleteNotebookResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *notebookClientDeleteNotebookPoller) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientDeleteNotebookResponse, error) {
+	result := notebookClientDeleteNotebookResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *notebookClientDeleteNotebookPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a notebookClientDeleteNotebookPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *notebookClientDeleteNotebookPoller) Resume(ctx context.Context, client *notebookClient, token string) (notebookClientDeleteNotebookResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.DeleteNotebook", token, client.pl); err != nil {
+		return notebookClientDeleteNotebookResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // notebookClientRenameNotebookPoller provides polling facilities until the operation reaches a terminal state.
@@ -696,36 +937,51 @@ func (p *notebookClientRenameNotebookPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *notebookClientRenameNotebookPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *notebookClientRenameNotebookPoller) Poll(ctx context.Context) (notebookClientRenameNotebookResponse, error) {
+	result := notebookClientRenameNotebookResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final notebookClientRenameNotebookResponse will be returned.
-func (p *notebookClientRenameNotebookPoller) FinalResponse(ctx context.Context) (notebookClientRenameNotebookResponse, error) {
-	respType := notebookClientRenameNotebookResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return notebookClientRenameNotebookResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *notebookClientRenameNotebookPoller) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientRenameNotebookResponse, error) {
+	result := notebookClientRenameNotebookResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *notebookClientRenameNotebookPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a notebookClientRenameNotebookPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *notebookClientRenameNotebookPoller) Resume(ctx context.Context, client *notebookClient, token string) (notebookClientRenameNotebookResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.RenameNotebook", token, client.pl); err != nil {
+		return notebookClientRenameNotebookResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // pipelineClientCreateOrUpdatePipelinePoller provides polling facilities until the operation reaches a terminal state.
@@ -738,36 +994,51 @@ func (p *pipelineClientCreateOrUpdatePipelinePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *pipelineClientCreateOrUpdatePipelinePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *pipelineClientCreateOrUpdatePipelinePoller) Poll(ctx context.Context) (pipelineClientCreateOrUpdatePipelineResponse, error) {
+	result := pipelineClientCreateOrUpdatePipelineResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.PipelineResource)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final pipelineClientCreateOrUpdatePipelineResponse will be returned.
-func (p *pipelineClientCreateOrUpdatePipelinePoller) FinalResponse(ctx context.Context) (pipelineClientCreateOrUpdatePipelineResponse, error) {
-	respType := pipelineClientCreateOrUpdatePipelineResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.PipelineResource)
-	if err != nil {
-		return pipelineClientCreateOrUpdatePipelineResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *pipelineClientCreateOrUpdatePipelinePoller) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientCreateOrUpdatePipelineResponse, error) {
+	result := pipelineClientCreateOrUpdatePipelineResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.PipelineResource)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *pipelineClientCreateOrUpdatePipelinePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a pipelineClientCreateOrUpdatePipelinePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *pipelineClientCreateOrUpdatePipelinePoller) Resume(ctx context.Context, client *pipelineClient, token string) (pipelineClientCreateOrUpdatePipelineResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.CreateOrUpdatePipeline", token, client.pl); err != nil {
+		return pipelineClientCreateOrUpdatePipelineResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // pipelineClientDeletePipelinePoller provides polling facilities until the operation reaches a terminal state.
@@ -780,36 +1051,51 @@ func (p *pipelineClientDeletePipelinePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *pipelineClientDeletePipelinePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *pipelineClientDeletePipelinePoller) Poll(ctx context.Context) (pipelineClientDeletePipelineResponse, error) {
+	result := pipelineClientDeletePipelineResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final pipelineClientDeletePipelineResponse will be returned.
-func (p *pipelineClientDeletePipelinePoller) FinalResponse(ctx context.Context) (pipelineClientDeletePipelineResponse, error) {
-	respType := pipelineClientDeletePipelineResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return pipelineClientDeletePipelineResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *pipelineClientDeletePipelinePoller) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientDeletePipelineResponse, error) {
+	result := pipelineClientDeletePipelineResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *pipelineClientDeletePipelinePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a pipelineClientDeletePipelinePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *pipelineClientDeletePipelinePoller) Resume(ctx context.Context, client *pipelineClient, token string) (pipelineClientDeletePipelineResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.DeletePipeline", token, client.pl); err != nil {
+		return pipelineClientDeletePipelineResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // pipelineClientRenamePipelinePoller provides polling facilities until the operation reaches a terminal state.
@@ -822,36 +1108,51 @@ func (p *pipelineClientRenamePipelinePoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *pipelineClientRenamePipelinePoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *pipelineClientRenamePipelinePoller) Poll(ctx context.Context) (pipelineClientRenamePipelineResponse, error) {
+	result := pipelineClientRenamePipelineResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final pipelineClientRenamePipelineResponse will be returned.
-func (p *pipelineClientRenamePipelinePoller) FinalResponse(ctx context.Context) (pipelineClientRenamePipelineResponse, error) {
-	respType := pipelineClientRenamePipelineResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return pipelineClientRenamePipelineResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *pipelineClientRenamePipelinePoller) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientRenamePipelineResponse, error) {
+	result := pipelineClientRenamePipelineResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *pipelineClientRenamePipelinePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a pipelineClientRenamePipelinePoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *pipelineClientRenamePipelinePoller) Resume(ctx context.Context, client *pipelineClient, token string) (pipelineClientRenamePipelineResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.RenamePipeline", token, client.pl); err != nil {
+		return pipelineClientRenamePipelineResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -864,36 +1165,51 @@ func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Done() 
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SparkJobDefinitionResource)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse will be returned.
-func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SparkJobDefinitionResource)
-	if err != nil {
-		return sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SparkJobDefinitionResource)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", token, client.pl); err != nil {
+		return sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // sparkJobDefinitionClientDebugSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -906,36 +1222,51 @@ func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SparkBatchJob)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final sparkJobDefinitionClientDebugSparkJobDefinitionResponse will be returned.
-func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SparkBatchJob)
-	if err != nil {
-		return sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SparkBatchJob)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a sparkJobDefinitionClientDebugSparkJobDefinitionPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.DebugSparkJobDefinition", token, client.pl); err != nil {
+		return sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // sparkJobDefinitionClientDeleteSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -948,36 +1279,51 @@ func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final sparkJobDefinitionClientDeleteSparkJobDefinitionResponse will be returned.
-func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a sparkJobDefinitionClientDeleteSparkJobDefinitionPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.DeleteSparkJobDefinition", token, client.pl); err != nil {
+		return sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // sparkJobDefinitionClientExecuteSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -990,36 +1336,51 @@ func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SparkBatchJob)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final sparkJobDefinitionClientExecuteSparkJobDefinitionResponse will be returned.
-func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SparkBatchJob)
-	if err != nil {
-		return sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SparkBatchJob)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a sparkJobDefinitionClientExecuteSparkJobDefinitionPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.ExecuteSparkJobDefinition", token, client.pl); err != nil {
+		return sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // sparkJobDefinitionClientRenameSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -1032,36 +1393,51 @@ func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final sparkJobDefinitionClientRenameSparkJobDefinitionResponse will be returned.
-func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) FinalResponse(ctx context.Context) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
+	result := sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a sparkJobDefinitionClientRenameSparkJobDefinitionPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.RenameSparkJobDefinition", token, client.pl); err != nil {
+		return sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // sqlScriptClientCreateOrUpdateSQLScriptPoller provides polling facilities until the operation reaches a terminal state.
@@ -1074,36 +1450,51 @@ func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Poll(ctx context.Context) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
+	result := sqlScriptClientCreateOrUpdateSQLScriptResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.SQLScriptResource)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final sqlScriptClientCreateOrUpdateSQLScriptResponse will be returned.
-func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) FinalResponse(ctx context.Context) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
-	respType := sqlScriptClientCreateOrUpdateSQLScriptResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.SQLScriptResource)
-	if err != nil {
-		return sqlScriptClientCreateOrUpdateSQLScriptResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
+	result := sqlScriptClientCreateOrUpdateSQLScriptResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.SQLScriptResource)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a sqlScriptClientCreateOrUpdateSQLScriptPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Resume(ctx context.Context, client *sqlScriptClient, token string) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.CreateOrUpdateSQLScript", token, client.pl); err != nil {
+		return sqlScriptClientCreateOrUpdateSQLScriptResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // sqlScriptClientDeleteSQLScriptPoller provides polling facilities until the operation reaches a terminal state.
@@ -1116,36 +1507,51 @@ func (p *sqlScriptClientDeleteSQLScriptPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *sqlScriptClientDeleteSQLScriptPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *sqlScriptClientDeleteSQLScriptPoller) Poll(ctx context.Context) (sqlScriptClientDeleteSQLScriptResponse, error) {
+	result := sqlScriptClientDeleteSQLScriptResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final sqlScriptClientDeleteSQLScriptResponse will be returned.
-func (p *sqlScriptClientDeleteSQLScriptPoller) FinalResponse(ctx context.Context) (sqlScriptClientDeleteSQLScriptResponse, error) {
-	respType := sqlScriptClientDeleteSQLScriptResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return sqlScriptClientDeleteSQLScriptResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *sqlScriptClientDeleteSQLScriptPoller) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientDeleteSQLScriptResponse, error) {
+	result := sqlScriptClientDeleteSQLScriptResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *sqlScriptClientDeleteSQLScriptPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a sqlScriptClientDeleteSQLScriptPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *sqlScriptClientDeleteSQLScriptPoller) Resume(ctx context.Context, client *sqlScriptClient, token string) (sqlScriptClientDeleteSQLScriptResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.DeleteSQLScript", token, client.pl); err != nil {
+		return sqlScriptClientDeleteSQLScriptResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // sqlScriptClientRenameSQLScriptPoller provides polling facilities until the operation reaches a terminal state.
@@ -1158,36 +1564,51 @@ func (p *sqlScriptClientRenameSQLScriptPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *sqlScriptClientRenameSQLScriptPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *sqlScriptClientRenameSQLScriptPoller) Poll(ctx context.Context) (sqlScriptClientRenameSQLScriptResponse, error) {
+	result := sqlScriptClientRenameSQLScriptResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final sqlScriptClientRenameSQLScriptResponse will be returned.
-func (p *sqlScriptClientRenameSQLScriptPoller) FinalResponse(ctx context.Context) (sqlScriptClientRenameSQLScriptResponse, error) {
-	respType := sqlScriptClientRenameSQLScriptResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return sqlScriptClientRenameSQLScriptResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *sqlScriptClientRenameSQLScriptPoller) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientRenameSQLScriptResponse, error) {
+	result := sqlScriptClientRenameSQLScriptResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *sqlScriptClientRenameSQLScriptPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a sqlScriptClientRenameSQLScriptPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *sqlScriptClientRenameSQLScriptPoller) Resume(ctx context.Context, client *sqlScriptClient, token string) (sqlScriptClientRenameSQLScriptResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.RenameSQLScript", token, client.pl); err != nil {
+		return sqlScriptClientRenameSQLScriptResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // triggerClientCreateOrUpdateTriggerPoller provides polling facilities until the operation reaches a terminal state.
@@ -1200,36 +1621,51 @@ func (p *triggerClientCreateOrUpdateTriggerPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *triggerClientCreateOrUpdateTriggerPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *triggerClientCreateOrUpdateTriggerPoller) Poll(ctx context.Context) (triggerClientCreateOrUpdateTriggerResponse, error) {
+	result := triggerClientCreateOrUpdateTriggerResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.TriggerResource)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final triggerClientCreateOrUpdateTriggerResponse will be returned.
-func (p *triggerClientCreateOrUpdateTriggerPoller) FinalResponse(ctx context.Context) (triggerClientCreateOrUpdateTriggerResponse, error) {
-	respType := triggerClientCreateOrUpdateTriggerResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.TriggerResource)
-	if err != nil {
-		return triggerClientCreateOrUpdateTriggerResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *triggerClientCreateOrUpdateTriggerPoller) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientCreateOrUpdateTriggerResponse, error) {
+	result := triggerClientCreateOrUpdateTriggerResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.TriggerResource)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *triggerClientCreateOrUpdateTriggerPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a triggerClientCreateOrUpdateTriggerPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *triggerClientCreateOrUpdateTriggerPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientCreateOrUpdateTriggerResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.CreateOrUpdateTrigger", token, client.pl); err != nil {
+		return triggerClientCreateOrUpdateTriggerResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // triggerClientDeleteTriggerPoller provides polling facilities until the operation reaches a terminal state.
@@ -1242,36 +1678,51 @@ func (p *triggerClientDeleteTriggerPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *triggerClientDeleteTriggerPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *triggerClientDeleteTriggerPoller) Poll(ctx context.Context) (triggerClientDeleteTriggerResponse, error) {
+	result := triggerClientDeleteTriggerResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final triggerClientDeleteTriggerResponse will be returned.
-func (p *triggerClientDeleteTriggerPoller) FinalResponse(ctx context.Context) (triggerClientDeleteTriggerResponse, error) {
-	respType := triggerClientDeleteTriggerResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return triggerClientDeleteTriggerResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *triggerClientDeleteTriggerPoller) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientDeleteTriggerResponse, error) {
+	result := triggerClientDeleteTriggerResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *triggerClientDeleteTriggerPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a triggerClientDeleteTriggerPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *triggerClientDeleteTriggerPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientDeleteTriggerResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.DeleteTrigger", token, client.pl); err != nil {
+		return triggerClientDeleteTriggerResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // triggerClientStartTriggerPoller provides polling facilities until the operation reaches a terminal state.
@@ -1284,36 +1735,51 @@ func (p *triggerClientStartTriggerPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *triggerClientStartTriggerPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *triggerClientStartTriggerPoller) Poll(ctx context.Context) (triggerClientStartTriggerResponse, error) {
+	result := triggerClientStartTriggerResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final triggerClientStartTriggerResponse will be returned.
-func (p *triggerClientStartTriggerPoller) FinalResponse(ctx context.Context) (triggerClientStartTriggerResponse, error) {
-	respType := triggerClientStartTriggerResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return triggerClientStartTriggerResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *triggerClientStartTriggerPoller) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientStartTriggerResponse, error) {
+	result := triggerClientStartTriggerResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *triggerClientStartTriggerPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a triggerClientStartTriggerPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *triggerClientStartTriggerPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientStartTriggerResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.StartTrigger", token, client.pl); err != nil {
+		return triggerClientStartTriggerResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // triggerClientStopTriggerPoller provides polling facilities until the operation reaches a terminal state.
@@ -1326,36 +1792,51 @@ func (p *triggerClientStopTriggerPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *triggerClientStopTriggerPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *triggerClientStopTriggerPoller) Poll(ctx context.Context) (triggerClientStopTriggerResponse, error) {
+	result := triggerClientStopTriggerResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, nil)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final triggerClientStopTriggerResponse will be returned.
-func (p *triggerClientStopTriggerPoller) FinalResponse(ctx context.Context) (triggerClientStopTriggerResponse, error) {
-	respType := triggerClientStopTriggerResponse{}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	if err != nil {
-		return triggerClientStopTriggerResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *triggerClientStopTriggerPoller) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientStopTriggerResponse, error) {
+	result := triggerClientStopTriggerResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, nil)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *triggerClientStopTriggerPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a triggerClientStopTriggerPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *triggerClientStopTriggerPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientStopTriggerResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.StopTrigger", token, client.pl); err != nil {
+		return triggerClientStopTriggerResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // triggerClientSubscribeTriggerToEventsPoller provides polling facilities until the operation reaches a terminal state.
@@ -1368,36 +1849,51 @@ func (p *triggerClientSubscribeTriggerToEventsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *triggerClientSubscribeTriggerToEventsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *triggerClientSubscribeTriggerToEventsPoller) Poll(ctx context.Context) (triggerClientSubscribeTriggerToEventsResponse, error) {
+	result := triggerClientSubscribeTriggerToEventsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.TriggerSubscriptionOperationStatus)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final triggerClientSubscribeTriggerToEventsResponse will be returned.
-func (p *triggerClientSubscribeTriggerToEventsPoller) FinalResponse(ctx context.Context) (triggerClientSubscribeTriggerToEventsResponse, error) {
-	respType := triggerClientSubscribeTriggerToEventsResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.TriggerSubscriptionOperationStatus)
-	if err != nil {
-		return triggerClientSubscribeTriggerToEventsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *triggerClientSubscribeTriggerToEventsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientSubscribeTriggerToEventsResponse, error) {
+	result := triggerClientSubscribeTriggerToEventsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.TriggerSubscriptionOperationStatus)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *triggerClientSubscribeTriggerToEventsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a triggerClientSubscribeTriggerToEventsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *triggerClientSubscribeTriggerToEventsPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientSubscribeTriggerToEventsResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.SubscribeTriggerToEvents", token, client.pl); err != nil {
+		return triggerClientSubscribeTriggerToEventsResponse{}, err
+	}
+	return p.Poll(ctx)
 }
 
 // triggerClientUnsubscribeTriggerFromEventsPoller provides polling facilities until the operation reaches a terminal state.
@@ -1410,34 +1906,49 @@ func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Done() bool {
 	return p.pt.Done()
 }
 
-// Poll fetches the latest state of the LRO.  It returns an HTTP response or error.
-// If the LRO has completed successfully, the poller's state is updated and the HTTP
+// Poll fetches the latest state of the LRO.
+// If the LRO has completed successfully, the poller's state is updated and the
 // response is returned.
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// the latest HTTP response is returned.
+// a zero-value response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
-// HTTP response or error.
-func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Poll(ctx context.Context) (*http.Response, error) {
-	return p.pt.Poll(ctx)
+// response or error.
+func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Poll(ctx context.Context) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
+	result := triggerClientUnsubscribeTriggerFromEventsResponse{}
+	if _, err := p.pt.Poll(ctx); err != nil {
+		return result, err
+	}
+	if !p.Done() {
+		return result, nil
+	}
+	_, err := p.pt.FinalResponse(ctx, &result.TriggerSubscriptionOperationStatus)
+	return result, err
 }
 
-// FinalResponse performs a final GET to the service and returns the final response
-// for the polling operation. If there is an error performing the final GET then an error is returned.
-// If the final GET succeeded then the final triggerClientUnsubscribeTriggerFromEventsResponse will be returned.
-func (p *triggerClientUnsubscribeTriggerFromEventsPoller) FinalResponse(ctx context.Context) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
-	respType := triggerClientUnsubscribeTriggerFromEventsResponse{}
-	_, err := p.pt.FinalResponse(ctx, &respType.TriggerSubscriptionOperationStatus)
-	if err != nil {
-		return triggerClientUnsubscribeTriggerFromEventsResponse{}, err
-	}
-	return respType, nil
+// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
+// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
+func (p *triggerClientUnsubscribeTriggerFromEventsPoller) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
+	result := triggerClientUnsubscribeTriggerFromEventsResponse{}
+	_, err := p.pt.PollUntilDone(ctx, freq, &result.TriggerSubscriptionOperationStatus)
+	return result, err
 }
 
 // ResumeToken returns a value representing the poller that can be used to resume
 // the LRO at a later time. ResumeTokens are unique per service operation.
+// Returns an error if the poller is in a terminal state.
 func (p *triggerClientUnsubscribeTriggerFromEventsPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
+}
+
+// Resume rehydrates a triggerClientUnsubscribeTriggerFromEventsPoller from the provided client and resume token.
+// Returns an error if the token is isn't applicable to this poller type.
+func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
+	var err error
+	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.UnsubscribeTriggerFromEvents", token, client.pl); err != nil {
+		return triggerClientUnsubscribeTriggerFromEventsResponse{}, err
+	}
+	return p.Poll(ctx)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"net/http"
 	"time"
 )
 
@@ -31,20 +32,19 @@ func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Poll(ctx context.Context) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
-	result := dataFlowClientCreateOrUpdateDataFlowResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DataFlowResource)
-	return result, err
+func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Result(ctx context.Context) (resp dataFlowClientCreateOrUpdateDataFlowResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -64,12 +64,9 @@ func (p *dataFlowClientCreateOrUpdateDataFlowPoller) ResumeToken() (string, erro
 
 // Resume rehydrates a dataFlowClientCreateOrUpdateDataFlowPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Resume(ctx context.Context, client *dataFlowClient, token string) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.CreateOrUpdateDataFlow", token, client.pl); err != nil {
-		return dataFlowClientCreateOrUpdateDataFlowResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *dataFlowClientCreateOrUpdateDataFlowPoller) Resume(token string, client *dataFlowClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.CreateOrUpdateDataFlow", token, client.pl)
+	return
 }
 
 // dataFlowClientDeleteDataFlowPoller provides polling facilities until the operation reaches a terminal state.
@@ -88,20 +85,19 @@ func (p *dataFlowClientDeleteDataFlowPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *dataFlowClientDeleteDataFlowPoller) Poll(ctx context.Context) (dataFlowClientDeleteDataFlowResponse, error) {
-	result := dataFlowClientDeleteDataFlowResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *dataFlowClientDeleteDataFlowPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *dataFlowClientDeleteDataFlowPoller) Result(ctx context.Context) (resp dataFlowClientDeleteDataFlowResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -121,12 +117,9 @@ func (p *dataFlowClientDeleteDataFlowPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a dataFlowClientDeleteDataFlowPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *dataFlowClientDeleteDataFlowPoller) Resume(ctx context.Context, client *dataFlowClient, token string) (dataFlowClientDeleteDataFlowResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.DeleteDataFlow", token, client.pl); err != nil {
-		return dataFlowClientDeleteDataFlowResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *dataFlowClientDeleteDataFlowPoller) Resume(token string, client *dataFlowClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.DeleteDataFlow", token, client.pl)
+	return
 }
 
 // dataFlowClientRenameDataFlowPoller provides polling facilities until the operation reaches a terminal state.
@@ -145,20 +138,19 @@ func (p *dataFlowClientRenameDataFlowPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *dataFlowClientRenameDataFlowPoller) Poll(ctx context.Context) (dataFlowClientRenameDataFlowResponse, error) {
-	result := dataFlowClientRenameDataFlowResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *dataFlowClientRenameDataFlowPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *dataFlowClientRenameDataFlowPoller) Result(ctx context.Context) (resp dataFlowClientRenameDataFlowResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -178,12 +170,9 @@ func (p *dataFlowClientRenameDataFlowPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a dataFlowClientRenameDataFlowPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *dataFlowClientRenameDataFlowPoller) Resume(ctx context.Context, client *dataFlowClient, token string) (dataFlowClientRenameDataFlowResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.RenameDataFlow", token, client.pl); err != nil {
-		return dataFlowClientRenameDataFlowResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *dataFlowClientRenameDataFlowPoller) Resume(token string, client *dataFlowClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("dataFlowClient.RenameDataFlow", token, client.pl)
+	return
 }
 
 // dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller provides polling facilities until the operation reaches a terminal state.
@@ -202,20 +191,19 @@ func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Done() bool
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Poll(ctx context.Context) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
-	result := dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.CreateDataFlowDebugSessionResponse)
-	return result, err
+func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Result(ctx context.Context) (resp dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -235,12 +223,9 @@ func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) ResumeToken
 
 // Resume rehydrates a dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Resume(ctx context.Context, client *dataFlowDebugSessionClient, token string) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowDebugSessionClient.CreateDataFlowDebugSession", token, client.pl); err != nil {
-		return dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller) Resume(token string, client *dataFlowDebugSessionClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("dataFlowDebugSessionClient.CreateDataFlowDebugSession", token, client.pl)
+	return
 }
 
 // dataFlowDebugSessionClientExecuteCommandPoller provides polling facilities until the operation reaches a terminal state.
@@ -259,20 +244,19 @@ func (p *dataFlowDebugSessionClientExecuteCommandPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *dataFlowDebugSessionClientExecuteCommandPoller) Poll(ctx context.Context) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
-	result := dataFlowDebugSessionClientExecuteCommandResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DataFlowDebugCommandResponse)
-	return result, err
+func (p *dataFlowDebugSessionClientExecuteCommandPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *dataFlowDebugSessionClientExecuteCommandPoller) Result(ctx context.Context) (resp dataFlowDebugSessionClientExecuteCommandResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -292,12 +276,9 @@ func (p *dataFlowDebugSessionClientExecuteCommandPoller) ResumeToken() (string, 
 
 // Resume rehydrates a dataFlowDebugSessionClientExecuteCommandPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *dataFlowDebugSessionClientExecuteCommandPoller) Resume(ctx context.Context, client *dataFlowDebugSessionClient, token string) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("dataFlowDebugSessionClient.ExecuteCommand", token, client.pl); err != nil {
-		return dataFlowDebugSessionClientExecuteCommandResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *dataFlowDebugSessionClientExecuteCommandPoller) Resume(token string, client *dataFlowDebugSessionClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("dataFlowDebugSessionClient.ExecuteCommand", token, client.pl)
+	return
 }
 
 // datasetClientCreateOrUpdateDatasetPoller provides polling facilities until the operation reaches a terminal state.
@@ -316,20 +297,19 @@ func (p *datasetClientCreateOrUpdateDatasetPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *datasetClientCreateOrUpdateDatasetPoller) Poll(ctx context.Context) (datasetClientCreateOrUpdateDatasetResponse, error) {
-	result := datasetClientCreateOrUpdateDatasetResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.DatasetResource)
-	return result, err
+func (p *datasetClientCreateOrUpdateDatasetPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *datasetClientCreateOrUpdateDatasetPoller) Result(ctx context.Context) (resp datasetClientCreateOrUpdateDatasetResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -349,12 +329,9 @@ func (p *datasetClientCreateOrUpdateDatasetPoller) ResumeToken() (string, error)
 
 // Resume rehydrates a datasetClientCreateOrUpdateDatasetPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *datasetClientCreateOrUpdateDatasetPoller) Resume(ctx context.Context, client *datasetClient, token string) (datasetClientCreateOrUpdateDatasetResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.CreateOrUpdateDataset", token, client.pl); err != nil {
-		return datasetClientCreateOrUpdateDatasetResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *datasetClientCreateOrUpdateDatasetPoller) Resume(token string, client *datasetClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.CreateOrUpdateDataset", token, client.pl)
+	return
 }
 
 // datasetClientDeleteDatasetPoller provides polling facilities until the operation reaches a terminal state.
@@ -373,20 +350,19 @@ func (p *datasetClientDeleteDatasetPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *datasetClientDeleteDatasetPoller) Poll(ctx context.Context) (datasetClientDeleteDatasetResponse, error) {
-	result := datasetClientDeleteDatasetResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *datasetClientDeleteDatasetPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *datasetClientDeleteDatasetPoller) Result(ctx context.Context) (resp datasetClientDeleteDatasetResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -406,12 +382,9 @@ func (p *datasetClientDeleteDatasetPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a datasetClientDeleteDatasetPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *datasetClientDeleteDatasetPoller) Resume(ctx context.Context, client *datasetClient, token string) (datasetClientDeleteDatasetResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.DeleteDataset", token, client.pl); err != nil {
-		return datasetClientDeleteDatasetResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *datasetClientDeleteDatasetPoller) Resume(token string, client *datasetClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.DeleteDataset", token, client.pl)
+	return
 }
 
 // datasetClientRenameDatasetPoller provides polling facilities until the operation reaches a terminal state.
@@ -430,20 +403,19 @@ func (p *datasetClientRenameDatasetPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *datasetClientRenameDatasetPoller) Poll(ctx context.Context) (datasetClientRenameDatasetResponse, error) {
-	result := datasetClientRenameDatasetResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *datasetClientRenameDatasetPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *datasetClientRenameDatasetPoller) Result(ctx context.Context) (resp datasetClientRenameDatasetResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -463,12 +435,9 @@ func (p *datasetClientRenameDatasetPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a datasetClientRenameDatasetPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *datasetClientRenameDatasetPoller) Resume(ctx context.Context, client *datasetClient, token string) (datasetClientRenameDatasetResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.RenameDataset", token, client.pl); err != nil {
-		return datasetClientRenameDatasetResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *datasetClientRenameDatasetPoller) Resume(token string, client *datasetClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("datasetClient.RenameDataset", token, client.pl)
+	return
 }
 
 // libraryClientCreatePoller provides polling facilities until the operation reaches a terminal state.
@@ -487,20 +456,19 @@ func (p *libraryClientCreatePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *libraryClientCreatePoller) Poll(ctx context.Context) (libraryClientCreateResponse, error) {
-	result := libraryClientCreateResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.LibraryResourceInfo)
-	return result, err
+func (p *libraryClientCreatePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *libraryClientCreatePoller) Result(ctx context.Context) (resp libraryClientCreateResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -520,12 +488,9 @@ func (p *libraryClientCreatePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a libraryClientCreatePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *libraryClientCreatePoller) Resume(ctx context.Context, client *libraryClient, token string) (libraryClientCreateResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Create", token, client.pl); err != nil {
-		return libraryClientCreateResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *libraryClientCreatePoller) Resume(token string, client *libraryClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Create", token, client.pl)
+	return
 }
 
 // libraryClientDeletePoller provides polling facilities until the operation reaches a terminal state.
@@ -544,20 +509,19 @@ func (p *libraryClientDeletePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *libraryClientDeletePoller) Poll(ctx context.Context) (libraryClientDeleteResponse, error) {
-	result := libraryClientDeleteResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.LibraryResourceInfo)
-	return result, err
+func (p *libraryClientDeletePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *libraryClientDeletePoller) Result(ctx context.Context) (resp libraryClientDeleteResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -577,12 +541,9 @@ func (p *libraryClientDeletePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a libraryClientDeletePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *libraryClientDeletePoller) Resume(ctx context.Context, client *libraryClient, token string) (libraryClientDeleteResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Delete", token, client.pl); err != nil {
-		return libraryClientDeleteResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *libraryClientDeletePoller) Resume(token string, client *libraryClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Delete", token, client.pl)
+	return
 }
 
 // libraryClientFlushPoller provides polling facilities until the operation reaches a terminal state.
@@ -601,20 +562,19 @@ func (p *libraryClientFlushPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *libraryClientFlushPoller) Poll(ctx context.Context) (libraryClientFlushResponse, error) {
-	result := libraryClientFlushResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.LibraryResourceInfo)
-	return result, err
+func (p *libraryClientFlushPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *libraryClientFlushPoller) Result(ctx context.Context) (resp libraryClientFlushResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -634,12 +594,9 @@ func (p *libraryClientFlushPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a libraryClientFlushPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *libraryClientFlushPoller) Resume(ctx context.Context, client *libraryClient, token string) (libraryClientFlushResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Flush", token, client.pl); err != nil {
-		return libraryClientFlushResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *libraryClientFlushPoller) Resume(token string, client *libraryClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("libraryClient.Flush", token, client.pl)
+	return
 }
 
 // linkedServiceClientCreateOrUpdateLinkedServicePoller provides polling facilities until the operation reaches a terminal state.
@@ -658,20 +615,19 @@ func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Poll(ctx context.Context) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
-	result := linkedServiceClientCreateOrUpdateLinkedServiceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.LinkedServiceResource)
-	return result, err
+func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Result(ctx context.Context) (resp linkedServiceClientCreateOrUpdateLinkedServiceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -691,12 +647,9 @@ func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) ResumeToken() (st
 
 // Resume rehydrates a linkedServiceClientCreateOrUpdateLinkedServicePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Resume(ctx context.Context, client *linkedServiceClient, token string) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.CreateOrUpdateLinkedService", token, client.pl); err != nil {
-		return linkedServiceClientCreateOrUpdateLinkedServiceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *linkedServiceClientCreateOrUpdateLinkedServicePoller) Resume(token string, client *linkedServiceClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.CreateOrUpdateLinkedService", token, client.pl)
+	return
 }
 
 // linkedServiceClientDeleteLinkedServicePoller provides polling facilities until the operation reaches a terminal state.
@@ -715,20 +668,19 @@ func (p *linkedServiceClientDeleteLinkedServicePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *linkedServiceClientDeleteLinkedServicePoller) Poll(ctx context.Context) (linkedServiceClientDeleteLinkedServiceResponse, error) {
-	result := linkedServiceClientDeleteLinkedServiceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *linkedServiceClientDeleteLinkedServicePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *linkedServiceClientDeleteLinkedServicePoller) Result(ctx context.Context) (resp linkedServiceClientDeleteLinkedServiceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -748,12 +700,9 @@ func (p *linkedServiceClientDeleteLinkedServicePoller) ResumeToken() (string, er
 
 // Resume rehydrates a linkedServiceClientDeleteLinkedServicePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *linkedServiceClientDeleteLinkedServicePoller) Resume(ctx context.Context, client *linkedServiceClient, token string) (linkedServiceClientDeleteLinkedServiceResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.DeleteLinkedService", token, client.pl); err != nil {
-		return linkedServiceClientDeleteLinkedServiceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *linkedServiceClientDeleteLinkedServicePoller) Resume(token string, client *linkedServiceClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.DeleteLinkedService", token, client.pl)
+	return
 }
 
 // linkedServiceClientRenameLinkedServicePoller provides polling facilities until the operation reaches a terminal state.
@@ -772,20 +721,19 @@ func (p *linkedServiceClientRenameLinkedServicePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *linkedServiceClientRenameLinkedServicePoller) Poll(ctx context.Context) (linkedServiceClientRenameLinkedServiceResponse, error) {
-	result := linkedServiceClientRenameLinkedServiceResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *linkedServiceClientRenameLinkedServicePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *linkedServiceClientRenameLinkedServicePoller) Result(ctx context.Context) (resp linkedServiceClientRenameLinkedServiceResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -805,12 +753,9 @@ func (p *linkedServiceClientRenameLinkedServicePoller) ResumeToken() (string, er
 
 // Resume rehydrates a linkedServiceClientRenameLinkedServicePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *linkedServiceClientRenameLinkedServicePoller) Resume(ctx context.Context, client *linkedServiceClient, token string) (linkedServiceClientRenameLinkedServiceResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.RenameLinkedService", token, client.pl); err != nil {
-		return linkedServiceClientRenameLinkedServiceResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *linkedServiceClientRenameLinkedServicePoller) Resume(token string, client *linkedServiceClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("linkedServiceClient.RenameLinkedService", token, client.pl)
+	return
 }
 
 // notebookClientCreateOrUpdateNotebookPoller provides polling facilities until the operation reaches a terminal state.
@@ -829,20 +774,19 @@ func (p *notebookClientCreateOrUpdateNotebookPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *notebookClientCreateOrUpdateNotebookPoller) Poll(ctx context.Context) (notebookClientCreateOrUpdateNotebookResponse, error) {
-	result := notebookClientCreateOrUpdateNotebookResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.NotebookResource)
-	return result, err
+func (p *notebookClientCreateOrUpdateNotebookPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *notebookClientCreateOrUpdateNotebookPoller) Result(ctx context.Context) (resp notebookClientCreateOrUpdateNotebookResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -862,12 +806,9 @@ func (p *notebookClientCreateOrUpdateNotebookPoller) ResumeToken() (string, erro
 
 // Resume rehydrates a notebookClientCreateOrUpdateNotebookPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *notebookClientCreateOrUpdateNotebookPoller) Resume(ctx context.Context, client *notebookClient, token string) (notebookClientCreateOrUpdateNotebookResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.CreateOrUpdateNotebook", token, client.pl); err != nil {
-		return notebookClientCreateOrUpdateNotebookResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *notebookClientCreateOrUpdateNotebookPoller) Resume(token string, client *notebookClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.CreateOrUpdateNotebook", token, client.pl)
+	return
 }
 
 // notebookClientDeleteNotebookPoller provides polling facilities until the operation reaches a terminal state.
@@ -886,20 +827,19 @@ func (p *notebookClientDeleteNotebookPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *notebookClientDeleteNotebookPoller) Poll(ctx context.Context) (notebookClientDeleteNotebookResponse, error) {
-	result := notebookClientDeleteNotebookResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *notebookClientDeleteNotebookPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *notebookClientDeleteNotebookPoller) Result(ctx context.Context) (resp notebookClientDeleteNotebookResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -919,12 +859,9 @@ func (p *notebookClientDeleteNotebookPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a notebookClientDeleteNotebookPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *notebookClientDeleteNotebookPoller) Resume(ctx context.Context, client *notebookClient, token string) (notebookClientDeleteNotebookResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.DeleteNotebook", token, client.pl); err != nil {
-		return notebookClientDeleteNotebookResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *notebookClientDeleteNotebookPoller) Resume(token string, client *notebookClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.DeleteNotebook", token, client.pl)
+	return
 }
 
 // notebookClientRenameNotebookPoller provides polling facilities until the operation reaches a terminal state.
@@ -943,20 +880,19 @@ func (p *notebookClientRenameNotebookPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *notebookClientRenameNotebookPoller) Poll(ctx context.Context) (notebookClientRenameNotebookResponse, error) {
-	result := notebookClientRenameNotebookResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *notebookClientRenameNotebookPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *notebookClientRenameNotebookPoller) Result(ctx context.Context) (resp notebookClientRenameNotebookResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -976,12 +912,9 @@ func (p *notebookClientRenameNotebookPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a notebookClientRenameNotebookPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *notebookClientRenameNotebookPoller) Resume(ctx context.Context, client *notebookClient, token string) (notebookClientRenameNotebookResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.RenameNotebook", token, client.pl); err != nil {
-		return notebookClientRenameNotebookResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *notebookClientRenameNotebookPoller) Resume(token string, client *notebookClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("notebookClient.RenameNotebook", token, client.pl)
+	return
 }
 
 // pipelineClientCreateOrUpdatePipelinePoller provides polling facilities until the operation reaches a terminal state.
@@ -1000,20 +933,19 @@ func (p *pipelineClientCreateOrUpdatePipelinePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *pipelineClientCreateOrUpdatePipelinePoller) Poll(ctx context.Context) (pipelineClientCreateOrUpdatePipelineResponse, error) {
-	result := pipelineClientCreateOrUpdatePipelineResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.PipelineResource)
-	return result, err
+func (p *pipelineClientCreateOrUpdatePipelinePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *pipelineClientCreateOrUpdatePipelinePoller) Result(ctx context.Context) (resp pipelineClientCreateOrUpdatePipelineResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1033,12 +965,9 @@ func (p *pipelineClientCreateOrUpdatePipelinePoller) ResumeToken() (string, erro
 
 // Resume rehydrates a pipelineClientCreateOrUpdatePipelinePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *pipelineClientCreateOrUpdatePipelinePoller) Resume(ctx context.Context, client *pipelineClient, token string) (pipelineClientCreateOrUpdatePipelineResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.CreateOrUpdatePipeline", token, client.pl); err != nil {
-		return pipelineClientCreateOrUpdatePipelineResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *pipelineClientCreateOrUpdatePipelinePoller) Resume(token string, client *pipelineClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.CreateOrUpdatePipeline", token, client.pl)
+	return
 }
 
 // pipelineClientDeletePipelinePoller provides polling facilities until the operation reaches a terminal state.
@@ -1057,20 +986,19 @@ func (p *pipelineClientDeletePipelinePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *pipelineClientDeletePipelinePoller) Poll(ctx context.Context) (pipelineClientDeletePipelineResponse, error) {
-	result := pipelineClientDeletePipelineResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *pipelineClientDeletePipelinePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *pipelineClientDeletePipelinePoller) Result(ctx context.Context) (resp pipelineClientDeletePipelineResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1090,12 +1018,9 @@ func (p *pipelineClientDeletePipelinePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a pipelineClientDeletePipelinePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *pipelineClientDeletePipelinePoller) Resume(ctx context.Context, client *pipelineClient, token string) (pipelineClientDeletePipelineResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.DeletePipeline", token, client.pl); err != nil {
-		return pipelineClientDeletePipelineResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *pipelineClientDeletePipelinePoller) Resume(token string, client *pipelineClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.DeletePipeline", token, client.pl)
+	return
 }
 
 // pipelineClientRenamePipelinePoller provides polling facilities until the operation reaches a terminal state.
@@ -1114,20 +1039,19 @@ func (p *pipelineClientRenamePipelinePoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *pipelineClientRenamePipelinePoller) Poll(ctx context.Context) (pipelineClientRenamePipelineResponse, error) {
-	result := pipelineClientRenamePipelineResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *pipelineClientRenamePipelinePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *pipelineClientRenamePipelinePoller) Result(ctx context.Context) (resp pipelineClientRenamePipelineResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1147,12 +1071,9 @@ func (p *pipelineClientRenamePipelinePoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a pipelineClientRenamePipelinePoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *pipelineClientRenamePipelinePoller) Resume(ctx context.Context, client *pipelineClient, token string) (pipelineClientRenamePipelineResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.RenamePipeline", token, client.pl); err != nil {
-		return pipelineClientRenamePipelineResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *pipelineClientRenamePipelinePoller) Resume(token string, client *pipelineClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("pipelineClient.RenamePipeline", token, client.pl)
+	return
 }
 
 // sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -1171,20 +1092,19 @@ func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Done() 
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
-	result := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SparkJobDefinitionResource)
-	return result, err
+func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Result(ctx context.Context) (resp sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1204,12 +1124,9 @@ func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) ResumeT
 
 // Resume rehydrates a sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", token, client.pl); err != nil {
-		return sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller) Resume(token string, client *sparkJobDefinitionClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", token, client.pl)
+	return
 }
 
 // sparkJobDefinitionClientDebugSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -1228,20 +1145,19 @@ func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
-	result := sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SparkBatchJob)
-	return result, err
+func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Result(ctx context.Context) (resp sparkJobDefinitionClientDebugSparkJobDefinitionResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1261,12 +1177,9 @@ func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) ResumeToken() (s
 
 // Resume rehydrates a sparkJobDefinitionClientDebugSparkJobDefinitionPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.DebugSparkJobDefinition", token, client.pl); err != nil {
-		return sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *sparkJobDefinitionClientDebugSparkJobDefinitionPoller) Resume(token string, client *sparkJobDefinitionClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.DebugSparkJobDefinition", token, client.pl)
+	return
 }
 
 // sparkJobDefinitionClientDeleteSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -1285,20 +1198,19 @@ func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
-	result := sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Result(ctx context.Context) (resp sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1318,12 +1230,9 @@ func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) ResumeToken() (
 
 // Resume rehydrates a sparkJobDefinitionClientDeleteSparkJobDefinitionPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.DeleteSparkJobDefinition", token, client.pl); err != nil {
-		return sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller) Resume(token string, client *sparkJobDefinitionClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.DeleteSparkJobDefinition", token, client.pl)
+	return
 }
 
 // sparkJobDefinitionClientExecuteSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -1342,20 +1251,19 @@ func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
-	result := sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SparkBatchJob)
-	return result, err
+func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Result(ctx context.Context) (resp sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1375,12 +1283,9 @@ func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) ResumeToken() 
 
 // Resume rehydrates a sparkJobDefinitionClientExecuteSparkJobDefinitionPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.ExecuteSparkJobDefinition", token, client.pl); err != nil {
-		return sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller) Resume(token string, client *sparkJobDefinitionClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.ExecuteSparkJobDefinition", token, client.pl)
+	return
 }
 
 // sparkJobDefinitionClientRenameSparkJobDefinitionPoller provides polling facilities until the operation reaches a terminal state.
@@ -1399,20 +1304,19 @@ func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Poll(ctx context.Context) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
-	result := sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Result(ctx context.Context) (resp sparkJobDefinitionClientRenameSparkJobDefinitionResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1432,12 +1336,9 @@ func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) ResumeToken() (
 
 // Resume rehydrates a sparkJobDefinitionClientRenameSparkJobDefinitionPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.RenameSparkJobDefinition", token, client.pl); err != nil {
-		return sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *sparkJobDefinitionClientRenameSparkJobDefinitionPoller) Resume(token string, client *sparkJobDefinitionClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.RenameSparkJobDefinition", token, client.pl)
+	return
 }
 
 // sqlScriptClientCreateOrUpdateSQLScriptPoller provides polling facilities until the operation reaches a terminal state.
@@ -1456,20 +1357,19 @@ func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Poll(ctx context.Context) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
-	result := sqlScriptClientCreateOrUpdateSQLScriptResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.SQLScriptResource)
-	return result, err
+func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Result(ctx context.Context) (resp sqlScriptClientCreateOrUpdateSQLScriptResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1489,12 +1389,9 @@ func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) ResumeToken() (string, er
 
 // Resume rehydrates a sqlScriptClientCreateOrUpdateSQLScriptPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Resume(ctx context.Context, client *sqlScriptClient, token string) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.CreateOrUpdateSQLScript", token, client.pl); err != nil {
-		return sqlScriptClientCreateOrUpdateSQLScriptResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *sqlScriptClientCreateOrUpdateSQLScriptPoller) Resume(token string, client *sqlScriptClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.CreateOrUpdateSQLScript", token, client.pl)
+	return
 }
 
 // sqlScriptClientDeleteSQLScriptPoller provides polling facilities until the operation reaches a terminal state.
@@ -1513,20 +1410,19 @@ func (p *sqlScriptClientDeleteSQLScriptPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *sqlScriptClientDeleteSQLScriptPoller) Poll(ctx context.Context) (sqlScriptClientDeleteSQLScriptResponse, error) {
-	result := sqlScriptClientDeleteSQLScriptResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *sqlScriptClientDeleteSQLScriptPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *sqlScriptClientDeleteSQLScriptPoller) Result(ctx context.Context) (resp sqlScriptClientDeleteSQLScriptResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1546,12 +1442,9 @@ func (p *sqlScriptClientDeleteSQLScriptPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a sqlScriptClientDeleteSQLScriptPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *sqlScriptClientDeleteSQLScriptPoller) Resume(ctx context.Context, client *sqlScriptClient, token string) (sqlScriptClientDeleteSQLScriptResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.DeleteSQLScript", token, client.pl); err != nil {
-		return sqlScriptClientDeleteSQLScriptResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *sqlScriptClientDeleteSQLScriptPoller) Resume(token string, client *sqlScriptClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.DeleteSQLScript", token, client.pl)
+	return
 }
 
 // sqlScriptClientRenameSQLScriptPoller provides polling facilities until the operation reaches a terminal state.
@@ -1570,20 +1463,19 @@ func (p *sqlScriptClientRenameSQLScriptPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *sqlScriptClientRenameSQLScriptPoller) Poll(ctx context.Context) (sqlScriptClientRenameSQLScriptResponse, error) {
-	result := sqlScriptClientRenameSQLScriptResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *sqlScriptClientRenameSQLScriptPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *sqlScriptClientRenameSQLScriptPoller) Result(ctx context.Context) (resp sqlScriptClientRenameSQLScriptResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1603,12 +1495,9 @@ func (p *sqlScriptClientRenameSQLScriptPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a sqlScriptClientRenameSQLScriptPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *sqlScriptClientRenameSQLScriptPoller) Resume(ctx context.Context, client *sqlScriptClient, token string) (sqlScriptClientRenameSQLScriptResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.RenameSQLScript", token, client.pl); err != nil {
-		return sqlScriptClientRenameSQLScriptResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *sqlScriptClientRenameSQLScriptPoller) Resume(token string, client *sqlScriptClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("sqlScriptClient.RenameSQLScript", token, client.pl)
+	return
 }
 
 // triggerClientCreateOrUpdateTriggerPoller provides polling facilities until the operation reaches a terminal state.
@@ -1627,20 +1516,19 @@ func (p *triggerClientCreateOrUpdateTriggerPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *triggerClientCreateOrUpdateTriggerPoller) Poll(ctx context.Context) (triggerClientCreateOrUpdateTriggerResponse, error) {
-	result := triggerClientCreateOrUpdateTriggerResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.TriggerResource)
-	return result, err
+func (p *triggerClientCreateOrUpdateTriggerPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *triggerClientCreateOrUpdateTriggerPoller) Result(ctx context.Context) (resp triggerClientCreateOrUpdateTriggerResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1660,12 +1548,9 @@ func (p *triggerClientCreateOrUpdateTriggerPoller) ResumeToken() (string, error)
 
 // Resume rehydrates a triggerClientCreateOrUpdateTriggerPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *triggerClientCreateOrUpdateTriggerPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientCreateOrUpdateTriggerResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.CreateOrUpdateTrigger", token, client.pl); err != nil {
-		return triggerClientCreateOrUpdateTriggerResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *triggerClientCreateOrUpdateTriggerPoller) Resume(token string, client *triggerClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.CreateOrUpdateTrigger", token, client.pl)
+	return
 }
 
 // triggerClientDeleteTriggerPoller provides polling facilities until the operation reaches a terminal state.
@@ -1684,20 +1569,19 @@ func (p *triggerClientDeleteTriggerPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *triggerClientDeleteTriggerPoller) Poll(ctx context.Context) (triggerClientDeleteTriggerResponse, error) {
-	result := triggerClientDeleteTriggerResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *triggerClientDeleteTriggerPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *triggerClientDeleteTriggerPoller) Result(ctx context.Context) (resp triggerClientDeleteTriggerResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1717,12 +1601,9 @@ func (p *triggerClientDeleteTriggerPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a triggerClientDeleteTriggerPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *triggerClientDeleteTriggerPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientDeleteTriggerResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.DeleteTrigger", token, client.pl); err != nil {
-		return triggerClientDeleteTriggerResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *triggerClientDeleteTriggerPoller) Resume(token string, client *triggerClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.DeleteTrigger", token, client.pl)
+	return
 }
 
 // triggerClientStartTriggerPoller provides polling facilities until the operation reaches a terminal state.
@@ -1741,20 +1622,19 @@ func (p *triggerClientStartTriggerPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *triggerClientStartTriggerPoller) Poll(ctx context.Context) (triggerClientStartTriggerResponse, error) {
-	result := triggerClientStartTriggerResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *triggerClientStartTriggerPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *triggerClientStartTriggerPoller) Result(ctx context.Context) (resp triggerClientStartTriggerResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1774,12 +1654,9 @@ func (p *triggerClientStartTriggerPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a triggerClientStartTriggerPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *triggerClientStartTriggerPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientStartTriggerResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.StartTrigger", token, client.pl); err != nil {
-		return triggerClientStartTriggerResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *triggerClientStartTriggerPoller) Resume(token string, client *triggerClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.StartTrigger", token, client.pl)
+	return
 }
 
 // triggerClientStopTriggerPoller provides polling facilities until the operation reaches a terminal state.
@@ -1798,20 +1675,19 @@ func (p *triggerClientStopTriggerPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *triggerClientStopTriggerPoller) Poll(ctx context.Context) (triggerClientStopTriggerResponse, error) {
-	result := triggerClientStopTriggerResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, nil)
-	return result, err
+func (p *triggerClientStopTriggerPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *triggerClientStopTriggerPoller) Result(ctx context.Context) (resp triggerClientStopTriggerResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1831,12 +1707,9 @@ func (p *triggerClientStopTriggerPoller) ResumeToken() (string, error) {
 
 // Resume rehydrates a triggerClientStopTriggerPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *triggerClientStopTriggerPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientStopTriggerResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.StopTrigger", token, client.pl); err != nil {
-		return triggerClientStopTriggerResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *triggerClientStopTriggerPoller) Resume(token string, client *triggerClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.StopTrigger", token, client.pl)
+	return
 }
 
 // triggerClientSubscribeTriggerToEventsPoller provides polling facilities until the operation reaches a terminal state.
@@ -1855,20 +1728,19 @@ func (p *triggerClientSubscribeTriggerToEventsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *triggerClientSubscribeTriggerToEventsPoller) Poll(ctx context.Context) (triggerClientSubscribeTriggerToEventsResponse, error) {
-	result := triggerClientSubscribeTriggerToEventsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.TriggerSubscriptionOperationStatus)
-	return result, err
+func (p *triggerClientSubscribeTriggerToEventsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *triggerClientSubscribeTriggerToEventsPoller) Result(ctx context.Context) (resp triggerClientSubscribeTriggerToEventsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1888,12 +1760,9 @@ func (p *triggerClientSubscribeTriggerToEventsPoller) ResumeToken() (string, err
 
 // Resume rehydrates a triggerClientSubscribeTriggerToEventsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *triggerClientSubscribeTriggerToEventsPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientSubscribeTriggerToEventsResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.SubscribeTriggerToEvents", token, client.pl); err != nil {
-		return triggerClientSubscribeTriggerToEventsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *triggerClientSubscribeTriggerToEventsPoller) Resume(token string, client *triggerClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.SubscribeTriggerToEvents", token, client.pl)
+	return
 }
 
 // triggerClientUnsubscribeTriggerFromEventsPoller provides polling facilities until the operation reaches a terminal state.
@@ -1912,20 +1781,19 @@ func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Done() bool {
 // If the LRO has completed with failure or was cancelled, the poller's state is
 // updated and the error is returned.
 // If the LRO has not reached a terminal state, the poller's state is updated and
-// a zero-value response is returned.
+// the response is returned.
 // If Poll fails, the poller's state is unmodified and the error is returned.
 // Calling Poll on an LRO that has reached a terminal state will return the final
 // response or error.
-func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Poll(ctx context.Context) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
-	result := triggerClientUnsubscribeTriggerFromEventsResponse{}
-	if _, err := p.pt.Poll(ctx); err != nil {
-		return result, err
-	}
-	if !p.Done() {
-		return result, nil
-	}
-	_, err := p.pt.FinalResponse(ctx, &result.TriggerSubscriptionOperationStatus)
-	return result, err
+func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+// Result returns the result of the LRO and is meant to be used in conjunction with Poll and Done.
+// Depending on the operation, calls to Result might perform an additional HTTP GET to fetch the result.
+func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Result(ctx context.Context) (resp triggerClientUnsubscribeTriggerFromEventsResponse, err error) {
+	_, err = p.pt.FinalResponse(ctx, &resp)
+	return
 }
 
 // PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
@@ -1945,10 +1813,7 @@ func (p *triggerClientUnsubscribeTriggerFromEventsPoller) ResumeToken() (string,
 
 // Resume rehydrates a triggerClientUnsubscribeTriggerFromEventsPoller from the provided client and resume token.
 // Returns an error if the token is isn't applicable to this poller type.
-func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Resume(ctx context.Context, client *triggerClient, token string) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
-	var err error
-	if p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.UnsubscribeTriggerFromEvents", token, client.pl); err != nil {
-		return triggerClientUnsubscribeTriggerFromEventsResponse{}, err
-	}
-	return p.Poll(ctx)
+func (p *triggerClientUnsubscribeTriggerFromEventsPoller) Resume(token string, client *triggerClient) (err error) {
+	p.pt, err = runtime.NewPollerFromResumeToken("triggerClient.UnsubscribeTriggerFromEvents", token, client.pl)
+	return
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_response_types.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_response_types.go
@@ -8,12 +8,6 @@
 
 package azartifacts
 
-import (
-	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"time"
-)
-
 // bigDataPoolsClientGetResponse contains the response from method bigDataPoolsClient.Get.
 type bigDataPoolsClientGetResponse struct {
 	BigDataPoolResourceInfo
@@ -24,77 +18,9 @@ type bigDataPoolsClientListResponse struct {
 	BigDataPoolResourceInfoListResult
 }
 
-// dataFlowClientCreateOrUpdateDataFlowPollerResponse contains the response from method dataFlowClient.CreateOrUpdateDataFlow.
-type dataFlowClientCreateOrUpdateDataFlowPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *dataFlowClientCreateOrUpdateDataFlowPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l dataFlowClientCreateOrUpdateDataFlowPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientCreateOrUpdateDataFlowResponse, error) {
-	respType := dataFlowClientCreateOrUpdateDataFlowResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DataFlowResource)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a dataFlowClientCreateOrUpdateDataFlowPollerResponse from the provided client and resume token.
-func (l *dataFlowClientCreateOrUpdateDataFlowPollerResponse) Resume(ctx context.Context, client *dataFlowClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("dataFlowClient.CreateOrUpdateDataFlow", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &dataFlowClientCreateOrUpdateDataFlowPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // dataFlowClientCreateOrUpdateDataFlowResponse contains the response from method dataFlowClient.CreateOrUpdateDataFlow.
 type dataFlowClientCreateOrUpdateDataFlowResponse struct {
 	DataFlowResource
-}
-
-// dataFlowClientDeleteDataFlowPollerResponse contains the response from method dataFlowClient.DeleteDataFlow.
-type dataFlowClientDeleteDataFlowPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *dataFlowClientDeleteDataFlowPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l dataFlowClientDeleteDataFlowPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientDeleteDataFlowResponse, error) {
-	respType := dataFlowClientDeleteDataFlowResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a dataFlowClientDeleteDataFlowPollerResponse from the provided client and resume token.
-func (l *dataFlowClientDeleteDataFlowPollerResponse) Resume(ctx context.Context, client *dataFlowClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("dataFlowClient.DeleteDataFlow", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &dataFlowClientDeleteDataFlowPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // dataFlowClientDeleteDataFlowResponse contains the response from method dataFlowClient.DeleteDataFlow.
@@ -112,40 +38,6 @@ type dataFlowClientGetDataFlowsByWorkspaceResponse struct {
 	DataFlowListResponse
 }
 
-// dataFlowClientRenameDataFlowPollerResponse contains the response from method dataFlowClient.RenameDataFlow.
-type dataFlowClientRenameDataFlowPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *dataFlowClientRenameDataFlowPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l dataFlowClientRenameDataFlowPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowClientRenameDataFlowResponse, error) {
-	respType := dataFlowClientRenameDataFlowResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a dataFlowClientRenameDataFlowPollerResponse from the provided client and resume token.
-func (l *dataFlowClientRenameDataFlowPollerResponse) Resume(ctx context.Context, client *dataFlowClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("dataFlowClient.RenameDataFlow", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &dataFlowClientRenameDataFlowPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // dataFlowClientRenameDataFlowResponse contains the response from method dataFlowClient.RenameDataFlow.
 type dataFlowClientRenameDataFlowResponse struct {
 	// placeholder for future response values
@@ -154,41 +46,6 @@ type dataFlowClientRenameDataFlowResponse struct {
 // dataFlowDebugSessionClientAddDataFlowResponse contains the response from method dataFlowDebugSessionClient.AddDataFlow.
 type dataFlowDebugSessionClientAddDataFlowResponse struct {
 	AddDataFlowToDebugSessionResponse
-}
-
-// dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse contains the response from method dataFlowDebugSessionClient.CreateDataFlowDebugSession.
-type dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse, error) {
-	respType := dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.CreateDataFlowDebugSessionResponse)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse from the provided client and resume
-// token.
-func (l *dataFlowDebugSessionClientCreateDataFlowDebugSessionPollerResponse) Resume(ctx context.Context, client *dataFlowDebugSessionClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("dataFlowDebugSessionClient.CreateDataFlowDebugSession", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &dataFlowDebugSessionClientCreateDataFlowDebugSessionPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // dataFlowDebugSessionClientCreateDataFlowDebugSessionResponse contains the response from method dataFlowDebugSessionClient.CreateDataFlowDebugSession.
@@ -201,40 +58,6 @@ type dataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse struct {
 	// placeholder for future response values
 }
 
-// dataFlowDebugSessionClientExecuteCommandPollerResponse contains the response from method dataFlowDebugSessionClient.ExecuteCommand.
-type dataFlowDebugSessionClientExecuteCommandPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *dataFlowDebugSessionClientExecuteCommandPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l dataFlowDebugSessionClientExecuteCommandPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (dataFlowDebugSessionClientExecuteCommandResponse, error) {
-	respType := dataFlowDebugSessionClientExecuteCommandResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DataFlowDebugCommandResponse)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a dataFlowDebugSessionClientExecuteCommandPollerResponse from the provided client and resume token.
-func (l *dataFlowDebugSessionClientExecuteCommandPollerResponse) Resume(ctx context.Context, client *dataFlowDebugSessionClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("dataFlowDebugSessionClient.ExecuteCommand", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &dataFlowDebugSessionClientExecuteCommandPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // dataFlowDebugSessionClientExecuteCommandResponse contains the response from method dataFlowDebugSessionClient.ExecuteCommand.
 type dataFlowDebugSessionClientExecuteCommandResponse struct {
 	DataFlowDebugCommandResponse
@@ -245,77 +68,9 @@ type dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse str
 	QueryDataFlowDebugSessionsResponse
 }
 
-// datasetClientCreateOrUpdateDatasetPollerResponse contains the response from method datasetClient.CreateOrUpdateDataset.
-type datasetClientCreateOrUpdateDatasetPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *datasetClientCreateOrUpdateDatasetPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l datasetClientCreateOrUpdateDatasetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientCreateOrUpdateDatasetResponse, error) {
-	respType := datasetClientCreateOrUpdateDatasetResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.DatasetResource)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a datasetClientCreateOrUpdateDatasetPollerResponse from the provided client and resume token.
-func (l *datasetClientCreateOrUpdateDatasetPollerResponse) Resume(ctx context.Context, client *datasetClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("datasetClient.CreateOrUpdateDataset", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &datasetClientCreateOrUpdateDatasetPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // datasetClientCreateOrUpdateDatasetResponse contains the response from method datasetClient.CreateOrUpdateDataset.
 type datasetClientCreateOrUpdateDatasetResponse struct {
 	DatasetResource
-}
-
-// datasetClientDeleteDatasetPollerResponse contains the response from method datasetClient.DeleteDataset.
-type datasetClientDeleteDatasetPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *datasetClientDeleteDatasetPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l datasetClientDeleteDatasetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientDeleteDatasetResponse, error) {
-	respType := datasetClientDeleteDatasetResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a datasetClientDeleteDatasetPollerResponse from the provided client and resume token.
-func (l *datasetClientDeleteDatasetPollerResponse) Resume(ctx context.Context, client *datasetClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("datasetClient.DeleteDataset", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &datasetClientDeleteDatasetPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // datasetClientDeleteDatasetResponse contains the response from method datasetClient.DeleteDataset.
@@ -331,40 +86,6 @@ type datasetClientGetDatasetResponse struct {
 // datasetClientGetDatasetsByWorkspaceResponse contains the response from method datasetClient.GetDatasetsByWorkspace.
 type datasetClientGetDatasetsByWorkspaceResponse struct {
 	DatasetListResponse
-}
-
-// datasetClientRenameDatasetPollerResponse contains the response from method datasetClient.RenameDataset.
-type datasetClientRenameDatasetPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *datasetClientRenameDatasetPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l datasetClientRenameDatasetPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (datasetClientRenameDatasetResponse, error) {
-	respType := datasetClientRenameDatasetResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a datasetClientRenameDatasetPollerResponse from the provided client and resume token.
-func (l *datasetClientRenameDatasetPollerResponse) Resume(ctx context.Context, client *datasetClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("datasetClient.RenameDataset", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &datasetClientRenameDatasetPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // datasetClientRenameDatasetResponse contains the response from method datasetClient.RenameDataset.
@@ -387,116 +108,14 @@ type libraryClientAppendResponse struct {
 	// placeholder for future response values
 }
 
-// libraryClientCreatePollerResponse contains the response from method libraryClient.Create.
-type libraryClientCreatePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *libraryClientCreatePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l libraryClientCreatePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientCreateResponse, error) {
-	respType := libraryClientCreateResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a libraryClientCreatePollerResponse from the provided client and resume token.
-func (l *libraryClientCreatePollerResponse) Resume(ctx context.Context, client *libraryClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("libraryClient.Create", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &libraryClientCreatePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // libraryClientCreateResponse contains the response from method libraryClient.Create.
 type libraryClientCreateResponse struct {
 	LibraryResourceInfo
 }
 
-// libraryClientDeletePollerResponse contains the response from method libraryClient.Delete.
-type libraryClientDeletePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *libraryClientDeletePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l libraryClientDeletePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientDeleteResponse, error) {
-	respType := libraryClientDeleteResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a libraryClientDeletePollerResponse from the provided client and resume token.
-func (l *libraryClientDeletePollerResponse) Resume(ctx context.Context, client *libraryClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("libraryClient.Delete", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &libraryClientDeletePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // libraryClientDeleteResponse contains the response from method libraryClient.Delete.
 type libraryClientDeleteResponse struct {
 	LibraryResourceInfo
-}
-
-// libraryClientFlushPollerResponse contains the response from method libraryClient.Flush.
-type libraryClientFlushPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *libraryClientFlushPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l libraryClientFlushPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (libraryClientFlushResponse, error) {
-	respType := libraryClientFlushResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LibraryResourceInfo)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a libraryClientFlushPollerResponse from the provided client and resume token.
-func (l *libraryClientFlushPollerResponse) Resume(ctx context.Context, client *libraryClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("libraryClient.Flush", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &libraryClientFlushPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // libraryClientFlushResponse contains the response from method libraryClient.Flush.
@@ -520,77 +139,9 @@ type libraryClientListResponse struct {
 	LibraryListResponse
 }
 
-// linkedServiceClientCreateOrUpdateLinkedServicePollerResponse contains the response from method linkedServiceClient.CreateOrUpdateLinkedService.
-type linkedServiceClientCreateOrUpdateLinkedServicePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *linkedServiceClientCreateOrUpdateLinkedServicePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l linkedServiceClientCreateOrUpdateLinkedServicePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientCreateOrUpdateLinkedServiceResponse, error) {
-	respType := linkedServiceClientCreateOrUpdateLinkedServiceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.LinkedServiceResource)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a linkedServiceClientCreateOrUpdateLinkedServicePollerResponse from the provided client and resume token.
-func (l *linkedServiceClientCreateOrUpdateLinkedServicePollerResponse) Resume(ctx context.Context, client *linkedServiceClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("linkedServiceClient.CreateOrUpdateLinkedService", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &linkedServiceClientCreateOrUpdateLinkedServicePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // linkedServiceClientCreateOrUpdateLinkedServiceResponse contains the response from method linkedServiceClient.CreateOrUpdateLinkedService.
 type linkedServiceClientCreateOrUpdateLinkedServiceResponse struct {
 	LinkedServiceResource
-}
-
-// linkedServiceClientDeleteLinkedServicePollerResponse contains the response from method linkedServiceClient.DeleteLinkedService.
-type linkedServiceClientDeleteLinkedServicePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *linkedServiceClientDeleteLinkedServicePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l linkedServiceClientDeleteLinkedServicePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientDeleteLinkedServiceResponse, error) {
-	respType := linkedServiceClientDeleteLinkedServiceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a linkedServiceClientDeleteLinkedServicePollerResponse from the provided client and resume token.
-func (l *linkedServiceClientDeleteLinkedServicePollerResponse) Resume(ctx context.Context, client *linkedServiceClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("linkedServiceClient.DeleteLinkedService", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &linkedServiceClientDeleteLinkedServicePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // linkedServiceClientDeleteLinkedServiceResponse contains the response from method linkedServiceClient.DeleteLinkedService.
@@ -608,116 +159,14 @@ type linkedServiceClientGetLinkedServicesByWorkspaceResponse struct {
 	LinkedServiceListResponse
 }
 
-// linkedServiceClientRenameLinkedServicePollerResponse contains the response from method linkedServiceClient.RenameLinkedService.
-type linkedServiceClientRenameLinkedServicePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *linkedServiceClientRenameLinkedServicePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l linkedServiceClientRenameLinkedServicePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (linkedServiceClientRenameLinkedServiceResponse, error) {
-	respType := linkedServiceClientRenameLinkedServiceResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a linkedServiceClientRenameLinkedServicePollerResponse from the provided client and resume token.
-func (l *linkedServiceClientRenameLinkedServicePollerResponse) Resume(ctx context.Context, client *linkedServiceClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("linkedServiceClient.RenameLinkedService", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &linkedServiceClientRenameLinkedServicePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // linkedServiceClientRenameLinkedServiceResponse contains the response from method linkedServiceClient.RenameLinkedService.
 type linkedServiceClientRenameLinkedServiceResponse struct {
 	// placeholder for future response values
 }
 
-// notebookClientCreateOrUpdateNotebookPollerResponse contains the response from method notebookClient.CreateOrUpdateNotebook.
-type notebookClientCreateOrUpdateNotebookPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *notebookClientCreateOrUpdateNotebookPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l notebookClientCreateOrUpdateNotebookPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientCreateOrUpdateNotebookResponse, error) {
-	respType := notebookClientCreateOrUpdateNotebookResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.NotebookResource)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a notebookClientCreateOrUpdateNotebookPollerResponse from the provided client and resume token.
-func (l *notebookClientCreateOrUpdateNotebookPollerResponse) Resume(ctx context.Context, client *notebookClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("notebookClient.CreateOrUpdateNotebook", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &notebookClientCreateOrUpdateNotebookPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // notebookClientCreateOrUpdateNotebookResponse contains the response from method notebookClient.CreateOrUpdateNotebook.
 type notebookClientCreateOrUpdateNotebookResponse struct {
 	NotebookResource
-}
-
-// notebookClientDeleteNotebookPollerResponse contains the response from method notebookClient.DeleteNotebook.
-type notebookClientDeleteNotebookPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *notebookClientDeleteNotebookPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l notebookClientDeleteNotebookPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientDeleteNotebookResponse, error) {
-	respType := notebookClientDeleteNotebookResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a notebookClientDeleteNotebookPollerResponse from the provided client and resume token.
-func (l *notebookClientDeleteNotebookPollerResponse) Resume(ctx context.Context, client *notebookClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("notebookClient.DeleteNotebook", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &notebookClientDeleteNotebookPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // notebookClientDeleteNotebookResponse contains the response from method notebookClient.DeleteNotebook.
@@ -740,77 +189,9 @@ type notebookClientGetNotebooksByWorkspaceResponse struct {
 	NotebookListResponse
 }
 
-// notebookClientRenameNotebookPollerResponse contains the response from method notebookClient.RenameNotebook.
-type notebookClientRenameNotebookPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *notebookClientRenameNotebookPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l notebookClientRenameNotebookPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (notebookClientRenameNotebookResponse, error) {
-	respType := notebookClientRenameNotebookResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a notebookClientRenameNotebookPollerResponse from the provided client and resume token.
-func (l *notebookClientRenameNotebookPollerResponse) Resume(ctx context.Context, client *notebookClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("notebookClient.RenameNotebook", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &notebookClientRenameNotebookPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // notebookClientRenameNotebookResponse contains the response from method notebookClient.RenameNotebook.
 type notebookClientRenameNotebookResponse struct {
 	// placeholder for future response values
-}
-
-// pipelineClientCreateOrUpdatePipelinePollerResponse contains the response from method pipelineClient.CreateOrUpdatePipeline.
-type pipelineClientCreateOrUpdatePipelinePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *pipelineClientCreateOrUpdatePipelinePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l pipelineClientCreateOrUpdatePipelinePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientCreateOrUpdatePipelineResponse, error) {
-	respType := pipelineClientCreateOrUpdatePipelineResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.PipelineResource)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a pipelineClientCreateOrUpdatePipelinePollerResponse from the provided client and resume token.
-func (l *pipelineClientCreateOrUpdatePipelinePollerResponse) Resume(ctx context.Context, client *pipelineClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("pipelineClient.CreateOrUpdatePipeline", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &pipelineClientCreateOrUpdatePipelinePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // pipelineClientCreateOrUpdatePipelineResponse contains the response from method pipelineClient.CreateOrUpdatePipeline.
@@ -821,40 +202,6 @@ type pipelineClientCreateOrUpdatePipelineResponse struct {
 // pipelineClientCreatePipelineRunResponse contains the response from method pipelineClient.CreatePipelineRun.
 type pipelineClientCreatePipelineRunResponse struct {
 	CreateRunResponse
-}
-
-// pipelineClientDeletePipelinePollerResponse contains the response from method pipelineClient.DeletePipeline.
-type pipelineClientDeletePipelinePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *pipelineClientDeletePipelinePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l pipelineClientDeletePipelinePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientDeletePipelineResponse, error) {
-	respType := pipelineClientDeletePipelineResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a pipelineClientDeletePipelinePollerResponse from the provided client and resume token.
-func (l *pipelineClientDeletePipelinePollerResponse) Resume(ctx context.Context, client *pipelineClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("pipelineClient.DeletePipeline", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &pipelineClientDeletePipelinePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // pipelineClientDeletePipelineResponse contains the response from method pipelineClient.DeletePipeline.
@@ -870,40 +217,6 @@ type pipelineClientGetPipelineResponse struct {
 // pipelineClientGetPipelinesByWorkspaceResponse contains the response from method pipelineClient.GetPipelinesByWorkspace.
 type pipelineClientGetPipelinesByWorkspaceResponse struct {
 	PipelineListResponse
-}
-
-// pipelineClientRenamePipelinePollerResponse contains the response from method pipelineClient.RenamePipeline.
-type pipelineClientRenamePipelinePollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *pipelineClientRenamePipelinePoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l pipelineClientRenamePipelinePollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (pipelineClientRenamePipelineResponse, error) {
-	respType := pipelineClientRenamePipelineResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a pipelineClientRenamePipelinePollerResponse from the provided client and resume token.
-func (l *pipelineClientRenamePipelinePollerResponse) Resume(ctx context.Context, client *pipelineClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("pipelineClient.RenamePipeline", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &pipelineClientRenamePipelinePoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // pipelineClientRenamePipelineResponse contains the response from method pipelineClient.RenamePipeline.
@@ -931,78 +244,9 @@ type pipelineRunClientQueryPipelineRunsByWorkspaceResponse struct {
 	PipelineRunsQueryResponse
 }
 
-// sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition.
-type sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkJobDefinitionResource)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse from the provided client and
-// resume token.
-func (l *sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition.
 type sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse struct {
 	SparkJobDefinitionResource
-}
-
-// sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.DebugSparkJobDefinition.
-type sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *sparkJobDefinitionClientDebugSparkJobDefinitionPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientDebugSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientDebugSparkJobDefinitionResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkBatchJob)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse from the provided client and resume token.
-func (l *sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.DebugSparkJobDefinition", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &sparkJobDefinitionClientDebugSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // sparkJobDefinitionClientDebugSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.DebugSparkJobDefinition.
@@ -1010,79 +254,9 @@ type sparkJobDefinitionClientDebugSparkJobDefinitionResponse struct {
 	SparkBatchJob
 }
 
-// sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.DeleteSparkJobDefinition.
-type sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *sparkJobDefinitionClientDeleteSparkJobDefinitionPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientDeleteSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientDeleteSparkJobDefinitionResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse from the provided client and resume
-// token.
-func (l *sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.DeleteSparkJobDefinition", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &sparkJobDefinitionClientDeleteSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // sparkJobDefinitionClientDeleteSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.DeleteSparkJobDefinition.
 type sparkJobDefinitionClientDeleteSparkJobDefinitionResponse struct {
 	// placeholder for future response values
-}
-
-// sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.ExecuteSparkJobDefinition.
-type sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *sparkJobDefinitionClientExecuteSparkJobDefinitionPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientExecuteSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientExecuteSparkJobDefinitionResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SparkBatchJob)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse from the provided client and resume
-// token.
-func (l *sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.ExecuteSparkJobDefinition", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &sparkJobDefinitionClientExecuteSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // sparkJobDefinitionClientExecuteSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.ExecuteSparkJobDefinition.
@@ -1100,41 +274,6 @@ type sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse struct {
 	SparkJobDefinitionsListResponse
 }
 
-// sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse contains the response from method sparkJobDefinitionClient.RenameSparkJobDefinition.
-type sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *sparkJobDefinitionClientRenameSparkJobDefinitionPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sparkJobDefinitionClientRenameSparkJobDefinitionResponse, error) {
-	respType := sparkJobDefinitionClientRenameSparkJobDefinitionResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse from the provided client and resume
-// token.
-func (l *sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse) Resume(ctx context.Context, client *sparkJobDefinitionClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("sparkJobDefinitionClient.RenameSparkJobDefinition", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &sparkJobDefinitionClientRenameSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // sparkJobDefinitionClientRenameSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.RenameSparkJobDefinition.
 type sparkJobDefinitionClientRenameSparkJobDefinitionResponse struct {
 	// placeholder for future response values
@@ -1150,77 +289,9 @@ type sqlPoolsClientListResponse struct {
 	SQLPoolInfoListResult
 }
 
-// sqlScriptClientCreateOrUpdateSQLScriptPollerResponse contains the response from method sqlScriptClient.CreateOrUpdateSQLScript.
-type sqlScriptClientCreateOrUpdateSQLScriptPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *sqlScriptClientCreateOrUpdateSQLScriptPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l sqlScriptClientCreateOrUpdateSQLScriptPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientCreateOrUpdateSQLScriptResponse, error) {
-	respType := sqlScriptClientCreateOrUpdateSQLScriptResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.SQLScriptResource)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a sqlScriptClientCreateOrUpdateSQLScriptPollerResponse from the provided client and resume token.
-func (l *sqlScriptClientCreateOrUpdateSQLScriptPollerResponse) Resume(ctx context.Context, client *sqlScriptClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("sqlScriptClient.CreateOrUpdateSQLScript", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &sqlScriptClientCreateOrUpdateSQLScriptPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // sqlScriptClientCreateOrUpdateSQLScriptResponse contains the response from method sqlScriptClient.CreateOrUpdateSQLScript.
 type sqlScriptClientCreateOrUpdateSQLScriptResponse struct {
 	SQLScriptResource
-}
-
-// sqlScriptClientDeleteSQLScriptPollerResponse contains the response from method sqlScriptClient.DeleteSQLScript.
-type sqlScriptClientDeleteSQLScriptPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *sqlScriptClientDeleteSQLScriptPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l sqlScriptClientDeleteSQLScriptPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientDeleteSQLScriptResponse, error) {
-	respType := sqlScriptClientDeleteSQLScriptResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a sqlScriptClientDeleteSQLScriptPollerResponse from the provided client and resume token.
-func (l *sqlScriptClientDeleteSQLScriptPollerResponse) Resume(ctx context.Context, client *sqlScriptClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("sqlScriptClient.DeleteSQLScript", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &sqlScriptClientDeleteSQLScriptPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // sqlScriptClientDeleteSQLScriptResponse contains the response from method sqlScriptClient.DeleteSQLScript.
@@ -1238,116 +309,14 @@ type sqlScriptClientGetSQLScriptsByWorkspaceResponse struct {
 	SQLScriptsListResponse
 }
 
-// sqlScriptClientRenameSQLScriptPollerResponse contains the response from method sqlScriptClient.RenameSQLScript.
-type sqlScriptClientRenameSQLScriptPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *sqlScriptClientRenameSQLScriptPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l sqlScriptClientRenameSQLScriptPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (sqlScriptClientRenameSQLScriptResponse, error) {
-	respType := sqlScriptClientRenameSQLScriptResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a sqlScriptClientRenameSQLScriptPollerResponse from the provided client and resume token.
-func (l *sqlScriptClientRenameSQLScriptPollerResponse) Resume(ctx context.Context, client *sqlScriptClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("sqlScriptClient.RenameSQLScript", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &sqlScriptClientRenameSQLScriptPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // sqlScriptClientRenameSQLScriptResponse contains the response from method sqlScriptClient.RenameSQLScript.
 type sqlScriptClientRenameSQLScriptResponse struct {
 	// placeholder for future response values
 }
 
-// triggerClientCreateOrUpdateTriggerPollerResponse contains the response from method triggerClient.CreateOrUpdateTrigger.
-type triggerClientCreateOrUpdateTriggerPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *triggerClientCreateOrUpdateTriggerPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l triggerClientCreateOrUpdateTriggerPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientCreateOrUpdateTriggerResponse, error) {
-	respType := triggerClientCreateOrUpdateTriggerResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerResource)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a triggerClientCreateOrUpdateTriggerPollerResponse from the provided client and resume token.
-func (l *triggerClientCreateOrUpdateTriggerPollerResponse) Resume(ctx context.Context, client *triggerClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("triggerClient.CreateOrUpdateTrigger", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &triggerClientCreateOrUpdateTriggerPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // triggerClientCreateOrUpdateTriggerResponse contains the response from method triggerClient.CreateOrUpdateTrigger.
 type triggerClientCreateOrUpdateTriggerResponse struct {
 	TriggerResource
-}
-
-// triggerClientDeleteTriggerPollerResponse contains the response from method triggerClient.DeleteTrigger.
-type triggerClientDeleteTriggerPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *triggerClientDeleteTriggerPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l triggerClientDeleteTriggerPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientDeleteTriggerResponse, error) {
-	respType := triggerClientDeleteTriggerResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a triggerClientDeleteTriggerPollerResponse from the provided client and resume token.
-func (l *triggerClientDeleteTriggerPollerResponse) Resume(ctx context.Context, client *triggerClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("triggerClient.DeleteTrigger", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &triggerClientDeleteTriggerPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // triggerClientDeleteTriggerResponse contains the response from method triggerClient.DeleteTrigger.
@@ -1370,77 +339,9 @@ type triggerClientGetTriggersByWorkspaceResponse struct {
 	TriggerListResponse
 }
 
-// triggerClientStartTriggerPollerResponse contains the response from method triggerClient.StartTrigger.
-type triggerClientStartTriggerPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *triggerClientStartTriggerPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l triggerClientStartTriggerPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientStartTriggerResponse, error) {
-	respType := triggerClientStartTriggerResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a triggerClientStartTriggerPollerResponse from the provided client and resume token.
-func (l *triggerClientStartTriggerPollerResponse) Resume(ctx context.Context, client *triggerClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("triggerClient.StartTrigger", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &triggerClientStartTriggerPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // triggerClientStartTriggerResponse contains the response from method triggerClient.StartTrigger.
 type triggerClientStartTriggerResponse struct {
 	// placeholder for future response values
-}
-
-// triggerClientStopTriggerPollerResponse contains the response from method triggerClient.StopTrigger.
-type triggerClientStopTriggerPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *triggerClientStopTriggerPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l triggerClientStopTriggerPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientStopTriggerResponse, error) {
-	respType := triggerClientStopTriggerResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, nil)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a triggerClientStopTriggerPollerResponse from the provided client and resume token.
-func (l *triggerClientStopTriggerPollerResponse) Resume(ctx context.Context, client *triggerClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("triggerClient.StopTrigger", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &triggerClientStopTriggerPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // triggerClientStopTriggerResponse contains the response from method triggerClient.StopTrigger.
@@ -1448,77 +349,9 @@ type triggerClientStopTriggerResponse struct {
 	// placeholder for future response values
 }
 
-// triggerClientSubscribeTriggerToEventsPollerResponse contains the response from method triggerClient.SubscribeTriggerToEvents.
-type triggerClientSubscribeTriggerToEventsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *triggerClientSubscribeTriggerToEventsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l triggerClientSubscribeTriggerToEventsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientSubscribeTriggerToEventsResponse, error) {
-	respType := triggerClientSubscribeTriggerToEventsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerSubscriptionOperationStatus)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a triggerClientSubscribeTriggerToEventsPollerResponse from the provided client and resume token.
-func (l *triggerClientSubscribeTriggerToEventsPollerResponse) Resume(ctx context.Context, client *triggerClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("triggerClient.SubscribeTriggerToEvents", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &triggerClientSubscribeTriggerToEventsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
-}
-
 // triggerClientSubscribeTriggerToEventsResponse contains the response from method triggerClient.SubscribeTriggerToEvents.
 type triggerClientSubscribeTriggerToEventsResponse struct {
 	TriggerSubscriptionOperationStatus
-}
-
-// triggerClientUnsubscribeTriggerFromEventsPollerResponse contains the response from method triggerClient.UnsubscribeTriggerFromEvents.
-type triggerClientUnsubscribeTriggerFromEventsPollerResponse struct {
-	// Poller contains an initialized poller.
-	Poller *triggerClientUnsubscribeTriggerFromEventsPoller
-}
-
-// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received.
-// freq: the time to wait between intervals in absence of a Retry-After header. Allowed minimum is one second.
-func (l triggerClientUnsubscribeTriggerFromEventsPollerResponse) PollUntilDone(ctx context.Context, freq time.Duration) (triggerClientUnsubscribeTriggerFromEventsResponse, error) {
-	respType := triggerClientUnsubscribeTriggerFromEventsResponse{}
-	_, err := l.Poller.pt.PollUntilDone(ctx, freq, &respType.TriggerSubscriptionOperationStatus)
-	if err != nil {
-		return respType, err
-	}
-	return respType, nil
-}
-
-// Resume rehydrates a triggerClientUnsubscribeTriggerFromEventsPollerResponse from the provided client and resume token.
-func (l *triggerClientUnsubscribeTriggerFromEventsPollerResponse) Resume(ctx context.Context, client *triggerClient, token string) error {
-	pt, err := runtime.NewPollerFromResumeToken("triggerClient.UnsubscribeTriggerFromEvents", token, client.pl)
-	if err != nil {
-		return err
-	}
-	poller := &triggerClientUnsubscribeTriggerFromEventsPoller{
-		pt: pt,
-	}
-	_, err = poller.Poll(ctx)
-	if err != nil {
-		return err
-	}
-	l.Poller = poller
-	return nil
 }
 
 // triggerClientUnsubscribeTriggerFromEventsResponse contains the response from method triggerClient.UnsubscribeTriggerFromEvents.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
@@ -40,20 +40,16 @@ func newSparkJobDefinitionClient(endpoint string, pl runtime.Pipeline) *sparkJob
 // sparkJobDefinition - Spark Job Definition resource definition.
 // options - sparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions contains the optional parameters for the
 // sparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition method.
-func (client *sparkJobDefinitionClient) BeginCreateOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *sparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions) (sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse, error) {
+func (client *sparkJobDefinitionClient) BeginCreateOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *sparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions) (*sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller, error) {
 	resp, err := client.createOrUpdateSparkJobDefinition(ctx, sparkJobDefinitionName, sparkJobDefinition, options)
 	if err != nil {
-		return sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result := sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", resp, client.pl)
 	if err != nil {
-		return sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &sparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionPoller{pt: pt}, nil
 }
 
 // CreateOrUpdateSparkJobDefinition - Creates or updates a Spark Job Definition.
@@ -99,20 +95,16 @@ func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionCreateRe
 // sparkJobDefinitionAzureResource - Spark Job Definition resource definition.
 // options - sparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginDebugSparkJobDefinition
 // method.
-func (client *sparkJobDefinitionClient) BeginDebugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *sparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions) (sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse, error) {
+func (client *sparkJobDefinitionClient) BeginDebugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *sparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions) (*sparkJobDefinitionClientDebugSparkJobDefinitionPoller, error) {
 	resp, err := client.debugSparkJobDefinition(ctx, sparkJobDefinitionAzureResource, options)
 	if err != nil {
-		return sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result := sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.DebugSparkJobDefinition", resp, client.pl)
 	if err != nil {
-		return sparkJobDefinitionClientDebugSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &sparkJobDefinitionClientDebugSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &sparkJobDefinitionClientDebugSparkJobDefinitionPoller{pt: pt}, nil
 }
 
 // DebugSparkJobDefinition - Debug the spark job definition.
@@ -151,20 +143,16 @@ func (client *sparkJobDefinitionClient) debugSparkJobDefinitionCreateRequest(ctx
 // sparkJobDefinitionName - The spark job definition name.
 // options - sparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginDeleteSparkJobDefinition
 // method.
-func (client *sparkJobDefinitionClient) BeginDeleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *sparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions) (sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse, error) {
+func (client *sparkJobDefinitionClient) BeginDeleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *sparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions) (*sparkJobDefinitionClientDeleteSparkJobDefinitionPoller, error) {
 	resp, err := client.deleteSparkJobDefinition(ctx, sparkJobDefinitionName, options)
 	if err != nil {
-		return sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result := sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.DeleteSparkJobDefinition", resp, client.pl)
 	if err != nil {
-		return sparkJobDefinitionClientDeleteSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &sparkJobDefinitionClientDeleteSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &sparkJobDefinitionClientDeleteSparkJobDefinitionPoller{pt: pt}, nil
 }
 
 // DeleteSparkJobDefinition - Deletes a Spark Job Definition.
@@ -207,20 +195,16 @@ func (client *sparkJobDefinitionClient) deleteSparkJobDefinitionCreateRequest(ct
 // sparkJobDefinitionName - The spark job definition name.
 // options - sparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginExecuteSparkJobDefinition
 // method.
-func (client *sparkJobDefinitionClient) BeginExecuteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *sparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions) (sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse, error) {
+func (client *sparkJobDefinitionClient) BeginExecuteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *sparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions) (*sparkJobDefinitionClientExecuteSparkJobDefinitionPoller, error) {
 	resp, err := client.executeSparkJobDefinition(ctx, sparkJobDefinitionName, options)
 	if err != nil {
-		return sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result := sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.ExecuteSparkJobDefinition", resp, client.pl)
 	if err != nil {
-		return sparkJobDefinitionClientExecuteSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &sparkJobDefinitionClientExecuteSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &sparkJobDefinitionClientExecuteSparkJobDefinitionPoller{pt: pt}, nil
 }
 
 // ExecuteSparkJobDefinition - Executes the spark job definition.
@@ -353,20 +337,16 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceHandleR
 // request - proposed new name.
 // options - sparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginRenameSparkJobDefinition
 // method.
-func (client *sparkJobDefinitionClient) BeginRenameSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *sparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions) (sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse, error) {
+func (client *sparkJobDefinitionClient) BeginRenameSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *sparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions) (*sparkJobDefinitionClientRenameSparkJobDefinitionPoller, error) {
 	resp, err := client.renameSparkJobDefinition(ctx, sparkJobDefinitionName, request, options)
 	if err != nil {
-		return sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result := sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse{}
 	pt, err := runtime.NewPoller("sparkJobDefinitionClient.RenameSparkJobDefinition", resp, client.pl)
 	if err != nil {
-		return sparkJobDefinitionClientRenameSparkJobDefinitionPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &sparkJobDefinitionClientRenameSparkJobDefinitionPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &sparkJobDefinitionClientRenameSparkJobDefinitionPoller{pt: pt}, nil
 }
 
 // RenameSparkJobDefinition - Renames a sparkJobDefinition.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
@@ -40,20 +40,16 @@ func newSQLScriptClient(endpoint string, pl runtime.Pipeline) *sqlScriptClient {
 // sqlScript - Sql Script resource definition.
 // options - sqlScriptClientBeginCreateOrUpdateSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginCreateOrUpdateSQLScript
 // method.
-func (client *sqlScriptClient) BeginCreateOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *sqlScriptClientBeginCreateOrUpdateSQLScriptOptions) (sqlScriptClientCreateOrUpdateSQLScriptPollerResponse, error) {
+func (client *sqlScriptClient) BeginCreateOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *sqlScriptClientBeginCreateOrUpdateSQLScriptOptions) (*sqlScriptClientCreateOrUpdateSQLScriptPoller, error) {
 	resp, err := client.createOrUpdateSQLScript(ctx, sqlScriptName, sqlScript, options)
 	if err != nil {
-		return sqlScriptClientCreateOrUpdateSQLScriptPollerResponse{}, err
+		return nil, err
 	}
-	result := sqlScriptClientCreateOrUpdateSQLScriptPollerResponse{}
 	pt, err := runtime.NewPoller("sqlScriptClient.CreateOrUpdateSQLScript", resp, client.pl)
 	if err != nil {
-		return sqlScriptClientCreateOrUpdateSQLScriptPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &sqlScriptClientCreateOrUpdateSQLScriptPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &sqlScriptClientCreateOrUpdateSQLScriptPoller{pt: pt}, nil
 }
 
 // CreateOrUpdateSQLScript - Creates or updates a Sql Script.
@@ -99,20 +95,16 @@ func (client *sqlScriptClient) createOrUpdateSQLScriptCreateRequest(ctx context.
 // sqlScriptName - The sql script name.
 // options - sqlScriptClientBeginDeleteSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginDeleteSQLScript
 // method.
-func (client *sqlScriptClient) BeginDeleteSQLScript(ctx context.Context, sqlScriptName string, options *sqlScriptClientBeginDeleteSQLScriptOptions) (sqlScriptClientDeleteSQLScriptPollerResponse, error) {
+func (client *sqlScriptClient) BeginDeleteSQLScript(ctx context.Context, sqlScriptName string, options *sqlScriptClientBeginDeleteSQLScriptOptions) (*sqlScriptClientDeleteSQLScriptPoller, error) {
 	resp, err := client.deleteSQLScript(ctx, sqlScriptName, options)
 	if err != nil {
-		return sqlScriptClientDeleteSQLScriptPollerResponse{}, err
+		return nil, err
 	}
-	result := sqlScriptClientDeleteSQLScriptPollerResponse{}
 	pt, err := runtime.NewPoller("sqlScriptClient.DeleteSQLScript", resp, client.pl)
 	if err != nil {
-		return sqlScriptClientDeleteSQLScriptPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &sqlScriptClientDeleteSQLScriptPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &sqlScriptClientDeleteSQLScriptPoller{pt: pt}, nil
 }
 
 // DeleteSQLScript - Deletes a Sql Script.
@@ -244,20 +236,16 @@ func (client *sqlScriptClient) getSQLScriptsByWorkspaceHandleResponse(resp *http
 // request - proposed new name.
 // options - sqlScriptClientBeginRenameSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginRenameSQLScript
 // method.
-func (client *sqlScriptClient) BeginRenameSQLScript(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *sqlScriptClientBeginRenameSQLScriptOptions) (sqlScriptClientRenameSQLScriptPollerResponse, error) {
+func (client *sqlScriptClient) BeginRenameSQLScript(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *sqlScriptClientBeginRenameSQLScriptOptions) (*sqlScriptClientRenameSQLScriptPoller, error) {
 	resp, err := client.renameSQLScript(ctx, sqlScriptName, request, options)
 	if err != nil {
-		return sqlScriptClientRenameSQLScriptPollerResponse{}, err
+		return nil, err
 	}
-	result := sqlScriptClientRenameSQLScriptPollerResponse{}
 	pt, err := runtime.NewPoller("sqlScriptClient.RenameSQLScript", resp, client.pl)
 	if err != nil {
-		return sqlScriptClientRenameSQLScriptPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &sqlScriptClientRenameSQLScriptPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &sqlScriptClientRenameSQLScriptPoller{pt: pt}, nil
 }
 
 // RenameSQLScript - Renames a sqlScript.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
@@ -40,20 +40,16 @@ func newTriggerClient(endpoint string, pl runtime.Pipeline) *triggerClient {
 // trigger - Trigger resource definition.
 // options - triggerClientBeginCreateOrUpdateTriggerOptions contains the optional parameters for the triggerClient.BeginCreateOrUpdateTrigger
 // method.
-func (client *triggerClient) BeginCreateOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, options *triggerClientBeginCreateOrUpdateTriggerOptions) (triggerClientCreateOrUpdateTriggerPollerResponse, error) {
+func (client *triggerClient) BeginCreateOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, options *triggerClientBeginCreateOrUpdateTriggerOptions) (*triggerClientCreateOrUpdateTriggerPoller, error) {
 	resp, err := client.createOrUpdateTrigger(ctx, triggerName, trigger, options)
 	if err != nil {
-		return triggerClientCreateOrUpdateTriggerPollerResponse{}, err
+		return nil, err
 	}
-	result := triggerClientCreateOrUpdateTriggerPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.CreateOrUpdateTrigger", resp, client.pl)
 	if err != nil {
-		return triggerClientCreateOrUpdateTriggerPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &triggerClientCreateOrUpdateTriggerPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &triggerClientCreateOrUpdateTriggerPoller{pt: pt}, nil
 }
 
 // CreateOrUpdateTrigger - Creates or updates a trigger.
@@ -99,20 +95,16 @@ func (client *triggerClient) createOrUpdateTriggerCreateRequest(ctx context.Cont
 // triggerName - The trigger name.
 // options - triggerClientBeginDeleteTriggerOptions contains the optional parameters for the triggerClient.BeginDeleteTrigger
 // method.
-func (client *triggerClient) BeginDeleteTrigger(ctx context.Context, triggerName string, options *triggerClientBeginDeleteTriggerOptions) (triggerClientDeleteTriggerPollerResponse, error) {
+func (client *triggerClient) BeginDeleteTrigger(ctx context.Context, triggerName string, options *triggerClientBeginDeleteTriggerOptions) (*triggerClientDeleteTriggerPoller, error) {
 	resp, err := client.deleteTrigger(ctx, triggerName, options)
 	if err != nil {
-		return triggerClientDeleteTriggerPollerResponse{}, err
+		return nil, err
 	}
-	result := triggerClientDeleteTriggerPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.DeleteTrigger", resp, client.pl)
 	if err != nil {
-		return triggerClientDeleteTriggerPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &triggerClientDeleteTriggerPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &triggerClientDeleteTriggerPoller{pt: pt}, nil
 }
 
 // DeleteTrigger - Deletes a trigger.
@@ -290,20 +282,16 @@ func (client *triggerClient) getTriggersByWorkspaceHandleResponse(resp *http.Res
 // triggerName - The trigger name.
 // options - triggerClientBeginStartTriggerOptions contains the optional parameters for the triggerClient.BeginStartTrigger
 // method.
-func (client *triggerClient) BeginStartTrigger(ctx context.Context, triggerName string, options *triggerClientBeginStartTriggerOptions) (triggerClientStartTriggerPollerResponse, error) {
+func (client *triggerClient) BeginStartTrigger(ctx context.Context, triggerName string, options *triggerClientBeginStartTriggerOptions) (*triggerClientStartTriggerPoller, error) {
 	resp, err := client.startTrigger(ctx, triggerName, options)
 	if err != nil {
-		return triggerClientStartTriggerPollerResponse{}, err
+		return nil, err
 	}
-	result := triggerClientStartTriggerPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.StartTrigger", resp, client.pl)
 	if err != nil {
-		return triggerClientStartTriggerPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &triggerClientStartTriggerPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &triggerClientStartTriggerPoller{pt: pt}, nil
 }
 
 // StartTrigger - Starts a trigger.
@@ -346,20 +334,16 @@ func (client *triggerClient) startTriggerCreateRequest(ctx context.Context, trig
 // triggerName - The trigger name.
 // options - triggerClientBeginStopTriggerOptions contains the optional parameters for the triggerClient.BeginStopTrigger
 // method.
-func (client *triggerClient) BeginStopTrigger(ctx context.Context, triggerName string, options *triggerClientBeginStopTriggerOptions) (triggerClientStopTriggerPollerResponse, error) {
+func (client *triggerClient) BeginStopTrigger(ctx context.Context, triggerName string, options *triggerClientBeginStopTriggerOptions) (*triggerClientStopTriggerPoller, error) {
 	resp, err := client.stopTrigger(ctx, triggerName, options)
 	if err != nil {
-		return triggerClientStopTriggerPollerResponse{}, err
+		return nil, err
 	}
-	result := triggerClientStopTriggerPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.StopTrigger", resp, client.pl)
 	if err != nil {
-		return triggerClientStopTriggerPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &triggerClientStopTriggerPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &triggerClientStopTriggerPoller{pt: pt}, nil
 }
 
 // StopTrigger - Stops a trigger.
@@ -402,20 +386,16 @@ func (client *triggerClient) stopTriggerCreateRequest(ctx context.Context, trigg
 // triggerName - The trigger name.
 // options - triggerClientBeginSubscribeTriggerToEventsOptions contains the optional parameters for the triggerClient.BeginSubscribeTriggerToEvents
 // method.
-func (client *triggerClient) BeginSubscribeTriggerToEvents(ctx context.Context, triggerName string, options *triggerClientBeginSubscribeTriggerToEventsOptions) (triggerClientSubscribeTriggerToEventsPollerResponse, error) {
+func (client *triggerClient) BeginSubscribeTriggerToEvents(ctx context.Context, triggerName string, options *triggerClientBeginSubscribeTriggerToEventsOptions) (*triggerClientSubscribeTriggerToEventsPoller, error) {
 	resp, err := client.subscribeTriggerToEvents(ctx, triggerName, options)
 	if err != nil {
-		return triggerClientSubscribeTriggerToEventsPollerResponse{}, err
+		return nil, err
 	}
-	result := triggerClientSubscribeTriggerToEventsPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.SubscribeTriggerToEvents", resp, client.pl)
 	if err != nil {
-		return triggerClientSubscribeTriggerToEventsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &triggerClientSubscribeTriggerToEventsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &triggerClientSubscribeTriggerToEventsPoller{pt: pt}, nil
 }
 
 // SubscribeTriggerToEvents - Subscribe event trigger to events.
@@ -458,20 +438,16 @@ func (client *triggerClient) subscribeTriggerToEventsCreateRequest(ctx context.C
 // triggerName - The trigger name.
 // options - triggerClientBeginUnsubscribeTriggerFromEventsOptions contains the optional parameters for the triggerClient.BeginUnsubscribeTriggerFromEvents
 // method.
-func (client *triggerClient) BeginUnsubscribeTriggerFromEvents(ctx context.Context, triggerName string, options *triggerClientBeginUnsubscribeTriggerFromEventsOptions) (triggerClientUnsubscribeTriggerFromEventsPollerResponse, error) {
+func (client *triggerClient) BeginUnsubscribeTriggerFromEvents(ctx context.Context, triggerName string, options *triggerClientBeginUnsubscribeTriggerFromEventsOptions) (*triggerClientUnsubscribeTriggerFromEventsPoller, error) {
 	resp, err := client.unsubscribeTriggerFromEvents(ctx, triggerName, options)
 	if err != nil {
-		return triggerClientUnsubscribeTriggerFromEventsPollerResponse{}, err
+		return nil, err
 	}
-	result := triggerClientUnsubscribeTriggerFromEventsPollerResponse{}
 	pt, err := runtime.NewPoller("triggerClient.UnsubscribeTriggerFromEvents", resp, client.pl)
 	if err != nil {
-		return triggerClientUnsubscribeTriggerFromEventsPollerResponse{}, err
+		return nil, err
 	}
-	result.Poller = &triggerClientUnsubscribeTriggerFromEventsPoller{
-		pt: pt,
-	}
-	return result, nil
+	return &triggerClientUnsubscribeTriggerFromEventsPoller{pt: pt}, nil
 }
 
 // UnsubscribeTriggerFromEvents - Unsubscribe event trigger from events.

--- a/test/synapse/2019-06-01/azspark/go.mod
+++ b/test/synapse/2019-06-01/azspark/go.mod
@@ -2,4 +2,4 @@ module azspark
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/synapse/2019-06-01/azspark/go.sum
+++ b/test/synapse/2019-06-01/azspark/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/test/tables/2019-02-02/aztables/go.mod
+++ b/test/tables/2019-02-02/aztables/go.mod
@@ -2,4 +2,4 @@ module aztables
 
 go 1.16
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1

--- a/test/tables/2019-02-02/aztables/go.sum
+++ b/test/tables/2019-02-02/aztables/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 h1:qoVeMsc9/fh/yhxVaA0obYjVH/oI/ihrOoMwsLS9KSA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 h1:E+m3SkZCN0Bf5q7YdTs5lSm2CYY3CK4spn5OmUIiQtk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
The previous design was not mockable due to mixing of exported fields and
methods.  With this new design, the Begin* methods return the poller
directly which contains only methods so they can be mocked.  Some of the
methods have also slightly changed in behavior.
PollUntilDone and Resume methods have moved from the poller response
envelope to the poller, and the poller response envelope is gone.
Poll and Resume now return the response if the LRO reached a successful,
terminal state.
FinalResponse has been removed, its behavior merged into the methods
that can return the final response.