### PR TITLE
Add missing strings import

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -796,6 +796,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
         }
         text += emitQueryParam(qp, setter);
       }
+      imports.add('strings');
       text += '\treq.Raw().URL.RawQuery = strings.Join(unencodedParams, "&")\n';
     }
   }


### PR DESCRIPTION
Fixes case when the import isn't added elsewhere.